### PR TITLE
Add SNMP sysDesc fingerprints for H3C Comware and VMware vSphere Management Assistant

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2765,6 +2765,18 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="2" name="os.version.version"/>
    </fingerprint>
 
+   <fingerprint pattern="^H3C Comware Platform Software, Software Version ([\d\.]+) Release \d+.*H3C (\S+).*Copyright.*$" flags="REG_DOT_NEWLINE">
+     <description>H3C Comware, generic, pre-HP acquisition</description>
+     <example os.version="5.20" hw.product="S5500-28C-EI">H3C Comware Platform Software, Software Version 5.20 Release 2208
+       H3C S5500-28C-EI
+     Copyright (c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved.</example>
+      <param pos="0" name="os.vendor" value="H3C"/>
+      <param pos="0" name="os.family" value="Comware"/>
+      <param pos="1" name="os.version"/>
+      <param pos="0" name="os.product" value="Comware"/>
+      <param pos="2" name="hw.product"/>
+   </fingerprint>
+
    <fingerprint pattern="^HP (V1910\S+) (?:\(.*?\) )?Switch Software Version (\S+).? Release (\S+) Copyright.*$">
       <description>HP Switch</description>
       <example>HP V1910-16G Switch Software Version 5.20 Release 1108 Copyright (c) 2004-2011 Hewlett-Packard Development Company, L.P.</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2766,15 +2766,28 @@ Copyright (c) 1995-2005 by Cisco Systems
    </fingerprint>
 
    <fingerprint pattern="^H3C Comware Platform Software, Software Version ([\d\.]+) Release \d+.*H3C (\S+).*Copyright.*$" flags="REG_DOT_NEWLINE">
-     <description>H3C Comware, generic, pre-HP acquisition</description>
-     <example os.version="5.20" hw.product="S5500-28C-EI">H3C Comware Platform Software, Software Version 5.20 Release 2208
+      <description>H3C Comware, generic, pre-HP acquisition</description>
+      <example os.version="5.20" hw.product="S5500-28C-EI">H3C Comware Platform Software, Software Version 5.20 Release 2208
        H3C S5500-28C-EI
-     Copyright (c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved.</example>
+       Copyright (c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved.</example>
       <param pos="0" name="os.vendor" value="H3C"/>
       <param pos="0" name="os.family" value="Comware"/>
       <param pos="1" name="os.version"/>
       <param pos="0" name="os.product" value="Comware"/>
       <param pos="2" name="hw.product"/>
+    </fingerprint>
+
+   <fingerprint pattern="^H3C Switch (\S+) Software Version ([\d\.]+), Release .*" flags="REG_DOT_NEWLINE">
+     <description>H3C Comware, switch, pre-HP acquisition</description>
+      <example os.version="5.20" hw.product="S5120-28P-SI">H3C Switch S5120-28P-SI Software Version 5.20, Release 1101P10
+       Copyright(c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved.
+      </example>
+      <param pos="0" name="os.vendor" value="H3C"/>
+      <param pos="0" name="os.family" value="Comware"/>
+      <param pos="0" name="os.device" value="Switch"/>
+      <param pos="2" name="os.version"/>
+      <param pos="0" name="os.product" value="Comware"/>
+      <param pos="1" name="hw.product"/>
    </fingerprint>
 
    <fingerprint pattern="^HP (V1910\S+) (?:\(.*?\) )?Switch Software Version (\S+).? Release (\S+) Copyright.*$">

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -8208,6 +8208,13 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="1" name="os.product"/>
       <param pos="2" name="os.version"/>
       <param pos="3" name="os.arch"/>
-   </fingerprint>
+    </fingerprint>
 
+   <fingerprint pattern="^&quot;vSphere Management Assistant ([\d\.]+)&quot;$">
+      <description>VMware vSphere Management assistant, which is a virtual machine (https://www.vmware.com/support/developer/vima/)</description>
+      <example os.version="4.1.0">"vSphere Management Assistant 4.1.0"</example>
+      <param pos="0" name="os.vendor" value="VMware"/>
+      <param pos="0" name="os.product" value="vSphere Management Assistant"/>
+      <param pos="1" name="os.version"/>
+   </fingerprint>
 </fingerprints>


### PR DESCRIPTION
The H3C SNMP fingerprints use a vendor/product of H3C/Comware, which is in-line with https://github.com/rapid7/recog/blob/master/xml/ssh_banners.xml#L781-791.  Note that unlike the fingerprints above, in https://github.com/rapid7/recog/blob/master/xml/snmp_sysdescr.xml#L2707-2766, these do _not_ use HP in the vendor name -- the thinking here is that yes, HP did eventually acquire H3C, but purely based on these banners we cannot say that these are HP.

/CC @alynn71 @gwiseman-r7 