### PR TITLE
Improve Aspen and Oracle Containers HTTP fingerprints

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1781,6 +1781,14 @@
       <param pos="0" name="service.product" value="Oracle Application Server Containers"/>
       <param pos="0" name="service.family" value="Oracle"/>
       <param pos="1" name="service.version"/>
+    </fingerprint>
+
+   <fingerprint pattern="^Oracle Containers for J2EE$">
+      <example>Oracle Containers for J2EE</example>
+      <description>Oracle Application Server Containers for J2EE</description>
+      <param pos="0" name="service.vendor" value="Oracle"/>
+      <param pos="0" name="service.product" value="Oracle Application Server Containers"/>
+      <param pos="0" name="service.family" value="Oracle"/>
    </fingerprint>
 
    <fingerprint pattern="^Oracle Application Server/10g \(([\d.]+)\) Apache/([12][\d.]+)\s*(.*)$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3376,6 +3376,13 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
+   <fingerprint pattern="^Aspen/(\S+)">
+      <description>Aspen web server</description>
+      <example service.version="0.8">Aspen/0.8</example>
+      <param pos="0" name="service.product" value="Aspen"/>
+      <param pos="1" name="service.version"/>
+    </fingerprint>
+
    <fingerprint pattern="^Boa/([\d\.]+\S*)">
       <description>Boa web server</description>
       <example service.version="0.94.14rc21">Boa/0.94.14rc21</example>


### PR DESCRIPTION
Newer versions of Oracle containers use a slightly different format that at least in the one example I found does not include a version.  Aspen is a Python based HTTP server.