### PR TITLE
Set-Cookie fingerprint improvements

### DIFF
--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -386,7 +386,13 @@ servers.
       <param pos="0" name="service.product" value="SMH"/>
     </fingerprint>
 
-    <!-- various cookies that should just be ignored -->
+    <!--
+        Ignore various cookies that are very generic cookies for session IDs
+        that are not necessarily indicative of any particular
+        product/device/etc.  If a future fingerprint comes along that utilizes
+        a similar cookie name, you must ensure that it is located prior to
+        these and this is enforced by rspec.
+    -->
 
     <fingerprint pattern="^JSESSIONID(?:\.[^=]+)?=[^;]+;.*$" flags="REG_ICASE">
       <description>Ignore simple JSESSIONID and related cookies</description>
@@ -407,5 +413,4 @@ servers.
       <description>Ignore simple SID and related cookies</description>
       <example>sid=sfd10bf73-654458f687aa3c68b3874915f651e0ca;path=/;"</example>
     </fingerprint>
-
 </fingerprints>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -375,5 +375,23 @@ servers.
       <param pos="0" name="service.vendor" value="Oracle"/>
       <param pos="0" name="service.family" value="OracleAS"/>
       <param pos="0" name="service.product" value="OracleAS Portal"/>
-   </fingerprint>
+    </fingerprint>
+
+    <fingerprint pattern="^Compaq-HMMD=[^;]+;.*$">
+      <description>HP System Management Homepage (SMH)</description>
+      <example>Compaq-HMMD=0001-c01fffff-487a-394a-aab0-ffffffffffff-ffffffffffffffff; path=/</example>
+      <example>Compaq-HMMD=0001-c01fffff-487a-394a-aab0-ffffffffffff-ffffffffffffffff; path=/; Secure</example>
+      <param pos="0" name="service.vendor" value="HP"/>
+      <param pos="0" name="service.family" value="SMH"/>
+      <param pos="0" name="service.product" value="SMH"/>
+    </fingerprint>
+
+    <!-- various cookies that should just be ignored -->
+    <fingerprint pattern="^JSESSIONID(?:\.[^=]+)?=[^;]+;.*$" flags="REG_ICASE">
+      <description>Ignore simple JSESSIONID and related cookies</description>
+      <example>JSESSIONID=6ooov35i4l3n36qtaf8csvg0;Path=/</example>
+      <example>jsessionid=6nkp66iogcdc92720%2Dc6e4%2D4989%2Db7b2%2D5021624cfdff;Path=/;secure</example>
+      <example>JSESSIONID.c00a9623=v216643eijh19p9duve5srgf;Path=/;HttpOnly</example>
+    </fingerprint>
+
 </fingerprints>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -403,4 +403,9 @@ servers.
       <example>_session_id=18b3e173aa11db0533fd01752e81f583; path=/; HttpOnly</example>
     </fingerprint>
 
+    <fingerprint pattern="^sid=[^;]+;.*$" flags="REG_ICASE">
+      <description>Ignore simple SID and related cookies</description>
+      <example>sid=sfd10bf73-654458f687aa3c68b3874915f651e0ca;path=/;"</example>
+    </fingerprint>
+
 </fingerprints>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -387,11 +387,20 @@ servers.
     </fingerprint>
 
     <!-- various cookies that should just be ignored -->
+
     <fingerprint pattern="^JSESSIONID(?:\.[^=]+)?=[^;]+;.*$" flags="REG_ICASE">
       <description>Ignore simple JSESSIONID and related cookies</description>
       <example>JSESSIONID=6ooov35i4l3n36qtaf8csvg0;Path=/</example>
       <example>jsessionid=6nkp66iogcdc92720%2Dc6e4%2D4989%2Db7b2%2D5021624cfdff;Path=/;secure</example>
       <example>JSESSIONID.c00a9623=v216643eijh19p9duve5srgf;Path=/;HttpOnly</example>
+    </fingerprint>
+
+    <fingerprint pattern="^_?SESSION_?ID\s*=\s*[^;]+;.*$" flags="REG_ICASE">
+      <description>Ignore simple SESSIONID and related cookies</description>
+      <example>sessionId=7dba3249cfcd4b59854055311099a294; path=/;</example>
+      <example>_session_id=7fe933db0fea13e9c872103ba2d142db; path=/; HttpOnly</example>
+      <example>sessionId =0VrS6Ro6uC5QPXKgNdqGvyUgUFtUOVwv6OWAEWcWQ3jLRtAk2TVAgAApN9yTWVz;postId=; path=/;</example>
+      <example>_session_id=18b3e173aa11db0533fd01752e81f583; path=/; HttpOnly</example>
     </fingerprint>
 
 </fingerprints>


### PR DESCRIPTION
Adds an explicit fingerprint for HP System Management Homepage (SMH) as well as adds ignored fingerprints for common generic cookies that can't be used to pinpoint anything.