### PR TITLE
Add Windows 8, Ubuntu, Fedora and Debian UPnP banners; correct miniupnp

### DIFF
--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -162,8 +162,9 @@
       <example os.version="6" service.version="1.0">FedoraCore/6 UPnP/1.0 miniupnpd/1.0</example>
       <param pos="0" name="service.product" value="MiniUPnP"/>
       <param pos="2" name="service.version"/>
-      <param pos="0" name="os.vendor" value="Fedora"/>
-      <param pos="0" name="os.product" value="Linux"/>
+      <param pos="0" name="os.family" value="Linux"/>
+      <param pos="0" name="os.vendor" value="Red Hat"/>
+      <param pos="0" name="os.product" value="Fedora Core Linux"/>
       <param pos="1" name="os.version"/>
     </fingerprint>
 
@@ -180,7 +181,6 @@
       <param pos="0" name="os.product" value="Linux"/>
       <param pos="1" name="os.version"/>
     </fingerprint>
-
 
    <fingerprint pattern="^Linux Mips (\S+) UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
       <example>Linux Mips 2.4.20 UPnP/1.0 MiniUPnPd/1.2</example>


### PR DESCRIPTION
While working on a Nexpose ticket and defect, I noticed we were missing some obvious UPnP fingerprints.  I've added them along with a few from a UPnP Sonar scan earlier this year, though there are still ~75 in there that I haven't yet added.  I or someone else can do them in a future PR as they are not as straight forward as this one.

Specs continue to pass.
