### PR TITLE
Initial fingerprints for mDNS: Avahi, Mac OS X, AirPort

### DIFF
--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+<!--
+  Fingerprint definitions that are matched against the string values in the
+  TXT record returned by an mDNS endpoint for the '_device-info._tcp.local.'
+  domain name.
+-->
+<fingerprints matches="mdns.device-info.txt">
+
+   <!--
+     OS X versions:
+     The number specified after osxvers= is equivalent to the major
+     version of OS X plus 4. E.g. osxvers=13 means OS X 10.9
+   -->
+   <fingerprint pattern="^osxvers=14">
+      <description>OS X 10.10 (Yosemite)</description>
+      <example>osxvers=14</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.10"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=13">
+      <description>OS X 10.9 (Mavericks)</description>
+      <example>osxvers=13</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.9"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=12">
+      <description>OS X 10.8 (Mountain Lion)</description>
+      <example>osxvers=12</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.8"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=11">
+      <description>Mac OS X 10.7 (Lion)</description>
+      <example>osxvers=11</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.7"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=10">
+      <description>Mac OS X 10.6 (Snow Leopard)</description>
+      <example>osxvers=10</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.6"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=9">
+      <description>Mac OS X 10.5 (Leopard)</description>
+      <example>osxvers=9</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.5"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=8">
+      <description>Mac OS X 10.4 (Tiger)</description>
+      <example>osxvers=8</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.4"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=7">
+      <description>Mac OS X 10.3 (Panther)</description>
+      <example>osxvers=7</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.3"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=6">
+      <description>Mac OS X 10.2 (Jaguar)</description>
+      <example>osxvers=6</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.2"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=5">
+      <description>Mac OS X 10.1 (Puma)</description>
+      <example>osxvers=5</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.1"/>
+   </fingerprint>
+
+   <fingerprint pattern="^osxvers=4">
+      <description>Mac OS X 10.0 (Cheetah)</description>
+      <example>osxvers=4</example>
+      <param pos="0" name="os.certainty" value="0.85"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="Mac OS X"/>
+      <param pos="0" name="os.product" value="Mac OS X"/>
+      <param pos="0" name="os.version" value="10.0"/>
+   </fingerprint>
+
+
+   <fingerprint pattern="^model=AirPort.*$">
+      <description>AirPort</description>
+      <!-- TODO: example -->
+      <param pos="0" name="os.certainty" value="0.8"/>
+      <param pos="0" name="os.vendor" value="Apple"/>
+      <param pos="0" name="os.family" value="AirPort"/>
+      <param pos="0" name="os.product" value="AirPort"/>
+   </fingerprint>
+
+</fingerprints>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -16,7 +16,6 @@
    <fingerprint pattern="^osxvers=14">
       <description>OS X 10.10 (Yosemite)</description>
       <example>osxvers=14</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -26,7 +25,6 @@
    <fingerprint pattern="^osxvers=13">
       <description>OS X 10.9 (Mavericks)</description>
       <example>osxvers=13</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -36,7 +34,6 @@
    <fingerprint pattern="^osxvers=12">
       <description>OS X 10.8 (Mountain Lion)</description>
       <example>osxvers=12</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -46,7 +43,6 @@
    <fingerprint pattern="^osxvers=11">
       <description>Mac OS X 10.7 (Lion)</description>
       <example>osxvers=11</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -56,7 +52,6 @@
    <fingerprint pattern="^osxvers=10">
       <description>Mac OS X 10.6 (Snow Leopard)</description>
       <example>osxvers=10</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -66,7 +61,6 @@
    <fingerprint pattern="^osxvers=9">
       <description>Mac OS X 10.5 (Leopard)</description>
       <example>osxvers=9</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -76,7 +70,6 @@
    <fingerprint pattern="^osxvers=8">
       <description>Mac OS X 10.4 (Tiger)</description>
       <example>osxvers=8</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -86,7 +79,6 @@
    <fingerprint pattern="^osxvers=7">
       <description>Mac OS X 10.3 (Panther)</description>
       <example>osxvers=7</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -96,7 +88,6 @@
    <fingerprint pattern="^osxvers=6">
       <description>Mac OS X 10.2 (Jaguar)</description>
       <example>osxvers=6</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -106,7 +97,6 @@
    <fingerprint pattern="^osxvers=5">
       <description>Mac OS X 10.1 (Puma)</description>
       <example>osxvers=5</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>
@@ -116,7 +106,6 @@
    <fingerprint pattern="^osxvers=4">
       <description>Mac OS X 10.0 (Cheetah)</description>
       <example>osxvers=4</example>
-      <param pos="0" name="os.certainty" value="0.85"/>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="Mac OS X"/>
       <param pos="0" name="os.product" value="Mac OS X"/>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -2,7 +2,9 @@
 <!--
   Fingerprint definitions that are matched against the string values in the
   TXT record returned by an mDNS endpoint for the '_device-info._tcp.local.'
-  domain name.
+  domain name (class IN). Note that the host name may need to be prepended
+  to the domain name for a server to respond with the record:
+  e.g. 'host-name._device-info._tcp.local'.
 -->
 <fingerprints matches="mdns.device-info.txt">
 
@@ -124,8 +126,7 @@
 
    <fingerprint pattern="^model=AirPort.*$">
       <description>AirPort</description>
-      <!-- TODO: example -->
-      <param pos="0" name="os.certainty" value="0.8"/>
+      <example>model=AirPort5,114</example>
       <param pos="0" name="os.vendor" value="Apple"/>
       <param pos="0" name="os.family" value="AirPort"/>
       <param pos="0" name="os.product" value="AirPort"/>

--- a/xml/mdns_workstation_txt.xml
+++ b/xml/mdns_workstation_txt.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+  Fingerprint definitions that are matched against the string values in the
+  TXT record returned by an mDNS endpoint for the '_workstation._tcp.local.'
+  domain name.
+-->
+<fingerprints matches="mdns.workstation.txt">
+   <fingerprint pattern="^org\.freedesktop\.Avahi\.cookie=\S+$">
+      <description>Avahi</description>
+      <example>org.freedesktop.Avahi.cookie=1023312927</example>
+      <param pos="0" name="service.product" value="Avahi"/>
+      <param pos="0" name="service.certainty" value="1.0"/>
+   </fingerprint>
+</fingerprints>

--- a/xml/mdns_workstation_txt.xml
+++ b/xml/mdns_workstation_txt.xml
@@ -2,7 +2,9 @@
 <!--
   Fingerprint definitions that are matched against the string values in the
   TXT record returned by an mDNS endpoint for the '_workstation._tcp.local.'
-  domain name.
+  domain name (class IN). Note that the host name may need to be prepended
+  to the domain name for a server to respond with the record:
+  e.g. 'host-name._workstation._tcp.local'.
 -->
 <fingerprints matches="mdns.workstation.txt">
    <fingerprint pattern="^org\.freedesktop\.Avahi\.cookie=\S+$">

--- a/xml/mdns_workstation_txt.xml
+++ b/xml/mdns_workstation_txt.xml
@@ -11,6 +11,5 @@
       <description>Avahi</description>
       <example>org.freedesktop.Avahi.cookie=1023312927</example>
       <param pos="0" name="service.product" value="Avahi"/>
-      <param pos="0" name="service.certainty" value="1.0"/>
    </fingerprint>
 </fingerprints>


### PR DESCRIPTION
This PR contains 2 new XML fingerprint files which each correspond to TXT records that can be retrieved from mDNS endpoints.

The TXT record for _device-info._tcp.local. (which sometimes needs the host name prepended for the query) may contain information that can be used to fingerprint certain systems, in particular Mac OS X.

The TXT record for _workstation._tcp.local. (ditto w/r/t prepending the hostname) may contain information that can be used to fingerprint the mDNS software, in particular Avahi.

Note that due to the nature of mDNS the service may need to be queried from the same subnet as the host.