### PR TITLE
Remove duplicate match/extract logic from recog_match

### DIFF
--- a/lib/recog/matcher.rb
+++ b/lib/recog/matcher.rb
@@ -22,27 +22,14 @@ class Matcher
         reporter.increment_line_count
 
         line = line.to_s.unpack("C*").pack("C*").strip.gsub(/\\[rn]/, '')
-        found = nil
+        extractions = nil
         fingerprints.each do |fp|
-          m = line.match(fp.regex)
-          if m
-            found = [fp, m]
-            break
-          end
+          break if (extractions = fp.match(line))
         end
 
-        if found
-          info = { }
-          fp, m = found
-          fp.params.each_pair do |k,v|
-            if v[0] == 0
-              info[k] = v[1]
-            else
-              info[k] = m[ v[0] ]
-            end
-          end
-          info['data'] = line
-          reporter.match "MATCH: #{info.inspect}"
+        if extractions
+          extractions['data'] = line
+          reporter.match "MATCH: #{extractions.inspect}"
         else
           reporter.failure "FAIL: #{line}"
         end


### PR DESCRIPTION
This code is only used by recog_match, but there were some problems:

* It was matching the line against the raw regex of the fingerprint rather than matching the fingerprint against the line 
* It was repeating the extraction logic already done in fingerprint.rb

This is not spec'd in the first place and may be deprecated in the future anyway, but the existing pass/fail functionality is maintained, however as you can see the output is a little different (caused by now using the correct match method):

Old:

```
$  echo "mbfcookie=adafadf" | ./bin/recog_match.rb xml/http_cookies.xml -
MATCH: {"cookie"=>"mbfcookie", "service.family"=>"Joom!Fish", "service.product"=>"Joom!Fish", "data"=>"mbfcookie=adafadf"}
$  echo "mabfcookie=adafadf" | ./bin/recog_match.rb xml/http_cookies.xml -
FAIL: mabfcookie=adafadf

```

New:

```
$  echo "mbfcookie=adafadf" | ./bin/recog_match.rb xml/http_cookies.xml - 
MATCH: {"matched"=>"Joom!Fish http://www.joomfish.net/", "cookie"=>"mbfcookie", "service.family"=>"Joom!Fish", "service.product"=>"Joom!Fish", "data"=>"mbfcookie=adafadf"}
$  echo "mabfcookie=adafadf" | ./bin/recog_match.rb xml/http_cookies.xml -
FAIL: mabfcookie=adafadf
```

More specifically, prior to the changes @hmoore-r7 made in https://github.com/rapid7/recog/commit/586e2a735e08bcb4afdd48ff4659931ca3100fdd, things like this would fail:

```
$  echo "mbfcookie=adafadf" | ./bin/recog_match.rb xml/http_cookies.xml - 
/home/jhart/labs/git/recog/lib/recog/fingerprint.rb:62:in `match': Regex (?-mix:^(mbfcookie(\[lang\])?)=.*) captures 1 too many (2 vs 1) (RuntimeError)
	from /home/jhart/labs/git/recog/lib/recog/matcher.rb:27:in `block (3 levels) in match_banners'
	from /home/jhart/labs/git/recog/lib/recog/matcher.rb:26:in `each'
	from /home/jhart/labs/git/recog/lib/recog/matcher.rb:26:in `block (2 levels) in match_banners'
	from /home/jhart/labs/git/recog/lib/recog/matcher.rb:21:in `each_line'
	from /home/jhart/labs/git/recog/lib/recog/matcher.rb:21:in `block in match_banners'
	from /home/jhart/labs/git/recog/lib/recog/match_reporter.rb:14:in `report'
	from /home/jhart/labs/git/recog/lib/recog/matcher.rb:11:in `match_banners'
	from ./bin/recog_match.rb:51:in `<main>'
```