### PR TITLE
Tighten capture/extraction spec even further, correct more miscaptures/etc

### DIFF
--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -45,7 +45,10 @@ describe Recog::DB do
               end
               # compare the captures actually performed to those being used and ensure that they contain
               # the same elements regardless of order, preventing, over-, under- and other forms of mis-capturing.
-              expect(actual_capture_positions.sort.uniq).to eq(expected_capture_positions.sort.uniq)
+              actual_capture_positions = actual_capture_positions.sort.uniq
+              expected_capture_positions = expected_capture_positions.sort.uniq
+              expect(actual_capture_positions).to eq(expected_capture_positions),
+                "Regex didn't capture (#{actual_capture_positions}) exactly what it extracted (#{expected_capture_positions})"
             end
           end
 
@@ -60,7 +63,7 @@ describe Recog::DB do
               expect(match).to_not be_nil, 'Regex did not match'
               # test any extractions specified in the example
               example.attributes.each_pair do |k,v|
-                expect(match[k]).to eq(v), "Regex didn't extracted expected value for fingerprint attribute #{k}"
+                expect(match[k]).to eq(v), "Regex didn't extract expected value for fingerprint attribute #{k} -- got #{v} instead of #{match[k]}"
               end
             end
 

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -48,7 +48,7 @@ describe Recog::DB do
               actual_capture_positions = actual_capture_positions.sort.uniq
               expected_capture_positions = expected_capture_positions.sort.uniq
               expect(actual_capture_positions).to eq(expected_capture_positions),
-                "Regex didn't capture (#{actual_capture_positions}) exactly what it extracted (#{expected_capture_positions})"
+                "Regex didn't capture (#{actual_capture_positions}) exactly what fingerprint extracted (#{expected_capture_positions})"
             end
           end
 

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -63,7 +63,7 @@ describe Recog::DB do
               expect(match).to_not be_nil, 'Regex did not match'
               # test any extractions specified in the example
               example.attributes.each_pair do |k,v|
-                expect(match[k]).to eq(v), "Regex didn't extract expected value for fingerprint attribute #{k} -- got #{v} instead of #{match[k]}"
+                expect(match[k]).to eq(v), "Regex didn't extract expected value for fingerprint attribute #{k} -- got #{match[k]} instead of #{v}"
               end
             end
 

--- a/xml/h323_callresp.xml
+++ b/xml/h323_callresp.xml
@@ -117,11 +117,11 @@ to fingerprint H.323 servers.
       <param pos="2" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^0x(82000002|a5000001)\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
+   <fingerprint pattern="^0x(?:82000002|a5000001)\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
       <description>Ericsson H.323 Server</description>
       <param pos="0" name="service.vendor" value="Ericsson"/>
-      <param pos="2" name="service.product"/>
-      <param pos="3" name="service.version"/>
+      <param pos="1" name="service.product"/>
+      <param pos="2" name="service.version"/>
    </fingerprint>
 
    <fingerprint pattern="^0x8a000003\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
@@ -657,11 +657,11 @@ to fingerprint H.323 servers.
       <param pos="2" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^0xb500(4c54|600d)\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
+   <fingerprint pattern="^0xb500(?:4c54|600d)\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
       <description>Lucent Technologies H.323 Server</description>
       <param pos="0" name="service.vendor" value="Lucent Technologies"/>
-      <param pos="2" name="service.product"/>
-      <param pos="3" name="service.version"/>
+      <param pos="1" name="service.product"/>
+      <param pos="2" name="service.version"/>
    </fingerprint>
 
    <fingerprint pattern="^0xb5004d47\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -231,7 +231,7 @@ servers.
       <param pos="0" name="service.product" value="Alteon Web Switch"/>
    </fingerprint>
 
-   <fingerprint pattern="^((SS_X_)?CSINTERSESSIONID)=.*">
+   <fingerprint pattern="^((?:SS_X_)?CSINTERSESSIONID)=.*">
       <description>OpenMarket/FatWire Content Server (www.fatwire.com)</description>
       <param pos="1" name="cookie"/>
       <param pos="0" name="service.vendor" value="FatWire"/>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -21,10 +21,10 @@ matched against these patterns to fingerprint POP3 servers.
       <param pos="1" name="host.domain"/>
     </fingerprint>
 
-   <fingerprint pattern="^([^ ]+) +Cyrus POP3 v([\d\.]+)[^OS\s+X].*$">
+   <fingerprint pattern="^([^ ]+) +Cyrus POP3 v([\d\.]+)">
       <description>CMU Cyrus POP</description>
       <example host.domain="foo" service.version="2.3">foo Cyrus POP3 v2.3</example>
-      <example host.domain="foo" service.version="2.3.13">foo Cyrus POP3 v2.3.14 server ready &lt;13087751828270990591.1301068892@foo&gt;</example>
+      <example host.domain="foo" service.version="2.3.14">foo Cyrus POP3 v2.3.14 server ready &lt;13087751828270990591.1301068892@foo&gt;</example>
       <param pos="0" name="service.vendor" value="CMU"/>
       <param pos="0" name="service.family" value="Cyrus"/>
       <param pos="0" name="service.product" value="Cyrus POP"/>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -8,7 +8,7 @@ matched against these patterns to fingerprint POP3 servers.
 
    <fingerprint pattern="^([^ ]+) +Cyrus POP3 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready">
       <description>OSX Cyrus POP</description>
-      <example>8.8.8.8 Cyrus POP3 v2.3.8-OS X Server 10.5: 9A562 server ready &lt;1999107648.1324502155@8.8.8.8&gt;</example>
+      <example host.domain="8.8.8.8" service.version="2.3.8" os.version="10.5">8.8.8.8 Cyrus POP3 v2.3.8-OS X Server 10.5: 9A562 server ready &lt;1999107648.1324502155@8.8.8.8&gt;</example>
       <param pos="0" name="service.family" value="Cyrus"/>
       <param pos="0" name="service.product" value="Cyrus POP"/>
       <param pos="0" name="service.vendor" value="CMU"/>
@@ -18,17 +18,18 @@ matched against these patterns to fingerprint POP3 servers.
       <param pos="0" name="os.product" value="Mac OS X"/>
       <param pos="0" name="os.device" value="General"/>
       <param pos="3" name="os.version"/>
+      <param pos="1" name="host.domain"/>
     </fingerprint>
 
    <fingerprint pattern="^([^ ]+) +Cyrus POP3 v([\d\.]+)[^OS\s+X].*$">
       <description>CMU Cyrus POP</description>
-      <example>foo Cyrus POP3 v2.3</example>
-      <example>foo Cyrus POP3 v2.3.14 server ready &lt;13087751828270990591.1301068892@foo&gt;</example>
+      <example host.domain="foo" service.version="2.3">foo Cyrus POP3 v2.3</example>
+      <example host.domain="foo" service.version="2.3.13">foo Cyrus POP3 v2.3.14 server ready &lt;13087751828270990591.1301068892@foo&gt;</example>
       <param pos="0" name="service.vendor" value="CMU"/>
       <param pos="0" name="service.family" value="Cyrus"/>
       <param pos="0" name="service.product" value="Cyrus POP"/>
-      <param pos="1" name="service.version"/>
-      <param pos="2" name="host.domain"/>
+      <param pos="2" name="service.version"/>
+      <param pos="1" name="host.domain"/>
     </fingerprint>
 
     <fingerprint pattern="^Lotus Notes POP3 server version X[^ ]+ ready on .*$">
@@ -248,15 +249,15 @@ matched against these patterns to fingerprint POP3 servers.
 
 // +OK X1 POP3 Mail Server
 
-// +OK server POP3 server (DeskNow POP3 Server 1.0) ready 
+// +OK server POP3 server (DeskNow POP3 Server 1.0) ready
 
 // +OK <1185161310.3352@goto15028.com> [XMail 1.24 POP3 Server] service ready; Mon, 23 Jul 2007 11:28:30 +0800
 
 // +OK IdeaPop3Server v0.50 ready.
 
-// +OK qxztmail POP3 server (STD Ymailserver v1.8 POP3) ready 
+// +OK qxztmail POP3 server (STD Ymailserver v1.8 POP3) ready
 
-// +OK blue.forest-green.lan POP3 server (JAMES POP3 Server 2.2.0) ready 
+// +OK blue.forest-green.lan POP3 server (JAMES POP3 Server 2.2.0) ready
 
 // +OK xxx CMailServer 5.2 POP3 Service Ready
 
@@ -299,7 +300,7 @@ matched against these patterns to fingerprint POP3 servers.
 -ERR sorry, POP server too busy right now.  Try again later.
 -ERR This IP is not configured for POP3 service.  Please contact Allstream at 1-888-655-7670.
 +OK
-+OK 
++OK
 +OK <0bdec6022085d6c34a0e48bb77bf8cf3@juno.thinkburst.com>
 +OK <869521546.23059@mail.tecedge.net>, POP3 server ready.
 +OK host CMailServer 5.2 POP3 Service Ready
@@ -307,7 +308,7 @@ matched against these patterns to fingerprint POP3 servers.
 +OK alakhan.kz POP MDaemon 6.8.4 ready <MDAEMON-F200707231617.AA1715437MD3489@alakhan.kz>
 +OK alquilerpc.com.mx POP3 Server (Version 1.020h) ready.
 +OK ArGoSoft Mail Server Pro for WinNT/2000/XP, Version 1.8 (1.8.8.9)
-+OK blue.forest-green.lan POP3 server (JAMES POP3 Server 2.2.0) ready 
++OK blue.forest-green.lan POP3 server (JAMES POP3 Server 2.2.0) ready
 +OK canoeregatta.org POP3 Server (Version 1.020h) ready.
 +OK codebase.com.au POP MDaemon 9.6.1 ready <MDAEMON-F200707220122.AA2235837MD8039@codebase.com.au>
 +OK Cubic Circle's v1.31 1998/05/13 POP3 ready <0c9300004104a246@www.dvdld.co.za>
@@ -402,9 +403,9 @@ matched against these patterns to fingerprint POP3 servers.
 +OK POP3 www.happytails2u.com 2004.89 server ready
 +OK POP3 www.homebasedwizard.com 2004.89 server ready
 +OK POP3 www.webmail.imperioe.com 2004.89 server ready
-+OK qxztmail POP3 server (STD Ymailserver v1.8 POP3) ready 
++OK qxztmail POP3 server (STD Ymailserver v1.8 POP3) ready
 +OK Radish (Version 3.0.0-b021) ready
-+OK ready  
++OK ready
 +OK ready  <11514.1185210732@freedom.concept69.de>
 +OK ready  <14026.1184992338@s076-129.ub.firstserver.ne.jp>
 +OK ready  <16013.1185110479@p1.in11.squarestart.ne.jp>
@@ -417,7 +418,7 @@ matched against these patterns to fingerprint POP3 servers.
 +OK recvmail/he.net POP3 Server
 +OK refinanceloanjones.com POP3 Server (Version 1.020h) ready.
 +OK samare.it POP MDaemon 6.8.5 ready <MDAEMON-F200707220351.AA513460MD5338@samare.it>
-+OK server POP3 server (DeskNow POP3 Server 1.0) ready 
++OK server POP3 server (DeskNow POP3 Server 1.0) ready
 +OK silexaviacion.com POP3 Server (Version 1.020h) ready.
 +OK simple-photography.com POP3 Server (Version 1.020h) ready.
 +OK Solid POP3 server ready

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -139,14 +139,14 @@
    </fingerprint>
 
    <!-- TODO: Need an example string -->
-   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
+   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
       <description>Windows Server 2008 Storage (SP)</description>
       <param pos="0" name="os.certainty" value="1.0"/>
       <param pos="0" name="os.vendor" value="Microsoft"/>
       <param pos="0" name="os.product" value="Windows Server 2008"/>
       <param pos="0" name="os.edition" value="Storage"/>
-      <param pos="2" name="os.build"/>
-      <param pos="3" name="os.version"/>
+      <param pos="1" name="os.build"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
    <!-- TODO: Need an example string -->
@@ -337,25 +337,25 @@
       <param pos="2" name="os.build"/>
    </fingerprint>
 
-   <fingerprint pattern="^Windows MultiPoint Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
+   <fingerprint pattern="^Windows MultiPoint Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
       <description>Windows MultiPoint Server 2012 (SP)</description>
-      <example>Windows MultiPoint Server 2012 Premium 9201 Service Pack 1</example>
+      <example os.build="9201" os.version="Service Pack 1">Windows MultiPoint Server 2012 Premium 9201 Service Pack 1</example>
       <param pos="0" name="os.certainty" value="1.0"/>
       <param pos="0" name="os.vendor" value="Microsoft"/>
       <param pos="0" name="os.product" value="Windows Server 2012"/>
       <param pos="0" name="os.edition" value="MultiPoint"/>
-      <param pos="2" name="os.build"/>
-      <param pos="3" name="os.version"/>
+      <param pos="1" name="os.build"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Windows MultiPoint Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+   <fingerprint pattern="^Windows MultiPoint Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
       <description>Windows MultiPoint Server 2012</description>
-      <example>Windows MultiPoint Server 2012 Premium 9200</example>
+      <example os.build="9200">Windows MultiPoint Server 2012 Premium 9200</example>
       <param pos="0" name="os.certainty" value="1.0"/>
       <param pos="0" name="os.vendor" value="Microsoft"/>
       <param pos="0" name="os.product" value="Windows Server 2012"/>
       <param pos="0" name="os.edition" value="MultiPoint"/>
-      <param pos="2" name="os.build"/>
+      <param pos="1" name="os.build"/>
    </fingerprint>
 
    <!-- TODO: Detect vendor, distribution, and package versions -->

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -150,13 +150,13 @@
    </fingerprint>
 
    <!-- TODO: Need an example string -->
-   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
       <description>Windows Web Server 2008 Storage</description>
       <param pos="0" name="os.certainty" value="1.0"/>
       <param pos="0" name="os.vendor" value="Microsoft"/>
       <param pos="0" name="os.product" value="Windows Server 2008"/>
       <param pos="0" name="os.edition" value="Storage"/>
-      <param pos="3" name="os.build"/>
+      <param pos="1" name="os.build"/>
    </fingerprint>
 
    <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+) (Service Pack \d+)$">

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -15,7 +15,7 @@ These XML files are used in this order:
    smtp_turn.xml
    smtp_rset.xml
    smtp_quit.xml
-   
+
 The system or service fingerprint with the highest certainty overwrites the others.
 -->
 
@@ -55,17 +55,19 @@ The system or service fingerprint with the highest certainty overwrites the othe
          AnalogX proxy
          http://www.analogx.com/contents/download/network/proxy.htm
       </description>
+      <example host.name="192.168.1.1" service.version="4.15">192.168.1.1 SMTP AnalogX Proxy 4.15 (Release) ready</example>
       <param pos="0" name="service.vendor" value="AnalogX"/>
       <param pos="0" name="service.family" value="Proxy"/>
       <param pos="0" name="service.product" value="Proxy"/>
-      <param pos="1" name="service.version"/>
+      <param pos="2" name="service.version"/>
+      <param pos="1" name="host.name"/>
    </fingerprint>
 
    <fingerprint pattern="^ArGoSoft Mail Server, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
       <description>
          ArGoSoft Mail Server is fully functional STMP/POP3/Finger server for Windows 95/98/NT/2000.
          http://www.argosoft.com/applications/mailserver/
-         Example: 220 ArGoSoft Mail Server, Version 1.4 (1.4.0.3)      
+         Example: 220 ArGoSoft Mail Server, Version 1.4 (1.4.0.3)
       </description>
       <param pos="0" name="service.vendor" value="ArGoSoft"/>
       <param pos="0" name="service.family" value="Mail Server"/>
@@ -124,7 +126,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="service.version" value="4"/>
    </fingerprint>
 
-   <fingerprint pattern="^([\*20 ]+)$">
+   <fingerprint pattern="^[\*20 ]+$">
       <description>
          Cisco PIX firewall: PIX sits between an internal SMTP server and the rest of the world.
 
@@ -275,7 +277,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="service.product" value="IIS"/>
       <param pos="3" name="service.version"/>
       <param pos="1" name="host.name"/>
-      <param pos="2" name="system.time"/>      
+      <param pos="2" name="system.time"/>
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="0" name="os.vendor" value="Microsoft"/>
       <param pos="0" name="os.family" value="Windows"/>
@@ -330,7 +332,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="1" name="host.name"/>
    </fingerprint>
 
-   <fingerprint pattern="^([^ ]+) +SMTP/smap Ready\.$">
+   <fingerprint pattern="^(?:[^ ]+) +SMTP/smap Ready\.$">
       <description>
          TIS FWTK and derivatives
          http://www.tis.com/research/software/
@@ -418,11 +420,12 @@ The system or service fingerprint with the highest certainty overwrites the othe
          Syntegra/CDC IntraStore TurboSendmail, part of the IntraStore server which runs on
          the following platforms ONLY: Linux, HP-UX, Solaris, AIX, and Windows NT/2000
          see http://www.cdc.com for more information
-         example: 220 tigger.disneyonline.com (IntraStore TurboSendmail) ESMTP Service ready
       </description>
+      <example host.name="192.168.1.1">192.168.1.1 (IntraStore TurboSendmail) ESMTP Service ready</example>
       <param pos="0" name="service.vendor" value="BT"/>
       <param pos="0" name="service.family" value="IntraStore"/>
       <param pos="0" name="service.product" value="IntraStore"/>
+      <param pos="1" name="host.name"/>
    </fingerprint>
 
    <fingerprint pattern="^([^ ]+) \(Mail-Max Version (\d+\.\d+\.\d+\.\d+), (.+, .+)\) ESMTP Mail Server Ready. *$">
@@ -436,7 +439,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="system.time"/>         
+      <param pos="3" name="system.time"/>
    </fingerprint>
 
    <fingerprint pattern="^([^ ]+) \(Mail-Max Version (\d+\.\d+), (.+, .+)\) ESMTP Mail Server Ready. *$">
@@ -450,7 +453,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="system.time"/>         
+      <param pos="3" name="system.time"/>
    </fingerprint>
 
    <fingerprint pattern="^([^ ]+) +MailSite ESMTP Receiver Version ([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+) Ready *$">
@@ -491,7 +494,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) UNREGISTERED; *(.+) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar ESMTP MDaemon 4.0.5 UNREGISTERED; Sat, 06 Oct 2001 09:10:56 +0400
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -511,7 +514,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar ESMTP MDaemon 4.0.2; Sat, 06 Oct 2001 01:46:44 -0500
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -530,7 +533,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) ready *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar ESMTP MDaemon 3.5.7 ready
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -547,7 +550,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] MDaemon v([^ ]+\.[^ ]+) ([^ ]+) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar.com ESMTP service ready [1] MDaemon v2.84 R
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -565,7 +568,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] using MDaemon v([^ ]+\.[^ ]+\.[^ ]+) ([^ ]+) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar.com ESMTP service ready [1] using MDaemon v3.0.3 R
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -583,7 +586,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] MDaemon v([^ ]+\.[^ ]+) ([^ ]+) ([^ ]+) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar.com ESMTP service ready [1] MDaemon v2.7 SP5 R
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -602,7 +605,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] MDaemon v([^ ]+)\.([^ ]+)\.([^ ]+)\.([^ ]+) ([^ ]+) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar.com ESMTP service ready [1] MDaemon v2.8.7.0 R
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -623,7 +626,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] \(MDaemon v([^ ]+\.[^ ]+) ([^ ]+) ([^ ]+)\) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar.com ESMTP service ready [2] (MDaemon v2.7 SP4 R)
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -642,7 +645,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] \(MDaemon v([^ ]+\.[^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)\) *$">
       <description>
-         MDaemon mail server 
+         MDaemon mail server
          220 foo.bar.com ESMTP service ready [1] (MDaemon v2.5 rB b1 32-T)
       </description>
       <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -700,7 +703,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy  HH:mm:ss zzz"/>
       <param pos="1" name="service.version"/>
       <param pos="2" name="service.version.version"/>
-      <param pos="3" name="service.version.version.version"/>         
+      <param pos="3" name="service.version.version.version"/>
       <param pos="4" name="mercur.os.info"/>
       <param pos="5" name="system.time"/>
    </fingerprint>
@@ -797,7 +800,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) Lotus SMTP MTA Service Ready *$">
       <description>
-         Lotus Notes 4 SMTP MTA      
+         Lotus Notes 4 SMTP MTA
       </description>
       <param pos="0" name="service.vendor" value="Lotus"/>
       <param pos="0" name="service.family" value="Lotus Domino"/>
@@ -808,7 +811,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) ESMTP Service \(Lotus Domino Release (\d+\.\d+\.\w+)\) ready at (.+) *$">
       <description>
-         Lotus Domino 5 SMTP MTA 
+         Lotus Domino 5 SMTP MTA
          220 foo.bar.com ESMTP Service (Lotus Domino Release 5.0.5) ready at Wed, 19 Dec 2001 19:54:55 -0500
       </description>
       <param pos="0" name="service.vendor" value="Lotus"/>
@@ -822,7 +825,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) ESMTP Service \(Lotus Domino Release (\d+\.\w+)\) ready at (.+) *$">
       <description>
-         Lotus Domino 5 SMTP MTA 
+         Lotus Domino 5 SMTP MTA
          example: 220 foo.bar.com ESMTP Service (Lotus Domino Release 5.0a) ready at Wed, 20 Jun 2001 08:59:17 +0200
       </description>
       <param pos="0" name="service.vendor" value="Lotus"/>
@@ -836,17 +839,17 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) ESMTP Service \(Lotus Domino Release (\d+\.\d+\.\w+) \(Intl\)\) ready at (.+) *$">
       <description>
-         Lotus Domino 5 SMTP MTA, International product version      
+         Lotus Domino 5 SMTP MTA, International product version
          example: 220 foo.bar.com ESMTP Service (Lotus Domino Release 5.0.5 (Intl)) ready at Tue, 6 Feb 2001 18:54:23 -0500
       </description>
       <param pos="0" name="service.vendor" value="Lotus"/>
       <param pos="0" name="service.family" value="Lotus Domino"/>
       <param pos="0" name="service.product" value="Lotus Domino"/>
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
-      <param pos="0" name="notes.intl" value="yes"/>         
+      <param pos="0" name="notes.intl" value="yes"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="system.time"/>            
+      <param pos="3" name="system.time"/>
    </fingerprint>
 
    <fingerprint pattern="^([^ ]+) ESMTP Service \(Lotus Domino Build (\d+\.\d+)\) ready at (.+) *$">
@@ -894,10 +897,10 @@ The system or service fingerprint with the highest certainty overwrites the othe
          versions 3.x and earlier of NTMail http://www.gordano.com (it was called Internet Shopper's something or other)
          example: 220 mail.Networkengineering WindowsNT SMTP Server v3.03.0018/1.aio1/SP ESMTP ready at Wed, 25 Jul 2001 23:03:11 -0400
          example: 220 mars.wvwc.edu WindowsNT SMTP Server v3.03.0018/1.ajhf/SP ESMTP ready at Thu, 29 Oct 1998 18:01:30 -0500
-         example: 220 mail.someisp.net WindowsNT SMTP Server v3.03.0017/1.aihl/SP ESMTP ready at Sun, 6 Jun 1999 10:39:30 -0400 
+         example: 220 mail.someisp.net WindowsNT SMTP Server v3.03.0017/1.aihl/SP ESMTP ready at Sun, 6 Jun 1999 10:39:30 -0400
          example: 220 nt03s02.switchlink.be WindowsNT SMTP Server v3.03.0014/1.aiss/SP ESMTP ready at Fri, 17 Apr 1998 16:59:04 +0100
          example: 220 www.afsc.org WindowsNT SMTP Server v3.03.0017/1.abkz/SP ESMTP ready at Mon, 2 Oct 2000 11:50:29 -0400
-         example: 220 wwmerchant.osopinion.com WindowsNT SMTP Server v3.03.0017/4c.adur/SP ESMTP ready at Fri, 26 Mar 1999 13:20:30 -0700 
+         example: 220 wwmerchant.osopinion.com WindowsNT SMTP Server v3.03.0017/4c.adur/SP ESMTP ready at Fri, 26 Mar 1999 13:20:30 -0700
          example: 220 digital-hoon.tecdm.dmi.co.kr WindowsNT SMTP Server v3.02.07/2c.aaaj ready at Thu, 5 Dec 1996 22:46:12 +0000
       </description>
       <param pos="0" name="service.vendor" value="Gordano"/>
@@ -1029,9 +1032,9 @@ The system or service fingerprint with the highest certainty overwrites the othe
 
    <fingerprint pattern="^([^ ]+) ESMTP server \(P|post\.O|office v([^ ]+\.[^ ]+) release (.+) ID# ([^ ]+)\) ready (.+) *$">
       <description>
-         Post.Office (2 version numbers)
-         example: 220 birg.connect.co.at ESMTP server (Post.Office v3.1 release PO205e ID# 0-42000U100L2S100) ready Tue, 6 Feb 2001 19:38:32 +0100
+        Post.Office (2 version numbers)
       </description>
+      <example host.name="192.168.1.1" service.version="3.1" postoffice.build="P0205e" postoffice.id="0-42000U100L2S100" system.time="Tue, 6 Feb 2001 19:38:32 +0100">192.168.1.1 ESMTP server (Post.Office v3.1 release PO205e ID# 0-42000U100L2S100) ready Tue, 6 Feb 2001 19:38:32 +0100</example>
       <param pos="0" name="service.family" value="Post.Office"/>
       <param pos="0" name="service.product" value="Post.Office"/>
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
@@ -1079,7 +1082,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.hpux.phne.version"/>         
+      <param pos="3" name="sendmail.hpux.phne.version"/>
       <param pos="4" name="sendmail.config.version"/>
       <param pos="5" name="system.time"/>
    </fingerprint>
@@ -1527,7 +1530,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
    <!-- these suckers can have LOTS of version numbers -->
    <fingerprint pattern="^([^ ]+) -- Server ESMTP \(Sun Internet Mail Server sims\.([^\.]+\.[^\.]+\.[^\.]+\.[^\.]+\.[^\.]+\.[^\.]+\.[^\.]+)\)$">
       <description>
-      220 mercury.doc.ntu.ac.uk -- Server ESMTP (Sun Internet Mail Server sims.4.0.1999.06.13.00.20)      
+      220 mercury.doc.ntu.ac.uk -- Server ESMTP (Sun Internet Mail Server sims.4.0.1999.06.13.00.20)
       </description>
       <param pos="0" name="service.vendor" value="Sun"/>
       <param pos="0" name="service.family" value="Internet Mail Server"/>
@@ -1604,7 +1607,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="service.product" value="VOPMail"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-   </fingerprint>   
+   </fingerprint>
 
    <fingerprint pattern="^([^ ]+) VPOP3 SMTP Server Ready *$">
       <description>
@@ -1718,12 +1721,12 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="service.family" value="ZMailer"/>
       <param pos="0" name="service.product" value="ZMailer"/>
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
-      <param pos="0" name="zmailer.ident" value="yes"/>         
+      <param pos="0" name="zmailer.ident" value="yes"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
       <param pos="3" name="service.version.version"/>
       <param pos="4" name="system.time"/>
-    </fingerprint>   
+    </fingerprint>
 
    <fingerprint pattern="^([^ ]+) E?SMTP(?: Ready\.?)?$">
      <description>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -1015,31 +1015,16 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="1" name="host.name"/>
    </fingerprint>
 
-   <fingerprint pattern="^([^ ]+) ESMTP server \(Post\.Office v([^ ]+\.[^ ]+\.[^ ]+) release (.+) ID# ([^ ]+)\) ready (.+) *$">
+   <fingerprint pattern="^([^ ]+) ESMTP server \(Post\.Office v([^ ]+) release (.+) ID# ([^ ]+)\) ready (.+) *$">
       <description>
          Post.Office (3 version numbers)
-         example: 220 birg.connect.co.at ESMTP server (Post.Office v3.1 release PO205e ID# 0-42000U100L2S100) ready Tue, 6 Feb 2001 19:38:32 +0100
       </description>
+      <example host.name="192.168.1.1" service.version="3.1" postoffice.build="PO205e" postoffice.id="0-42000U100L2S100" system.time="Tue, 6 Feb 2001 19:38:32 +0100">192.168.1.1 ESMTP server (Post.Office v3.1 release PO205e ID# 0-42000U100L2S100) ready Tue, 6 Feb 2001 19:38:32 +0100</example>
       <param pos="0" name="service.family" value="Post.Office"/>
       <param pos="0" name="service.product" value="Post.Office"/>
+      <param pos="2" name="service.version"/>
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
-      <param pos="2" name="service.version"/>
-      <param pos="3" name="postoffice.build"/>
-      <param pos="3" name="postoffice.id"/>
-      <param pos="4" name="system.time"/>
-   </fingerprint>
-
-   <fingerprint pattern="^([^ ]+) ESMTP server \(P|post\.O|office v([^ ]+\.[^ ]+) release (.+) ID# ([^ ]+)\) ready (.+) *$">
-      <description>
-        Post.Office (2 version numbers)
-      </description>
-      <example host.name="192.168.1.1" service.version="3.1" postoffice.build="P0205e" postoffice.id="0-42000U100L2S100" system.time="Tue, 6 Feb 2001 19:38:32 +0100">192.168.1.1 ESMTP server (Post.Office v3.1 release PO205e ID# 0-42000U100L2S100) ready Tue, 6 Feb 2001 19:38:32 +0100</example>
-      <param pos="0" name="service.family" value="Post.Office"/>
-      <param pos="0" name="service.product" value="Post.Office"/>
-      <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
-      <param pos="1" name="host.name"/>
-      <param pos="2" name="service.version"/>
       <param pos="3" name="postoffice.build"/>
       <param pos="4" name="postoffice.id"/>
       <param pos="5" name="system.time"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -188,15 +188,15 @@
       <param pos="1" name="os.product"/>
    </fingerprint>
 
-   <fingerprint pattern="^3Com (11 Mbps|11a/b/g) (Wireless .*)$">
+   <fingerprint pattern="^3Com (?:11 Mbps|11a/b/g) (Wireless .*)$">
       <description>3COM WAP</description>
-      <example>3Com 11 Mbps Wireless Building to Building Bridge</example>
-      <example>3Com 11 Mbps Wireless LAN Access Point 2000</example>
-      <example>3Com 11 Mbps Wireless LAN Access Point 8000</example>
-      <example>3Com 11a/b/g Wireless Workgroup Bridge</example>
+      <example os.product="Wireless Building to Building Bridge">3Com 11 Mbps Wireless Building to Building Bridge</example>
+      <example os.product="Wireless LAN Access Point 2000">3Com 11 Mbps Wireless LAN Access Point 2000</example>
+      <example os.product="Wireless LAN Access Point 8000">3Com 11 Mbps Wireless LAN Access Point 8000</example>
+      <example os.product="Wireless Workgroup Bridge">3Com 11a/b/g Wireless Workgroup Bridge</example>
       <param pos="0" name="os.vendor" value="3Com"/>
       <param pos="0" name="os.device" value="WAP"/>
-      <param pos="2" name="os.product"/>
+      <param pos="1" name="os.product"/>
    </fingerprint>
 
    <fingerprint pattern="^3Com 3Com (?:SuperStack 4 )?Switch (\S+).*Software Version 3Com OS V(\S+)$">
@@ -672,7 +672,7 @@
       <param pos="2" name="os.product"/>
    </fingerprint>
 
-   <fingerprint pattern="^APC (Environmental (Management System|Manager|Monitoring Unit)|InfraStruXure Manager|.* Rack PDU|NetBotz Rack Access|Web/SNMP Management Card ).*AF1:\s*v?(\S+).*MN:\s*(\S+).*$">
+   <fingerprint pattern="^APC (?:Environmental (?:Management System|Manager|Monitoring Unit)|InfraStruXure Manager|.* Rack PDU|NetBotz Rack Access|Web/SNMP Management Card).*AF1:\s*v?(\S+).*MN:\s*(\S+).*$">
       <description>APC UPS</description>
       <example>APC Environmental Management System (MB:v3.6.9 PF:v2.6.4 PN:apc_hw02_aos_264.bin AF1:v2.6.7 AN1:apc_hw02_ems_267.bin MN:AP9320 HR:4 SN: ZA0747015277 MD:11/25/2007)</example>
       <example>APC Environmental Manager (MB:v3.8.0 PF:v3.0.3 PN:apc_hw03_aos_303.bin AF1:v3.0.4 AN1:apc_hw03_mem_304.bin MN:AP9340 HR:05 SN: ZA0739002849 MD:09/25/2007)</example>
@@ -688,8 +688,8 @@
       <example>APC Web/SNMP Management Card (MB:v3.2.0 PF:v3.0.9.a PN:aos309a.bin AF1:v2.2.5.a AN1:ms225a.bin MN: AP9606 HR: J9 SN: WA0121006888 MD: 12/20/2002)</example>
       <param pos="0" name="os.vendor" value="APC"/>
       <param pos="0" name="os.device" value="UPS"/>
-      <param pos="3" name="os.version"/>
-      <param pos="4" name="os.product"/>
+      <param pos="1" name="os.version"/>
+      <param pos="2" name="os.product"/>
    </fingerprint>
 
    <!--
@@ -805,20 +805,15 @@
       <param pos="2" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Avaya (Inc.\s*\-\s*)?([^,]+),.*SW version (\S+).*$">
+   <fingerprint pattern="^Avaya (?:Inc\.\s*\-\s*)?([^,]+?)[\s,]*SW version (\S+).*$">
       <description>Avaya Switch</description>
-      <example>Avaya Inc. - C360 , SW version 4.3.12 , CS 1.1</example>
-      <example>Avaya Inc. - C360 , SW version 4.5.14 , CS 1.2</example>
-      <example>Avaya Inc. - P330 Stackable Switch, SW version 3.12.0</example>
-      <example>Avaya Inc. - P330 Stackable Switch, SW version 3.12.1</example>
-      <example>Avaya Inc. - P333R , SW version 3.9.1 , CS 2.4</example>
-      <example>Avaya Inc.- C360 Stackable Switch, SW version 4.5.14</example>
-      <example>Avaya Inc.- P330 Stackable Switch, SW version 4.5.8</example>
-      <example>Avaya P130 workgroup switch, SW version 2.9.2</example>
+      <example os.product="C360" os.version="4.3.12">Avaya Inc. - C360 , SW version 4.3.12 , CS 1.1</example>
+      <example os.product="C360 Stackable Switch" os.version="4.5.14">Avaya Inc.- C360 Stackable Switch, SW version 4.5.14</example>
+      <example os.product="P130 workgroup switch" os.version="2.9.2">Avaya P130 workgroup switch, SW version 2.9.2</example>
       <param pos="0" name="os.vendor" value="Avaya"/>
       <param pos="0" name="os.device" value="Switch"/>
-      <param pos="2" name="os.product"/>
-      <param pos="3" name="os.version"/>
+      <param pos="1" name="os.product"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Avaya Inc\., (.* Media Gateway), SW Version (\S+).*$">
@@ -972,28 +967,25 @@
       <param pos="1" name="os.product"/>
       <param pos="2" name="os.version"/>
    </fingerprint>
+
    <!--======================================================================
                               AXIS
    =======================================================================-->
 
-   <fingerprint pattern="^AXIS (.*server)\s*.*?(v|Version:\s*)(\S+).*$" flags="REG_ICASE">
+   <fingerprint pattern="^AXIS (.*server).*(?:v|Version:\s*)([\d\.]+)" flags="REG_ICASE">
       <description>AXIS Network Print Server</description>
-      <example>AXIS 5470e Network Print Server V6.21 Dec  5 2000</example>
-      <example>AXIS 70U Network Document Server,Version: 1.08</example>
-      <example>AXIS 540/542 Print Server V5.43 Feb 2 1998</example>
-      <example>AXIS 540/542 Print Server V5.48 Dec 14 1998</example>
-      <example>AXIS 560Print serverV5.36 Jul 7 1997</example>
-      <example>AXIS OfficeBasic Parallel Network Print Server V6.43 Sep 4 2003</example>
-      <example>AXIS OfficeBasic Parallel Network Print Server V7.06 Nov 3 2005</example>
-      <example>AXIS OfficeBasic USB Network Print Server V6.43 Sep 4 2003</example>
-      <example>AXIS OfficeBasic USB Network Print Server V7.03 Feb 14 2005</example>
-      <example>AXIS PrintPoint 560/100 Print server V5.39 Dec 12 1997</example>
-      <example>Axis NPS 550R Printer Server V4.11 Mar 1 1994</example>
-      <example>Axis NPS 550RPrint serverV5.22 Oct 07 1996</example>
+      <example os.product="5470e Network Print Server" os.version="6.21">AXIS 5470e Network Print Server V6.21 Dec  5 2000</example>
+      <example os.product="70U Network Document Server" os.version="1.08">AXIS 70U Network Document Server,Version: 1.08</example>
+      <example os.product="540/542 Print Server" os.version="5.43">AXIS 540/542 Print Server V5.43 Feb 2 1998</example>
+      <example os.product="560Print server" os.version="5.36">AXIS 560Print serverV5.36 Jul 7 1997</example>
+      <example os.product="OfficeBasic USB Network Print Server" os.version="7.03">AXIS OfficeBasic USB Network Print Server V7.03 Feb 14 2005</example>
+      <example os.product="PrintPoint 560/100 Print server" os.version="5.39">AXIS PrintPoint 560/100 Print server V5.39 Dec 12 1997</example>
+      <example os.product="NPS 550R Printer Server" os.version="4.11">Axis NPS 550R Printer Server V4.11 Mar 1 1994</example>
+      <example os.product="NPS 550RPrint server" os.version="5.22">Axis NPS 550RPrint serverV5.22 Oct 07 1996</example>
       <param pos="0" name="os.vendor" value="Axis"/>
       <param pos="0" name="os.device" value="Print Server"/>
       <param pos="1" name="os.product"/>
-      <param pos="3" name="os.version"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
 
@@ -1001,33 +993,27 @@
                               BLUE COAT
    =======================================================================-->
 
-   <fingerprint pattern="^Blue Coat (SG\S+)( Series)?,.*\s+SGOS ([^,]+), Release id:\s*(\S+).*$">
+   <fingerprint pattern="^Blue Coat (SG\S+)(?: Series)?,.*\s+SGOS ([^,]+), Release id:\s*(\S+).*$">
       <description>Blue Coat Proxy SG</description>
-      <example>Blue Coat SG400 Series, Version: SGOS 5.2.4.8, Release id: 35838 Proxy Edition</example>
-      <example>Blue Coat SG200 Series, ProxySG Version: SGOS 4.3.2.3, Release id: 37535</example>
-      <example>Blue Coat SG400, ProxySG Version: SGOS 4.1.1.1, Release id: 22695</example>
-      <example>Blue Coat SG510 Series, ProxySG Version: SGOS 4.2.3.12, Release id: 28131</example>
-      <example>Blue Coat SG6000 Series, ProxySG Version: SGOS 3.2.4.8, Release id: 22001</example>
-      <example>Blue Coat SG800 Series, ProxySG Version: SGOS 4.3.3.1, Release id: 39753</example>
-      <example>Blue Coat SG800 Series, Security-Gateway Version: SGOS 2.1.6044, Release id: 19480 Service Pack 4</example>
-      <example>Blue Coat SG810 Series, ProxySG Version: SGOS 4.3.3.1, Release id: 39753</example>
-      <example>Blue Coat SG8100 Series, ProxySG Version: SGOS 4.3.3.16, Release id: 50237</example>
-      <example>Blue Coat SG8100 Series, ProxySG Version: SGOS 4.3.4.1, Release id: 52168</example>
+      <example os.product="SG400" os.version="5.2.4.8" os.version.version="35838">Blue Coat SG400 Series, Version: SGOS 5.2.4.8, Release id: 35838 Proxy Edition</example>
+      <example os.product="SG800" os.version="2.1.6044" os.version.version="19480">Blue Coat SG800 Series, Security-Gateway Version: SGOS 2.1.6044, Release id: 19480 Service Pack 4</example>
+      <example os.product="SG400" os.version="4.1.1.1" os.version.version="22695">Blue Coat SG400, ProxySG Version: SGOS 4.1.1.1, Release id: 22695</example>
+      <example os.product="SG8100" os.version="4.3.4.1" os.version.version="52168">Blue Coat SG8100 Series, ProxySG Version: SGOS 4.3.4.1, Release id: 52168</example>
       <param pos="0" name="os.vendor" value="Blue Coat"/>
       <param pos="0" name="os.device" value="Web proxy"/>
       <param pos="1" name="os.product"/>
-      <param pos="3" name="os.version"/>
-      <param pos="4" name="os.version.version"/>
+      <param pos="2" name="os.version"/>
+      <param pos="3" name="os.version.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Blue Coat (AV\S+)( Series)?, ProxyAV Version: ([^,]+). Release id:\s*(\S+).*$">
+   <fingerprint pattern="^Blue Coat (AV\S+)(?: Series)?, ProxyAV Version: ([^,]+). Release id:\s*(\S+).*$">
       <description>Blue Coat ProxyAV</description>
-      <example>Blue Coat AV1200 Series, ProxyAV Version: 3.2.6.1, Release id: 51482</example>
+      <example os.product="AV1200" os.version="3.2.6.1" os.version.version="51482">Blue Coat AV1200 Series, ProxyAV Version: 3.2.6.1, Release id: 51482</example>
       <param pos="0" name="os.vendor" value="Blue Coat"/>
       <param pos="0" name="os.device" value="Web proxy"/>
       <param pos="1" name="os.product"/>
-      <param pos="3" name="os.version"/>
-      <param pos="4" name="os.version.version"/>
+      <param pos="2" name="os.version"/>
+      <param pos="3" name="os.version.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Blue Coat PacketShaper (\S+)$">
@@ -2216,25 +2202,17 @@ Copyright (c) 1995-2005 by Cisco Systems
 
 
    <!-- Epson uses the 201207171045 / 02.23.00 version format, but the latter is more consistent -->
-   <fingerprint pattern="^EPSON ([A-Z]\S+); Net ([^,]+),ESS ([^,]+),IOT (\S+)$">
+   <fingerprint pattern="^EPSON ([A-Z]\S+); Net ([^,]+),ESS (?:[^,]+),IOT (\S+)$">
       <description>Epson Printer</description>
-      <example>EPSON AL-C1750N; Net 98.48,ESS 201103111031,IOT 02.17.00</example>
-      <example>EPSON AL-C1750N; Net 98.49,ESS 201107271418,IOT 02.17.00</example>
-      <example>EPSON AL-C1750N; Net 98.49,ESS 201107271418,IOT 02.17.02</example>
-      <example>EPSON AL-C1750N; Net 98.49,ESS 201107271418,IOT 02.17.04</example>
-      <example>EPSON AL-C1750W; Net 98.49,ESS 201107271419,IOT 02.17.00</example>
-      <example>EPSON AL-C1750W; Net 98.49,ESS 201107271419,IOT 02.17.02</example>
-      <example>EPSON AL-C1750W; Net 98.49,ESS 201107271419,IOT 02.17.04</example>
-      <example>EPSON AL-C2900; Net 96.51,ESS 201103101328,IOT 04.00.00</example>
-      <example>EPSON AL-C2900; Net 96.55,ESS 201108091219,IOT 04.00.01</example>
-      <example>EPSON AL-CX29; Net 96.55,ESS 201106281159,IOT 04.00.00</example>
-      <example>EPSON AL-CX29; Net 96.55,ESS 201110211025,IOT 04.00.01</example>
-      <example>EPSON LP-S620; Net 98.48,ESS 201103111031,IOT 02.17.02</example>
+      <example os.product="AL-C1750N" os.version="02.17.00" os.version.version="98.48">EPSON AL-C1750N; Net 98.48,ESS 201103111031,IOT 02.17.00</example>
+      <example os.product="AL-C2900" os.version="04.00.00" os.version.version="96.51">EPSON AL-C2900; Net 96.51,ESS 201103101328,IOT 04.00.00</example>
+      <example os.product="AL-CX29" os.version="04.00.00" os.version.version="96.55">EPSON AL-CX29; Net 96.55,ESS 201106281159,IOT 04.00.00</example>
+      <example os.product="LP-S620" os.version="02.17.02" os.version.version="98.48">EPSON LP-S620; Net 98.48,ESS 201103111031,IOT 02.17.02</example>
       <param pos="0" name="os.vendor" value="Epson"/>
       <param pos="0" name="os.device" value="Printer"/>
       <param pos="1" name="os.product"/>
-      <param pos="4" name="os.version"/>
-      <param pos="3" name="os.version.version"/>
+      <param pos="3" name="os.version"/>
+      <param pos="2" name="os.version.version"/>
    </fingerprint>
 
    <fingerprint pattern="^EPSON ([A-Z]\S+) (\d+\.\S+)$">
@@ -4992,23 +4970,21 @@ Copyright (c) 1995-2005 by Cisco Systems
       Note: The "hostname" is not really a hostname in this case, it is the MAC
       address.
    -->
-   <fingerprint pattern="^Linux (SUNSP00144F\S+) (2\.4\.22).* (\S+)$">
+   <fingerprint pattern="^Linux (?:SUNSP00144F\S+) (\S*).* (\S+)$">
       <description>Ubuntu Linux 7.04</description>
-      <example>Linux SUNSP00144F9E0508 2.4.22 #1 Sat Apr 21 11:28:21 PDT 2007 ppc</example>
-      <example>Linux SUNSP00144F794047 2.4.22 #1 Tue Feb 27 19:45:33 PST 2007 ppc</example>
-      <example>Linux SUNSP00144F8E3F54 2.4.22 #1 Tue Feb 27 19:45:33 PST 2007 ppc</example>
+      <example os.arch="ppc" linux.kernel.version="2.4.22">Linux SUNSP00144F9E0508 2.4.22 #1 Sat Apr 21 11:28:21 PDT 2007 ppc</example>
       <param pos="0" name="os.certainty" value="0.9"/>
       <param pos="0" name="os.family" value="Linux"/>
       <param pos="0" name="os.vendor" value="Sun"/>
       <param pos="0" name="os.product" value="Integrated Lights Out Manager"/>
       <param pos="0" name="os.device" value="Lights Out Management"/>
-      <param pos="2" name="linux.kernel.version"/>
-      <param pos="3" name="os.arch"/>
+      <param pos="1" name="linux.kernel.version"/>
+      <param pos="2" name="os.arch"/>
    </fingerprint>
 
-   <fingerprint pattern="^Silver Peak Systems, Inc\. (\S+) Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*).* ([0-9]{4}|[A-Z][A-Z][A-Z]{1,2}|\+[0-9]+|Local time.*(manual|zic|m\S*)) (\S+).*$">
+   <fingerprint pattern="^Silver Peak Systems, Inc\. (\S+) Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*).* (?:[0-9]{4}|[A-Z][A-Z][A-Z]{1,2}|\+[0-9]+|Local time.*(?:manual|zic|m\S*)) (\S+).*$">
       <description>Silver Peak Systems</description>
-      <example>Silver Peak Systems, Inc. NX7600 Linux Baghdad1C 2.6.22.14 hidalgo 3.3.0.0_32549 #1 2010-07-20 04:25:08 SMP x86_64</example>
+      <example os.product="NX7600" host.name="foo" os.version="2.6.22.14" os.arch="x86_64">Silver Peak Systems, Inc. NX7600 Linux foo 2.6.22.14 hidalgo 3.3.0.0_32549 #1 2010-07-20 04:25:08 SMP x86_64</example>
       <param pos="0" name="os.certainty" value="0.9"/>
       <param pos="0" name="os.family" value="Linux"/>
       <param pos="0" name="os.device" value="WAN Accelerator"/>
@@ -5017,7 +4993,7 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="3" name="os.version"/>
       <param pos="2" name="host.name"/>
       <param pos="3" name="linux.kernel.version"/>
-      <param pos="6" name="os.arch"/>
+      <param pos="4" name="os.arch"/>
    </fingerprint>
 
    <!--
@@ -5025,9 +5001,9 @@ Copyright (c) 1995-2005 by Cisco Systems
       specific pattern available.
    -->
 
-   <fingerprint pattern="^Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*).* ([0-9]{4}|[A-Z][A-Z][A-Z]{1,2}|\+[0-9]+|Local time.*(manual|zic|m\S*)) (\S+).*$">
+   <fingerprint pattern="^Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*).* (?:[0-9]{4}|[A-Z][A-Z][A-Z]{1,2}|\+[0-9]+|Local time.*(?:manual|zic|m\S*)) (\S+).*$">
       <description>Linux Generic</description>
-      <example>Linux hostname 2.6.9 #2 SMP Tue Jun 26 16:10:49 EDT 2012 x86_64</example>
+      <example os.arch="x86_64" os.version="2.6.9" linux.kernel.version="2.6.9" host.name="hostname">Linux hostname 2.6.9 #2 SMP Tue Jun 26 16:10:49 EDT 2012 x86_64</example>
       <param pos="0" name="os.certainty" value="0.5"/>
       <param pos="0" name="os.family" value="Linux"/>
       <param pos="0" name="os.product" value="Linux"/>
@@ -5035,19 +5011,19 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="2" name="os.version"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="linux.kernel.version"/>
-      <param pos="5" name="os.arch"/>
+      <param pos="3" name="os.arch"/>
    </fingerprint>
 
-   <fingerprint pattern="^Linux ([0-9]+\.[0-9]+\.[0-9]+\S*).* ([0-9]{4}|[A-Z][A-Z][A-Z]{1,2}|\+[0-9]+|Local time.*(manual|zic|m\S*)) (\S+).*$">
+   <fingerprint pattern="^Linux ([0-9]+\.[0-9]+\.[0-9]+\S*).* (?:[0-9]{4}|[A-Z][A-Z][A-Z]{1,2}|\+[0-9]+|Local time.*(?:manual|zic|m\S*)) (\S+).*$">
       <description>Linux Generic</description>
-      <example>Linux 2.6.9 #2 SMP Tue Jun 26 16:10:49 EDT 2012 x86_64</example>
+      <example os.version="2.6.9" linux.kernel.version="2.6.9" os.arch="x86_64">Linux 2.6.9 #2 SMP Tue Jun 26 16:10:49 EDT 2012 x86_64</example>
       <param pos="0" name="os.certainty" value="0.5"/>
       <param pos="0" name="os.family" value="Linux"/>
       <param pos="0" name="os.product" value="Linux"/>
       <param pos="0" name="os.device" value="General"/>
       <param pos="1" name="os.version"/>
       <param pos="1" name="linux.kernel.version"/>
-      <param pos="4" name="os.arch"/>
+      <param pos="2" name="os.arch"/>
    </fingerprint>
 
    <fingerprint pattern="^Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*) (\S+)$">
@@ -5611,15 +5587,15 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="1" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Nortel( Networks|), CS 1000 Signaling Server, Software Release (\S+)$">
+   <fingerprint pattern="^Nortel(?: Networks)?, CS 1000 Signaling Server, Software Release (\S+)$">
       <description>Nortel CS 1000</description>
-      <example>Nortel, CS 1000 Signaling Server, Software Release sse-4.50.88</example>
-      <example>Nortel Networks, CS 1000 Signaling Server, Software Release sse-4.00.55</example>
+      <example os.version="sse-4.50.88">Nortel, CS 1000 Signaling Server, Software Release sse-4.50.88</example>
+      <example os.version="sse-4.00.55">Nortel Networks, CS 1000 Signaling Server, Software Release sse-4.00.55</example>
       <param pos="0" name="os.vendor" value="Nortel"/>
       <param pos="0" name="os.family" value="CS 1000"/>
       <param pos="0" name="os.device" value="VoIP"/>
       <param pos="0" name="os.product" value="CS 1000 Signaling Server"/>
-      <param pos="2" name="os.version"/>
+      <param pos="1" name="os.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Nortel, CS 1000 VGMC, Software Release (\S+)$">
@@ -5656,17 +5632,17 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="1" name="os.version.version.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Nortel( Networks|), Meridian 1 Call Server, System (\S+), Release (\S+), Issue (\S+)$">
+   <fingerprint pattern="^Nortel(?: Networks)?, Meridian 1 Call Server, System (\S+), Release (\S+), Issue (\S+)$">
       <description>Nortel Networks Meridian 1 Call Server</description>
-      <example>Nortel Networks, Meridian 1 Call Server, System 2121, Release 4, Issue 0</example>
-      <example>Nortel, Meridian 1 Call Server, System 2121, Release 4, Issue 50</example>
+      <example os.version.version.version="2121" os.version="4" os.version.version="0">Nortel Networks, Meridian 1 Call Server, System 2121, Release 4, Issue 0</example>
+      <example os.version.version.version="2121" os.version="4" os.version.version="50">Nortel, Meridian 1 Call Server, System 2121, Release 4, Issue 50</example>
       <param pos="0" name="os.vendor" value="Nortel"/>
       <param pos="0" name="os.family" value="Meridian 1"/>
       <param pos="0" name="os.device" value="VoIP"/>
       <param pos="0" name="os.product" value="Meridian 1 Call Server"/>
-      <param pos="3" name="os.version"/>
-      <param pos="4" name="os.version.version"/>
-      <param pos="2" name="os.version.version.version"/>
+      <param pos="2" name="os.version"/>
+      <param pos="3" name="os.version.version"/>
+      <param pos="1" name="os.version.version.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Nortel Application Switch (\S+)(?:\s+\S+|)$">
@@ -5678,15 +5654,15 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="1" name="os.product"/>
    </fingerprint>
 
-   <fingerprint pattern="^Ethernet Routing Switch (\S+)\s+(\(Stack Enabled\)\s+|)HW:.*FW:.*SW:(\S+).*\(c\) Nortel Networks$">
+   <fingerprint pattern="^Ethernet Routing Switch (\S+)\s+(?:\(Stack Enabled\)\s+)?HW:.*FW:.*SW:(\S+).*\(c\) Nortel Networks$">
       <description>Nortel Ethernet switch</description>
-      <example>Ethernet Routing Switch 5520-48T-PWR  HW:32       FW:5.0.0.3   SW:v5.0.4.011 BN:00 (c) Nortel Networks</example>
-      <example>Ethernet Routing Switch 2526T (Stack Enabled) HW:01 FW:1.0.0.13 SW:v4.1.0.000 BN:00 (c) Nortel Networks</example>
+      <example os.product="5520-48T-PWR" os.version="v5.0.4.011">Ethernet Routing Switch 5520-48T-PWR  HW:32       FW:5.0.0.3   SW:v5.0.4.011 BN:00 (c) Nortel Networks</example>
+      <example os.product="2526T" os.version="v4.1.0.000">Ethernet Routing Switch 2526T (Stack Enabled) HW:01 FW:1.0.0.13 SW:v4.1.0.000 BN:00 (c) Nortel Networks</example>
       <param pos="0" name="os.vendor" value="Nortel"/>
       <param pos="0" name="os.family" value="Ethernet Routing Switch"/>
       <param pos="0" name="os.device" value="Switch"/>
       <param pos="1" name="os.product"/>
-      <param pos="3" name="os.version"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Nortel SR ([^,\s]+).*Software Version = ([^,]+),.*$">
@@ -6298,28 +6274,28 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="2" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Paradyne (ATM (ReachDSL|ADSL) Unit); Model: ([^;]+);.*S/W Release: ([^;]+);.*$">
+   <fingerprint pattern="^Paradyne (ATM (?:ReachDSL|ADSL) Unit); Model: ([^;]+);.*S/W Release: ([^;]+);.*$">
       <description>Paradyne ATM DSL Unit</description>
-      <example>Paradyne ATM ADSL Unit; Model: 4223-A1-532; CCA: 868-5969-8200; S/W Release: 02.03.08; Hardware Revision: 5969-82A; Serial number: 6963727 ;</example>
-      <example>Paradyne ATM ReachDSL Unit; Model: 4211-A1-530; CCA: 868-5315-8200; S/W Release: 02.03.04; Hardware Revision: 5315-82G; Serial number: 6066448 ;</example>
+      <example os.family="ATM ADSL Unit" os.product="4223-A1-532" os.version="02.03.08">Paradyne ATM ADSL Unit; Model: 4223-A1-532; CCA: 868-5969-8200; S/W Release: 02.03.08; Hardware Revision: 5969-82A; Serial number: 6963727 ;</example>
+      <example os.family="ATM ReachDSL Unit" os.product="4211-A1-530" os.version="02.03.04">Paradyne ATM ReachDSL Unit; Model: 4211-A1-530; CCA: 868-5315-8200; S/W Release: 02.03.04; Hardware Revision: 5315-82G; Serial number: 6066448 ;</example>
       <param pos="0" name="os.certainty" value="1.0"/>
       <param pos="0" name="os.vendor" value="Paradyne"/>
       <param pos="0" name="os.device" value="ATM DSL Unit"/>
       <param pos="1" name="os.family"/>
-      <param pos="3" name="os.product"/>
-      <param pos="4" name="os.version"/>
+      <param pos="2" name="os.product"/>
+      <param pos="3" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Paradyne (Hot[wW]ire [^;]+); Model: ([^;]+);.*S/W Release: ([^;]+);.*$">
+   <fingerprint pattern="^Paradyne (?:Hot[wW]ire [^;]+); Model: ([^;]+);.*S/W Release: ([^;]+);.*$">
       <description>Paradyne HotWire</description>
-      <example>Paradyne Hotwire DSL4; Model: 8546-B1-000; Card: R4IP; S/W Release: 02.03.15; H/W Revision: 1004-80A; Serial number: 7HMOC</example>
-      <example>Paradyne HotWire MCC; Model: 8000-B1-000; Card: MC-M; S/W Release: 02.00.22; H/W Revision: 1010-80A; Serial number: 7HHJR</example>
+      <example os.product="8546-B1-000" os.version="02.03.15">Paradyne Hotwire DSL4; Model: 8546-B1-000; Card: R4IP; S/W Release: 02.03.15; H/W Revision: 1004-80A; Serial number: 7HMOC</example>
+      <example os.product="8000-B1-000" os.version="02.00.22">Paradyne HotWire MCC; Model: 8000-B1-000; Card: MC-M; S/W Release: 02.00.22; H/W Revision: 1010-80A; Serial number: 7HHJR</example>
       <param pos="0" name="os.certainty" value="1.0"/>
       <param pos="0" name="os.vendor" value="Paradyne"/>
       <param pos="0" name="os.device" value="DSL Modem"/>
       <param pos="0" name="os.family" value="HotWire"/>
-      <param pos="2" name="os.product"/>
-      <param pos="3" name="os.version"/>
+      <param pos="1" name="os.product"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
    <!--
@@ -7164,38 +7140,38 @@ Copyright (c) 1995-2005 by Cisco Systems
                               SGI
    =======================================================================-->
 
-   <fingerprint pattern="^.* IRIX (version )?(\d+\S+).*$">
+   <fingerprint pattern="^.* IRIX (?:version )?(\d+\S+).*$">
       <description>SGI IRIX</description>
-      <example>Silicon Graphics IRIS Indigo2  running IRIX version 6.5</example>
-      <example>Silicon Graphics IRIS Indigo2 Elan running IRIX 5.3</example>
-      <example>Silicon Graphics IRIS Indigo2 running IRIX 5.3</example>
-      <example>Silicon Graphics IRIS O2 CRM running IRIX 6.3</example>
+      <example os.version="6.5">Silicon Graphics IRIS Indigo2  running IRIX version 6.5</example>
+      <example os.version="5.3">Silicon Graphics IRIS Indigo2 Elan running IRIX 5.3</example>
+      <example os.version="5.3">Silicon Graphics IRIS Indigo2 running IRIX 5.3</example>
+      <example os.version="6.3">Silicon Graphics IRIS O2 CRM running IRIX 6.3</example>
       <param pos="0" name="os.certainty" value="0.9"/>
       <param pos="0" name="os.vendor" value="SGI"/>
       <param pos="0" name="os.family" value="IRIX"/>
       <param pos="0" name="os.product" value="IRIX"/>
       <param pos="0" name="os.device" value="General"/>
       <param pos="0" name="os.arch" value="MIPS"/> <!-- We should differentiate Indigo2 vs. Indigo -->
-      <param pos="2" name="os.version"/>
+      <param pos="1" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^.* IRIX64 (version )?(\d+\S+).*$">
+   <fingerprint pattern="^.* IRIX64 (?:version )?(\d+\S+).*$">
       <description>SGI IRIX</description>
-      <example>Silicon Graphics Challenge/1 running IRIX64 6.5</example>
-      <example>Silicon Graphics Fuel running IRIX64 version 6.5</example>
-      <example>Silicon Graphics IRIS Octane running IRIX64 version 6.5</example>
-      <example>Silicon Graphics Octane2 running IRIX64 version 6.5</example>
-      <example>Silicon Graphics Onyx2 running IRIX64 version 6.5</example>
-      <example>Silicon Graphics Origin 200 running IRIX64 version 6.5</example>
-      <example>Silicon Graphics Origin 2000 running IRIX64 version 6.5</example>
-      <example>Silicon Graphics Origin 3000 running IRIX64 version 6.5</example>
+      <example os.version="6.5">Silicon Graphics Challenge/1 running IRIX64 6.5</example>
+      <example os.version="6.5">Silicon Graphics Fuel running IRIX64 version 6.5</example>
+      <example os.version="6.5">Silicon Graphics IRIS Octane running IRIX64 version 6.5</example>
+      <example os.version="6.5">Silicon Graphics Octane2 running IRIX64 version 6.5</example>
+      <example os.version="6.5">Silicon Graphics Onyx2 running IRIX64 version 6.5</example>
+      <example os.version="6.5">Silicon Graphics Origin 200 running IRIX64 version 6.5</example>
+      <example os.version="6.5">Silicon Graphics Origin 2000 running IRIX64 version 6.5</example>
+      <example os.version="6.5">Silicon Graphics Origin 3000 running IRIX64 version 6.5</example>
       <param pos="0" name="os.certainty" value="0.9"/>
       <param pos="0" name="os.vendor" value="SGI"/>
       <param pos="0" name="os.family" value="IRIX"/>
       <param pos="0" name="os.product" value="IRIX"/>
       <param pos="0" name="os.device" value="General"/>
       <param pos="0" name="os.arch" value="MIPS64"/>
-      <param pos="2" name="os.version"/>
+      <param pos="1" name="os.version"/>
    </fingerprint>
 
 
@@ -7250,9 +7226,9 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="1" name="os.product"/>
    </fingerprint>
 
- <fingerprint pattern="^HiPath Wireless Access Controller - (\S+( \S+)?)\s*, System Version (V\d+ )?(\S+)$">
+ <fingerprint pattern="^HiPath Wireless Access Controller - ([^,]+)\s*, System Version ((?:V\d+ )?\S+)$">
       <description>Siemens HiPath Wireless Access Point</description>
-      <example>HiPath Wireless Access Controller - C20 Office, System Version V6R1.10507.0</example>
+      <example os.product="C20 Office" os.version="V6R1.10507.0">HiPath Wireless Access Controller - C20 Office, System Version V6R1.10507.0</example>
       <example>HiPath Wireless Access Controller - C2400 Enterprise, System Version 07.41.01.0192</example>
       <example>HiPath Wireless Access Controller - C2400 Enterprise, System Version 07.41.03.0006</example>
       <example>HiPath Wireless Access Controller - C25, System Version 07.41.02.0009</example>
@@ -7266,7 +7242,7 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="0" name="os.device" value="HiPath"/>
       <param pos="0" name="os.family" value="WAP"/>
       <param pos="1" name="os.product"/>
-      <param pos="4" name="os.version"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
  <fingerprint pattern="^HiPath (optiPoint \S+ \S+) HFA$">
@@ -7386,28 +7362,18 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="2" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Siemens, SIMATIC NET, ([^,]+),.*FW:\s*(Version )?V?([^,]+).*$">
+   <fingerprint pattern="^Siemens, SIMATIC NET, ([^,]+),.*FW:\s*(?:Version )?V?([^,]+).*$">
       <description>Siemens NET</description>
-      <example>Siemens, SIMATIC NET, CP 343-1 Advanced, 6GK7 343-1GX30-0XE0, HW: Version 3, FW: Version V1.2.3, VPB9502953</example>
-      <example>Siemens, SIMATIC NET, CP 343-1 Lean, 6GK7 343-1CX10-0XE0, HW: Version 6, FW: Version V2.6.0, VPC3513639</example>
-      <example>Siemens, SIMATIC NET, CP 343-1, 6GK7 343-1EX30-0XE0, HW: Version 3, FW: Version V2.2.20, VPXN545808</example>
-      <example>Siemens, SIMATIC NET, CP 343-1, 6GK7 343-1EX30-0XE0, HW: Version 6, FW: Version V2.6.0, VPC3523329</example>
-      <example>Siemens, SIMATIC NET, CP 443-1 Advanced, 6GK7 443-1GX20-0XE0, HW: Version 4, FW: Version V2.1.12, VPAO470672</example>
-      <example>Siemens, SIMATIC NET, CP343-1 Advanced, 6GK7 343-1GX30-0XE0, HW: Version 2, FW: Version V1.0.23, VPX1507972</example>
-      <example>Siemens, SIMATIC NET, CP343-1, 6GK7 343-1CX10-0XE0, HW: Version 2, FW: Version V2.0.16, VPV2516052</example>
-      <example>Siemens, SIMATIC NET, CP443-1 Advanced, 6GK7 443-1GX20-0XE0, HW: Version 3, FW: Version V2.0.49, VPA2470202</example>
-      <example>Siemens, SIMATIC NET, CP443-1, 6GK7 443-1EX20-0XE0, HW: Version 2, FW: Version V1.0.26, VPW6470099</example>
-      <example>Siemens, SIMATIC NET, SCALANCE X204-2, 6GK5 204-2BB10-2AA3, HW: 4, FW: V4.01</example>
-      <example>Siemens, SIMATIC NET, SCALANCE X204-2, 6GK5 204-2BB10-2AA3, HW: 7, FW: V4.03</example>
-      <example>Siemens, SIMATIC NET, SCALANCE X208, 6GK5 208-0BA10-2AA3, HW: 2, FW: V4.00</example>
-      <example>Siemens, SIMATIC NET, SCALANCE X208, 6GK5 208-0BA10-2AA3, HW: 5, FW: V4.02</example>
-      <example>Siemens, SIMATIC NET, Scalance S612, 6GK56120BA102AA3, HW: Version 6, FW: Version S03.01.00.00_01.00.00.01, VPB9542952</example>
-      <example>Siemens, SIMATIC NET, Scalance S612, 6GK56120BA102AA3, HW: Version 6, FW: Version T03.00.00.00_25.00.00.01, VPB9542952</example>
+      <example os.product="CP 343-1 Advanced" os.version="1.2.3">Siemens, SIMATIC NET, CP 343-1 Advanced, 6GK7 343-1GX30-0XE0, HW: Version 3, FW: Version V1.2.3, VPB9502953</example>
+      <example os.product="CP 343-1 Lean" os.version="2.6.0">Siemens, SIMATIC NET, CP 343-1 Lean, 6GK7 343-1CX10-0XE0, HW: Version 6, FW: Version V2.6.0, VPC3513639</example>
+      <example os.product="CP 343-1" os.version="2.2.20">Siemens, SIMATIC NET, CP 343-1, 6GK7 343-1EX30-0XE0, HW: Version 3, FW: Version V2.2.20, VPXN545808</example>
+      <example os.product="SCALANCE X204-2" os.version="4.01">Siemens, SIMATIC NET, SCALANCE X204-2, 6GK5 204-2BB10-2AA3, HW: 4, FW: V4.01</example>
+      <example os.product="Scalance S612" os.version="T03.00.00.00_25.00.00.01">Siemens, SIMATIC NET, Scalance S612, 6GK56120BA102AA3, HW: Version 6, FW: Version T03.00.00.00_25.00.00.01, VPB9542952</example>
       <param pos="0" name="os.vendor" value="Siemens"/>
       <param pos="0" name="os.device" value="General"/>
       <param pos="0" name="os.family" value="Simatic NET"/>
       <param pos="1" name="os.product"/>
-      <param pos="3" name="os.version"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Siemens, SIMATIC NET (\S+) FW V (\S+)$">
@@ -7420,21 +7386,16 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="2" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Siemens, SIMATIC S7, ([^,]+), .*?FW: (Version )?V?\.?([^,]+).*$">
+   <fingerprint pattern="^Siemens, SIMATIC S7, ([^,]+), .*?FW: (?:Version )?V?\.?([^,]+).*$">
       <description>Siemens S7</description>
-      <example>Siemens, SIMATIC S7, CPU-1200, 6ES7 211-1BD30-0XB0, HW: 1, FW: V.2.0.2, SZVX8YU9000553</example>
-      <example>Siemens, SIMATIC S7, CPU-1200, 6ES7 212-1BD30-0XB0, HW: 1, FW: V.2.0.2, SZVB5YU6023612</example>
-      <example>Siemens, SIMATIC S7, CPU-1200, 6ES7 214-1AE30-0XB0, HW: 1, FW: V.2.0.2, SZVB5YYW030600</example>
-      <example>Siemens, SIMATIC S7, CPU-1200, 6ES7 214-1BE30-0XB0, HW: 1, FW: V.2.0.2, SZVB5YYY021744</example>
-      <example>Siemens, SIMATIC S7, CPU314C-2 PN/DP, 6ES7 314-6EH04-0AB0 , HW: 1, FW: V3.3.6, S C-C2TP66392012</example>
-      <example>Siemens, SIMATIC S7, CPU315-2 PN/DP, 6ES7 315-2EH13-0AB0 , HW: 3, FW: V2.5.0, S C-V4P07826200</example>
-      <example>Siemens, SIMATIC S7, IM151-8, 6ES7 151-8AB00-0AB0 , HW: 2, FW: V2.7.1, S C-X7UR7434200</example>
-      <example>Siemens, SIMATIC S7, IM151-8, 6ES7 151-8AB01-0AB0 , HW: 2, FW: V3.2.3, S C-B3UC78192011</example>
+      <example os.product="CPU-1200" os.version="2.0.2">Siemens, SIMATIC S7, CPU-1200, 6ES7 211-1BD30-0XB0, HW: 1, FW: V.2.0.2, SZVX8YU9000553</example>
+      <example os.product="CPU315-2 PN/DP" os.version="2.5.0">Siemens, SIMATIC S7, CPU315-2 PN/DP, 6ES7 315-2EH13-0AB0 , HW: 3, FW: V2.5.0, S C-V4P07826200</example>
+      <example os.product="IM151-8" os.version="3.2.3">Siemens, SIMATIC S7, IM151-8, 6ES7 151-8AB01-0AB0 , HW: 2, FW: V3.2.3, S C-B3UC78192011</example>
       <param pos="0" name="os.vendor" value="Siemens"/>
       <param pos="0" name="os.device" value="General"/>
       <param pos="0" name="os.family" value="Simatic S7"/>
       <param pos="1" name="os.product"/>
-      <param pos="3" name="os.version"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Siemens, SIMATIC S7, ([^,]+), .*?, V\.([^,]+).*$">
@@ -7810,16 +7771,16 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="0" name="os.device" value="WAP"/>
    </fingerprint>
 
-   <fingerprint pattern="^Symbol ((Spectrum24 (FHSS|Ethernet) )?Access Point)[,-].*S/W rev:\s*(\S+).*$">
+   <fingerprint pattern="^Symbol ((?:Spectrum24 (?:FHSS|Ethernet) )?Access Point)[,-].*S/W rev:\s*(\S+).*$">
       <description>Symbol Access Point</description>
-      <example>Symbol Access Point, S/W rev:- S/W rev: 02.70-06</example>
-      <example>Symbol Access Point, S/W rev:02.21-01</example>
-      <example>Symbol Spectrum24 FHSS Access Point, S/W rev: 04.02-12</example>
-      <example>Symbol Access Point- S/W rev: 03.50-26</example>
+      <example os.product="Access Point" os.version="02.70-06">Symbol Access Point, S/W rev:- S/W rev: 02.70-06</example>
+      <example os.product="Access Point" os.version="02.21-01">Symbol Access Point, S/W rev:02.21-01</example>
+      <example os.product="Spectrum24 FHSS Access Point" os.version="04.02-12">Symbol Spectrum24 FHSS Access Point, S/W rev: 04.02-12</example>
+      <example os.product="Access Point" os.version="03.50-26">Symbol Access Point- S/W rev: 03.50-26</example>
       <param pos="0" name="os.vendor" value="Symbol"/>
       <param pos="1" name="os.product"/>
       <param pos="0" name="os.device" value="WAP"/>
-      <param pos="4" name="os.version"/>
+      <param pos="2" name="os.version"/>
    </fingerprint>
 
    <fingerprint pattern="^Symbol (AP\S+|WS\S+) .* SW=(\S+) .*$">

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -451,7 +451,7 @@ fingerprint SSH servers.
    </fingerprint>
 
    <fingerprint pattern="^OpenSSH_(.*)_Mikrotik_v(.*)$">
-      <description>Huawei Versatile Routing Platform (VRP)</description>
+      <description>OpenSSH on MicroTik</description>
       <param pos="1" name="service.version"/>
       <param pos="2" name="os.version"/>
       <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -547,17 +547,18 @@ fingerprint SSH servers.
       <param pos="0" name="os.product" value="ScreenOS"/>
    </fingerprint>
 
-   <fingerprint pattern="^(HUAWEI-VRP-?|VRP-)(.*)$">
+   <fingerprint pattern="^(?:HUAWEI-VRP-?|VRP-)(.*)$">
       <description>Huawei Versatile Routing Platform (VRP)</description>
-      <param pos="2" name="service.version"/>
-      <param pos="2" name="os.version"/>
+      <example os.version="3.10" service.version="3.10">HUAWEI-VRP-3.10</example>
       <param pos="0" name="service.vendor" value="Huawei"/>
       <param pos="0" name="service.family" value="VRP"/>
       <param pos="0" name="service.product" value="VRP"/>
+      <param pos="1" name="service.version"/>
       <param pos="0" name="os.vendor" value="Huawei"/>
       <param pos="0" name="os.device" value="Router"/>
       <param pos="0" name="os.family" value="VRP"/>
       <param pos="0" name="os.product" value="VRP"/>
+      <param pos="1" name="os.version"/>
    </fingerprint>
 
    <fingerprint pattern="^([^\s]+) sshlib: GlobalScape$">

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -446,7 +446,7 @@
       <param pos="1" name="os.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Linux/(\S+), UPnP/(\S+), Free UPnP Entertainment Service/$">
+   <fingerprint pattern="^Linux/(\S+), UPnP/\S+, Free UPnP Entertainment Service/$">
       <description>Free UPnP Entertainment Service UPnP Server</description>
       <param pos="0" name="service.vendor" value="Unknown"/>
       <param pos="0" name="service.product" value="FUPPES"/>


### PR DESCRIPTION
The logic for detecting cases where the capture groups in the regular expression don't align with what is actually used (extracted) was getting a little out of hand so i simplified it a bit, which in turn caught several more defects with the existing fingerprints.  I've done my best to fix all of the fingerprints, add examples where possible, etc.  

On a related note, we should strive to ensure that any future PRs that modify any existing fingerprints ensure that an example exists and the expectations for what is extracted are checked.  A number of the fingerprints which I've fixed in this PR could have been caught with a simple test, but for a variety of reasons lots of what started recog is missing examples and extraction tests.