### PR TITLE
Enable use of Travis-CI's container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 cache: bundler
 rvm:
   - 2.1.5


### PR DESCRIPTION
This may improve performance for tests/builds on Travis-CI. Faster build starts and better caching of dependencies are the high points of this change. I don't believe Recog requires anything that is restricted in the container environment so this should Just Work (:tm:).

See http://docs.travis-ci.com/user/migrating-from-legacy/ for more info.