### PR TITLE
SMB banners for VisionFS and OS/400

### DIFF
--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -364,9 +364,9 @@
 
   <!-- VisionFS -->
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ai([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ai(\d{4})">
     <description>AIX</description>
-    <example service.version="1234">axai1234</example>
+    <example service.version="9876">axai9876</example>
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.family" value="AIX"/>
     <param pos="0" name="os.product" value="AIX"/>
@@ -374,9 +374,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dg([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dg(\d{4})">
     <description>DG/UX</description>
-    <example service.version="1234">i3dg1234</example>
+    <example service.version="9876">i3dg9876</example>
     <param pos="0" name="os.vendor" value="Data General"/>
     <param pos="0" name="os.family" value="DG/UX"/>
     <param pos="0" name="os.product" value="DG/UX"/>
@@ -384,9 +384,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dw([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dw(\d{4})">
     <description>Darwin</description>
-    <example service.version="1234">m8dw1234</example>
+    <example service.version="9876">m8dw9876</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
@@ -394,9 +394,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dy([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dy(\d{4})">
     <description>DYNIX</description>
-    <example service.version="1234">m8dy1234</example>
+    <example service.version="9876">m8dy9876</example>
     <param pos="0" name="os.vendor" value="Sequent"/>
     <param pos="0" name="os.family" value="Dynix"/>
     <param pos="0" name="os.product" value="Dynix"/>
@@ -404,9 +404,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)fb([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)fb(\d{4})">
     <description>FreeBSD</description>
-    <example service.version="1234">m8fb1234</example>
+    <example service.version="9876">m8fb9876</example>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -414,9 +414,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)hp([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)hp(\d{4})">
     <description>HP-UX</description>
-    <example service.version="1234">m8hp1234</example>
+    <example service.version="9876">m8hp9876</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="HP-UX"/>
     <param pos="0" name="os.product" value="HP-UX"/>
@@ -424,9 +424,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ir([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ir(\d{4})">
     <description>IRIX</description>
-    <example service.version="1234">m8ir1234</example>
+    <example service.version="9876">m8ir9876</example>
     <param pos="0" name="os.vendor" value="SGI"/>
     <param pos="0" name="os.family" value="Irix"/>
     <param pos="0" name="os.product" value="Irix"/>
@@ -434,9 +434,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)li([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)li(\d{4})">
     <description>Linux</description>
-    <example service.version="1234">m8li1234</example>
+    <example service.version="9876">m8li9876</example>
     <param pos="0" name="os.vendor" value="Linux"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -444,9 +444,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)mo([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)mo(\d{4})">
     <description>SVR</description>
-    <example service.version="1234">m8mo1234</example>
+    <example service.version="9876">m8mo9876</example>
     <param pos="0" name="os.vendor" value="Motorola"/>
     <param pos="0" name="os.family" value="SVR4"/>
     <param pos="0" name="os.product" value="SVR"/>
@@ -454,9 +454,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)o1([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)o1(\d{4})">
     <description>OSF/1</description>
-    <example service.version="1234">m8o11234</example>
+    <example service.version="9876">m8o19876</example>
     <param pos="0" name="os.vendor" value="DEC"/>
     <param pos="0" name="os.family" value="Digital UNIX"/>
     <param pos="0" name="os.product" value="OSF/1"/>
@@ -464,18 +464,18 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ro([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ro(\d{4})">
     <description>RISC OS</description>
-    <example service.version="1234">m8ro1234</example>
+    <example service.version="9876">m8ro9876</example>
     <param pos="0" name="os.family" value="RISC OS"/>
     <param pos="0" name="os.product" value="RISC OS"/>
     <param pos="0" name="service.product" value="VisionFS"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)sc([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)sc(\d{4})">
     <description>OpenServer</description>
-    <example service.version="1234">m8sc1234</example>
+    <example service.version="9876">m8sc9876</example>
     <param pos="0" name="os.vendor" value="SCO"/>
     <param pos="0" name="os.family" value="OpenServer"/>
     <param pos="0" name="os.product" value="OpenServer"/>
@@ -483,9 +483,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)so([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)so(\d{4})">
     <description>SunOS</description>
-    <example service.version="1234">m8so1234</example>
+    <example service.version="9876">m8so9876</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="SunOS"/>
     <param pos="0" name="os.product" value="SunOS"/>
@@ -493,9 +493,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)su([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)su(\d{4})">
     <description>Solaris</description>
-    <example service.version="1234">m8su1234</example>
+    <example service.version="9876">m8su9876</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
@@ -503,9 +503,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)sx([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)sx(\d{4})">
     <description>SINIX</description>
-    <example service.version="1234">m8sx1234</example>
+    <example service.version="9876">m8sx9876</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.family" value="SINIX"/>
     <param pos="0" name="os.product" value="SINIX"/>
@@ -513,9 +513,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ul([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ul(\d{4})">
     <description>Ultrix/1</description>
-    <example service.version="1234">m8ul1234</example>
+    <example service.version="9876">m8ul9876</example>
     <param pos="0" name="os.vendor" value="DEC"/>
     <param pos="0" name="os.family" value="Ultrix"/>
     <param pos="0" name="os.product" value="Ultrix"/>
@@ -523,9 +523,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)un([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)un(\d{4})">
     <description>UnixWare</description>
-    <example service.version="1234">m8un1234</example>
+    <example service.version="9876">m8un9876</example>
     <param pos="0" name="os.vendor" value="SCO"/>
     <param pos="0" name="os.family" value="UnixWare"/>
     <param pos="0" name="os.product" value="UnixWare"/>
@@ -533,9 +533,9 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)wi([\d]+4)">
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)wi(\d{4})">
     <description>Windows</description>
-    <example service.version="1234">m8wi1234</example>
+    <example service.version="9876">m8wi9876</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -351,4 +351,196 @@
     <param pos="0" name="service.vendor" value="Wind River"/>
     <param pos="0" name="service.product" value="VxWorks CIFS"/>
   </fingerprint>
+
+  <fingerprint pattern="^OS/400 \D(\d+)\D(\d+)\D(\d+)">
+    <description>OS/400</description>
+    <example os.version="4" os.version.version="5" os.version.version.version="0">OS/400 V4R5M0</example>
+    <param pos="0" name="os.vendor" value="IBM"/>
+    <param pos="0" name="os.product" value="OS/400"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.version.version"/>
+    <param pos="3" name="os.version.version.version"/>
+  </fingerprint>
+
+  <!-- VisionFS -->
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ai([\d]+4)">
+    <description>AIX</description>
+    <example service.version="1234">axai1234</example>
+    <param pos="0" name="os.vendor" value="IBM"/>
+    <param pos="0" name="os.family" value="AIX"/>
+    <param pos="0" name="os.product" value="AIX"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dg([\d]+4)">
+    <description>DG/UX</description>
+    <example service.version="1234">i3dg1234</example>
+    <param pos="0" name="os.vendor" value="Data General"/>
+    <param pos="0" name="os.family" value="DG/UX"/>
+    <param pos="0" name="os.product" value="DG/UX"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dw([\d]+4)">
+    <description>Darwin</description>
+    <example service.version="1234">m8dw1234</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)dy([\d]+4)">
+    <description>DYNIX</description>
+    <example service.version="1234">m8dy1234</example>
+    <param pos="0" name="os.vendor" value="Sequent"/>
+    <param pos="0" name="os.family" value="Dynix"/>
+    <param pos="0" name="os.product" value="Dynix"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)fb([\d]+4)">
+    <description>FreeBSD</description>
+    <example service.version="1234">m8fb1234</example>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)hp([\d]+4)">
+    <description>HP-UX</description>
+    <example service.version="1234">m8hp1234</example>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.family" value="HP-UX"/>
+    <param pos="0" name="os.product" value="HP-UX"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ir([\d]+4)">
+    <description>IRIX</description>
+    <example service.version="1234">m8ir1234</example>
+    <param pos="0" name="os.vendor" value="SGI"/>
+    <param pos="0" name="os.family" value="Irix"/>
+    <param pos="0" name="os.product" value="Irix"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)li([\d]+4)">
+    <description>Linux</description>
+    <example service.version="1234">m8li1234</example>
+    <param pos="0" name="os.vendor" value="Linux"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)mo([\d]+4)">
+    <description>SVR</description>
+    <example service.version="1234">m8mo1234</example>
+    <param pos="0" name="os.vendor" value="Motorola"/>
+    <param pos="0" name="os.family" value="SVR4"/>
+    <param pos="0" name="os.product" value="SVR"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)o1([\d]+4)">
+    <description>OSF/1</description>
+    <example service.version="1234">m8o11234</example>
+    <param pos="0" name="os.vendor" value="DEC"/>
+    <param pos="0" name="os.family" value="Digital UNIX"/>
+    <param pos="0" name="os.product" value="OSF/1"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ro([\d]+4)">
+    <description>RISC OS</description>
+    <example service.version="1234">m8ro1234</example>
+    <param pos="0" name="os.family" value="RISC OS"/>
+    <param pos="0" name="os.product" value="RISC OS"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)sc([\d]+4)">
+    <description>OpenServer</description>
+    <example service.version="1234">m8sc1234</example>
+    <param pos="0" name="os.vendor" value="SCO"/>
+    <param pos="0" name="os.family" value="OpenServer"/>
+    <param pos="0" name="os.product" value="OpenServer"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)so([\d]+4)">
+    <description>SunOS</description>
+    <example service.version="1234">m8so1234</example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="SunOS"/>
+    <param pos="0" name="os.product" value="SunOS"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)su([\d]+4)">
+    <description>Solaris</description>
+    <example service.version="1234">m8su1234</example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)sx([\d]+4)">
+    <description>SINIX</description>
+    <example service.version="1234">m8sx1234</example>
+    <param pos="0" name="os.vendor" value="Siemens"/>
+    <param pos="0" name="os.family" value="SINIX"/>
+    <param pos="0" name="os.product" value="SINIX"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ul([\d]+4)">
+    <description>Ultrix/1</description>
+    <example service.version="1234">m8ul1234</example>
+    <param pos="0" name="os.vendor" value="DEC"/>
+    <param pos="0" name="os.family" value="Ultrix"/>
+    <param pos="0" name="os.product" value="Ultrix"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)un([\d]+4)">
+    <description>UnixWare</description>
+    <example service.version="1234">m8un1234</example>
+    <param pos="0" name="os.vendor" value="SCO"/>
+    <param pos="0" name="os.family" value="UnixWare"/>
+    <param pos="0" name="os.product" value="UnixWare"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)wi([\d]+4)">
+    <description>Windows</description>
+    <example service.version="1234">m8wi1234</example>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="service.product" value="VisionFS"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
Banners for VisionFS and OS/400

According to our code comments VisionFS returns [AR][OS][VFVR] which is arch, os and VisionFS version. The remainder of the visionFS banner contains the "uname -a" output, such as: `[abbrev] [uname -a output...`:
```
i3un0210 UnixWare unixware7 5 7 i386
```

After discussion within the team, we decided to error on the safe side and only match on the [abbrev].

RSpec output:
```rspec
Finished in 53.32 seconds (files took 1.9 seconds to load)
17868 examples, 0 failures

Randomized with seed 64103

/opt/ruby2.2/lib/ruby/gems/2.2.0/gems/simplecov-0.10.0/lib/simplecov/defaults.rb:50: warning: global variable `$ERROR_INFO' not initialized
Coverage report generated for RSpec to /home/jkennedy/rapid7/recog/coverage. 690 / 722 LOC (95.57%) covered.
```