### PR TITLE
Revert Rakefile to e038f1e, undo work in #40 for #31

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,5 @@
 require "bundler/gem_tasks"
 
-# append to the release task to tag this as 'release',
-# meaning it is the most recent release
-task :release do |t|
-  sh "git tag -a -f release -m \"Update release tag for #{Bundler::GemHelper.gemspec.version}\""
-end
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new do |t|
     t.pattern = "spec/**/*_spec.rb"


### PR DESCRIPTION
Per discussions elsewhere, the work done in #40 which fixed https://github.com/rapid7/recog/issues/31 and got recog to a point that would streamline the release of Recog releases into other products isn't necessary as it was just a stop-gap measure until GES could implement the more ideal solution.

This PR simply undoes that work.  No need to issue a release when landing this.

After this lands, I'll clean up any tags or release issues to return everything to normal.