### PR TITLE
Update PHP regex to work with ZendServer string (X-POWERED-BY header)

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1766,11 +1766,18 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^PHP/(\S+)(?:\s.+)?$">
+   <fingerprint pattern="^PHP/(\S+)$">
       <example service.component.version="4.4.2-1build1">PHP/4.4.2-1build1</example>
       <example service.component.version="5.1.2">PHP/5.1.2</example>
-      <example service.component.version="5.3.14">PHP/5.3.14 ZendServer/5.0</example>
       <description>PHP</description>
+      <param pos="0" name="service.component.product" value="PHP"/>
+      <param pos="1" name="service.component.version"/>
+   </fingerprint>
+
+   <!-- TODO: Capture ZendServer version in fingerprint -->
+   <fingerprint pattern="^PHP/(\S+)\s+ZendServer/\S+$">
+      <example service.component.version="5.3.14">PHP/5.3.14 ZendServer/5.0</example>
+      <description>PHP with ZendServer</description>
       <param pos="0" name="service.component.product" value="PHP"/>
       <param pos="1" name="service.component.version"/>
    </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1766,9 +1766,10 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^PHP/(\S+)$">
-      <example>PHP/4.4.2-1build1</example>
-      <example>PHP/5.1.2</example>
+   <fingerprint pattern="^PHP/(\S+)(\s.+)?$">
+      <example service.component.version="4.4.2-1build1">PHP/4.4.2-1build1</example>
+      <example service.component.version="5.1.2">PHP/5.1.2</example>
+      <example service.component.version="5.3.14">PHP/5.3.14 ZendServer/5.0</example>
       <description>PHP</description>
       <param pos="0" name="service.component.product" value="PHP"/>
       <param pos="1" name="service.component.version"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1766,7 +1766,7 @@
       <param pos="1" name="service.version"/>
    </fingerprint>
 
-   <fingerprint pattern="^PHP/(\S+)(\s.+)?$">
+   <fingerprint pattern="^PHP/(\S+)(?:\s.+)?$">
       <example service.component.version="4.4.2-1build1">PHP/4.4.2-1build1</example>
       <example service.component.version="5.1.2">PHP/5.1.2</example>
       <example service.component.version="5.3.14">PHP/5.3.14 ZendServer/5.0</example>


### PR DESCRIPTION
Based on the header `X-POWERED-BY: PHP/5.3.14 ZendServer/5.0`

I don't know what else besides ZendServer could appear in these headers. I also didn't investigate the difficulty (or possibility) of also capturing the ZendServer name and version at the same time as PHP in this fingerprint. I did not see anything that could conflict on this, but I didn't look very hard either. It might be worth looking through scans.io or Sonar data to see if this could be further improved for other situations.

Tests:
- [x] Ran `bin/recog_verify xml/http_servers.xml` and passed
- [x] Ran `bin/recog_match xml/http_servers.xml` and used STDIN to test some examples:
```
$ bin/recog_match -f d -c xml/http_servers.xml
PHP/5.3.14 ZendServer/5.0
MATCH: {"matched"=>"PHP", "service.component.product"=>"PHP", "service.component.version"=>"5.3.14", "data"=>"PHP/5.3.14 ZendServer/5.0"}
PHP/4.4.2-1build1
MATCH: {"matched"=>"PHP", "service.component.product"=>"PHP", "service.component.version"=>"4.4.2-1build1", "data"=>"PHP/4.4.2-1build1"}
```