### PR TITLE
Tag latest release as 'release', fixes #31

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,11 @@
 require "bundler/gem_tasks"
 
+# append to the release task to tag this as 'release',
+# meaning it is the most recent release
+task :release do |t|
+  sh "git tag -a -f release -m \"Update release tag for #{Bundler::GemHelper.gemspec.version}\""
+end
+
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new do |t|
     t.pattern = "spec/**/*_spec.rb"


### PR DESCRIPTION
I believe this fixes https://github.com/rapid7/recog/issues/31 by simply updating `release` tag to point to the most recent release as part of `rake release`.    Note that this `release` task does not overwrite the existing `release` task caused by the inclusion right before, but rather appends to it per http://ruby-doc.org/core-1.9.3/doc/rake/rakefile_rdoc.html#label-Multiple+Definitions.  Furthermore, I don't believe any of the API stuff mentioned in #31 is necessary, because github appears to automatically release new releases that correspond to the current tags.

I have tested this a bit in my own fork, but it had the unfortunate side effect of me releasing several bogus versions of the gem (which I've since yanked).  That may be the only way to test this but I'll think about it more.  For now, all I did was bump the version, ran `rake release` and then saw the new gem get pushed along with the updated release tag, and I could then fetch the newest release from `https://github.com/jhart-r7/recog/archive/release.zip` which is how I've addressed GES-2536 in https://github.com/rapid7/nexpose-content/pull/251