### PR TITLE
Document, enhance and test flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ A fingerprint file consists of an XML document like the following:
     12:
     13: </fingerprints>
 
-The first line should always consist of the XML version declaration. The first element should always be a `fingerpints` block with a `matches` attribute indicating what this fingerprint file is supposed to match. The `matches` attribute is normally in the form of `protocol.field`.
+The first line should always consist of the XML version declaration. The first element should always be a `fingerpints` block with a `matches` attribute indicating what data this fingerprint file is supposed to match. The `matches` attribute is normally in the form of `protocol.field`.
 
-Inside of the `fingerprints` element there should be one or more `fingerprint` elements. Every `fingerprint` must contain a `pattern` attribute, which contains the regular expression to be used against the match key.  
+Inside of the `fingerprints` element there should be one or more `fingerprint` elements. Every `fingerprint` must contain a `pattern` attribute, which contains the regular expression to be used to match against the data.  An optional `flags` attribute can be specified to control how the regular expression is to be interpreted.  See [the Recog documentation for `FLAG_MAP`](http://www.rubydoc.info/gems/recog/Recog/Fingerprint/RegexpFactory#FLAG_MAP-constant) for more information.
 
 Inside of the fingerprint, a `description` element should contain a human-readable string describing this fingerprint.
 
 At least one `example` element should be present, however multiple `example` elements are preferred.  These elements are used as part of the test coverage present in rspec which validates that the provided data matches the specified regular expression.  Additionally, if the fingerprint is using the `param` elements to extract field values from the data (described next), you can add these expected extractions as attributes for the `example` elements.  In the example above, this:
 
     07:  <example service.version="4.62">RomSShell_4.62</example>
-    
+
 tests that `RomSShell_4.62` matches the provided regular expression and that the value of `service.version` is 4.62.
 
 The `param` elements contain a `pos` attribute, which indicates what capture field from the `pattern` should be extracted, or `0` for a static string. The `name` attribute is the key that will be reported in the case of a successful match and the `value` will either be a static string for `pos` values of `0` or missing and taken from the captured field.

--- a/lib/recog/fingerprint/regexp_factory.rb
+++ b/lib/recog/fingerprint/regexp_factory.rb
@@ -9,11 +9,22 @@ module Recog
     #
     module RegexpFactory
 
-      # Map strings as used in Recog XML to Fixnum values used by Regexp
+      # Currently, only options relating to case insensitivity and
+      # multiline/newline are supported.  Because Recog's data is used by tools
+      # written in different languages like Ruby and Java, we currently support
+      # specifying them in a variety of ways.  This map controls how they can
+      # be specified.
+      #
+      # TODO: consider supporting only a simpler variant and require that tools
+      # that use Recog data translate accordingly
       FLAG_MAP = {
+        # multiline variations
         'REG_DOT_NEWLINE'   => Regexp::MULTILINE,
         'REG_LINE_ANY_CRLF' => Regexp::MULTILINE,
+        'MULTILINE'         => Regexp::MULTILINE,
+        # case variations
         'REG_ICASE'         => Regexp::IGNORECASE,
+        'IGNORECASE'        => Regexp::IGNORECASE
       }
 
       # @return [Regexp]
@@ -29,6 +40,10 @@ module Recog
       # @param flags [Array<String>]
       # @return [Fixnum] Flags for creating a regular expression object
       def self.build_options(flags)
+        unsupported_flags = flags.select { |flag| !FLAG_MAP.key?(flag) }
+        unless unsupported_flags.empty?
+          fail "Unsupported regular expression flags found: #{unsupported_flags.join(',')}. Must be one of: #{FLAG_MAP.keys.join(',')}"
+        end
         flags.reduce(Regexp::NOENCODING) do |sum, flag|
           sum |= (FLAG_MAP[flag] || 0)
         end

--- a/spec/lib/recog/fingerprint/regexp_factory.rb
+++ b/spec/lib/recog/fingerprint/regexp_factory.rb
@@ -6,8 +6,8 @@ describe Recog::Fingerprint::RegexpFactory do
   describe 'FLAG_MAP' do
     subject { described_class::FLAG_MAP }
 
-    it "should have three flags" do
-      expect(subject.size).to be 3
+    it "should have the right number of flags" do
+      expect(subject.size).to be 5
     end
   end
 
@@ -56,6 +56,11 @@ describe Recog::Fingerprint::RegexpFactory do
       end
     end
 
+    context 'with invalid flags' do
+      let(:flags) { %w(SYN ACK FIN) } # oh, wrong flags!
+      specify 'raises and lists supported/unsupported flags' do
+        expect { subject }.to raise_error(/SYN,ACK,FIN. Must be one of: .+/)
+      end
+    end
   end
 end
-


### PR DESCRIPTION
In updating README.md for #20, I noticed that `flags` was not documented.  When I went to document it, I realized it wasn't clear how this is used and when I figured that out I realized that it would be nice to be able to use a subset of the actual Regexp constants rather than our current model which is part GNU RE and part Nexpose leftovers.  Eventually this probably needs to be removed entirely or re-implemented differently.