### PR TITLE
Run all tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
 matrix:
   allow_failures:
     - rvm: jruby
-script: bundle exec rspec spec features
+script: bundle exec rake tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ rvm:
   - 2.1.5
   - 1.9.3
   - jruby
-matrix:
-  allow_failures:
-    - rvm: jruby
+before_install:
+  - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+  - rake --version
+before_script:
+  - bundle exec rake --version
 script: bundle exec rake tests

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem 'nokogiri'
 
 group :test do
+  gem 'rake'
   gem 'rspec', '>= 2.99'
   gem 'cucumber', '~> 1.3.8'
   gem 'aruba', '~> 0.5.3'

--- a/Rakefile
+++ b/Rakefile
@@ -18,5 +18,5 @@ Cucumber::Rake::Task.new(:features) do |t|
     t.cucumber_opts = "features --format pretty"
 end
 
-task :default => [ :spec, :features, :yard ]
-
+task :default => [ :tests, :yard ]
+task :tests => [ :spec, :features ]

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,4 +2,5 @@ require 'aruba/cucumber'
 
 Before do
   @dirs = ["features/xml"]
+  @aruba_timeout_seconds = 30
 end

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -30,7 +30,7 @@ describe Recog::DB do
 
           it 'uses capturing regular expressions properly' do
             # the list of index-based captures that the fingerprint is expecting
-            expected_capture_positions = fp.params.values.map(&:first).map(&:to_i).select { |i| i > 0 }
+            expected_capture_positions = fp.params.values.map(&:first).map(&:to_i).select { |position| position > 0 }
             if fp.params.empty? && expected_capture_positions.size > 0
               fail "Non-asserting fingerprint with regex #{fp.regex} captures #{expected_capture_positions.size} time(s); 0 are needed"
             else


### PR DESCRIPTION
When I originally tried this, I guess I didn't validate that it actually ran cucumber in Travis.  It should now.

# Validation:
 - [ ] Travis is Green 
 - [ ] Travis ran cucumber
 - [ ] Travis ran rspec
 - [ ] ```rake tests``` runs cucumber and rspec
 - [ ] ```rake``` runs cucumber, rspec and yard.