### PR TITLE
Remove newlines from descriptions.

### DIFF
--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -128,7 +128,7 @@ class Fingerprint
   # @return [String] Contents of the source XML's `description` tag
   def parse_description(xml)
     element = xml.xpath('description')
-    element.empty? ? '' : element.first.content.gsub(/[\r\n]+/, ' ').gsub(/\s{3,}/, '  ').strip
+    element.empty? ? '' : element.first.content.to_s.gsub(/\s+/, ' ').strip
   end
 
   # @param xml [Nokogiri::XML::Element]

--- a/lib/recog/version.rb
+++ b/lib/recog/version.rb
@@ -1,3 +1,3 @@
 module Recog
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 end


### PR DESCRIPTION
This fixes #Fingerprint.name entries to remove the newlines. This results in a much more readable string:

Before:
```
Embedded HTTP server used by many vendors and device\n      types, including APC, 3Com, Andover Controls, Cisco VoIP, D-Link,\n      Extreme Networks, Foundry Networks, Konica Minolta, Kronos\n      Timekeeper, McDATA, Netopia, Nortel Networks, Power Measurement Ltd,\n      and Xerox.
```

After:
```
Embedded HTTP server used by many vendors and device types, including APC, 3Com, Andover Controls, Cisco VoIP, D-Link, Extreme Networks, Foundry Networks, Konica Minolta, Kronos Timekeeper, McDATA, Netopia, Nortel Networks, Power Measurement Ltd, and Xerox.
```

Only downstream impact today is Recog matching through DAP