### PR TITLE
SMTP: sendmail.config => .config

### DIFF
--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -1256,8 +1256,8 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
-      <param pos="4" name="sendmail.vendor.version"/>
+      <param pos="3" name="config.version"/>
+      <param pos="4" name="vendor.version"/>
       <param pos="5" name="system.time"/>
    </fingerprint>
 
@@ -1275,7 +1275,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
+      <param pos="3" name="config.version"/>
       <param pos="4" name="system.time"/>
    </fingerprint>
 
@@ -1293,7 +1293,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
+      <param pos="3" name="config.version"/>
       <param pos="4" name="system.time"/>
    </fingerprint>
 
@@ -1311,8 +1311,8 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
-      <param pos="4" name="sendmail.vendor.version"/>
+      <param pos="3" name="config.version"/>
+      <param pos="4" name="vendor.version"/>
       <param pos="5" name="system.time"/>
    </fingerprint>
 
@@ -1330,8 +1330,8 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
-      <param pos="4" name="sendmail.vendor.version"/>
+      <param pos="3" name="config.version"/>
+      <param pos="4" name="vendor.version"/>
       <param pos="5" name="system.time"/>
    </fingerprint>
 
@@ -1366,7 +1366,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
+      <param pos="3" name="config.version"/>
       <param pos="4" name="system.time"/>
    </fingerprint>
 
@@ -1383,7 +1383,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
+      <param pos="3" name="config.version"/>
       <param pos="4" name="system.time"/>
    </fingerprint>
 
@@ -1404,7 +1404,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="2" name="metainfo.version"/>
       <param pos="3" name="metainfo.version.version"/>
       <param pos="4" name="service.version"/>
-      <param pos="5" name="sendmail.config.version"/>
+      <param pos="5" name="config.version"/>
       <param pos="6" name="system.time"/>
   </fingerprint>
 
@@ -1418,7 +1418,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
+      <param pos="3" name="config.version"/>
       <param pos="4" name="system.time"/>
    </fingerprint>
 
@@ -1426,16 +1426,16 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <description>
         sendmail where neither daemon nor config file are patched, with and without timezone
       </description>
-      <example host.name="example.com" service.version="8.8.8" sendmail.config.version="8.8.9">example.com ESMTP Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
-      <example host.name="example.com" service.version="8.8.8" sendmail.config.version="8.8.9">example.com ESMTP blah Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
-      <example host.name="example.com" service.version="8.10.2" sendmail.config.version="8.10.3">example.com ESMTP Sendmail 8.10.2/8.10.3; Mon, 10 Sep 2001 08:37:14 -0400</example>
-      <example host.name="example.com" service.version="8.13.8" sendmail.config.version="8.13.9">example.com ESMTP foo-MTA Sendmail 8.13.8/8.13.9; Mon, 18 Apr 2011 08:52:38 -0700</example>
+      <example host.name="example.com" service.version="8.8.8" config.version="8.8.9">example.com ESMTP Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
+      <example host.name="example.com" service.version="8.8.8" config.version="8.8.9">example.com ESMTP blah Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
+      <example host.name="example.com" service.version="8.10.2" config.version="8.10.3">example.com ESMTP Sendmail 8.10.2/8.10.3; Mon, 10 Sep 2001 08:37:14 -0400</example>
+      <example host.name="example.com" service.version="8.13.8" config.version="8.13.9">example.com ESMTP foo-MTA Sendmail 8.13.8/8.13.9; Mon, 18 Apr 2011 08:52:38 -0700</example>
       <param pos="0" name="service.family" value="Sendmail"/>
       <param pos="0" name="service.product" value="Sendmail"/>
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
+      <param pos="3" name="config.version"/>
       <param pos="4" name="system.time"/>
    </fingerprint>
 
@@ -1508,7 +1508,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="service.family" value="Sendmail"/>
       <param pos="0" name="service.product" value="Sendmail"/>
       <param pos="1" name="service.version"/>
-      <param pos="2" name="sendmail.config.version"/>
+      <param pos="2" name="config.version"/>
       <param pos="3" name="host.name"/>
    </fingerprint>
 
@@ -1550,7 +1550,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
       <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss zzz"/>
       <param pos="1" name="host.name"/>
       <param pos="2" name="service.version"/>
-      <param pos="3" name="sendmail.config.version"/>
+      <param pos="3" name="config.version"/>
       <param pos="4" name="system.time"/>
    </fingerprint>
 


### PR DESCRIPTION
Hi all, I found there has some unnecessary field in `smtp_banners.xml`.

For example, each `sendmail.config.xxx` in `smtp_banners.xml` has same `service.product`: `Sendmail`.

Can we omit the prefix `sendmail.` ?