### PR TITLE
Changes to MySQL banners for Nexpose support

### DIFF
--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -62,7 +62,6 @@
     <param pos="0" name="service.edition" value="Community Edition"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?(?:-gamma)?(?:-max)?-nt(?:-max)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL with Named Pipes (Windows)</description>
@@ -77,7 +76,6 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-cll$" flags="REG_ICASE">
     <description>Oracle MySQL hosted on CPanel</description>
@@ -87,7 +85,6 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-community-cll$" flags="REG_ICASE">
     <description>Oracle MySQL Community hosted on CPanel</description>
@@ -99,7 +96,6 @@
     <param pos="0" name="service.edition" value="Community Edition"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-cll-lve$" flags="REG_ICASE">
     <description>Oracle MySQL on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
@@ -111,7 +107,6 @@
     <param pos="0" name="os.vendor" value="CloudLinux"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-community-cll-lve$" flags="REG_ICASE">
     <description>Oracle MySQL Community on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
@@ -124,7 +119,6 @@
     <param pos="0" name="os.vendor" value="CloudLinux"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})-0ubuntu0.(\d\d\.\d\d)[.\d]*(?:-log)?$">
     <description>Oracle MySQL on Ubuntu</description>
@@ -138,8 +132,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})-(?:Debian_)?\dubuntu(\d{1,2}\.\d\d)[.\d]*(?:-log)?$">
     <description>Oracle MySQL on Ubuntu</description>
@@ -153,8 +145,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})[-_](?:Ubuntu[_-])?(?:Debian[_-])?\d{1,2}(?:~exp1)?ubuntu\d{1,2}(?:\.\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL on Ubuntu where trailing digits aren't OS version</description>
@@ -172,7 +162,6 @@
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+deb\.sury\.org~precise\+\d(?:-log)?$">
     <description>Oracle MySQL on Ubuntu 12.04 (Precise Pangolin) packaged by deb.sury.org</description>
@@ -186,8 +175,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+deb\.sury\.org~trusty\+\d(?:-log)?$">
     <description>Oracle MySQL on Ubuntu 14.04 (Trusty Tahr) packaged by deb.sury.org</description>
@@ -201,8 +188,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+(?:squeeze\d|deb6u1)(?:-log)?$">
     <description>Oracle MySQL on Debian 6.0 (squeeze)</description>
@@ -217,8 +202,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+wheezy\d(?:-log)?$">
     <description>Oracle MySQL on Debian 7.0 (wheezy)</description>
@@ -232,8 +215,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+lenny\d*(?:\+spu\d)?(?:-log)?$">
     <description>Oracle MySQL on Debian 5.0 (lenny)</description>
@@ -248,8 +229,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d~bpo50" flags="REG_ICASE">
     <description>Oracle MySQL Backport on Debian 5.0 (lenny)</description>
@@ -262,8 +241,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}).*~?bpo40(?:\+\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Backport on Debian 4.0 (etch)</description>
@@ -276,8 +253,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="4.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Debian.*~?bpo31(?:\+\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Backport on Debian 3.1 (sarge)</description>
@@ -290,8 +265,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.1"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- FIXFIX -->
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Debian_\d~?bpo\.?\d" flags="REG_ICASE">
@@ -305,7 +278,6 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})-Debian_\d?etch\d*(?:-log)?$">
     <description>Oracle MySQL on Debian 4.0 (etch)</description>
@@ -319,8 +291,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="4.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})[_-]Debian[_-]\d{1,2}sarge\d*(?:-log)?$">
     <description>Oracle MySQL on Debian 3.1 (sarge)</description>
@@ -334,8 +304,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.1"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})[_-]Debian[_-]\d{1,2}woody\d*(?:-log)?$">
     <description>Oracle MySQL on Debian 3.0 (woody)</description>
@@ -348,8 +316,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:[_-]\d{8})?[_-]Debian[_-]\d{1,2}(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL on Debian (Generic match)</description>
@@ -362,7 +328,6 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})(?:-rc)?[_-]Debian[_-]\d{1,2}~ppa\d(?:-log)?$">
     <description>Oracle MySQL on Debian (Generic match) using PPA</description>
@@ -374,7 +339,6 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-\d{1,2})?(?:-Debian)?(?:-Dotdeb)?[-~_\d\.]+dotdeb\.\d(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL packaged by DotDeb.org</description>
@@ -389,7 +353,6 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-rc)?-standard(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Standard Edition</description>
@@ -413,7 +376,6 @@
     <param pos="0" name="service.edition" value="Commercial Edition"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-pro(?:-gpl)?(?:-cert)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Commercial Edition</description>
@@ -445,7 +407,6 @@
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-rc)?-enterprise" flags="REG_ICASE">
     <description>Oracle MySQL Enterprise Edition</description>
@@ -499,7 +460,6 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d{1,2}-rel\d\d\.\d{1,2}(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) match w/ 'rel' variant 1</description>
@@ -510,7 +470,6 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-(?:rc)?percona" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) w/ percona in banner</description>
@@ -523,7 +482,6 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d{1,2}(?:-\d\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) (just version number match)</description>
@@ -536,7 +494,6 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-rc\d\d\.\d(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) match w/ 'rc'</description>
@@ -548,7 +505,6 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.trusty(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 14.04 (Trusty Tahr)</description>
@@ -561,8 +517,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.saucy(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 13.10 (Saucy Salamander)</description>
@@ -575,8 +529,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.quantal(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 12.10 (Quantal Quetzal)</description>
@@ -589,8 +541,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.precise(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 12.04 LTS (Precise Pangolin)</description>
@@ -603,8 +553,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.wheezy(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Debian 7.0 (wheezy)</description>
@@ -617,8 +565,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.squeeze(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Debian 6.0 (squeeze)</description>
@@ -631,8 +577,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-nmm" flags="REG_ICASE">
     <description>Oracle MySQL (nmm variant)</description>
@@ -684,7 +628,6 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})[\.-]d\d{1,2}-ourdelta\d{0,2}(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL tweaked and packaged by OurDelta</description>
@@ -696,7 +639,6 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Alibaba(?:-rds)?-\d{6}(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Alibaba build? distro? Aliyun.com hosted?</description>
@@ -718,7 +660,6 @@
     <param pos="0" name="os.vendor" value="CloudLinux"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~wheezy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian 7.0 (wheezy)</description>
@@ -733,8 +674,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~squeeze(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian 6.0 (squeeze)</description>
@@ -748,8 +687,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-MariaDB.+~lenny(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian 5.0 (lenny)</description>
@@ -762,8 +699,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~sid(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian Unstable/No version  (sid)</description>
@@ -775,7 +710,6 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,4})-MariaDB-\dubuntu\d\.(\d{1,2}\.\d\d)[\.\d]*(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu</description>
@@ -788,8 +722,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~utopic(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 14.10 (Utopic Unicorn)</description>
@@ -802,8 +734,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.10"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~trusty(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 14.04 (Trusty Tahr)</description>
@@ -816,8 +746,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~saucy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 13.10 (Saucy Salamander)</description>
@@ -830,8 +758,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~raring(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 13.04 (Raring Ringtail)</description>
@@ -844,8 +770,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~quantal(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 12.10 (Quantal Quetzal)</description>
@@ -859,8 +783,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~precise(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 12.04 LTS (Precise Pangolin)</description>
@@ -874,8 +796,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~lucid(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 10.04 (Lucid Lynx)</description>
@@ -888,8 +808,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~hardy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 8.04 LTS (Hardy Heron)</description>
@@ -902,8 +820,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~trusty-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 14.04 (Trusty Tahr)</description>
@@ -917,8 +833,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~saucy-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 13.10 (Saucy Salamander)</description>
@@ -932,8 +846,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~precise-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 12.04 (Precise Pangolin)</description>
@@ -947,8 +859,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~lucid-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 10.04 TLS (Lucid Lynx)</description>
@@ -962,8 +872,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.04"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~wheezy-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Debian 7.0 (wheezy)</description>
@@ -977,8 +885,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~squeeze-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Debian 6.0 (squeeze)</description>
@@ -992,8 +898,6 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.certainty" value="0.80"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~sid-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Debian Unstable/No version (sid)</description>
@@ -1006,7 +910,6 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster</description>
@@ -1049,7 +952,6 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha(?:-community)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL with defunct Falcon Storage Engine</description>
@@ -1096,7 +998,6 @@
     <param pos="0" name="os.vendor" value="TLD"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Debian_\d\.infrant\d$" flags="REG_ICASE">
     <description>Oracle MySQL on a Netgear ReadyNAS</description>
@@ -1208,7 +1109,6 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}) Complete MySQL by Server Logistics(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL packaged by Server Logistics, Mac specific</description>
@@ -1220,6 +1120,5 @@
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
 </fingerprints>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -707,10 +707,10 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB-cll-lve$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB-cll-lve$">
     <description>MariaDB MariaDB on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-cll-lve</example>
-    <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-cll-lve</example>
+    <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-cll-lve</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -720,11 +720,11 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~wheezy(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~wheezy(?:-log)?$">
     <description>MariaDB MariaDB on Debian 7.0 (wheezy)</description>
     <example service.version="5.5.37">5.5.37-MariaDB-1~wheezy-log</example>
     <example service.version="10.0.11">10.0.11-MariaDB-1~wheezy-log</example>
-    <example service.version="5.5.5">5.5.5-10.0.14-MariaDB-1~wheezy-log</example>
+    <example service.version="10.0.14">5.5.5-10.0.14-MariaDB-1~wheezy-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -736,10 +736,10 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~squeeze(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~squeeze(?:-log)?$">
     <description>MariaDB MariaDB on Debian 6.0 (squeeze)</description>
     <example service.version="5.5.31">5.5.31-MariaDB-1~squeeze-log</example>
-    <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-1~squeeze-log</example>
+    <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-1~squeeze-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -765,9 +765,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~sid(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~sid(?:-log)?$">
     <description>MariaDB MariaDB on Debian Unstable/No version  (sid)</description>
-    <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~sid</example>
+    <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~sid</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -791,9 +791,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~utopic(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~utopic(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 14.10 (Utopic Unicorn)</description>
-    <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~utopic-log</example>
+    <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~utopic-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -805,9 +805,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~trusty(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~trusty(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 14.04 (Trusty Tahr)</description>
-    <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-1~trusty</example>
+    <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-1~trusty</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -819,7 +819,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~saucy(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~saucy(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 13.10 (Saucy Salamander)</description>
     <example service.version="5.5.39">5.5.39-MariaDB-1~saucy-log</example>
     <param pos="1" name="service.version"/>
@@ -833,7 +833,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~raring(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~raring(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 13.04 (Raring Ringtail)</description>
     <example service.version="5.5.32">5.5.32-MariaDB-1~raring-log</example>
     <param pos="1" name="service.version"/>
@@ -847,9 +847,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~quantal(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~quantal(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 12.10 (Quantal Quetzal)</description>
-    <example service.version="5.5.5">5.5.5-10.0.12-MariaDB-1~quantal-log</example>
+    <example service.version="10.0.12">5.5.5-10.0.12-MariaDB-1~quantal-log</example>
     <example service.version="5.5.38">5.5.38-MariaDB-1~quantal-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
@@ -862,10 +862,10 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~precise(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~precise(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 12.04 LTS (Precise Pangolin)</description>
     <example service.version="5.5.41">5.5.41-MariaDB-1~precise-log</example>
-    <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~precise-log</example>
+    <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~precise-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -877,7 +877,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~lucid(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~lucid(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 10.04 (Lucid Lynx)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-1~lucid-log</example>
     <param pos="1" name="service.version"/>
@@ -891,7 +891,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~hardy(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~hardy(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 8.04 LTS (Hardy Heron)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-mariadb122~hardy-log</example>
     <param pos="1" name="service.version"/>
@@ -905,9 +905,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-[Mm]ariaDB.+~trusty-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-[Mm]ariaDB.+~trusty-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 14.04 (Trusty Tahr)</description>
-    <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~trusty-wsrep-log</example>
+    <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~trusty-wsrep-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -920,9 +920,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~saucy-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~saucy-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 13.10 (Saucy Salamander)</description>
-    <example service.version="5.5.5">5.5.5-10.0.10-MariaDB-1~saucy-wsrep-log</example>
+    <example service.version="10.0.10">5.5.5-10.0.10-MariaDB-1~saucy-wsrep-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -935,9 +935,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~precise-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~precise-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 12.04 (Precise Pangolin)</description>
-    <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~precise-wsrep</example>
+    <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~precise-wsrep</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -950,7 +950,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~lucid-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~lucid-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 10.04 TLS (Lucid Lynx)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-1~lucid-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -965,9 +965,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~wheezy-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~wheezy-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Debian 7.0 (wheezy)</description>
-    <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~wheezy-wsrep-log</example>
+    <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~wheezy-wsrep-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -980,9 +980,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~squeeze-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~squeeze-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Debian 6.0 (squeeze)</description>
-    <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~squeeze-wsrep</example>
+    <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~squeeze-wsrep</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -995,9 +995,9 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~sid-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~sid-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Debian Unstable/No version (sid)</description>
-    <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~sid-wsrep</example>
+    <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~sid-wsrep</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1008,22 +1008,22 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-[Mm]ariaDB-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-[Mm]ariaDB-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster</description>
-    <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-wsrep</example>
+    <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-wsrep</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Galera Cluster"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-[Mm]aria(?:DB)?[-\d]*(?:-debug)?(?:-ga)?(?:-beta)?(?:-mariadb)?[~\.\d]*(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-[Mm]aria(?:DB)?[-\d]*(?:-debug)?(?:-ga)?(?:-beta)?(?:-mariadb)?[~\.\d]*(?:-log)?$">
     <description>MariaDB MariaDB</description>
     <example service.version="5.1.39">5.1.39-maria-beta</example>
     <example service.version="5.3.5">5.3.5-MariaDB-ga-mariadb113-log</example>
     <example service.version="5.5.24">5.5.24-MariaDB-mariadb1~0.1</example>
     <example service.version="10.0.1">10.0.1-MariaDB-log</example>
-    <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-log</example>
+    <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-log</example>
     <example service.version="5.5.30">5.5.30-MariaDB-debug</example>
     <example service.version="5.2.10">5.2.10-MariaDB-mariadb107</example>
     <param pos="1" name="service.version"/>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -11,7 +11,7 @@
      from this version.
 -->
 <fingerprints matches="mysql.banners">
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?[Mm]ax)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?[Mm]ax)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$">
     <description>Oracle MySQL (common)</description>
     <example service.version="4.1.20">4.1.20</example>
     <example service.version="5.5.23-55">5.5.23-55</example>
@@ -32,7 +32,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-m\d)?(?:-rc)?(?:-alpha)?(?:-beta)?-[Cc]ommunity(?:-max)?(?:-debug)?(?:-log)?(?:-debug)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-m\d)?(?:-rc)?(?:-alpha)?(?:-beta)?-[Cc]ommunity(?:-max)?(?:-debug)?(?:-log)?(?:-debug)?$">
     <description>Oracle MySQL Community Edition</description>
     <example service.version="5.0.95">5.0.95-community-log</example>
     <example service.version="5.0.37">5.0.37-Community-log</example>
@@ -47,7 +47,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Community Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?-[Cc]ommunity(?:-max)?-nt(?:-log)?(?:-debug)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?-[Cc]ommunity(?:-max)?-nt(?:-log)?(?:-debug)?(?:-log)?$">
     <description>Oracle MySQL Community Edition with Named Pipes (Windows)</description>
     <example service.version="4.1.22">4.1.22-community-max-nt</example>
     <example service.version="5.0.88">5.0.88-community-nt</example>
@@ -62,8 +62,9 @@
     <param pos="0" name="service.edition" value="Community Edition"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?(?:-gamma)?(?:-max)?-nt(?:-max)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?(?:-gamma)?(?:-max)?-nt(?:-max)?(?:-log)?$">
     <description>Oracle MySQL with Named Pipes (Windows)</description>
     <example service.version="5.0.18">5.0.18-nt</example>
     <example service.version="4.1.12a">4.1.12a-nt-max-log</example>
@@ -76,8 +77,9 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-cll$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-cll$">
     <description>Oracle MySQL hosted on CPanel</description>
     <example service.version="5.5.25a">5.5.25a-cll</example>
     <param pos="1" name="service.version"/>
@@ -85,8 +87,9 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-community-cll$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-community-cll$">
     <description>Oracle MySQL Community hosted on CPanel</description>
     <example service.version="5.0.91">5.0.91-community-cll</example>
     <param pos="1" name="service.version"/>
@@ -96,8 +99,9 @@
     <param pos="0" name="service.edition" value="Community Edition"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-cll-lve$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-cll-lve$">
     <description>Oracle MySQL on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.1.66">5.1.66-cll-lve</example>
     <param pos="1" name="service.version"/>
@@ -107,8 +111,9 @@
     <param pos="0" name="os.vendor" value="CloudLinux"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-community-cll-lve$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-community-cll-lve$">
     <description>Oracle MySQL Community on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.0.95">5.0.95-community-cll-lve</example>
     <param pos="1" name="service.version"/>
@@ -119,6 +124,7 @@
     <param pos="0" name="os.vendor" value="CloudLinux"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})-0ubuntu0.(\d\d\.\d\d)[.\d]*(?:-log)?$">
     <description>Oracle MySQL on Ubuntu</description>
@@ -132,6 +138,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})-(?:Debian_)?\dubuntu(\d{1,2}\.\d\d)[.\d]*(?:-log)?$">
     <description>Oracle MySQL on Ubuntu</description>
@@ -145,8 +153,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})[-_](?:Ubuntu[_-])?(?:Debian[_-])?\d{1,2}(?:~exp1)?ubuntu\d{1,2}(?:\.\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})[-_](?:Ubuntu[_-])?(?:Debian[_-])?\d{1,2}(?:~exp1)?ubuntu\d{1,2}(?:\.\d)?(?:-log)?$">
     <description>Oracle MySQL on Ubuntu where trailing digits aren't OS version</description>
     <example service.version="5.0.45">5.0.45-Debian_1ubuntu3.4</example>
     <example service.version="5.0.51a">5.0.51a-3ubuntu5.5</example>
@@ -162,6 +172,7 @@
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+deb\.sury\.org~precise\+\d(?:-log)?$">
     <description>Oracle MySQL on Ubuntu 12.04 (Precise Pangolin) packaged by deb.sury.org</description>
@@ -175,6 +186,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+deb\.sury\.org~trusty\+\d(?:-log)?$">
     <description>Oracle MySQL on Ubuntu 14.04 (Trusty Tahr) packaged by deb.sury.org</description>
@@ -188,6 +201,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+(?:squeeze\d|deb6u1)(?:-log)?$">
     <description>Oracle MySQL on Debian 6.0 (squeeze)</description>
@@ -202,6 +217,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+wheezy\d(?:-log)?$">
     <description>Oracle MySQL on Debian 7.0 (wheezy)</description>
@@ -215,6 +232,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[^+]+)\+lenny\d*(?:\+spu\d)?(?:-log)?$">
     <description>Oracle MySQL on Debian 5.0 (lenny)</description>
@@ -229,8 +248,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d~bpo50">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d~bpo50">
     <description>Oracle MySQL Backport on Debian 5.0 (lenny)</description>
     <example service.version="5.1.49">5.1.49-3~bpo50+1-log</example>
     <param pos="1" name="service.version"/>
@@ -241,8 +262,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}).*~?bpo40(?:\+\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}).*~?bpo40(?:\+\d)?(?:-log)?$">
     <description>Oracle MySQL Backport on Debian 4.0 (etch)</description>
     <example service.version="5.0.51a">5.0.51a-24+lenny2~bpo40+1-log</example>
     <param pos="1" name="service.version"/>
@@ -253,8 +276,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="4.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-Debian.*~?bpo31(?:\+\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Debian.*~?bpo31(?:\+\d)?(?:-log)?$">
     <description>Oracle MySQL Backport on Debian 3.1 (sarge)</description>
     <example service.version="5.0.32">5.0.32-Debian_7etch5~bpo31+1-log</example>
     <param pos="1" name="service.version"/>
@@ -265,9 +290,11 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.1"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- FIXFIX -->
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-Debian_\d~?bpo\.?\d">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Debian_\d~?bpo\.?\d">
     <description>Oracle MySQL Backport on Debian</description>
     <example service.version="5.0.22">5.0.22-Debian_2bpo1</example>
     <example service.version="5.0.32">5.0.32-Debian_7~bpo.1-log</example>
@@ -278,6 +305,7 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})-Debian_\d?etch\d*(?:-log)?$">
     <description>Oracle MySQL on Debian 4.0 (etch)</description>
@@ -291,6 +319,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="4.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})[_-]Debian[_-]\d{1,2}sarge\d*(?:-log)?$">
     <description>Oracle MySQL on Debian 3.1 (sarge)</description>
@@ -304,6 +334,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.1"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})[_-]Debian[_-]\d{1,2}woody\d*(?:-log)?$">
     <description>Oracle MySQL on Debian 3.0 (woody)</description>
@@ -316,8 +348,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:[_-]\d{8})?[_-]Debian[_-]\d{1,2}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:[_-]\d{8})?[_-]Debian[_-]\d{1,2}(?:-log)?$">
     <description>Oracle MySQL on Debian (Generic match)</description>
     <example service.version="4.0.23">4.0.23_Debian-3-log</example>
     <example service.version="4.0.31">4.0.31-20070605_Debian-7-log</example>
@@ -328,6 +362,7 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})(?:-rc)?[_-]Debian[_-]\d{1,2}~ppa\d(?:-log)?$">
     <description>Oracle MySQL on Debian (Generic match) using PPA</description>
@@ -339,8 +374,9 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2})?(?:-Debian)?(?:-Dotdeb)?[-~_\d\.]+dotdeb\.\d(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2})?(?:-Debian)?(?:-Dotdeb)?[-~_\d\.]+dotdeb\.\d(?:-log)?$">
     <description>Oracle MySQL packaged by DotDeb.org</description>
     <example service.version="5.1.54">5.1.54-0.dotdeb.0</example>
     <example service.version="5.1.58">5.1.58-1~dotdeb.0</example>
@@ -353,8 +389,9 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-rc)?-standard(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-rc)?-standard(?:-log)?$">
     <description>Oracle MySQL Standard Edition</description>
     <example service.version="5.0.13">5.0.13-rc-standard-log</example>
     <example service.version="5.0.37">5.0.37-standard</example>
@@ -365,7 +402,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Standard Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-pro(?:-gpl)?-nt(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-pro(?:-gpl)?-nt(?:-log)?$">
     <description>Oracle MySQL Commercial Edition with Named Pipes (Windows)</description>
     <example service.version="5.0.24">5.0.24-pro-nt</example>
     <example service.version="4.1.25">4.1.25-pro-gpl-nt-log</example>
@@ -376,8 +413,9 @@
     <param pos="0" name="service.edition" value="Commercial Edition"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-pro(?:-gpl)?(?:-cert)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-pro(?:-gpl)?(?:-cert)?(?:-log)?$">
     <description>Oracle MySQL Commercial Edition</description>
     <example service.version="4.1.23">4.1.23-pro-gpl-log</example>
     <example service.version="5.0.17c">5.0.17c-pro-gpl-cert</example>
@@ -387,7 +425,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Commercial Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}sp1)">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}sp1)">
     <description>Oracle MySQL Enterprise Edition</description>
     <example service.version="5.0.82sp1">5.0.82sp1</example>
     <example service.version="5.1.46sp1">5.1.46sp1-enterprise-gpl-advanced-log</example>
@@ -397,7 +435,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-enterprise-nt">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-enterprise-nt">
     <description>Oracle MySQL Enterprise Edition with Named Pipes (Windows)</description>
     <example service.version="5.0.84">5.0.84-enterprise-nt</example>
     <param pos="1" name="service.version"/>
@@ -407,8 +445,9 @@
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-rc)?-enterprise">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-rc)?-enterprise">
     <description>Oracle MySQL Enterprise Edition</description>
     <example service.version="5.1.26">5.1.26-rc-enterprise-gpl-log</example>
     <example service.version="5.5.27">5.5.27-enterprise-commercial-advanced-log</example>
@@ -418,7 +457,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}-ndb-\d\.\d{1,2}\.\h{1,3})">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-ndb-\d\.\d{1,2}\.[a-fA-F\d]{1,3})">
     <description>Oracle MySQL Cluster Edition</description>
     <example service.version="5.1.30-ndb-6.3.20">5.1.30-ndb-6.3.20-cluster-gpl-log</example>
     <example service.version="5.5.20-ndb-7.2.5">5.5.20-ndb-7.2.5-gpl</example>
@@ -428,7 +467,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Cluster Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-CLUSTERS?(?:-log)?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-CLUSTERS?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Cluster Edition</description>
     <example service.version="4.1.21">4.1.21-CLUSTERS</example>
     <example service.version="5.0.46">5.0.46-cluster</example>
@@ -438,7 +477,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Cluster Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-classic(?:-log)?">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-classic(?:-log)?">
     <description>Oracle MySQL Classic Edition</description>
     <example service.version="5.0.86">5.0.86-classic-log</example>
     <param pos="1" name="service.version"/>
@@ -449,7 +488,7 @@
   </fingerprint>
   <!-- Linux only - http://www.percona.com/services/mysql-support/supported-platforms -->
   <!-- Build list - http://www.percona.com/doc/percona-server/5.1/release-notes/release-notes_index.html -->
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}-?rel\d\d\.\d)(?:-log)?">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-?rel\d\d\.\d)(?:-log)?">
     <description>Percona Server (MySQL fork) match w/ 'rel'</description>
     <example service.version="5.1.57-rel12.8">5.1.57-rel12.8</example>
     <example service.version="5.1.60rel13.1">5.1.60rel13.1-log</example>
@@ -460,8 +499,9 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d{1,2}-rel\d\d\.\d{1,2}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d{1,2}-rel\d\d\.\d{1,2}(?:-log)?$">
     <description>Percona Server (MySQL fork) match w/ 'rel' variant 1</description>
     <example service.version="5.6.17">5.6.17-65.0-rel65.0</example>
     <param pos="1" name="service.version"/>
@@ -470,8 +510,9 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-(?:rc)?[Pp]ercona">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-(?:rc)?[Pp]ercona">
     <description>Percona Server (MySQL fork) w/ percona in banner</description>
     <example service.version="5.1.50">5.1.50-percona</example>
     <example service.version="5.5.27">5.5.27-percona-sure1-log</example>
@@ -482,8 +523,9 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d{1,2}(?:-\d\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d{1,2}(?:-\d\d)?(?:-log)?$">
     <description>Percona Server (MySQL fork) (just version number match)</description>
     <example service.version="5.1.73">5.1.73-14.12</example>
     <example service.version="5.6.20">5.6.20-68.0-56</example>
@@ -494,8 +536,9 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-rc\d\d\.\d(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-rc\d\d\.\d(?:-log)?$">
     <description>Percona Server (MySQL fork) match w/ 'rc'</description>
     <example service.version="5.6.13">5.6.13-rc60.6</example>
     <example service.version="5.6.13">5.6.13-rc61.0-log</example>
@@ -505,8 +548,9 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d-\d{3}\.trusty(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.trusty(?:-log)?$">
     <description>Percona Server (MySQL fork) on Ubuntu 14.04 (Trusty Tahr)</description>
     <example service.version="5.6.17">5.6.17-65.0-583.trusty</example>
     <param pos="1" name="service.version"/>
@@ -517,8 +561,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d-\d{3}\.saucy(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.saucy(?:-log)?$">
     <description>Percona Server (MySQL fork) on Ubuntu 13.10 (Saucy Salamander)</description>
     <example service.version="5.6.17">5.6.17-65.0-587.saucy</example>
     <param pos="1" name="service.version"/>
@@ -529,8 +575,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d-\d{3}\.quantal(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.quantal(?:-log)?$">
     <description>Percona Server (MySQL fork) on Ubuntu 12.10 (Quantal Quetzal)</description>
     <example service.version="5.6.16">5.6.16-64.2-569.quantal-log</example>
     <param pos="1" name="service.version"/>
@@ -541,8 +589,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d-\d{3}\.precise(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.precise(?:-log)?$">
     <description>Percona Server (MySQL fork) on Ubuntu 12.04 LTS (Precise Pangolin)</description>
     <example service.version="5.6.16">5.6.16-64.2-569.precise-log</example>
     <param pos="1" name="service.version"/>
@@ -553,8 +603,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d-\d{3}\.wheezy(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.wheezy(?:-log)?$">
     <description>Percona Server (MySQL fork) on Debian 7.0 (wheezy)</description>
     <example service.version="5.5.36">5.5.36-34.2-648.wheezy-log</example>
     <param pos="1" name="service.version"/>
@@ -565,8 +617,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d-\d{3}\.squeeze(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.squeeze(?:-log)?$">
     <description>Percona Server (MySQL fork) on Debian 6.0 (squeeze)</description>
     <example service.version="5.5.36">5.5.36-34.2-648.squeeze</example>
     <param pos="1" name="service.version"/>
@@ -577,8 +631,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-nmm">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-nmm">
     <description>Oracle MySQL (nmm variant)</description>
     <example service.version="4.0.27">4.0.27-nmm1-log</example>
     <example service.version="4.1.22">4.1.22-nmm-1-log</example>
@@ -587,7 +643,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-nightly-\d{8}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-nightly-\d{8}(?:-log)?$">
     <description>Oracle MySQL nightly build</description>
     <example service.version="3.23.59">3.23.59-nightly-20050301-log</example>
     <param pos="1" name="service.version"/>
@@ -595,7 +651,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-SERVER">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-SERVER">
     <description>Oracle MySQL (SERVER variant)</description>
     <example service.version="5.1.30">5.1.30-SERVER-104</example>
     <param pos="1" name="service.version"/>
@@ -603,7 +659,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-ISPrime">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-ISPrime">
     <description>Oracle MySQL (ISPrime variant)</description>
     <example service.version="4.0.15a">4.0.15a-ISPrime</example>
     <param pos="1" name="service.version"/>
@@ -611,7 +667,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-rc-\d\.\d{1,2}\.\h{1,3}">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-rc-\d\.\d{1,2}\.[a-fA-F\d]{1,3}">
     <description>Oracle MySQL possibly Debian specific</description>
     <example service.version="5.1.26">5.1.26-rc-5.1.26rc-log</example>
     <param pos="1" name="service.version"/>
@@ -619,7 +675,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-ius(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-ius(?:-log)?$">
     <description>Oracle MySQL packaged for RHEL/CentOS by IUS</description>
     <example service.version="5.1.66">5.1.66-ius-log</example>
     <param pos="1" name="service.version"/>
@@ -628,8 +684,9 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})[\.-]d\d{1,2}-ourdelta\d{0,2}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})[\.-]d\d{1,2}-ourdelta\d{0,2}(?:-log)?$">
     <description>Oracle MySQL tweaked and packaged by OurDelta</description>
     <example service.version="5.0.67">5.0.67.d7-ourdelta-log</example>
     <example service.version="5.0.87">5.0.87-d10-ourdelta65-log</example>
@@ -639,8 +696,9 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-Alibaba(?:-rds)?-\d{6}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Alibaba(?:-rds)?-\d{6}(?:-log)?$">
     <description>Oracle MySQL Alibaba build? distro? Aliyun.com hosted?</description>
     <example service.version="5.1.61">5.1.61-Alibaba-121011-log</example>
     <example service.version="5.1.61">5.1.61-Alibaba-rds-201404-log</example>
@@ -649,7 +707,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB-cll-lve$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB-cll-lve$">
     <description>MariaDB MariaDB on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-cll-lve</example>
     <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-cll-lve</example>
@@ -660,8 +718,9 @@
     <param pos="0" name="os.vendor" value="CloudLinux"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~wheezy(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~wheezy(?:-log)?$">
     <description>MariaDB MariaDB on Debian 7.0 (wheezy)</description>
     <example service.version="5.5.37">5.5.37-MariaDB-1~wheezy-log</example>
     <example service.version="10.0.11">10.0.11-MariaDB-1~wheezy-log</example>
@@ -674,8 +733,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~squeeze(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~squeeze(?:-log)?$">
     <description>MariaDB MariaDB on Debian 6.0 (squeeze)</description>
     <example service.version="5.5.31">5.5.31-MariaDB-1~squeeze-log</example>
     <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-1~squeeze-log</example>
@@ -687,8 +748,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-MariaDB.+~lenny(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-MariaDB.+~lenny(?:-log)?$">
     <description>MariaDB MariaDB on Debian 5.0 (lenny)</description>
     <example service.version="5.3.2">5.3.2-MariaDB-beta-mariadb102~lenny</example>
     <param pos="1" name="service.version"/>
@@ -699,8 +762,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~sid(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~sid(?:-log)?$">
     <description>MariaDB MariaDB on Debian Unstable/No version  (sid)</description>
     <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~sid</example>
     <param pos="1" name="service.version"/>
@@ -710,6 +775,7 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,4})-MariaDB-\dubuntu\d\.(\d{1,2}\.\d\d)[\.\d]*(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu</description>
@@ -722,8 +788,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~utopic(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~utopic(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 14.10 (Utopic Unicorn)</description>
     <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~utopic-log</example>
     <param pos="1" name="service.version"/>
@@ -734,8 +802,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.10"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~trusty(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~trusty(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 14.04 (Trusty Tahr)</description>
     <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-1~trusty</example>
     <param pos="1" name="service.version"/>
@@ -746,8 +816,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~saucy(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~saucy(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 13.10 (Saucy Salamander)</description>
     <example service.version="5.5.39">5.5.39-MariaDB-1~saucy-log</example>
     <param pos="1" name="service.version"/>
@@ -758,8 +830,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~raring(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~raring(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 13.04 (Raring Ringtail)</description>
     <example service.version="5.5.32">5.5.32-MariaDB-1~raring-log</example>
     <param pos="1" name="service.version"/>
@@ -770,8 +844,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~quantal(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~quantal(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 12.10 (Quantal Quetzal)</description>
     <example service.version="5.5.5">5.5.5-10.0.12-MariaDB-1~quantal-log</example>
     <example service.version="5.5.38">5.5.38-MariaDB-1~quantal-log</example>
@@ -783,10 +859,13 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~precise(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~precise(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 12.04 LTS (Precise Pangolin)</description>
     <example service.version="5.5.41">5.5.41-MariaDB-1~precise-log</example>
+    <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~precise-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -795,8 +874,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~lucid(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~lucid(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 10.04 (Lucid Lynx)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-1~lucid-log</example>
     <param pos="1" name="service.version"/>
@@ -807,8 +888,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~hardy(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~hardy(?:-log)?$">
     <description>MariaDB MariaDB on Ubuntu 8.04 LTS (Hardy Heron)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-mariadb122~hardy-log</example>
     <param pos="1" name="service.version"/>
@@ -819,8 +902,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-[Mm]ariaDB.+~trusty-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-[Mm]ariaDB.+~trusty-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 14.04 (Trusty Tahr)</description>
     <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~trusty-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -832,8 +917,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~saucy-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~saucy-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 13.10 (Saucy Salamander)</description>
     <example service.version="5.5.5">5.5.5-10.0.10-MariaDB-1~saucy-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -845,8 +932,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~precise-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~precise-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 12.04 (Precise Pangolin)</description>
     <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~precise-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -858,8 +947,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~lucid-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~lucid-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 10.04 TLS (Lucid Lynx)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-1~lucid-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -871,8 +962,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.04"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~wheezy-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~wheezy-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Debian 7.0 (wheezy)</description>
     <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~wheezy-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -884,8 +977,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~squeeze-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~squeeze-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Debian 6.0 (squeeze)</description>
     <example service.version="5.5.5">5.5.5-10.1.1-MariaDB-1~squeeze-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -897,8 +992,10 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
+    <param pos="0" name="os.certainty" value="0.80"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-MariaDB.+~sid-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-MariaDB.+~sid-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster on Debian Unstable/No version (sid)</description>
     <example service.version="5.5.5">5.5.5-10.0.16-MariaDB-1~sid-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -909,8 +1006,9 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-[Mm]ariaDB-wsrep(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-[Mm]ariaDB-wsrep(?:-log)?$">
     <description>MariaDB MariaDB with Galera Cluster</description>
     <example service.version="5.5.5">5.5.5-10.0.15-MariaDB-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -919,7 +1017,7 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Galera Cluster"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,4})?-[Mm]aria(?:DB)?[-\d]*(?:-debug)?(?:-ga)?(?:-beta)?(?:-mariadb)?[~\.\d]*(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})?-[Mm]aria(?:DB)?[-\d]*(?:-debug)?(?:-ga)?(?:-beta)?(?:-mariadb)?[~\.\d]*(?:-log)?$">
     <description>MariaDB MariaDB</description>
     <example service.version="5.1.39">5.1.39-maria-beta</example>
     <example service.version="5.3.5">5.3.5-MariaDB-ga-mariadb113-log</example>
@@ -933,7 +1031,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-[Cc]ommunity-[Mm]aria(?:DB)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-[Cc]ommunity-[Mm]aria(?:DB)?(?:-log)?$">
     <description>MariaDB MariaDB Community Edition</description>
     <example service.version="5.1.44">5.1.44-community-maria-log</example>
     <param pos="1" name="service.version"/>
@@ -942,7 +1040,7 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Community Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-falcon-alpha-community-nt">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-falcon-alpha-community-nt">
     <description>Oracle MySQL with defunct Falcon Storage Engine with Named Pipes (Windows)</description>
     <example service.version="5.2.0">5.2.0-falcon-alpha-community-nt</example>
     <param pos="1" name="service.version"/>
@@ -951,8 +1049,9 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-falcon-alpha(?:-community)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-falcon-alpha(?:-community)?(?:-log)?$">
     <description>Oracle MySQL with defunct Falcon Storage Engine</description>
     <example service.version="5.2.0">5.2.0-falcon-alpha-log</example>
     <example service.version="5.2.0">5.2.0-falcon-alpha-community</example>
@@ -961,7 +1060,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-tokudb-\d\.\d\.\d{1,2}(?:-\d*)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-tokudb-\d\.\d\.\d{1,2}(?:-\d*)?(?:-log)?$">
     <description>Tokutek customized MySQL</description>
     <example service.version="5.5.40">5.5.40-tokudb-7.5.3-log</example>
     <example service.version="5.5.21">5.5.21-tokudb-6.0.0-42634</example>
@@ -970,7 +1069,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-tokudb-.*MariaDB(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-tokudb-.*MariaDB(?:-log)?$">
     <description>Tokutek customized MariaDB</description>
     <example service.version="5.5.25">5.5.25-tokudb-6.1.1-47477-MariaDB-log</example>
     <param pos="1" name="service.version"/>
@@ -978,7 +1077,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
   </fingerprint>
-  <fingerprint pattern="^^(\d{1,2}\.\d{1,2}\.\h{1,3})-Sphinx">
+  <fingerprint pattern="^^(\d{1,2}\.\d{1,2}\.[a-fA-F\d]{1,3})-Sphinx">
     <description>Oracle MySQL with the Sphinx full text search engine</description>
     <example service.version="5.1.40">5.1.40-Sphinx</example>
     <param pos="1" name="service.version"/>
@@ -986,7 +1085,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})(?:-\d{1,2}\.\d{1,3}\.\h{1,3})?\+tld\d">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})?\+tld\d">
     <description>Oracle MySQL packaged by TLD Linux</description>
     <example service.version="5.0.91">5.0.91+tld0-log</example>
     <example service.version="5.1.57">5.1.57-5.1.57+tld2-log</example>
@@ -997,8 +1096,9 @@
     <param pos="0" name="os.vendor" value="TLD"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-Debian_\d\.infrant\d$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Debian_\d\.infrant\d$">
     <description>Oracle MySQL on a Netgear ReadyNAS</description>
     <example service.version="5.0.24a">5.0.24a-Debian_3.infrant1</example>
     <param pos="1" name="service.version"/>
@@ -1008,12 +1108,13 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Storage"/>
     <param pos="0" name="hw.vendor" value="Netgear"/>
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.family" value="ReadyNAS"/>
     <param pos="0" name="hw.product" value="ReadyNAS"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-beget(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-beget(?:-log)?$">
     <description>Oracle MySQL at Ukrainian hoster BeGet(?)</description>
     <example service.version="5.1.61">5.1.61-beget-log</example>
     <param pos="1" name="service.version"/>
@@ -1021,7 +1122,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-(?:Linuxtone.Org|LTOPS)(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-(?:Linuxtone.Org|LTOPS)(?:-log)?$">
     <description>Oracle MySQL at Chinese hoster Linuxtone.org</description>
     <example service.version="5.0.56">5.0.56-Linuxtone.Org</example>
     <example service.version="5.1.53">5.1.53-LTOPS-log</example>
@@ -1030,7 +1131,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-xencdn.net(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-xencdn.net(?:-log)?$">
     <description>Oracle MySQL at Chinese hoster Xencdn.net</description>
     <example service.version="5.1.66">5.1.66-xencdn.net-log</example>
     <param pos="1" name="service.version"/>
@@ -1038,7 +1139,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-Comsenz(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Comsenz(?:-log)?$">
     <description>Oracle MySQL at Chinese hoster Comsenz</description>
     <example service.version="5.0.27">5.0.27-Comsenz-log</example>
     <param pos="1" name="service.version"/>
@@ -1046,7 +1147,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-www\.gamewave\.net(?:-edition)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-www\.gamewave\.net(?:-edition)?(?:-log)?$">
     <description>Oracle MySQL at Chinese game hoster Gamewave</description>
     <example service.version="5.1.56">5.1.56-www.gamewave.net-edition-log</example>
     <example service.version="5.1.56">5.1.56-www.gamewave.net-log</example>
@@ -1055,7 +1156,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)[-\d]*-beget(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)[-\d]*-beget(?:-log)?$">
     <description>Oracle MySQL at Russian hoster Beget</description>
     <example service.version="5.6.16-64.0">5.6.16-64.0-beget-log</example>
     <example service.version="5.6.21-70.0">5.6.21-70.0-1-beget-log</example>
@@ -1064,7 +1165,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})yes(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})yes(?:-log)?$">
     <description>Oracle MySQL part of KB2 / Kimsboard (Korean site mgmt)?</description>
     <example service.version="4.0.27">4.0.27yes</example>
     <param pos="1" name="service.version"/>
@@ -1072,7 +1173,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})\.t\d{1,2}(?:[\.\d]{3})?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})\.t\d{1,2}(?:[\.\d]{3})?(?:-log)?$">
     <description>Oracle MySQL audited/published by Twitter</description>
     <example service.version="5.5.24">5.5.24.t7-log</example>
     <example service.version="5.5.31">5.5.31.t11.1</example>
@@ -1081,7 +1182,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}) Hybrid Cluster MySQL Proxy to$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}) Hybrid Cluster MySQL Proxy to$">
     <description>Oracle MySQL by Hybrid Cluster (hosted?)</description>
     <example service.version="5.5.15">5.5.15 Hybrid Cluster MySQL Proxy to</example>
     <param pos="1" name="service.version"/>
@@ -1089,7 +1190,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}) ScaleBase Data Traffic Manager [\.\d]+$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}) ScaleBase Data Traffic Manager [\.\d]+$">
     <description>Oracle MySQL behind ScaleBase Data Traffic Manager</description>
     <example service.version="5.1.53">5.1.53 ScaleBase Data Traffic Manager 3.2.3</example>
     <param pos="1" name="service.version"/>
@@ -1097,7 +1198,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3})-\d\d\.\d{1,2}-\d\.ctbanco\d+(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d{1,2}-\d\.ctbanco\d+(?:-log)?$">
     <description>Percona Server (MySQL fork) with 'ctbanco' </description>
     <example service.version="5.6.16">5.6.16-64.1-1.ctbanco60-log</example>
     <example service.version="5.6.16">5.6.16-64.1-1.ctbanco7-log</example>
@@ -1107,8 +1208,9 @@
     <param pos="0" name="service.product" value="Percona Server"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\h{1,3}) Complete MySQL by Server Logistics(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}) Complete MySQL by Server Logistics(?:-log)?$">
     <description>Oracle MySQL packaged by Server Logistics, Mac specific</description>
     <example service.version="4.0.21">4.0.21 Complete MySQL by Server Logistics-log</example>
     <param pos="1" name="service.version"/>
@@ -1118,5 +1220,6 @@
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
 </fingerprints>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -11,7 +11,7 @@
      from this version.
 -->
 <fingerprints matches="mysql.banners">
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?[Mm]ax)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?max)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL (common)</description>
     <example service.version="4.1.20">4.1.20</example>
     <example service.version="5.5.23-55">5.5.23-55</example>
@@ -32,7 +32,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-m\d)?(?:-rc)?(?:-alpha)?(?:-beta)?-[Cc]ommunity(?:-max)?(?:-debug)?(?:-log)?(?:-debug)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-m\d)?(?:-rc)?(?:-alpha)?(?:-beta)?-community(?:-max)?(?:-debug)?(?:-log)?(?:-debug)?$" flags="REG_ICASE">
     <description>Oracle MySQL Community Edition</description>
     <example service.version="5.0.95">5.0.95-community-log</example>
     <example service.version="5.0.37">5.0.37-Community-log</example>
@@ -47,7 +47,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Community Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?-[Cc]ommunity(?:-max)?-nt(?:-log)?(?:-debug)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?-community(?:-max)?-nt(?:-log)?(?:-debug)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Community Edition with Named Pipes (Windows)</description>
     <example service.version="4.1.22">4.1.22-community-max-nt</example>
     <example service.version="5.0.88">5.0.88-community-nt</example>
@@ -64,7 +64,7 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?(?:-gamma)?(?:-max)?-nt(?:-max)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-alpha)?(?:-beta)?(?:-rc)?(?:-gamma)?(?:-max)?-nt(?:-max)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL with Named Pipes (Windows)</description>
     <example service.version="5.0.18">5.0.18-nt</example>
     <example service.version="4.1.12a">4.1.12a-nt-max-log</example>
@@ -79,7 +79,7 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-cll$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-cll$" flags="REG_ICASE">
     <description>Oracle MySQL hosted on CPanel</description>
     <example service.version="5.5.25a">5.5.25a-cll</example>
     <param pos="1" name="service.version"/>
@@ -89,7 +89,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-community-cll$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-community-cll$" flags="REG_ICASE">
     <description>Oracle MySQL Community hosted on CPanel</description>
     <example service.version="5.0.91">5.0.91-community-cll</example>
     <param pos="1" name="service.version"/>
@@ -101,7 +101,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-cll-lve$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-cll-lve$" flags="REG_ICASE">
     <description>Oracle MySQL on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.1.66">5.1.66-cll-lve</example>
     <param pos="1" name="service.version"/>
@@ -113,7 +113,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-community-cll-lve$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-community-cll-lve$" flags="REG_ICASE">
     <description>Oracle MySQL Community on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.0.95">5.0.95-community-cll-lve</example>
     <param pos="1" name="service.version"/>
@@ -156,7 +156,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})[-_](?:Ubuntu[_-])?(?:Debian[_-])?\d{1,2}(?:~exp1)?ubuntu\d{1,2}(?:\.\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})[-_](?:Ubuntu[_-])?(?:Debian[_-])?\d{1,2}(?:~exp1)?ubuntu\d{1,2}(?:\.\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL on Ubuntu where trailing digits aren't OS version</description>
     <example service.version="5.0.45">5.0.45-Debian_1ubuntu3.4</example>
     <example service.version="5.0.51a">5.0.51a-3ubuntu5.5</example>
@@ -251,7 +251,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d~bpo50">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d~bpo50" flags="REG_ICASE">
     <description>Oracle MySQL Backport on Debian 5.0 (lenny)</description>
     <example service.version="5.1.49">5.1.49-3~bpo50+1-log</example>
     <param pos="1" name="service.version"/>
@@ -265,7 +265,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}).*~?bpo40(?:\+\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}).*~?bpo40(?:\+\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Backport on Debian 4.0 (etch)</description>
     <example service.version="5.0.51a">5.0.51a-24+lenny2~bpo40+1-log</example>
     <param pos="1" name="service.version"/>
@@ -279,7 +279,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Debian.*~?bpo31(?:\+\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Debian.*~?bpo31(?:\+\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Backport on Debian 3.1 (sarge)</description>
     <example service.version="5.0.32">5.0.32-Debian_7etch5~bpo31+1-log</example>
     <param pos="1" name="service.version"/>
@@ -294,7 +294,7 @@
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- FIXFIX -->
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Debian_\d~?bpo\.?\d">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Debian_\d~?bpo\.?\d" flags="REG_ICASE">
     <description>Oracle MySQL Backport on Debian</description>
     <example service.version="5.0.22">5.0.22-Debian_2bpo1</example>
     <example service.version="5.0.32">5.0.32-Debian_7~bpo.1-log</example>
@@ -351,7 +351,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:[_-]\d{8})?[_-]Debian[_-]\d{1,2}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:[_-]\d{8})?[_-]Debian[_-]\d{1,2}(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL on Debian (Generic match)</description>
     <example service.version="4.0.23">4.0.23_Debian-3-log</example>
     <example service.version="4.0.31">4.0.31-20070605_Debian-7-log</example>
@@ -376,7 +376,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2})?(?:-Debian)?(?:-Dotdeb)?[-~_\d\.]+dotdeb\.\d(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-\d{1,2})?(?:-Debian)?(?:-Dotdeb)?[-~_\d\.]+dotdeb\.\d(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL packaged by DotDeb.org</description>
     <example service.version="5.1.54">5.1.54-0.dotdeb.0</example>
     <example service.version="5.1.58">5.1.58-1~dotdeb.0</example>
@@ -391,7 +391,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-rc)?-standard(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-rc)?-standard(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Standard Edition</description>
     <example service.version="5.0.13">5.0.13-rc-standard-log</example>
     <example service.version="5.0.37">5.0.37-standard</example>
@@ -402,7 +402,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Standard Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-pro(?:-gpl)?-nt(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-pro(?:-gpl)?-nt(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Commercial Edition with Named Pipes (Windows)</description>
     <example service.version="5.0.24">5.0.24-pro-nt</example>
     <example service.version="4.1.25">4.1.25-pro-gpl-nt-log</example>
@@ -415,7 +415,7 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-pro(?:-gpl)?(?:-cert)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-pro(?:-gpl)?(?:-cert)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Commercial Edition</description>
     <example service.version="4.1.23">4.1.23-pro-gpl-log</example>
     <example service.version="5.0.17c">5.0.17c-pro-gpl-cert</example>
@@ -425,7 +425,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Commercial Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}sp1)">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}sp1)" flags="REG_ICASE">
     <description>Oracle MySQL Enterprise Edition</description>
     <example service.version="5.0.82sp1">5.0.82sp1</example>
     <example service.version="5.1.46sp1">5.1.46sp1-enterprise-gpl-advanced-log</example>
@@ -435,7 +435,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-enterprise-nt">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-enterprise-nt" flags="REG_ICASE">
     <description>Oracle MySQL Enterprise Edition with Named Pipes (Windows)</description>
     <example service.version="5.0.84">5.0.84-enterprise-nt</example>
     <param pos="1" name="service.version"/>
@@ -447,7 +447,7 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-rc)?-enterprise">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-rc)?-enterprise" flags="REG_ICASE">
     <description>Oracle MySQL Enterprise Edition</description>
     <example service.version="5.1.26">5.1.26-rc-enterprise-gpl-log</example>
     <example service.version="5.5.27">5.5.27-enterprise-commercial-advanced-log</example>
@@ -457,7 +457,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-ndb-\d\.\d{1,2}\.[a-fA-F\d]{1,3})">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-ndb-\d\.\d{1,2}\.[a-f\d]{1,3})" flags="REG_ICASE">
     <description>Oracle MySQL Cluster Edition</description>
     <example service.version="5.1.30-ndb-6.3.20">5.1.30-ndb-6.3.20-cluster-gpl-log</example>
     <example service.version="5.5.20-ndb-7.2.5">5.5.20-ndb-7.2.5-gpl</example>
@@ -467,7 +467,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Cluster Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-CLUSTERS?(?:-log)?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-CLUSTERS?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Cluster Edition</description>
     <example service.version="4.1.21">4.1.21-CLUSTERS</example>
     <example service.version="5.0.46">5.0.46-cluster</example>
@@ -477,7 +477,7 @@
     <param pos="0" name="service.product" value="MySQL"/>
     <param pos="0" name="service.edition" value="Cluster Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-classic(?:-log)?">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-classic(?:-log)?" flags="REG_ICASE">
     <description>Oracle MySQL Classic Edition</description>
     <example service.version="5.0.86">5.0.86-classic-log</example>
     <param pos="1" name="service.version"/>
@@ -488,7 +488,7 @@
   </fingerprint>
   <!-- Linux only - http://www.percona.com/services/mysql-support/supported-platforms -->
   <!-- Build list - http://www.percona.com/doc/percona-server/5.1/release-notes/release-notes_index.html -->
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-?rel\d\d\.\d)(?:-log)?">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-?rel\d\d\.\d)(?:-log)?" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) match w/ 'rel'</description>
     <example service.version="5.1.57-rel12.8">5.1.57-rel12.8</example>
     <example service.version="5.1.60rel13.1">5.1.60rel13.1-log</example>
@@ -501,7 +501,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d{1,2}-rel\d\d\.\d{1,2}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d{1,2}-rel\d\d\.\d{1,2}(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) match w/ 'rel' variant 1</description>
     <example service.version="5.6.17">5.6.17-65.0-rel65.0</example>
     <param pos="1" name="service.version"/>
@@ -512,7 +512,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-(?:rc)?[Pp]ercona">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-(?:rc)?percona" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) w/ percona in banner</description>
     <example service.version="5.1.50">5.1.50-percona</example>
     <example service.version="5.5.27">5.5.27-percona-sure1-log</example>
@@ -525,7 +525,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d{1,2}(?:-\d\d)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d{1,2}(?:-\d\d)?(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) (just version number match)</description>
     <example service.version="5.1.73">5.1.73-14.12</example>
     <example service.version="5.6.20">5.6.20-68.0-56</example>
@@ -538,7 +538,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-rc\d\d\.\d(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-rc\d\d\.\d(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) match w/ 'rc'</description>
     <example service.version="5.6.13">5.6.13-rc60.6</example>
     <example service.version="5.6.13">5.6.13-rc61.0-log</example>
@@ -550,7 +550,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.trusty(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.trusty(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 14.04 (Trusty Tahr)</description>
     <example service.version="5.6.17">5.6.17-65.0-583.trusty</example>
     <param pos="1" name="service.version"/>
@@ -564,7 +564,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.saucy(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.saucy(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 13.10 (Saucy Salamander)</description>
     <example service.version="5.6.17">5.6.17-65.0-587.saucy</example>
     <param pos="1" name="service.version"/>
@@ -578,7 +578,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.quantal(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.quantal(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 12.10 (Quantal Quetzal)</description>
     <example service.version="5.6.16">5.6.16-64.2-569.quantal-log</example>
     <param pos="1" name="service.version"/>
@@ -592,7 +592,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.precise(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.precise(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Ubuntu 12.04 LTS (Precise Pangolin)</description>
     <example service.version="5.6.16">5.6.16-64.2-569.precise-log</example>
     <param pos="1" name="service.version"/>
@@ -606,7 +606,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.wheezy(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.wheezy(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Debian 7.0 (wheezy)</description>
     <example service.version="5.5.36">5.5.36-34.2-648.wheezy-log</example>
     <param pos="1" name="service.version"/>
@@ -620,7 +620,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d-\d{3}\.squeeze(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d-\d{3}\.squeeze(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) on Debian 6.0 (squeeze)</description>
     <example service.version="5.5.36">5.5.36-34.2-648.squeeze</example>
     <param pos="1" name="service.version"/>
@@ -634,7 +634,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-nmm">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-nmm" flags="REG_ICASE">
     <description>Oracle MySQL (nmm variant)</description>
     <example service.version="4.0.27">4.0.27-nmm1-log</example>
     <example service.version="4.1.22">4.1.22-nmm-1-log</example>
@@ -643,7 +643,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-nightly-\d{8}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-nightly-\d{8}(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL nightly build</description>
     <example service.version="3.23.59">3.23.59-nightly-20050301-log</example>
     <param pos="1" name="service.version"/>
@@ -651,7 +651,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-SERVER">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-SERVER" flags="REG_ICASE">
     <description>Oracle MySQL (SERVER variant)</description>
     <example service.version="5.1.30">5.1.30-SERVER-104</example>
     <param pos="1" name="service.version"/>
@@ -659,7 +659,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-ISPrime">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-ISPrime" flags="REG_ICASE">
     <description>Oracle MySQL (ISPrime variant)</description>
     <example service.version="4.0.15a">4.0.15a-ISPrime</example>
     <param pos="1" name="service.version"/>
@@ -667,7 +667,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-rc-\d\.\d{1,2}\.[a-fA-F\d]{1,3}">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-rc-\d\.\d{1,2}\.[a-f\d]{1,3}" flags="REG_ICASE">
     <description>Oracle MySQL possibly Debian specific</description>
     <example service.version="5.1.26">5.1.26-rc-5.1.26rc-log</example>
     <param pos="1" name="service.version"/>
@@ -675,7 +675,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-ius(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-ius(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL packaged for RHEL/CentOS by IUS</description>
     <example service.version="5.1.66">5.1.66-ius-log</example>
     <param pos="1" name="service.version"/>
@@ -686,7 +686,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})[\.-]d\d{1,2}-ourdelta\d{0,2}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})[\.-]d\d{1,2}-ourdelta\d{0,2}(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL tweaked and packaged by OurDelta</description>
     <example service.version="5.0.67">5.0.67.d7-ourdelta-log</example>
     <example service.version="5.0.87">5.0.87-d10-ourdelta65-log</example>
@@ -698,7 +698,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Alibaba(?:-rds)?-\d{6}(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Alibaba(?:-rds)?-\d{6}(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL Alibaba build? distro? Aliyun.com hosted?</description>
     <example service.version="5.1.61">5.1.61-Alibaba-121011-log</example>
     <example service.version="5.1.61">5.1.61-Alibaba-rds-201404-log</example>
@@ -707,7 +707,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB-cll-lve$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-cll-lve$" flags="REG_ICASE">
     <description>MariaDB MariaDB on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-cll-lve</example>
     <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-cll-lve</example>
@@ -720,7 +720,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~wheezy(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~wheezy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian 7.0 (wheezy)</description>
     <example service.version="5.5.37">5.5.37-MariaDB-1~wheezy-log</example>
     <example service.version="10.0.11">10.0.11-MariaDB-1~wheezy-log</example>
@@ -736,7 +736,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~squeeze(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~squeeze(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian 6.0 (squeeze)</description>
     <example service.version="5.5.31">5.5.31-MariaDB-1~squeeze-log</example>
     <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-1~squeeze-log</example>
@@ -751,7 +751,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-MariaDB.+~lenny(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-MariaDB.+~lenny(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian 5.0 (lenny)</description>
     <example service.version="5.3.2">5.3.2-MariaDB-beta-mariadb102~lenny</example>
     <param pos="1" name="service.version"/>
@@ -765,7 +765,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~sid(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~sid(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Debian Unstable/No version  (sid)</description>
     <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~sid</example>
     <param pos="1" name="service.version"/>
@@ -791,7 +791,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~utopic(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~utopic(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 14.10 (Utopic Unicorn)</description>
     <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~utopic-log</example>
     <param pos="1" name="service.version"/>
@@ -805,7 +805,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~trusty(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~trusty(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 14.04 (Trusty Tahr)</description>
     <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-1~trusty</example>
     <param pos="1" name="service.version"/>
@@ -819,7 +819,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~saucy(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~saucy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 13.10 (Saucy Salamander)</description>
     <example service.version="5.5.39">5.5.39-MariaDB-1~saucy-log</example>
     <param pos="1" name="service.version"/>
@@ -833,7 +833,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~raring(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~raring(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 13.04 (Raring Ringtail)</description>
     <example service.version="5.5.32">5.5.32-MariaDB-1~raring-log</example>
     <param pos="1" name="service.version"/>
@@ -847,7 +847,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~quantal(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~quantal(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 12.10 (Quantal Quetzal)</description>
     <example service.version="10.0.12">5.5.5-10.0.12-MariaDB-1~quantal-log</example>
     <example service.version="5.5.38">5.5.38-MariaDB-1~quantal-log</example>
@@ -862,7 +862,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~precise(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~precise(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 12.04 LTS (Precise Pangolin)</description>
     <example service.version="5.5.41">5.5.41-MariaDB-1~precise-log</example>
     <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~precise-log</example>
@@ -877,7 +877,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~lucid(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~lucid(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 10.04 (Lucid Lynx)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-1~lucid-log</example>
     <param pos="1" name="service.version"/>
@@ -891,7 +891,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~hardy(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~hardy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 8.04 LTS (Hardy Heron)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-mariadb122~hardy-log</example>
     <param pos="1" name="service.version"/>
@@ -905,7 +905,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-[Mm]ariaDB.+~trusty-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~trusty-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 14.04 (Trusty Tahr)</description>
     <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~trusty-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -920,7 +920,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~saucy-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~saucy-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 13.10 (Saucy Salamander)</description>
     <example service.version="10.0.10">5.5.5-10.0.10-MariaDB-1~saucy-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -935,7 +935,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~precise-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~precise-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 12.04 (Precise Pangolin)</description>
     <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~precise-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -950,7 +950,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~lucid-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~lucid-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Ubuntu 10.04 TLS (Lucid Lynx)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-1~lucid-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -965,7 +965,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~wheezy-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~wheezy-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Debian 7.0 (wheezy)</description>
     <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~wheezy-wsrep-log</example>
     <param pos="1" name="service.version"/>
@@ -980,7 +980,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~squeeze-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~squeeze-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Debian 6.0 (squeeze)</description>
     <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~squeeze-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -995,7 +995,7 @@
     <param pos="0" name="os.certainty" value="0.80"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-MariaDB.+~sid-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~sid-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Debian Unstable/No version (sid)</description>
     <example service.version="10.0.16">5.5.5-10.0.16-MariaDB-1~sid-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -1008,7 +1008,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-[Mm]ariaDB-wsrep(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster</description>
     <example service.version="10.0.15">5.5.5-10.0.15-MariaDB-wsrep</example>
     <param pos="1" name="service.version"/>
@@ -1017,7 +1017,7 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Galera Cluster"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,4})-[Mm]aria(?:DB)?[-\d]*(?:-debug)?(?:-ga)?(?:-beta)?(?:-mariadb)?[~\.\d]*(?:-log)?$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-Maria(?:DB)?[-\d]*(?:-debug)?(?:-ga)?(?:-beta)?(?:-mariadb)?[~\.\d]*(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB</description>
     <example service.version="5.1.39">5.1.39-maria-beta</example>
     <example service.version="5.3.5">5.3.5-MariaDB-ga-mariadb113-log</example>
@@ -1031,7 +1031,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-[Cc]ommunity-[Mm]aria(?:DB)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Community-Maria(?:DB)?(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB Community Edition</description>
     <example service.version="5.1.44">5.1.44-community-maria-log</example>
     <param pos="1" name="service.version"/>
@@ -1040,7 +1040,7 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Community Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-falcon-alpha-community-nt">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha-community-nt" flags="REG_ICASE">
     <description>Oracle MySQL with defunct Falcon Storage Engine with Named Pipes (Windows)</description>
     <example service.version="5.2.0">5.2.0-falcon-alpha-community-nt</example>
     <param pos="1" name="service.version"/>
@@ -1051,7 +1051,7 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-falcon-alpha(?:-community)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha(?:-community)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL with defunct Falcon Storage Engine</description>
     <example service.version="5.2.0">5.2.0-falcon-alpha-log</example>
     <example service.version="5.2.0">5.2.0-falcon-alpha-community</example>
@@ -1060,7 +1060,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-tokudb-\d\.\d\.\d{1,2}(?:-\d*)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-tokudb-\d\.\d\.\d{1,2}(?:-\d*)?(?:-log)?$" flags="REG_ICASE">
     <description>Tokutek customized MySQL</description>
     <example service.version="5.5.40">5.5.40-tokudb-7.5.3-log</example>
     <example service.version="5.5.21">5.5.21-tokudb-6.0.0-42634</example>
@@ -1069,7 +1069,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-tokudb-.*MariaDB(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-tokudb-.*MariaDB(?:-log)?$" flags="REG_ICASE">
     <description>Tokutek customized MariaDB</description>
     <example service.version="5.5.25">5.5.25-tokudb-6.1.1-47477-MariaDB-log</example>
     <param pos="1" name="service.version"/>
@@ -1077,7 +1077,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
   </fingerprint>
-  <fingerprint pattern="^^(\d{1,2}\.\d{1,2}\.[a-fA-F\d]{1,3})-Sphinx">
+  <fingerprint pattern="^^(\d{1,2}\.\d{1,2}\.[a-f\d]{1,3})-Sphinx" flags="REG_ICASE">
     <description>Oracle MySQL with the Sphinx full text search engine</description>
     <example service.version="5.1.40">5.1.40-Sphinx</example>
     <param pos="1" name="service.version"/>
@@ -1085,7 +1085,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})?\+tld\d">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})?\+tld\d" flags="REG_ICASE">
     <description>Oracle MySQL packaged by TLD Linux</description>
     <example service.version="5.0.91">5.0.91+tld0-log</example>
     <example service.version="5.1.57">5.1.57-5.1.57+tld2-log</example>
@@ -1098,7 +1098,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Debian_\d\.infrant\d$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Debian_\d\.infrant\d$" flags="REG_ICASE">
     <description>Oracle MySQL on a Netgear ReadyNAS</description>
     <example service.version="5.0.24a">5.0.24a-Debian_3.infrant1</example>
     <param pos="1" name="service.version"/>
@@ -1114,7 +1114,7 @@
     <param pos="0" name="hw.family" value="ReadyNAS"/>
     <param pos="0" name="hw.product" value="ReadyNAS"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-beget(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-beget(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL at Ukrainian hoster BeGet(?)</description>
     <example service.version="5.1.61">5.1.61-beget-log</example>
     <param pos="1" name="service.version"/>
@@ -1122,7 +1122,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-(?:Linuxtone.Org|LTOPS)(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-(?:Linuxtone.Org|LTOPS)(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL at Chinese hoster Linuxtone.org</description>
     <example service.version="5.0.56">5.0.56-Linuxtone.Org</example>
     <example service.version="5.1.53">5.1.53-LTOPS-log</example>
@@ -1131,7 +1131,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-xencdn.net(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-xencdn.net(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL at Chinese hoster Xencdn.net</description>
     <example service.version="5.1.66">5.1.66-xencdn.net-log</example>
     <param pos="1" name="service.version"/>
@@ -1139,7 +1139,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-Comsenz(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-Comsenz(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL at Chinese hoster Comsenz</description>
     <example service.version="5.0.27">5.0.27-Comsenz-log</example>
     <param pos="1" name="service.version"/>
@@ -1147,7 +1147,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-www\.gamewave\.net(?:-edition)?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-www\.gamewave\.net(?:-edition)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL at Chinese game hoster Gamewave</description>
     <example service.version="5.1.56">5.1.56-www.gamewave.net-edition-log</example>
     <example service.version="5.1.56">5.1.56-www.gamewave.net-log</example>
@@ -1156,7 +1156,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)[-\d]*-beget(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)[-\d]*-beget(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL at Russian hoster Beget</description>
     <example service.version="5.6.16-64.0">5.6.16-64.0-beget-log</example>
     <example service.version="5.6.21-70.0">5.6.21-70.0-1-beget-log</example>
@@ -1165,7 +1165,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})yes(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})yes(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL part of KB2 / Kimsboard (Korean site mgmt)?</description>
     <example service.version="4.0.27">4.0.27yes</example>
     <param pos="1" name="service.version"/>
@@ -1173,7 +1173,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})\.t\d{1,2}(?:[\.\d]{3})?(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})\.t\d{1,2}(?:[\.\d]{3})?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL audited/published by Twitter</description>
     <example service.version="5.5.24">5.5.24.t7-log</example>
     <example service.version="5.5.31">5.5.31.t11.1</example>
@@ -1182,7 +1182,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}) Hybrid Cluster MySQL Proxy to$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}) Hybrid Cluster MySQL Proxy to$" flags="REG_ICASE">
     <description>Oracle MySQL by Hybrid Cluster (hosted?)</description>
     <example service.version="5.5.15">5.5.15 Hybrid Cluster MySQL Proxy to</example>
     <param pos="1" name="service.version"/>
@@ -1190,7 +1190,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}) ScaleBase Data Traffic Manager [\.\d]+$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}) ScaleBase Data Traffic Manager [\.\d]+$" flags="REG_ICASE">
     <description>Oracle MySQL behind ScaleBase Data Traffic Manager</description>
     <example service.version="5.1.53">5.1.53 ScaleBase Data Traffic Manager 3.2.3</example>
     <param pos="1" name="service.version"/>
@@ -1198,7 +1198,7 @@
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MySQL"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3})-\d\d\.\d{1,2}-\d\.ctbanco\d+(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-\d\d\.\d{1,2}-\d\.ctbanco\d+(?:-log)?$" flags="REG_ICASE">
     <description>Percona Server (MySQL fork) with 'ctbanco' </description>
     <example service.version="5.6.16">5.6.16-64.1-1.ctbanco60-log</example>
     <example service.version="5.6.16">5.6.16-64.1-1.ctbanco7-log</example>
@@ -1210,7 +1210,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
-  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-fA-F\d]{1,3}) Complete MySQL by Server Logistics(?:-log)?$">
+  <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}) Complete MySQL by Server Logistics(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL packaged by Server Logistics, Mac specific</description>
     <example service.version="4.0.21">4.0.21 Complete MySQL by Server Logistics-log</example>
     <param pos="1" name="service.version"/>


### PR DESCRIPTION
Changed uses of `\h` to ~~`[a-fA-F\d]`~~ (update: now `[a-f\d]` with case-insensitive flag) since `\h` seems to be a ruby-specific thing and Nexpose could not match with it.

~~Added `os.device` to fingerprints that have OS info.~~

~~Added `os.certainty` to fingerprints that have OS versions. Somewhat arbitrarily chose 0.80 as likely to be useful and not likely to interfere with potentially superior fingerprints from SSH or other services.~~

One thing I wonder about is switching the MariaDB version match group to the 2nd set of numbers, but that probably means lots of edits/new fingerprints to keep compatibility with banners that don't have the 2nd set. **Update 4/13: Done** - I swapped the optional groups around for MariaDB so that 10.x.x versions will capture instead of 5.5.5, but 5.x.x versions can still capture when there is no 10.x.x version.

cc @jhart-r7 @pdeardorff-r7 @TomSellers (basically everyone who touched this file and might have input)