### PR TITLE
Correct Allegro vendor name and add expected version extractions to examples

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2656,9 +2656,10 @@
       Extreme Networks, Foundry Networks, Konica Minolta, Kronos
       Timekeeper, McDATA, Netopia, Nortel Networks, Power Measurement Ltd,
       and Xerox.</description>
-      <example>RomPager/4.07 UPnP/1.0</example>
-      <example>Allegro-Software-RomPager/4.30b3</example>
-      <param pos="0" name="service.vendor" value="Allegro"/>
+      <example service.version="4.01">Allegro-Software-RomPager/4.01</example>
+      <example service.version="4.07">RomPager/4.07 UPnP/1.0</example>
+      <example service.version="4.30b3">Allegro-Software-RomPager/4.30b3</example>
+      <param pos="0" name="service.vendor" value="Allegro Software"/>
       <param pos="0" name="service.product" value="RomPager"/>
       <param pos="1" name="service.version"/>
    </fingerprint>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -16,8 +16,8 @@ fingerprint SSH servers.
 
     <fingerprint pattern="^RomSShell_([\d\.]+)$">
       <description>Allegro RomSShell SSH</description>
-      <example>RomSShell_4.62</example>
-      <param pos="0" name="service.vendor" value="Allegro"/>
+      <example service.version="4.62">RomSShell_4.62</example>
+      <param pos="0" name="service.vendor" value="Allegro Software"/>
       <param pos="0" name="service.product" value="RomSShell"/>
       <param pos="1" name="service.version"/>
     </fingerprint>


### PR DESCRIPTION
Allegro Software is the correct name, so I've changed it.  This name was unused in Metasploit and Nexpose.   I've also updated the tests here to ensure that version extraction happens.  {{rspec}} passes.
