### PR TITLE
Fix #37 -- Add OpenVMS AXP NTP fingerprint and correct F5 BIG-IP

### DIFF
--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -809,7 +809,7 @@ NTP "banners", taken from a readvar response
     <param pos="0" name="os.product" value="OpenVMS"/>
     <param pos="0" name="os.arch" value="Alpha"/>
   </fingerprint>
-  <fingerprint pattern=".*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,\s*processor=&quot;([^ ]+)&quot;,\s*system=&quot;[^ ]+.([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern=".*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,\s*processor=&quot;([^ ]+)&quot;,\s*system=&quot;BIG-IPBIG-IP\s+([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>F5 Big-IP Load Balancers NTP</description>
     <example service.version="4.1.1a@1.791" os.arch="i386" os.version="4.5PTF-0">
       version="ntpd 4.1.1a@1.791 Fri Aug  8 04:08:19 PDT 2003 (1)",

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -797,6 +797,18 @@ NTP "banners", taken from a readvar response
     <param pos="2" name="os.arch"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
+  <fingerprint pattern="version=&quot;ntpd version = ([^ ]+)&quot;,\s*processor=&quot;unknown&quot;,\s*system=&quot;OpenVMS AXP&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>OpenVMS AXP (Alpha) NTP Server</description>
+    <example service.version="4.1.0" os.arch="Alpha">
+      version="ntpd version = 4.1.0", processor="unknown", system="OpenVMS AXP"
+    </example>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="os.vendor" value="OpenVMS"/>
+    <param pos="0" name="os.product" value="OpenVMS"/>
+    <param pos="0" name="os.arch" value="Alpha"/>
+  </fingerprint>
   <fingerprint pattern=".*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,\s*processor=&quot;([^ ]+)&quot;,\s*system=&quot;[^ ]+.([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>F5 Big-IP Load Balancers NTP</description>
     <example service.version="4.1.1a@1.791" os.arch="i386" os.version="4.5PTF-0">


### PR DESCRIPTION
This makes the existing F5 NTP regex more closely match the one known example, but also adds a fingerprint for OpenVMS AXP which was previously matching on the existing F5 fingerprint due to it being too loose.