### PR TITLE
Modified 19 patterns to allow major only style version number

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3034,6 +3034,7 @@
       <example>SentinelProtectionServer/7.1</example>
       <example>SentinelProtectionServer/7.3</example>
       <example>SentinelProtectionServer/7.0</example>
+      <example>SentinelProtectionServer/7</example>
       <description>Embedded web server in SafeNet's memory key dongles.</description>
       <param pos="0" name="service.vendor" value="SafeNet"/>
       <param pos="0" name="service.product" value="Sentinel Protection Server"/>
@@ -3044,6 +3045,7 @@
    <fingerprint pattern="^SentinelKeysServer/((?:\d+\.)*\d+)$">
       <example>SentinelKeysServer/1.3.1</example>
       <example>SentinelKeysServer/1.0</example>
+      <example>SentinelKeysServer/1</example>
       <description>Embedded web server in SafeNet's memory key dongles.</description>
       <param pos="0" name="service.vendor" value="SafeNet"/>
       <param pos="0" name="service.product" value="Sentinel Keys Server"/>
@@ -3053,6 +3055,7 @@
 
    <fingerprint pattern="^CherryPy/((?:\d+\.)*\d+)$">
       <example>CherryPy/3.1.2</example>
+      <example>CherryPy/3</example>
       <description>Web server component of CherryPy web application framework.</description>
       <param pos="0" name="service.vendor" value="CherryPy"/>
       <param pos="0" name="service.product" value="CherryPy"/>
@@ -3082,6 +3085,7 @@
 
    <fingerprint pattern="^HP Web Jetadmin/((?:\d+\.)*\d+)\s*(.*)$">
       <example>HP Web Jetadmin/2.0.50 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
+      <example>HP Web Jetadmin/2 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
       <description>Apache variant for web access to HP printers.</description>
       <param pos="0" name="service.vendor" value="Apache"/>
       <param pos="0" name="service.product" value="HTTPD"/>
@@ -3103,6 +3107,7 @@
 
    <fingerprint pattern="^Lotus Expeditor Web Container/((?:\d+\.)*\d+)$">
       <example>Lotus Expeditor Web Container/6.1</example>
+      <example>Lotus Expeditor Web Container/6</example>
       <description>Expeditor is a framework used by IBM in many products in the Lotus brand, such as Sametime and Notes.</description>
       <param pos="0" name="service.vendor" value="IBM"/>
       <param pos="0" name="service.product" value="Lotus Expeditor Server"/>
@@ -3121,6 +3126,7 @@
    <fingerprint pattern="^Mbedthis-Appweb/((?:\d+\.)*\d+)$">
       <example>Mbedthis-Appweb/2.4.0</example>
       <example>Mbedthis-Appweb/2.4.2</example>
+      <example>Mbedthis-Appweb/2</example>
       <description>An embedded web server for hosting dynamic web applications.</description>
       <param pos="0" name="service.vendor" value="Embedthis"/>
       <param pos="0" name="service.product" value="Appweb"/>
@@ -3130,6 +3136,7 @@
 
    <fingerprint pattern="^Avaya CMBE/((?:\d+\.)*\d+)$">
       <example>Avaya CMBE/2.0.0</example>
+      <example>Avaya CMBE/2</example>
       <description>Web server for Avaya Aura Communication Manager Branch, a SIP-based communications platform.</description>
       <param pos="0" name="service.vendor" value="Avaya"/>
       <param pos="0" name="service.product" value="Aura Communication Manager"/>
@@ -3140,6 +3147,7 @@
 
    <fingerprint pattern="^Rapid Logic/((?:\d+\.)*\d+)$">
       <example>Rapid Logic/1.1</example>
+      <example>Rapid Logic/1</example>
       <description>Embedded web server by Rapid Logic, which was acquired by Wind River.</description>
       <!-- From Googling, it sounds like this is just referred to as the
            Rapid Logic web server. -->
@@ -3179,6 +3187,7 @@
 
    <fingerprint pattern="^mini_httpd/((?:\d+\.)*\d+) \S*$">
       <example>mini_httpd/1.14 23jun2000</example>
+      <example>mini_httpd/1 23jun2000</example>
       <description>A small HTTP server</description>
       <param pos="0" name="service.vendor" value="ACME Laboratories"/>
       <param pos="0" name="service.product" value="mini_httpd"/>
@@ -3188,6 +3197,7 @@
 
    <fingerprint pattern="^thin ((?:\d+\.)*\d+) codename .+$">
       <example>thin 1.2.4 codename Flaming Astroboy</example>
+      <example>thin 1 codename Flaming Astroboy</example>
       <description>A Ruby-based web server.</description>
       <!-- By private developer Marc-Andre Cournoyer; assert
            nothing for service.vendor. -->
@@ -3198,6 +3208,7 @@
 
    <fingerprint pattern="^Avocent DSView \d+/((?:\d+\.)*\d+)$">
       <example>Avocent DSView 3/3.7.0.71</example>
+      <example>Avocent DSView 3/3</example>
       <description>Web server interface for controlling data centers.</description>
       <param pos="0" name="service.vendor" value="Avocent"/>
       <param pos="0" name="service.product" value="DSView"/>
@@ -3207,6 +3218,7 @@
 
    <fingerprint pattern="^Mongrel ((?:\d+\.)*\d+)$">
       <example>Mongrel 1.1.5</example>
+      <example>Mongrel 1</example>
       <description>Ruby-based web server and HTTP library.</description>
       <!-- By private developer Zed A. Shaw; assert
            nothing for service.vendor. -->
@@ -3218,6 +3230,7 @@
    <fingerprint pattern="^Microplex emHTTPD/((?:\d+\.)*\d+)$">
       <example>Microplex emHTTPD/1.0</example>
       <example>Microplex emHTTPD/1.1</example>
+      <example>Microplex emHTTPD/1</example>
       <description>Embedded web server used by Microplex.</description>
       <param pos="0" name="service.vendor" value="Microplex"/>
       <!-- Per Microplex M307 data sheet, the device is manageable
@@ -3234,6 +3247,7 @@
 
    <fingerprint pattern="^UPS_Server/((?:\d+\.)*\d+)$">
       <example>UPS_Server/1.0</example>
+      <example>UPS_Server/1</example>
       <description>An embedded web server used for UPS management; primarily by Eaton, but also by APC.</description>
       <param pos="0" name="service.vendor" value="Eaton"/>
       <param pos="0" name="service.product" value="ConnectUPS"/>
@@ -3245,6 +3259,7 @@
 
    <fingerprint pattern="^JC-HTTPD/((?:\d+\.)*\d+)$">
       <example>JC-HTTPD/1.11.14</example>
+      <example>JC-HTTPD/1</example>
       <!-- Shodan shows multiple printers with servers having this
            banner, but I can't find a project page. -->
       <description>An embedded web server, used notably by Oki and Kyocera in printers.</description>
@@ -3255,6 +3270,7 @@
 
    <fingerprint pattern="^JC-SHTTPD/((?:\d+\.)*\d+)$">
       <example>JC-SHTTPD/1.17.20</example>
+      <example>JC-SHTTPD/1</example>
       <!-- The only Google hits for "JC-SHTTPD" list it as being
       a Sharp printer. There is a project called SHTTPD (now Mongoose),
       but version 1.17 does not have this banner.
@@ -3270,6 +3286,7 @@
 
    <fingerprint pattern="^Oracle XML DB/Oracle\S+ Enterprise Edition Release ((?:\d+\.)*\d+) - Production$">
       <example>Oracle XML DB/Oracle9i Enterprise Edition Release 9.2.0.1.0 - Production</example>
+      <example>Oracle XML DB/Oracle9i Enterprise Edition Release 9 - Production</example>
       <!-- Oracle provides a laundry list of HTTP(S) features not
       supported by the XML DB's web server; I think it's safe
       to say that it is almost certainly not Apache under the hood:
@@ -3302,6 +3319,7 @@
 
    <fingerprint pattern="^Ews/((?:\d+\.)*\d+)$">
       <example>Ews/0.1</example>
+      <example>Ews/0</example>
       <description>IBM Network Printer Manager.</description>
       <param pos="0" name="service.vendor" value="IBM"/>
       <param pos="0" name="service.product" value="Network Printer Manager"/>
@@ -3413,6 +3431,7 @@
 
    <fingerprint pattern="^GFE/((?:\d+\.)*\d+)$">
       <example>GFE/1.3</example>
+      <example>GFE/1</example>
       <description>Google Front End for apps running on Google services.</description>
       <param pos="0" name="service.vendor" value="Google"/>
       <param pos="0" name="service.product" value="Google Front End"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3030,7 +3030,7 @@
    </fingerprint>
    -->
 
-   <fingerprint pattern="^SentinelProtectionServer/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^SentinelProtectionServer/((?:\d+\.)*\d+)$">
       <example>SentinelProtectionServer/7.1</example>
       <example>SentinelProtectionServer/7.3</example>
       <example>SentinelProtectionServer/7.0</example>
@@ -3041,7 +3041,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^SentinelKeysServer/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^SentinelKeysServer/((?:\d+\.)*\d+)$">
       <example>SentinelKeysServer/1.3.1</example>
       <example>SentinelKeysServer/1.0</example>
       <description>Embedded web server in SafeNet's memory key dongles.</description>
@@ -3051,7 +3051,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^CherryPy/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^CherryPy/((?:\d+\.)*\d+)$">
       <example>CherryPy/3.1.2</example>
       <description>Web server component of CherryPy web application framework.</description>
       <param pos="0" name="service.vendor" value="CherryPy"/>
@@ -3080,7 +3080,7 @@
       <param pos="2" name="python.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^HP Web Jetadmin/((?:\d+\.)+\d+)\s*(.*)$">
+   <fingerprint pattern="^HP Web Jetadmin/((?:\d+\.)*\d+)\s*(.*)$">
       <example>HP Web Jetadmin/2.0.50 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
       <description>Apache variant for web access to HP printers.</description>
       <param pos="0" name="service.vendor" value="Apache"/>
@@ -3101,7 +3101,7 @@
       <param pos="0" name="service.family" value="Web PN Server"/>
    </fingerprint>
 
-   <fingerprint pattern="^Lotus Expeditor Web Container/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Lotus Expeditor Web Container/((?:\d+\.)*\d+)$">
       <example>Lotus Expeditor Web Container/6.1</example>
       <description>Expeditor is a framework used by IBM in many products in the Lotus brand, such as Sametime and Notes.</description>
       <param pos="0" name="service.vendor" value="IBM"/>
@@ -3118,7 +3118,7 @@
       <param pos="0" name="service.family" value="GoAhead Webserver"/>
    </fingerprint>
 
-   <fingerprint pattern="^Mbedthis-Appweb/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Mbedthis-Appweb/((?:\d+\.)*\d+)$">
       <example>Mbedthis-Appweb/2.4.0</example>
       <example>Mbedthis-Appweb/2.4.2</example>
       <description>An embedded web server for hosting dynamic web applications.</description>
@@ -3128,7 +3128,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Avaya CMBE/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Avaya CMBE/((?:\d+\.)*\d+)$">
       <example>Avaya CMBE/2.0.0</example>
       <description>Web server for Avaya Aura Communication Manager Branch, a SIP-based communications platform.</description>
       <param pos="0" name="service.vendor" value="Avaya"/>
@@ -3138,7 +3138,7 @@
    </fingerprint>
 
 
-   <fingerprint pattern="^Rapid Logic/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Rapid Logic/((?:\d+\.)*\d+)$">
       <example>Rapid Logic/1.1</example>
       <description>Embedded web server by Rapid Logic, which was acquired by Wind River.</description>
       <!-- From Googling, it sounds like this is just referred to as the
@@ -3177,7 +3177,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^mini_httpd/((?:\d+\.)+\d+) \S*$">
+   <fingerprint pattern="^mini_httpd/((?:\d+\.)*\d+) \S*$">
       <example>mini_httpd/1.14 23jun2000</example>
       <description>A small HTTP server</description>
       <param pos="0" name="service.vendor" value="ACME Laboratories"/>
@@ -3186,7 +3186,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^thin ((?:\d+\.)+\d+) codename .+$">
+   <fingerprint pattern="^thin ((?:\d+\.)*\d+) codename .+$">
       <example>thin 1.2.4 codename Flaming Astroboy</example>
       <description>A Ruby-based web server.</description>
       <!-- By private developer Marc-Andre Cournoyer; assert
@@ -3196,7 +3196,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Avocent DSView \d+/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Avocent DSView \d+/((?:\d+\.)*\d+)$">
       <example>Avocent DSView 3/3.7.0.71</example>
       <description>Web server interface for controlling data centers.</description>
       <param pos="0" name="service.vendor" value="Avocent"/>
@@ -3205,7 +3205,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Mongrel ((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Mongrel ((?:\d+\.)*\d+)$">
       <example>Mongrel 1.1.5</example>
       <description>Ruby-based web server and HTTP library.</description>
       <!-- By private developer Zed A. Shaw; assert
@@ -3215,7 +3215,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Microplex emHTTPD/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Microplex emHTTPD/((?:\d+\.)*\d+)$">
       <example>Microplex emHTTPD/1.0</example>
       <example>Microplex emHTTPD/1.1</example>
       <description>Embedded web server used by Microplex.</description>
@@ -3232,7 +3232,7 @@
       <param pos="0" name="os.device" value="Print server"/>
    </fingerprint>
 
-   <fingerprint pattern="^UPS_Server/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^UPS_Server/((?:\d+\.)*\d+)$">
       <example>UPS_Server/1.0</example>
       <description>An embedded web server used for UPS management; primarily by Eaton, but also by APC.</description>
       <param pos="0" name="service.vendor" value="Eaton"/>
@@ -3243,7 +3243,7 @@
       <param pos="0" name="os.device" value="UPS"/>
    </fingerprint>
 
-   <fingerprint pattern="^JC-HTTPD/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^JC-HTTPD/((?:\d+\.)*\d+)$">
       <example>JC-HTTPD/1.11.14</example>
       <!-- Shodan shows multiple printers with servers having this
            banner, but I can't find a project page. -->
@@ -3253,7 +3253,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^JC-SHTTPD/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^JC-SHTTPD/((?:\d+\.)*\d+)$">
       <example>JC-SHTTPD/1.17.20</example>
       <!-- The only Google hits for "JC-SHTTPD" list it as being
       a Sharp printer. There is a project called SHTTPD (now Mongoose),
@@ -3268,7 +3268,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^Oracle XML DB/Oracle\S+ Enterprise Edition Release ((?:\d+\.)+\d+) - Production$">
+   <fingerprint pattern="^Oracle XML DB/Oracle\S+ Enterprise Edition Release ((?:\d+\.)*\d+) - Production$">
       <example>Oracle XML DB/Oracle9i Enterprise Edition Release 9.2.0.1.0 - Production</example>
       <!-- Oracle provides a laundry list of HTTP(S) features not
       supported by the XML DB's web server; I think it's safe
@@ -3300,7 +3300,7 @@
       <param pos="0" name="os.device" value="Firewall"/>
    </fingerprint>
 
-   <fingerprint pattern="^Ews/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^Ews/((?:\d+\.)*\d+)$">
       <example>Ews/0.1</example>
       <description>IBM Network Printer Manager.</description>
       <param pos="0" name="service.vendor" value="IBM"/>
@@ -3411,7 +3411,7 @@
       <param pos="0" name="service.family" value="Google Web Server"/>
    </fingerprint>
 
-   <fingerprint pattern="^GFE/((?:\d+\.)+\d+)$">
+   <fingerprint pattern="^GFE/((?:\d+\.)*\d+)$">
       <example>GFE/1.3</example>
       <description>Google Front End for apps running on Google services.</description>
       <param pos="0" name="service.vendor" value="Google"/>


### PR DESCRIPTION
As suggested in #20 I modified the 19 patterns that used `((?:\d+\.)+\d+)` to match the service version to also allow for major only style version numbers.

### bin/recog_match Results Before Fix
```
FAIL: SentinelProtectionServer/7
FAIL: SentinelKeysServer/1
FAIL: CherryPy/3
FAIL: HP Web Jetadmin/2 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m
FAIL: Lotus Expeditor Web Container/6
FAIL: Mbedthis-Appweb/2
FAIL: Avaya CMBE/2
FAIL: Rapid Logic/1
FAIL: mini_httpd/1 23jun2000
FAIL: thin 2 codename Flaming Astroboy
FAIL: Avocent DSView 3/3
FAIL: Mongrel 1
FAIL: Microplex emHTTPD/1
FAIL: UPS_Server/1
FAIL: JC-HTTPD/1
FAIL: JC-SHTTPD/1
FAIL: Oracle XML DB/Oracle9i Enterprise Edition Release 9 - Production
FAIL: Ews/1
FAIL: GFE/1
```

### bin/recog_match Results After Fix
```
MATCH: {"matched"=>"Embedded web server in SafeNet's memory key dongles.", "service.vendor"=>"SafeNet", "service.product"=>"Sentinel Protection Server", "service.family"=>"Sentinel", "service.version"=>"7", "data"=>"SentinelProtectionServer/7"}
MATCH: {"matched"=>"Embedded web server in SafeNet's memory key dongles.", "service.vendor"=>"SafeNet", "service.product"=>"Sentinel Keys Server", "service.family"=>"Sentinel", "service.version"=>"1", "data"=>"SentinelKeysServer/1"}
MATCH: {"matched"=>"Web server component of CherryPy web application framework.", "service.vendor"=>"CherryPy", "service.product"=>"CherryPy", "service.family"=>"CherryPy", "service.version"=>"3", "data"=>"CherryPy/3"}
MATCH: {"matched"=>"Apache variant for web access to HP printers.", "service.vendor"=>"Apache", "service.product"=>"HTTPD", "service.family"=>"Apache", "apache.variant"=>"HP Web Jetadmin", "service.version"=>"2", "apache.info"=>"(Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m", "data"=>"HP Web Jetadmin/2 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m"}
MATCH: {"matched"=>"Expeditor is a framework used by IBM in many products in the Lotus brand, such as Sametime and Notes.", "service.vendor"=>"IBM", "service.product"=>"Lotus Expeditor Server", "service.family"=>"Lotus Expeditor", "service.version"=>"6", "data"=>"Lotus Expeditor Web Container/6"}
MATCH: {"matched"=>"An embedded web server for hosting dynamic web applications.", "service.vendor"=>"Embedthis", "service.product"=>"Appweb", "service.family"=>"Appweb", "service.version"=>"2", "data"=>"Mbedthis-Appweb/2"}
MATCH: {"matched"=>"Web server for Avaya Aura Communication Manager Branch, a SIP-based communications platform.", "service.vendor"=>"Avaya", "service.product"=>"Aura Communication Manager", "service.family"=>"Aura", "service.version"=>"2", "data"=>"Avaya CMBE/2"}
MATCH: {"matched"=>"Embedded web server by Rapid Logic, which was acquired by Wind River.", "service.vendor"=>"Wind River", "service.product"=>"Rapid Logic", "service.version"=>"1", "data"=>"Rapid Logic/1"}
MATCH: {"matched"=>"A small HTTP server", "service.vendor"=>"ACME Laboratories", "service.product"=>"mini_httpd", "service.family"=>"mini_httpd", "service.version"=>"1", "data"=>"mini_httpd/1 23jun2000"}
MATCH: {"matched"=>"A Ruby-based web server.", "service.product"=>"Thin", "service.family"=>"Thin", "service.version"=>"2", "data"=>"thin 2 codename Flaming Astroboy"}
MATCH: {"matched"=>"Web server interface for controlling data centers.", "service.vendor"=>"Avocent", "service.product"=>"DSView", "service.family"=>"DSView", "service.version"=>"3", "data"=>"Avocent DSView 3/3"}
MATCH: {"matched"=>"Ruby-based web server and HTTP library.", "service.product"=>"Mongrel", "service.family"=>"Mongrel", "service.version"=>"1", "data"=>"Mongrel 1"}
MATCH: {"matched"=>"Embedded web server used by Microplex.", "service.vendor"=>"Microplex", "service.product"=>"emHTTPD", "service.family"=>"emHTTPD", "service.version"=>"1", "os.vendor"=>"Microplex", "os.device"=>"Print server", "data"=>"Microplex emHTTPD/1"}
MATCH: {"matched"=>"An embedded web server used for UPS management; primarily by Eaton, but also by APC.", "service.vendor"=>"Eaton", "service.product"=>"ConnectUPS", "service.family"=>"ConnectUPS", "service.version"=>"1", "os.vendor"=>"Eaton", "os.device"=>"UPS", "data"=>"UPS_Server/1"}
MATCH: {"matched"=>"An embedded web server, used notably by Oki and Kyocera in printers.", "service.product"=>"JC-HTTPD", "service.family"=>"JC-HTTPD", "service.version"=>"1", "data"=>"JC-HTTPD/1"}
MATCH: {"matched"=>"An embedded web server.", "service.product"=>"JC-SHTTPD", "service.family"=>"JC-SHTTPD", "service.version"=>"1", "data"=>"JC-SHTTPD/1"}
MATCH: {"matched"=>"Web server providing web services for Oracle's XML DB.", "service.vendor"=>"Oracle", "service.product"=>"XML DB", "service.family"=>"Oracle", "service.version"=>"9", "data"=>"Oracle XML DB/Oracle9i Enterprise Edition Release 9 - Production"}
MATCH: {"matched"=>"IBM Network Printer Manager.", "service.vendor"=>"IBM", "service.product"=>"Network Printer Manager", "service.family"=>"Network Printer Manager", "service.version"=>"1", "data"=>"Ews/1"}
MATCH: {"matched"=>"Google Front End for apps running on Google services.", "service.vendor"=>"Google", "service.product"=>"Google Front End", "service.family"=>"Google Web Server", "service.version"=>"1", "data"=>"GFE/1"}
```