### PR TITLE
Fix the use of MULTILINE

### DIFF
--- a/lib/recog/fingerprint/regexp_factory.rb
+++ b/lib/recog/fingerprint/regexp_factory.rb
@@ -21,7 +21,7 @@ module Recog
         # multiline variations
         'REG_DOT_NEWLINE'   => Regexp::MULTILINE,
         'REG_LINE_ANY_CRLF' => Regexp::MULTILINE,
-        'MULTILINE'         => Regexp::MULTILINE,
+        'REG_MULTILINE'     => Regexp::MULTILINE,
         # case variations
         'REG_ICASE'         => Regexp::IGNORECASE,
         'IGNORECASE'        => Regexp::IGNORECASE

--- a/lib/recog/version.rb
+++ b/lib/recog/version.rb
@@ -1,3 +1,3 @@
 module Recog
-  VERSION = '2.0.6'
+  VERSION = '2.0.7'
 end

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -104,7 +104,7 @@ against these patterns to fingerprint FTP servers.
     <param pos="1" name="host.name"/>
     <param pos="2" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^(\S+)\s+FTP Server \(Version:\s+Mac OS X Server\s+([\d\.]+).*\) ready\.?" flags="REG_ICASE,MULTILINE">
+  <fingerprint pattern="^(\S+)\s+FTP Server \(Version:\s+Mac OS X Server\s+([\d\.]+).*\) ready\.?" flags="REG_ICASE,REG_MULTILINE">
     <description>FTPD on Mac OS X Server with a version</description>
     <example host.name="example.com" os.version="10.3">example.com FTP server (Version:  Mac OS X Server 10.3 - +GSSAPI) ready.</example>
     <example host.name="example.com" os.version="10.3">this is a banner.  change it.&#13;&#10;example.com FTP server (Version:  Mac OS X Server 10.3 - +GSSAPI) ready.</example>
@@ -117,7 +117,7 @@ against these patterns to fingerprint FTP servers.
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^(\S+)\s+FTP Server \(Version:\s+Mac OS X Server\) ready\.?" flags="REG_ICASE,MULTILINE">
+  <fingerprint pattern="^(\S+)\s+FTP Server \(Version:\s+Mac OS X Server\) ready\.?" flags="REG_ICASE,REG_MULTILINE">
     <description>FTPD on Mac OS X Server without a version</description>
     <example host.name="example.com">example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <example host.name="example.com">this is a banner.  change it.&#13;&#10;example.com FTP server (Version:  Mac OS X Server) ready.</example>
@@ -204,7 +204,7 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
   </fingerprint>
-  <fingerprint pattern="^=\(&lt;\*&gt;\)=-\.:\. \(\( Welcome to Pure-FTPd ([\d.]+) \)\) \.:\.-=\(&lt;\*&gt;\)=-" flags="MULTILINE">
+  <fingerprint pattern="^=\(&lt;\*&gt;\)=-\.:\. \(\( Welcome to Pure-FTPd ([\d.]+) \)\) \.:\.-=\(&lt;\*&gt;\)=-" flags="REG_MULTILINE">
     <!-- yes, the leading and trailing text is not balanced.
          the leading text is missing the - at the beginning -->
     <example service.version="1.0.11">=(&lt;*&gt;)=-.:. (( Welcome to Pure-FTPd 1.0.11 )) .:.-=(&lt;*&gt;)=-</example>
@@ -214,7 +214,7 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.product" value="Pure-FTPd"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^-{9,10} Welcome to Pure-FTPd (.*)-{9,10}" flags="MULTILINE">
+  <fingerprint pattern="^-{9,10} Welcome to Pure-FTPd (.*)-{9,10}" flags="REG_MULTILINE">
     <example>---------- Welcome to Pure-FTPd ----------</example>
     <example>--------- Welcome to Pure-FTPd [privsep] [TLS] ----------</example>
     <example>--------- Welcome to Pure-FTPd [privsep] [TLS] ----------&#13;&#10;more text</example>
@@ -225,7 +225,7 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.family" value="Pure-FTPd"/>
     <param pos="0" name="service.product" value="Pure-FTPd"/>
   </fingerprint>
-  <fingerprint pattern="^=\(.\*.\)=-\.:\. \(\( Welcome to PureFTPd (\d+\..+) \)\) \.:\.-=\(.\*.\)=-" flags="MULTILINE">
+  <fingerprint pattern="^=\(.\*.\)=-\.:\. \(\( Welcome to PureFTPd (\d+\..+) \)\) \.:\.-=\(.\*.\)=-" flags="REG_MULTILINE">
     <example service.version="1.1.0">=(&lt;*&gt;)=-.:. (( Welcome to PureFTPd 1.1.0 )) .:.-=(&lt;*&gt;)=-</example>
     <example service.version="1.1.0">=(&lt;*&gt;)=-.:. (( Welcome to PureFTPd 1.1.0 )) .:.-=(&lt;*&gt;)=-&#13;&#10;more text</example>
     <description>Older Pure-FTPd versions</description>


### PR DESCRIPTION
This patch fixes a regression where MULTILINE was specified, but REG_MULTILINE was needed.