### PR TITLE
Add missing OS for iLO using SNMP and OpenVMS using SSH

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3357,7 +3357,8 @@ Copyright (c) 1995-2005 by Cisco Systems
       <!--2.02 is firmware version-->
       <param pos="0" name="os.vendor" value="HP"/>
       <param pos="0" name="os.family" value="iLO"/>
-      <param pos="0" name="os.device" value="iLO"/>
+      <param pos="0" name="os.product" value="iLO"/>
+      <param pos="0" name="os.device" value="Lights Out Management"/>
       <param pos="1" name="os.version"/>
     </fingerprint>
 
@@ -3366,7 +3367,8 @@ Copyright (c) 1995-2005 by Cisco Systems
       <example os.version="2">Integrated Lights-Out 2 (iLO 2) for Integrity</example>
       <param pos="0" name="os.vendor" value="HP"/>
       <param pos="0" name="os.family" value="iLO"/>
-      <param pos="0" name="os.device" value="iLO"/>
+      <param pos="0" name="os.product" value="iLO"/>
+      <param pos="0" name="os.device" value="Lights Out Management"/>
       <param pos="1" name="os.version"/>
    </fingerprint>
 

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2701,34 +2701,34 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="0" name="os.device" value="Router"/>
       <param pos="0" name="os.family" value="Comware"/>
       <param pos="1" name="os.version"/>
-      <param pos="3" name="os.product"/>
+      <param pos="0" name="os.product" value="Comware"/>
       <param pos="3" name="hw.product"/>
       <param pos="2" name="os.version.version"/>
    </fingerprint>
 
   <fingerprint pattern="^HP Series Router (\S+) HP Comware Platform Software Comware Software Version ([^\s,]+)[,\s]\s*Release ([^,\s]+)?[,\s].*Copyright.*$">
       <description>HP Comware</description>
-      <example hw.product="A-MSR20-40" os.product="A-MSR20-40" os.version="5.20" os.version.version="2209P15">HP Series Router A-MSR20-40 HP Comware Platform Software Comware Software Version 5.20, Release 2209P15, Standard Copyright(c) 2010-2012 Hewlett-Packard Development Company, L.P.</example>
+      <example hw.product="A-MSR20-40" os.version="5.20" os.version.version="2209P15">HP Series Router A-MSR20-40 HP Comware Platform Software Comware Software Version 5.20, Release 2209P15, Standard Copyright(c) 2010-2012 Hewlett-Packard Development Company, L.P.</example>
       <example>HP Series Router A-MSR30-20 HP Comware Platform Software Comware Software Version 5.20, Release 2207P41, Standard Copyright(c) 2010 Hewlett-Packard Development Company, L.P.</example>
       <example>HP Series Router A-MSR900 HP Comware Platform Software Comware Software Version 5.20, Release 2207P41 Copyright(c) 2010 Hewlett-Packard Development Company, L.P.</example>
       <param pos="0" name="os.vendor" value="HP"/>
       <param pos="0" name="os.device" value="Router"/>
       <param pos="0" name="os.family" value="Comware"/>
       <param pos="2" name="os.version"/>
-      <param pos="1" name="os.product"/>
+      <param pos="0" name="os.product" value="Comware"/>
       <param pos="1" name="hw.product"/>
       <param pos="3" name="os.version.version"/>
    </fingerprint>
 
   <fingerprint pattern="^HP Series Router (\S+) HP Comware Platform Software Comware Software Version ([^,]+), (\S+) Copyright.*$">
       <description>HP Comware</description>
-      <example os.product="A-MSR20-40" hw.product="A-MSR20-40" os.version="5.20" os.version.version="T2207L16">HP Series Router A-MSR20-40 HP Comware Platform Software Comware Software Version 5.20, T2207L16 Copyright(c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+      <example hw.product="A-MSR20-40" os.version="5.20" os.version.version="T2207L16">HP Series Router A-MSR20-40 HP Comware Platform Software Comware Software Version 5.20, T2207L16 Copyright(c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
       <param pos="0" name="os.vendor" value="HP"/>
       <param pos="0" name="os.device" value="Router"/>
       <param pos="0" name="os.family" value="Comware"/>
       <param pos="2" name="os.version"/>
       <param pos="3" name="os.version.version"/>
-      <param pos="1" name="os.product"/>
+      <param pos="0" name="os.product" value="Comware"/>
       <param pos="1" name="hw.product"/>
    </fingerprint>
 
@@ -2749,7 +2749,7 @@ Copyright (c) 1995-2005 by Cisco Systems
       <param pos="0" name="os.device" value="Switch"/>
       <param pos="0" name="os.family" value="Comware"/>
       <param pos="1" name="os.version"/>
-      <param pos="3" name="os.product"/>
+      <param pos="0" name="os.product" value="Comware"/>
       <param pos="3" name="hw.product"/>
       <param pos="2" name="os.version.version"/>
    </fingerprint>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -813,6 +813,7 @@ fingerprint SSH servers.
       <param pos="0" name="service.product" value="SSH"/>
       <param pos="0" name="os.vendor" value="H3C"/>
       <param pos="0" name="os.device" value="Network"/>
+      <param pos="0" name="os.product" value="Comware"/>
       <param pos="0" name="os.family" value="Comware"/>
       <param pos="1" name="os.version"/>
     </fingerprint>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -825,10 +825,11 @@ fingerprint SSH servers.
       <param pos="0" name="os.product" value="Data ONTAP"/>
    </fingerprint>
 
-   <fingerprint pattern="^(\d\.\d+\.\d+) SSH Secure Shell OpenVMS V\d\.\d$">
-      <description>SSH for OpenVMS </description>
+   <fingerprint pattern="^(\d\.\d+\.\d+) SSH Secure Shell OpenVMS V\d+\.\d+$">
+      <description>SSH for OpenVMS</description>
+      <!-- The VX.Y at the end refers to TCP/IP Services for OpenVMS version -->
       <example service.component.version="3.2.0">3.2.0 SSH Secure Shell OpenVMS V5.5</example>
-      <!--V5.5 refers to TCP/IP Services for OpenVMS version -->
+      <example service.component.version="2.4.1">2.4.1 SSH Secure Shell OpenVMS V1.0</example>
       <param pos="1" name="service.component.version"/>
       <param pos="0" name="service.component.vendor" value="SSH Communication Security"/>
       <param pos="0" name="service.component.family" value="SSH Secure Shell"/>
@@ -839,6 +840,7 @@ fingerprint SSH servers.
       <param pos="0" name="os.vendor" value="HP"/>
       <param pos="0" name="os.device" value="General"/>
       <param pos="0" name="os.family" value="OpenVMS"/>
+      <param pos="0" name="os.product" value="OpenVMS"/>
       <param pos="0" name="os.certainty" value="0.75"/>
    </fingerprint>
 


### PR DESCRIPTION
It was reported that some fingerprints were missing the appropriate `os.product` and I corrected the two instances.  While here I also made the `os.device` for HP iLO more consistent with what is done elsewhere and similarly with Comware.

/CC @alynn71 