### PR TITLE
Move all capture validation to rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :test do
   gem 'rspec', '>= 2.99'
   gem 'cucumber', '~> 1.3.8'
   gem 'aruba', '~> 0.5.3'
+  gem 'regexp_parser', '~> 0.2.0'
 end

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -45,26 +45,6 @@ class Fingerprint
     match_data = @regex.match(match_string)
     return if match_data.nil?
 
-    # sanity check any positional extractions
-    positions = @params.values.map(&:first).map(&:to_i)
-    captures_size = match_data.captures.size
-    if @params.empty? && captures_size > 0
-      raise "Non-asserting fingerprint with regex #{@regex} captures #{captures_size} time(s); 0 are needed"
-    else
-      if captures_size > 0
-        max_pos = positions.max
-        # if it is actually looking to extract, ensure that there is enough to extract
-        if max_pos > 0 && captures_size < max_pos
-          raise "Regex #{@regex} only has #{captures_size} captures; cannot extract from position #{max_pos}"
-        end
-        # if there is not extraction but capturing is happening, fail since this is a waste
-        if captures_size > max_pos
-          raise "Regex #{@regex} captures #{captures_size - max_pos} too many (#{captures_size} vs #{max_pos})"
-        end
-      end
-    end
-
-    # now do extraction
     result = { 'matched' => @name }
     @params.each_pair do |k,v|
       pos = v[0]


### PR DESCRIPTION
This simply takes the capture validation (too many captures, too few) logic from the functional recog code and moves it to the specs instead.  In doing this, it will flag 8 fingerprints as having incorrect groups (which I'll also fix in this PR but want to show that rspec will flag them)