### PR TITLE
Improve Debian and Ubuntu OpenSSH fingerprints

### DIFF
--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -477,7 +477,7 @@ fingerprint SSH servers.
 
    <!-- SSH-1.99-OpenSSH_4.3p2-4.cern-hpn-CERN-4.3p2-4.cern -->
 
-   <fingerprint pattern="^OpenSSH_?([^\s]*)\s*(.*)$">
+   <!--<fingerprint pattern="^OpenSSH_?([^\s]*)\s*(.*)$">
       <description>Catch all for OpenSSH based SSH servers
       ******************** NOTE ********************
       Be sure to put any specific OpenSSH derivative
@@ -489,7 +489,7 @@ fingerprint SSH servers.
       <param pos="0" name="service.vendor" value="OpenBSD"/>
       <param pos="0" name="service.family" value="OpenSSH"/>
       <param pos="0" name="service.product" value="OpenSSH"/>
-   </fingerprint>
+   </fingerprint>-->
 
    <!-- TODO: Handle "vpn3" banners for Cisco 3000 VPN Concentrators (need example banners first) -->
 

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -362,6 +362,23 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="15.04"/>
    </fingerprint>
 
+   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-4(?:\+deb7u\d+)?)$">
+      <description>OpenSSH running on Debian 7.x (wheezy)</description>
+      <example service.version="6.0p1" openssh.comment="Debian-4">OpenSSH_6.0p1 Debian-4</example>
+      <example service.version="6.0p1" openssh.comment="Debian-4+deb7u1">OpenSSH_6.0p1 Debian-4+deb7u1</example>
+      <example service.version="6.0p1" openssh.comment="Debian-4+deb7u2">OpenSSH_6.0p1 Debian-4+deb7u2</example>
+      <param pos="1" name="service.version"/>
+      <param pos="2" name="openssh.comment"/>
+      <param pos="0" name="service.vendor" value="OpenBSD"/>
+      <param pos="0" name="service.family" value="OpenSSH"/>
+      <param pos="0" name="service.product" value="OpenSSH"/>
+      <param pos="0" name="os.vendor" value="Debian"/>
+      <param pos="0" name="os.device" value="General"/>
+      <param pos="0" name="os.family" value="Linux"/>
+      <param pos="0" name="os.product" value="Linux"/>
+      <param pos="0" name="os.version" value="7.0"/>
+    </fingerprint>
+
    <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+squeeze.*)$">
       <description>OpenSSH running on Debian 6.0 (squeeze)</description>
       <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -465,6 +465,16 @@ fingerprint SSH servers.
       <param pos="0" name="os.product" value="Windows"/>
    </fingerprint>
 
+   <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:p\d+)?)$">
+      <description>OpenSSH with just a version, no comment by vendor</description>
+      <example service.version="5.9p1">OpenSSH_5.9p1</example>
+      <example service.version="5.9">OpenSSH_5.9</example>
+      <param pos="1" name="service.version"/>
+      <param pos="0" name="service.vendor" value="OpenBSD"/>
+      <param pos="0" name="service.family" value="OpenSSH"/>
+      <param pos="0" name="service.product" value="OpenSSH"/>
+    </fingerprint>
+
    <!-- SSH-1.99-OpenSSH_4.3p2-4.cern-hpn-CERN-4.3p2-4.cern -->
 
    <fingerprint pattern="^OpenSSH_?([^\s]*)\s*(.*)$">

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -500,6 +500,22 @@ fingerprint SSH servers.
       <param pos="0" name="service.product" value="OpenSSH"/>
     </fingerprint>
 
+   <!-- SSH-1.99-OpenSSH_4.3p2-4.cern-hpn-CERN-4.3p2-4.cern -->
+
+   <!--<fingerprint pattern="^OpenSSH_?([^\s]*)\s*(.*)$">
+      <description>Catch all for OpenSSH based SSH servers
+      ******************** NOTE ********************
+      Be sure to put any specific OpenSSH derivative
+      checks above this block.
+      ******************** NOTE ********************
+      </description>
+      <param pos="1" name="service.version"/>
+      <param pos="2" name="openssh.comment"/>
+      <param pos="0" name="service.vendor" value="OpenBSD"/>
+      <param pos="0" name="service.family" value="OpenSSH"/>
+      <param pos="0" name="service.product" value="OpenSSH"/>
+   </fingerprint>-->
+
    <!-- TODO: Handle "vpn3" banners for Cisco 3000 VPN Concentrators (need example banners first) -->
 
    <fingerprint pattern="^Cisco-(.*)$">

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -238,10 +238,11 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="10.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.5p1) (Debian-4ubuntu[45])$">
+   <fingerprint pattern="^OpenSSH_(5\.5p1) (Debian-4ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 10.10</description>
-      <example>OpenSSH_5.5p1 Debian-4ubuntu4</example>
-      <example>OpenSSH_5.5p1 Debian-4ubuntu5</example>
+      <example service.version="5.5p1" openssh.comment="Debian-4ubuntu4">OpenSSH_5.5p1 Debian-4ubuntu4</example>
+      <example service.version="5.5p1" openssh.comment="Debian-4ubuntu5">OpenSSH_5.5p1 Debian-4ubuntu5</example>
+      <example service.version="5.5p1" openssh.comment="Debian-4ubuntu6">OpenSSH_5.5p1 Debian-4ubuntu6</example>
       <param pos="1" name="service.version"/>
       <param pos="2" name="openssh.comment"/>
       <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -255,7 +255,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="10.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-1ubuntu3)$">
+   <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-1ubuntu\d(?:\.\d)?)$">
       <description>OpenSSH running on Ubuntu 11.04</description>
       <example>OpenSSH_5.8p1 Debian-1ubuntu3</example>
       <param pos="1" name="service.version"/>
@@ -270,7 +270,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="11.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-7ubuntu1)$">
+   <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-7ubuntu\d(?:\.\d)?)$">
       <description>OpenSSH running on Ubuntu 11.10</description>
       <example>OpenSSH_5.8p1 Debian-7ubuntu1</example>
       <param pos="1" name="service.version"/>
@@ -344,6 +344,21 @@ fingerprint SSH servers.
       <param pos="0" name="os.family" value="Linux"/>
       <param pos="0" name="os.product" value="Linux"/>
       <param pos="0" name="os.version" value="14.04"/>
+    </fingerprint>
+
+   <fingerprint pattern="^OpenSSH_(6\.7p1) (Ubuntu-5ubuntu\d(?:\.\d)?)$">
+      <description>OpenSSH running on Ubuntu 15.04 (vivid)</description>
+      <example service.version="6.7p1" openssh.comment="Ubuntu-5ubuntu1">OpenSSH_6.7p1 Ubuntu-5ubuntu1</example>
+      <param pos="1" name="service.version"/>
+      <param pos="2" name="openssh.comment"/>
+      <param pos="0" name="service.vendor" value="OpenBSD"/>
+      <param pos="0" name="service.family" value="OpenSSH"/>
+      <param pos="0" name="service.product" value="OpenSSH"/>
+      <param pos="0" name="os.vendor" value="Ubuntu"/>
+      <param pos="0" name="os.device" value="General"/>
+      <param pos="0" name="os.family" value="Linux"/>
+      <param pos="0" name="os.product" value="Linux"/>
+      <param pos="0" name="os.version" value="15.04"/>
    </fingerprint>
 
    <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+squeeze.*)$">

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -218,55 +218,14 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="9.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.3p1) (Debian-3ubuntu3)$">
+   <fingerprint pattern="^OpenSSH_(5\.3p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 10.04 (lucid)</description>
-      <example>OpenSSH_5.3p1 Debian-3ubuntu3</example>
-      <param pos="1" name="service.version"/>
-      <param pos="2" name="openssh.comment"/>
-      <param pos="0" name="service.vendor" value="OpenBSD"/>
-      <param pos="0" name="service.family" value="OpenSSH"/>
-      <param pos="0" name="service.product" value="OpenSSH"/>
-      <param pos="0" name="os.vendor" value="Ubuntu"/>
-      <param pos="0" name="os.device" value="General"/>
-      <param pos="0" name="os.family" value="Linux"/>
-      <param pos="0" name="os.product" value="Linux"/>
-      <param pos="0" name="os.version" value="10.04"/>
-   </fingerprint>
-
-   <fingerprint pattern="^OpenSSH_(5\.3p1) (Debian-3ubuntu4)$">
-      <description>OpenSSH running on Ubuntu 10.04 (lucid) update 1</description>
-      <example>OpenSSH_5.3p1 Debian-3ubuntu4</example>
-      <param pos="1" name="service.version"/>
-      <param pos="2" name="openssh.comment"/>
-      <param pos="0" name="service.vendor" value="OpenBSD"/>
-      <param pos="0" name="service.family" value="OpenSSH"/>
-      <param pos="0" name="service.product" value="OpenSSH"/>
-      <param pos="0" name="os.vendor" value="Ubuntu"/>
-      <param pos="0" name="os.device" value="General"/>
-      <param pos="0" name="os.family" value="Linux"/>
-      <param pos="0" name="os.product" value="Linux"/>
-      <param pos="0" name="os.version" value="10.04"/>
-   </fingerprint>
-
-   <fingerprint pattern="^OpenSSH_(5\.3p1) (Debian-3ubuntu[56])$">
-      <description>OpenSSH running on Ubuntu 10.04 (lucid) update 2</description>
-      <example>OpenSSH_5.3p1 Debian-3ubuntu5</example>
-      <example>OpenSSH_5.3p1 Debian-3ubuntu6</example>
-      <param pos="1" name="service.version"/>
-      <param pos="2" name="openssh.comment"/>
-      <param pos="0" name="service.vendor" value="OpenBSD"/>
-      <param pos="0" name="service.family" value="OpenSSH"/>
-      <param pos="0" name="service.product" value="OpenSSH"/>
-      <param pos="0" name="os.vendor" value="Ubuntu"/>
-      <param pos="0" name="os.device" value="General"/>
-      <param pos="0" name="os.family" value="Linux"/>
-      <param pos="0" name="os.product" value="Linux"/>
-      <param pos="0" name="os.version" value="10.04"/>
-   </fingerprint>
-
-   <fingerprint pattern="^OpenSSH_(5\.3p1) (Debian-3ubuntu7)$">
-      <description>OpenSSH running on Ubuntu 10.04 (lucid) update 3 or update 4</description>
-      <example>OpenSSH_5.3p1 Debian-3ubuntu7</example>
+      <example service.version="5.3p1" openssh.comment="Debian-3ubuntu3">OpenSSH_5.3p1 Debian-3ubuntu3</example>
+      <example service.version="5.3p1" openssh.comment="Debian-3ubuntu4">OpenSSH_5.3p1 Debian-3ubuntu4</example>
+      <example service.version="5.3p1" openssh.comment="Debian-3ubuntu5">OpenSSH_5.3p1 Debian-3ubuntu5</example>
+      <example service.version="5.3p1" openssh.comment="Debian-3ubuntu6">OpenSSH_5.3p1 Debian-3ubuntu6</example>
+      <example service.version="5.3p1" openssh.comment="Debian-3ubuntu7">OpenSSH_5.3p1 Debian-3ubuntu7</example>
+      <example service.version="5.3p1" openssh.comment="Debian-3ubuntu7.1">OpenSSH_5.3p1 Debian-3ubuntu7.1</example>
       <param pos="1" name="service.version"/>
       <param pos="2" name="openssh.comment"/>
       <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -465,10 +465,12 @@ fingerprint SSH servers.
       <param pos="0" name="os.product" value="Windows"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:p\d+)?)$">
+   <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)$">
       <description>OpenSSH with just a version, no comment by vendor</description>
       <example service.version="5.9p1">OpenSSH_5.9p1</example>
       <example service.version="5.9">OpenSSH_5.9</example>
+      <example service.version="3.8.1p1">OpenSSH_3.8.1p1</example>
+      <example service.version="6.6.1">OpenSSH_6.6.1</example>
       <param pos="1" name="service.version"/>
       <param pos="0" name="service.vendor" value="OpenBSD"/>
       <param pos="0" name="service.family" value="OpenSSH"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -79,7 +79,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.product" value="NetBSD"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(4\.1p1) (Debian-7ubuntu4)$">
+   <fingerprint pattern="^OpenSSH_(4\.1p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 5.10</description>
       <example>OpenSSH_4.1p1 Debian-7ubuntu4</example>
       <param pos="1" name="service.version"/>
@@ -94,7 +94,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="5.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(4\.2p1) (Debian-7ubuntu3.*)$">
+   <fingerprint pattern="^OpenSSH_(4\.2p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 6.04</description>
       <example>OpenSSH_4.2p1 Debian-7ubuntu3.1</example>
       <example>OpenSSH_4.2p1 Debian-7ubuntu3.2</example>
@@ -110,7 +110,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="6.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(4\.3p2) (Debian-8ubuntu1.*)$">
+   <fingerprint pattern="^OpenSSH_(4\.3p2) (Debian-8ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 7.04</description>
       <example>OpenSSH_4.3p2 Debian-8ubuntu1.4</example>
       <param pos="1" name="service.version"/>
@@ -125,7 +125,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="7.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(4\.6p1) (Debian-5ubuntu0.*)$">
+   <fingerprint pattern="^OpenSSH_(4\.6p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 7.10</description>
       <example>OpenSSH_4.6p1 Debian-5ubuntu0.2</example>
       <example>OpenSSH_4.6p1 Debian-5ubuntu0.5</example>
@@ -157,7 +157,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="7.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(4\.7p1) (Debian-8ubuntu[13].*)$">
+   <fingerprint pattern="^OpenSSH_(4\.7p1) (Debian-8ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 8.04</description>
       <example service.version="4.7p1" openssh.comment="Debian-8ubuntu1.2">OpenSSH_4.7p1 Debian-8ubuntu1.2</example>
       <example service.version="4.7p1" openssh.comment="Debian-8ubuntu3">OpenSSH_4.7p1 Debian-8ubuntu3</example>
@@ -173,7 +173,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="8.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-3ubuntu1)$">
+   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 8.10</description>
       <example>OpenSSH_5.1p1 Debian-3ubuntu1</example>
       <param pos="1" name="service.version"/>
@@ -188,7 +188,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="8.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-5ubuntu1)$">
+   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 9.04</description>
       <example>OpenSSH_5.1p1 Debian-5ubuntu1</example>
       <param pos="1" name="service.version"/>
@@ -203,7 +203,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="9.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-6ubuntu2)$">
+   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-6ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 9.10</description>
       <example>OpenSSH_5.1p1 Debian-6ubuntu2</example>
       <param pos="1" name="service.version"/>
@@ -285,7 +285,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="11.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.9p1) (Debian-5ubuntu1(?:\.\d)?)$">
+   <fingerprint pattern="^OpenSSH_(5\.9p1) (Debian-5ubuntu\d(?:\.\d)?)$">
       <description>OpenSSH running on Ubuntu 12.04</description>
       <example service.version="5.9p1" openssh.comment="Debian-5ubuntu1">OpenSSH_5.9p1 Debian-5ubuntu1</example>
       <example service.version="5.9p1" openssh.comment="Debian-5ubuntu1.4">OpenSSH_5.9p1 Debian-5ubuntu1.4</example>
@@ -301,7 +301,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="12.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(6\.0p1) (Debian-3ubuntu1)$">
+   <fingerprint pattern="^OpenSSH_(6\.0p1) (Debian-3ubuntu\d(?:\.\d)?)$">
       <description>OpenSSH running on Ubuntu 12.10</description>
       <example>OpenSSH_6.0p1 Debian-3ubuntu1</example>
       <param pos="1" name="service.version"/>
@@ -331,7 +331,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="13.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(6\.6p1) (Ubuntu-2ubuntu1)$">
+   <fingerprint pattern="^OpenSSH_(6\.6p1) (Ubuntu-2ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 14.04</description>
       <example>OpenSSH_6.6p1 Ubuntu-2ubuntu1</example>
       <param pos="1" name="service.version"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -157,9 +157,10 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="7.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(4\.7p1) (Debian-8ubuntu1.*)$">
+   <fingerprint pattern="^OpenSSH_(4\.7p1) (Debian-8ubuntu[13].*)$">
       <description>OpenSSH running on Ubuntu 8.04</description>
-      <example>OpenSSH_4.7p1 Debian-8ubuntu1.2</example>
+      <example service.version="4.7p1" openssh.comment="Debian-8ubuntu1.2">OpenSSH_4.7p1 Debian-8ubuntu1.2</example>
+      <example service.version="4.7p1" openssh.comment="Debian-8ubuntu3">OpenSSH_4.7p1 Debian-8ubuntu3</example>
       <param pos="1" name="service.version"/>
       <param pos="2" name="openssh.comment"/>
       <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -331,9 +331,10 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="13.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(6\.6p1) (Ubuntu-2ubuntu\d+(?:\.\d+)?)$">
+   <fingerprint pattern="^OpenSSH_(6\.6(?:\.\d)?p1) (Ubuntu-2ubuntu\d+(?:\.\d+)?)$">
       <description>OpenSSH running on Ubuntu 14.04</description>
-      <example>OpenSSH_6.6p1 Ubuntu-2ubuntu1</example>
+      <example service.version="6.6p1" openssh.comment="Ubuntu-2ubuntu1">OpenSSH_6.6p1 Ubuntu-2ubuntu1</example>
+      <example service.version="6.6.1p1" openssh.comment="Ubuntu-2ubuntu2">OpenSSH_6.6.1p1 Ubuntu-2ubuntu2</example>
       <param pos="1" name="service.version"/>
       <param pos="2" name="openssh.comment"/>
       <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -394,6 +394,20 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="6.0"/>
    </fingerprint>
 
+   <fingerprint pattern="^OpenSSH_([^\s]+)\s+((?:Debian|Ubuntu).+ubuntu.*)$">
+      <description>OpenSSH running on Ubuntu</description>
+      <param pos="1" name="service.version"/>
+      <param pos="2" name="openssh.comment"/>
+      <param pos="0" name="service.vendor" value="OpenBSD"/>
+      <param pos="0" name="service.family" value="OpenSSH"/>
+      <param pos="0" name="service.product" value="OpenSSH"/>
+      <param pos="0" name="os.vendor" value="Ubuntu"/>
+      <param pos="0" name="os.device" value="General"/>
+      <param pos="0" name="os.family" value="Linux"/>
+      <param pos="0" name="os.product" value="Linux"/>
+      <param pos="0" name="os.certainty" value="0.75"/>
+   </fingerprint>
+
    <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+etch.*)$">
       <description>OpenSSH running on Debian 4.0 (etch)</description>
       <param pos="1" name="service.version"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -486,22 +486,6 @@ fingerprint SSH servers.
       <param pos="0" name="service.product" value="OpenSSH"/>
     </fingerprint>
 
-   <!-- SSH-1.99-OpenSSH_4.3p2-4.cern-hpn-CERN-4.3p2-4.cern -->
-
-   <!--<fingerprint pattern="^OpenSSH_?([^\s]*)\s*(.*)$">
-      <description>Catch all for OpenSSH based SSH servers
-      ******************** NOTE ********************
-      Be sure to put any specific OpenSSH derivative
-      checks above this block.
-      ******************** NOTE ********************
-      </description>
-      <param pos="1" name="service.version"/>
-      <param pos="2" name="openssh.comment"/>
-      <param pos="0" name="service.vendor" value="OpenBSD"/>
-      <param pos="0" name="service.family" value="OpenSSH"/>
-      <param pos="0" name="service.product" value="OpenSSH"/>
-   </fingerprint>-->
-
    <!-- TODO: Handle "vpn3" banners for Cisco 3000 VPN Concentrators (need example banners first) -->
 
    <fingerprint pattern="^Cisco-(.*)$">

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -370,6 +370,21 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="14.04"/>
    </fingerprint>
 
+   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+squeeze.*)$">
+      <description>OpenSSH running on Debian 6.0 (squeeze)</description>
+      <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>
+      <param pos="1" name="service.version"/>
+      <param pos="2" name="openssh.comment"/>
+      <param pos="0" name="service.vendor" value="OpenBSD"/>
+      <param pos="0" name="service.family" value="OpenSSH"/>
+      <param pos="0" name="service.product" value="OpenSSH"/>
+      <param pos="0" name="os.vendor" value="Debian"/>
+      <param pos="0" name="os.device" value="General"/>
+      <param pos="0" name="os.family" value="Linux"/>
+      <param pos="0" name="os.product" value="Linux"/>
+      <param pos="0" name="os.version" value="6.0"/>
+   </fingerprint>
+
    <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+etch.*)$">
       <description>OpenSSH running on Debian 4.0 (etch)</description>
       <param pos="1" name="service.version"/>
@@ -410,19 +425,6 @@ fingerprint SSH servers.
       <param pos="0" name="os.family" value="Linux"/>
       <param pos="0" name="os.product" value="Linux"/>
       <param pos="0" name="os.version" value="3.0"/>
-   </fingerprint>
-
-   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.*)$">
-      <description>OpenSSH running on Debian (unknown version)</description>
-      <param pos="1" name="service.version"/>
-      <param pos="2" name="openssh.comment"/>
-      <param pos="0" name="service.vendor" value="OpenBSD"/>
-      <param pos="0" name="service.family" value="OpenSSH"/>
-      <param pos="0" name="service.product" value="OpenSSH"/>
-      <param pos="0" name="os.vendor" value="Debian"/>
-      <param pos="0" name="os.device" value="General"/>
-      <param pos="0" name="os.family" value="Linux"/>
-      <param pos="0" name="os.product" value="Linux"/>
    </fingerprint>
 
    <fingerprint pattern="^OpenSSH_(.*)\+(CAN-[0-9]{4}-[0-9]{4})$">

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -309,9 +309,10 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="11.10"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_(5\.9p1) (Debian-5ubuntu1(?:\.3|))$">
+   <fingerprint pattern="^OpenSSH_(5\.9p1) (Debian-5ubuntu1(?:\.\d)?)$">
       <description>OpenSSH running on Ubuntu 12.04</description>
-      <example>OpenSSH_5.9p1 Debian-5ubuntu1</example>
+      <example service.version="5.9p1" openssh.comment="Debian-5ubuntu1">OpenSSH_5.9p1 Debian-5ubuntu1</example>
+      <example service.version="5.9p1" openssh.comment="Debian-5ubuntu1.4">OpenSSH_5.9p1 Debian-5ubuntu1.4</example>
       <param pos="1" name="service.version"/>
       <param pos="2" name="openssh.comment"/>
       <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -370,19 +370,6 @@ fingerprint SSH servers.
       <param pos="0" name="os.version" value="14.04"/>
    </fingerprint>
 
-   <fingerprint pattern="^OpenSSH_([^\s]+)\s+((?:Debian|Ubuntu).+ubuntu.*)$">
-      <description>OpenSSH running on Ubuntu</description>
-      <param pos="1" name="service.version"/>
-      <param pos="2" name="openssh.comment"/>
-      <param pos="0" name="service.vendor" value="OpenBSD"/>
-      <param pos="0" name="service.family" value="OpenSSH"/>
-      <param pos="0" name="service.product" value="OpenSSH"/>
-      <param pos="0" name="os.vendor" value="Ubuntu"/>
-      <param pos="0" name="os.device" value="General"/>
-      <param pos="0" name="os.family" value="Linux"/>
-      <param pos="0" name="os.product" value="Linux"/>
-   </fingerprint>
-
    <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+etch.*)$">
       <description>OpenSSH running on Debian 4.0 (etch)</description>
       <param pos="1" name="service.version"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -140,6 +140,21 @@ fingerprint SSH servers.
       <param pos="0" name="os.family" value="Linux"/>
       <param pos="0" name="os.product" value="Linux"/>
       <param pos="0" name="os.version" value="7.10"/>
+    </fingerprint>
+
+   <fingerprint pattern="^OpenSSH_(4\.6p1) (Debian-5build1)$">
+      <description>OpenSSH running on very early versions of Ubuntu 7.10</description>
+      <example service.version="4.6p1" openssh.comment="Debian-5build1">OpenSSH_4.6p1 Debian-5build1</example>
+      <param pos="1" name="service.version"/>
+      <param pos="2" name="openssh.comment"/>
+      <param pos="0" name="service.vendor" value="OpenBSD"/>
+      <param pos="0" name="service.family" value="OpenSSH"/>
+      <param pos="0" name="service.product" value="OpenSSH"/>
+      <param pos="0" name="os.vendor" value="Ubuntu"/>
+      <param pos="0" name="os.device" value="General"/>
+      <param pos="0" name="os.family" value="Linux"/>
+      <param pos="0" name="os.product" value="Linux"/>
+      <param pos="0" name="os.version" value="7.10"/>
    </fingerprint>
 
    <fingerprint pattern="^OpenSSH_(4\.7p1) (Debian-8ubuntu1.*)$">


### PR DESCRIPTION
There were several catch-all OpenSSH fingerprints that were resulting in us only getting very generic versions from some OpenSSH installations.  I've removed those and updated all of the Ubuntu and Debian fingerprints I could find.

I also ran this PR through a set of Sonar data for 22/TCP from earlier this year.  As I expected, we actually lose quite a bit of coverage.  Without this PR, we miss 76021 out of 78603 unique banners.  With this PR, we miss 77494 out of 78603.  So, neither are especially good, but now we are worse in terms of overall coverage but it will now give us a chance to track down all of the banners that had previously been matching these catch-alls and see if we can do better.

/CC @gwiseman-r7 