### PR TITLE
Add os.family to Windows CIFS fingerprints

### DIFF
--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -8,6 +8,7 @@
     <example os.product="Windows NT 4.0">Windows NT 4.0</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^(Windows (?:95|98|ME))$">
@@ -16,6 +17,7 @@
     <example os.product="Windows 98">Windows 98</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Windows 5\.0$">
@@ -30,6 +32,7 @@
     <example>Windows 5.1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
   </fingerprint>
   <fingerprint pattern="^Windows XP (\d+) (Service Pack \d+)$">
@@ -37,6 +40,7 @@
     <example os.build="2600" os.version="Service Pack 1">Windows XP 2600 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -46,6 +50,7 @@
     <example os.build="2600">Windows XP 2600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
@@ -53,6 +58,7 @@
     <description>Windows Server 2003 Beta</description>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
     <param pos="0" name="os.version" value="Beta"/>
   </fingerprint>
@@ -60,6 +66,7 @@
     <description>Windows Server 2003 R2</description>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
@@ -68,6 +75,7 @@
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 R2 3790 Service Pack 2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -77,6 +85,7 @@
     <example os.build="3790">Windows Server 2003 3790</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
@@ -86,6 +95,7 @@
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 3790 Service Pack 2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -97,6 +107,7 @@
     <example os.edition="Enterprise" os.version="Service Pack 2">Windows Server (R) 2008 Enterprise 6002 Service Pack 2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -108,6 +119,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -118,6 +130,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
@@ -127,6 +140,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Storage"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -137,6 +151,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Storage"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
@@ -146,6 +161,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="HPC"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -156,6 +172,7 @@
     <example>Windows Server 2008 HPC Edition 7600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.edition" value="HPC"/>
     <param pos="1" name="os.build"/>
@@ -167,6 +184,7 @@
     <example>Windows Server 2008 R2 Standard 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -179,6 +197,7 @@
     <example os.edition="Datacenter">Windows Server 2008 R2 Datacenter 7600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -189,6 +208,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -198,6 +218,7 @@
     <example>Windows Web Server 2008 R2 7600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
@@ -207,6 +228,7 @@
     <example os.edition="Home Premium" os.version="Service Pack 2">Windows Vista (TM) Home Premium 6002 Service Pack 2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -217,6 +239,7 @@
     <example os.edition="Home Premium">Windows Vista (TM) Home Premium 6000</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -226,6 +249,7 @@
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows 7 Enterprise 7601 Service Pack 1</example>
     <example os.edition="Starter" os.version="Service Pack 1">Windows 7 Starter 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.edition"/>
@@ -236,6 +260,7 @@
     <description>Windows 7/8 (SP)</description>
     <example os.version="Service Pack 1">Windows 7 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.build"/>
@@ -247,6 +272,7 @@
     <example os.edition="Enterprise">Windows 8.1 Enterprise 9600</example>
     <example os.edition="Enterprise">Windows 8 Enterprise 9200</example>
     <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.edition"/>
@@ -256,6 +282,7 @@
     <description>Windows 7/8</description>
     <example>Windows 8 9200</example>
     <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.build"/>
@@ -266,6 +293,7 @@
     <description>Windows Server 2012 R2 (SP)</description>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -276,6 +304,7 @@
     <example os.edition="Standard">Windows Server 2012 R2 Standard 9600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -285,6 +314,7 @@
     <description>Windows Server 2012 (SP)</description>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -295,6 +325,7 @@
     <example>Windows Server 2012 Standard 9200</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -305,6 +336,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="MultiPoint"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
@@ -315,6 +347,7 @@
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="MultiPoint"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
@@ -324,6 +357,7 @@
     <example os.build="10130" os.edition="Enterprise">Windows 10 Enterprise Insider Preview 10130</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 10"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
@@ -338,6 +372,7 @@
     <example os.build="10130" os.edition="Professional">Windows 10 Professional 10130</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 10"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>


### PR DESCRIPTION
Rspec test:
```rspec
Finished in 53.18 seconds (files took 1.89 seconds to load)
17773 examples, 0 failures

Randomized with seed 56817

/opt/ruby2.2/lib/ruby/gems/2.2.0/gems/simplecov-0.10.0/lib/simplecov/defaults.rb:50: warning: global variable `$ERROR_INFO' not initialized
Coverage report generated for RSpec to /home/jkennedy/rapid7/recog/coverage. 690 / 722 LOC (95.57%) covered.
```