### PR TITLE
EOL 1.9.3 support, fixes #26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 rvm:
   - 2.1.5
-  - 1.9.3
   - jruby
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"

--- a/lib/recog/version.rb
+++ b/lib/recog/version.rb
@@ -1,3 +1,3 @@
 module Recog
-  VERSION = '1.0.18'
+  VERSION = '2.0.0'
 end

--- a/lib/recog/version.rb
+++ b/lib/recog/version.rb
@@ -1,3 +1,3 @@
 module Recog
-  VERSION = '1.0.17'
+  VERSION = '1.0.18'
 end

--- a/recog.gemspec
+++ b/recog.gemspec
@@ -5,6 +5,7 @@ require 'recog/version'
 Gem::Specification.new do |s|
   s.name        = 'recog'
   s.version     = Recog::VERSION
+  s.required_ruby_version = '>= 2.1'
   s.authors     = [
       'Rapid7 Research'
   ]


### PR DESCRIPTION
Remove 1.9.3 from Travis
Set minimum ruby version for the gem to 2.1+
Bump recog version

I can still build the gem on 1.9.3 but it won't install:

```
$  gem build recog.gemspec && gem install recog-1.0.18.gem 
  Successfully built RubyGem
  Name: recog
  Version: 1.0.18
  File: recog-1.0.18.gem
ERROR:  Error installing recog-1.0.18.gem:
	recog requires Ruby version >= 2.1.
```

