### PR TITLE
Adding support for modern Nexpose fingerprint matching

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2813,7 +2813,7 @@
     <description>Rapid7 NSC</description>
     <example>NSC/0.6.4 (JVM)</example>
     <param pos="0" name="service.vendor" value="Rapid7"/>
-    <param pos="0" name="service.product" value="NeXpose"/>
+    <param pos="0" name="service.product" value="Nexpose"/>
   </fingerprint>
   <fingerprint pattern="^Security Console$">
     <description>Rapid7 Nexpose Security Console</description>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2815,6 +2815,12 @@
     <param pos="0" name="service.vendor" value="Rapid7"/>
     <param pos="0" name="service.product" value="NeXpose"/>
   </fingerprint>
+  <fingerprint pattern="^Security Console$">
+    <description>Rapid7 Nexpose Security Console</description>
+    <example>Security Console</example>
+    <param pos="0" name="service.vendor" value="Rapid7"/>
+    <param pos="0" name="service.product" value="Nexpose"/>
+  </fingerprint>
   <fingerprint pattern="^Polycom SoundPoint IP Telephone HTTPd$">
     <description>Polycom Soundpoint IP Telephone</description>
     <example>Polycom SoundPoint IP Telephone HTTPd</example>


### PR DESCRIPTION
Adding an additional fingerprint pattern for the Nexpose Security Console that uses a new pattern to be changed in an upcoming release of Nexpose. This pattern is version-less.