### PR TITLE
Update SNMP regex for Extreme Networks XOS v15

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2314,7 +2314,7 @@ Copyright (c) 1995-2005 by Cisco Systems
    =======================================================================-->
 
    <!-- Sneaky. The XOS uses both Zero and Oh depending on version -->
-   <fingerprint pattern="Extreme(?:X[0O]S|Ware X[0O]S) version (\S+) \S+ by \S+ on .*$">
+   <fingerprint pattern="Extreme(?:X[0O]S|Ware X[0O]S) (?:\s?\([Xx]\d{0,3}-\d{0,2}[Xx]\)\s)?version (\S+) \S+ by \S+ on .*$">
       <description>Extreme Networks Switches</description>
       <example>ExtremeWare X0S version 11.2.0.15 v1120b15 by release-manager on Fri Apr 1 18:40:23 PST 2005</example>
       <example>ExtremeWare X0S version 11.2.2.4 v1122b4 by release-manager on Fri Jun 3 23:50:48 PDT 2005</example>
@@ -2331,6 +2331,7 @@ Copyright (c) 1995-2005 by Cisco Systems
       <example>ExtremeWare XOS version 11.5.2.10 v1152b10 by release-manager on Thu Oct 26 10:28:55 PDT 2006</example>
       <example>ExtremeXOS version 12.1.4.2 v1214b2 by release-manager on Wed Dec 9 13:32:31 PST 2009</example>
       <example>ExtremeXOS version 11.6.3.5 v1163b5 by release-manager on Sun Sep 9 10:46:16 PDT 2007</example>
+      <example>ExtremeXOS (X460-24x) version 15.6.1.4 v1561b4 by release-manager on Tue Sep 30 14:06:19 EDT 2014</example>
       <param pos="0" name="os.vendor" value="Extreme Networks"/>
       <param pos="0" name="os.device" value="Switch"/>
       <param pos="0" name="os.product" value="XOS"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2314,7 +2314,7 @@ Copyright (c) 1995-2005 by Cisco Systems
    =======================================================================-->
 
    <!-- Sneaky. The XOS uses both Zero and Oh depending on version -->
-   <fingerprint pattern="Extreme(?:X[0O]S|Ware X[0O]S) (?:\s?\([Xx]\d{0,3}-\d{0,2}[Xx]\)\s)?version (\S+) \S+ by \S+ on .*$">
+   <fingerprint pattern="Extreme(?:X[0O]S|Ware X[0O]S) (?:\S+ )?version (\S+) \S+ by \S+ on .*$">
       <description>Extreme Networks Switches</description>
       <example>ExtremeWare X0S version 11.2.0.15 v1120b15 by release-manager on Fri Apr 1 18:40:23 PST 2005</example>
       <example>ExtremeWare X0S version 11.2.2.4 v1122b4 by release-manager on Fri Jun 3 23:50:48 PDT 2005</example>


### PR DESCRIPTION
The new example banner contains some hardware information: X460 series 24-port switch.

I have no idea what else this might look like for other hardware, so it's very likely this will still miss some banners. This was just one banner found to be missing a match recently. I may have more examples coming up to improve this further.

Test:
```shell
$ bin/recog_match xml/snmp_sysdescr.xml xos15.txt
MATCH: {"matched"=>"Extreme Networks Switches", 
"os.vendor"=>"Extreme Networks", 
"os.device"=>"Switch", 
"os.product"=>"XOS", 
"os.version"=>"15.6.1.4", 
"data"=>"ExtremeXOS (X460-24x) version 15.6.1.4 v1561b4 by release-manager on Tue Sep 30 14:06:19 EDT 2014"}
```

cc @jhart-r7 