### PR TITLE
Split out SMB Native LM fingerprints

### DIFF
--- a/spec/data/smb_native_os.txt
+++ b/spec/data/smb_native_os.txt
@@ -23,9 +23,3 @@ Windows 7 Starter 7601 Service Pack 1
 Windows 7 Home Premium 7600
 Windows 7 Enterprise 7601 Service Pack 1
 Windows 7 Enterprise 7600
-Samba 3.6.9-151.el6_4.1
-Samba 3.6.6
-Samba 3.6.3
-Samba 3.0.32-0.2-2210-SUSE-SL10.3
-Samba 3.0.28a
-Samba 3.0.24

--- a/spec/lib/recog/nizer_spec.rb
+++ b/spec/lib/recog/nizer_spec.rb
@@ -22,10 +22,6 @@ describe Recog::Nizer do
           if data =~ /^Windows/
             expect(match_result['os.product']).to match(/^Windows/)
           end
-
-          if data =~ /^Samba/
-            expect(match_result['service.product']).to match(/^Samba/)
-          end
         end
 
       end

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SMB fingerprints obtained from the Native LM (LAN manager) field of SMB
+  negotations
+-->
+<fingerprints matches="smb.native_lm">
+  <!-- Mac OS X -->
+  <fingerprint pattern="^Samba (3\.0\.28a-apple)$">
+    <description>Samba on OS X 10.6</description>
+    <example service.version="3.0.28a-apple">Samba 3.0.28a-apple</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.version" value="10.6"/>
+    <param pos="0" name="service.vendor" value="Samba"/>
+    <param pos="0" name="service.product" value="Samba"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Samba (3\.0\.25b-apple)$">
+    <description>Samba on OS X 10.5</description>
+    <example service.version="3.0.25b-apple">Samba 3.0.25b-apple</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.version" value="10.5"/>
+    <param pos="0" name="service.vendor" value="Samba"/>
+    <param pos="0" name="service.product" value="Samba"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <!-- TODO: Detect vendor, distribution, and package versions -->
+  <fingerprint pattern="^Samba (\d\.\d+.\d+\w*)">
+    <description>Samba</description>
+    <example>Samba 3.0.24</example>
+    <example>Samba 3.0.28a</example>
+    <example>Samba 3.0.32-0.2-2210-SUSE-SL10.3</example>
+    <example>Samba 3.6.3</example>
+    <example>Samba 3.6.6</example>
+    <example>Samba 3.6.9-151.el6_4.1</example>
+    <param pos="0" name="service.vendor" value="Samba"/>
+    <param pos="0" name="service.product" value="Samba"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+</fingerprints>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  SMB Native OS Fingerprints
+  SMB fingerprints obtained from the Native OS field of SMB negotations
 -->
 <fingerprints matches="smb.native_os">
   <fingerprint pattern="^(Windows NT \d\.\d+)$">
@@ -341,44 +341,6 @@
     <param pos="0" name="os.product" value="Windows 10"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
-  </fingerprint>
-  <!-- Mac OS X -->
-  <fingerprint pattern="^Samba (3\.0\.28a-apple)$">
-    <description>Samba on OS X 10.6</description>
-    <example service.version="3.0.28a-apple">Samba 3.0.28a-apple</example>
-    <param pos="0" name="os.vendor" value="Apple"/>
-    <param pos="0" name="os.family" value="Mac OS X"/>
-    <param pos="0" name="os.product" value="Mac OS X"/>
-    <param pos="0" name="os.device" value="General"/>
-    <param pos="0" name="os.version" value="10.6"/>
-    <param pos="0" name="service.vendor" value="Samba"/>
-    <param pos="0" name="service.product" value="Samba"/>
-    <param pos="1" name="service.version"/>
-  </fingerprint>
-  <fingerprint pattern="^Samba (3\.0\.25b-apple)$">
-    <description>Samba on OS X 10.5</description>
-    <example service.version="3.0.25b-apple">Samba 3.0.25b-apple</example>
-    <param pos="0" name="os.vendor" value="Apple"/>
-    <param pos="0" name="os.family" value="Mac OS X"/>
-    <param pos="0" name="os.product" value="Mac OS X"/>
-    <param pos="0" name="os.device" value="General"/>
-    <param pos="0" name="os.version" value="10.5"/>
-    <param pos="0" name="service.vendor" value="Samba"/>
-    <param pos="0" name="service.product" value="Samba"/>
-    <param pos="1" name="service.version"/>
-  </fingerprint>
-  <!-- TODO: Detect vendor, distribution, and package versions -->
-  <fingerprint pattern="^Samba (\d\.\d+.\d+\w*)">
-    <description>Samba</description>
-    <example>Samba 3.0.24</example>
-    <example>Samba 3.0.28a</example>
-    <example>Samba 3.0.32-0.2-2210-SUSE-SL10.3</example>
-    <example>Samba 3.6.3</example>
-    <example>Samba 3.6.6</example>
-    <example>Samba 3.6.9-151.el6_4.1</example>
-    <param pos="0" name="service.vendor" value="Samba"/>
-    <param pos="0" name="service.product" value="Samba"/>
-    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^VxWorks">
     <description>VxWorks</description>


### PR DESCRIPTION
Fixes #96

Eventually all of the fingerprints in smb_native_os will need to have their counterparts added in smb_native_lm.

Specs pass, tested by locally releasing a newer version of recog with this new fingerprint in it, then using that new version of recog in a local fix for https://github.com/rapid7/metasploit-framework/issues/6021 and saw it also using the SMB Native LM fields for fingerprinting.  