### PR TITLE
SMB banners for Windows

### DIFF
--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -54,6 +54,7 @@
     <example service.product="Windows Server 2012 R2 Standard 6.3">Windows Server 2012 R2 Standard 6.3</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="1" name="service.product"/>
+    <param pos="0" name="service.certainty" value="1.00"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -41,6 +41,7 @@
     <param pos="0" name="service.vendor" value="Samba"/>
     <param pos="0" name="service.product" value="Samba"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.certainty" value="1.00"/>
   </fingerprint>
 
   <!-- Windows -->

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -42,4 +42,18 @@
     <param pos="0" name="service.product" value="Samba"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
+
+  <!-- Windows -->
+  <fingerprint pattern="^(Windows [\W*\w*]*)$">
+    <description>Windows</description>
+    <example service.product="Windows Server 2008 R2 Enterprise 6.1">Windows Server 2008 R2 Enterprise 6.1</example>
+    <example service.product="Windows 7 Enterprise 6.1">Windows 7 Enterprise 6.1</example>
+    <example service.product="Windows Server 2003 R2 5.2">Windows Server 2003 R2 5.2</example>
+    <example service.product="Windows Server 2012 Standard 6.2">Windows Server 2012 Standard 6.2</example>
+    <example service.product="Windows 8 Enterprise 6.2">Windows 8 Enterprise 6.2</example>
+    <example service.product="Windows Server 2012 R2 Standard 6.3">Windows Server 2012 R2 Standard 6.3</example>
+    <param pos="0" name="service.vendor" value="Microsoft"/>
+    <param pos="1" name="service.product"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -6,7 +6,7 @@
   <fingerprint pattern="^(Windows NT \d\.\d+)$">
     <description>Windows NT</description>
     <example os.product="Windows NT 4.0">Windows NT 4.0</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>
@@ -16,7 +16,7 @@
     <description>Windows 95/98/ME</description>
     <example os.product="Windows 95">Windows 95</example>
     <example os.product="Windows 98">Windows 98</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>
@@ -25,7 +25,7 @@
   <fingerprint pattern="^Windows 5\.0$">
     <description>Windows 2000</description>
     <example>Windows 5.0</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
     <param pos="0" name="os.device" value="General"/>
@@ -33,7 +33,7 @@
   <fingerprint pattern="^Windows 5\.1$">
     <description>Windows XP</description>
     <example>Windows 5.1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
@@ -42,7 +42,7 @@
   <fingerprint pattern="^Windows XP (\d+) (Service Pack \d+)$">
     <description>Windows XP</description>
     <example os.build="2600" os.version="Service Pack 1">Windows XP 2600 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
@@ -53,7 +53,7 @@
   <fingerprint pattern="^Windows XP (\d+)$">
     <description>Windows XP</description>
     <example os.build="2600">Windows XP 2600</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
@@ -62,7 +62,7 @@
   </fingerprint>
   <fingerprint pattern="^Windows \.NET">
     <description>Windows Server 2003 Beta</description>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
@@ -71,7 +71,7 @@
   </fingerprint>
   <fingerprint pattern="^Windows Server 2003 R2 (\d+)$">
     <description>Windows Server 2003 R2</description>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
@@ -81,7 +81,7 @@
   <fingerprint pattern="^Windows Server 2003 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2003 R2 (SP)</description>
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 R2 3790 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
@@ -92,7 +92,7 @@
   <fingerprint pattern="^Windows Server 2003 (\d+)$">
     <description>Windows Server 2003</description>
     <example os.build="3790">Windows Server 2003 3790</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
@@ -103,7 +103,7 @@
     <description>Windows Server 2003 (SP)</description>
     <example os.build="3790" os.version="Service Pack 1">Windows Server 2003 3790 Service Pack 1</example>
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 3790 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
@@ -116,7 +116,7 @@
     <description>Windows Server 2008</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows Server (R) 2008 Enterprise without Hyper-V 6001 Service Pack 1</example>
     <example os.edition="Enterprise" os.version="Service Pack 2">Windows Server (R) 2008 Enterprise 6002 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -128,7 +128,7 @@
   <fingerprint pattern="^Windows \(R\) Web Server 2008 (\d+) (Service Pack \d+)$">
     <description>Windows Web Server 2008 (SP)</description>
     <example os.edition="Web" os.version="Service Pack 2">Windows (R) Web Server 2008 6002 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -140,7 +140,7 @@
   <fingerprint pattern="^Windows \(R\) Web Server 2008 (\d+)$">
     <description>Windows Web Server 2008</description>
     <example>Windows (R) Web Server 2008 6002</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -151,7 +151,7 @@
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 Storage (SP)</description>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -163,7 +163,7 @@
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Web Server 2008 Storage</description>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -174,7 +174,7 @@
   <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 HPC</description>
     <example>Windows Server 2008 HPC Edition 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -187,7 +187,7 @@
   <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+)$">
     <description>Windows Web Server 2008 HPC</description>
     <example>Windows Server 2008 HPC Edition 7600</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -200,7 +200,7 @@
     <description>Windows Server 2008</description>
     <example>Windows Server 2008 R2 Enterprise 7601 Service Pack 1</example>
     <example>Windows Server 2008 R2 Standard 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -214,7 +214,7 @@
     <example os.edition="Enterprise">Windows Server 2008 R2 Enterprise 7600</example>
     <example os.edition="Standard">Windows Server 2008 R2 Standard 7600</example>
     <example os.edition="Datacenter">Windows Server 2008 R2 Datacenter 7600</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -225,7 +225,7 @@
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 R2 Web</description>
     <example os.version="Service Pack 1">Windows Web Server 2008 R2 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -237,7 +237,7 @@
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+)$">
     <description>Windows Web Server 2008 R2 Web</description>
     <example>Windows Web Server 2008 R2 7600</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -248,7 +248,7 @@
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Vista (SP)</description>
     <example os.edition="Home Premium" os.version="Service Pack 2">Windows Vista (TM) Home Premium 6002 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
@@ -260,7 +260,7 @@
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Vista</description>
     <example os.edition="Home Premium">Windows Vista (TM) Home Premium 6000</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
@@ -272,7 +272,7 @@
     <description>Windows 7/8 (SP + Edition)</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows 7 Enterprise 7601 Service Pack 1</example>
     <example os.edition="Starter" os.version="Service Pack 1">Windows 7 Starter 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -284,7 +284,7 @@
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\d+) (Service Pack \d+)$">
     <description>Windows 7/8 (SP)</description>
     <example os.version="Service Pack 1">Windows 7 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -297,7 +297,7 @@
     <example os.edition="Enterprise">Windows 7 Enterprise 7600</example>
     <example os.edition="Enterprise">Windows 8.1 Enterprise 9600</example>
     <example os.edition="Enterprise">Windows 8 Enterprise 9200</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -308,7 +308,7 @@
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\d+)$">
     <description>Windows 7/8</description>
     <example>Windows 8 9200</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -319,7 +319,7 @@
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows Server 2012 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2012 R2 (SP)</description>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
@@ -331,7 +331,7 @@
   <fingerprint pattern="^Windows Server 2012 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2012 R2</description>
     <example os.edition="Standard">Windows Server 2012 R2 Standard 9600</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
@@ -342,7 +342,7 @@
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2012 (SP)</description>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
@@ -354,7 +354,7 @@
   <fingerprint pattern="^Windows Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2012</description>
     <example>Windows Server 2012 Standard 9200</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
@@ -365,7 +365,7 @@
   <fingerprint pattern="^Windows MultiPoint Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows MultiPoint Server 2012 (SP)</description>
     <example os.build="9201" os.version="Service Pack 1">Windows MultiPoint Server 2012 Premium 9201 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -377,7 +377,7 @@
   <fingerprint pattern="^Windows MultiPoint Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows MultiPoint Server 2012</description>
     <example os.build="9200">Windows MultiPoint Server 2012 Premium 9200</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -388,7 +388,7 @@
   <fingerprint pattern="^Windows Storage Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Storage Server 2012</description>
     <example os.build="9200">Windows Storage Server 2012 Standard 9200</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -400,7 +400,7 @@
   <fingerprint pattern="^Windows 10 (\w+|\w+ \w+|\w+ \w+ \w+) Insider Preview (\d+)$">
     <description>Windows 10 Enterprise Insider Preview</description>
     <example os.build="10130" os.edition="Enterprise">Windows 10 Enterprise Insider Preview 10130</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 10"/>
@@ -416,7 +416,7 @@
     <example os.build="10130" os.edition="Home">Windows 10 Home 10130</example>
     <example os.build="10130" os.edition="Education">Windows 10 Education 10130</example>
     <example os.build="10130" os.edition="Professional">Windows 10 Professional 10130</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 10"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -6,361 +6,396 @@
   <fingerprint pattern="^(Windows NT \d\.\d+)$">
     <description>Windows NT</description>
     <example os.product="Windows NT 4.0">Windows NT 4.0</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(Windows (?:95|98|ME))$">
     <description>Windows 95/98/ME</description>
     <example os.product="Windows 95">Windows 95</example>
     <example os.product="Windows 98">Windows 98</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows 5\.0$">
     <description>Windows 2000</description>
     <example>Windows 5.0</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows 5\.1$">
     <description>Windows XP</description>
     <example>Windows 5.1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows XP (\d+) (Service Pack \d+)$">
     <description>Windows XP</description>
     <example os.build="2600" os.version="Service Pack 1">Windows XP 2600 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows XP (\d+)$">
     <description>Windows XP</description>
     <example os.build="2600">Windows XP 2600</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows \.NET">
     <description>Windows Server 2003 Beta</description>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
     <param pos="0" name="os.version" value="Beta"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2003 R2 (\d+)$">
     <description>Windows Server 2003 R2</description>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2003 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2003 R2 (SP)</description>
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 R2 3790 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2003 (\d+)$">
     <description>Windows Server 2003</description>
     <example os.build="3790">Windows Server 2003 3790</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2003 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2003 (SP)</description>
     <example os.build="3790" os.version="Service Pack 1">Windows Server 2003 3790 Service Pack 1</example>
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 3790 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- Note that 2008 SP1 is technically "2008 Gold" according to Microsoft -->
   <fingerprint pattern="^Windows Server \(R\) 2008 (\w+|\w+ \w+|\w+ \w+ \w+)(?: (?:with|without) Hyper-V|) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows Server (R) 2008 Enterprise without Hyper-V 6001 Service Pack 1</example>
     <example os.edition="Enterprise" os.version="Service Pack 2">Windows Server (R) 2008 Enterprise 6002 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows \(R\) Web Server 2008 (\d+) (Service Pack \d+)$">
     <description>Windows Web Server 2008 (SP)</description>
     <example os.edition="Web" os.version="Service Pack 2">Windows (R) Web Server 2008 6002 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows \(R\) Web Server 2008 (\d+)$">
     <description>Windows Web Server 2008</description>
     <example>Windows (R) Web Server 2008 6002</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 Storage (SP)</description>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Storage"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Web Server 2008 Storage</description>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Storage"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 HPC</description>
     <example>Windows Server 2008 HPC Edition 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="HPC"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+)$">
     <description>Windows Web Server 2008 HPC</description>
     <example>Windows Server 2008 HPC Edition 7600</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
     <param pos="0" name="os.edition" value="HPC"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- 2008 R2 -->
   <fingerprint pattern="^Windows Server 2008 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008</description>
     <example>Windows Server 2008 R2 Enterprise 7601 Service Pack 1</example>
     <example>Windows Server 2008 R2 Standard 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2008 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2008 R2</description>
     <example os.edition="Enterprise">Windows Server 2008 R2 Enterprise 7600</example>
     <example os.edition="Standard">Windows Server 2008 R2 Standard 7600</example>
     <example os.edition="Datacenter">Windows Server 2008 R2 Datacenter 7600</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 R2 Web</description>
     <example os.version="Service Pack 1">Windows Web Server 2008 R2 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+)$">
     <description>Windows Web Server 2008 R2 Web</description>
     <example>Windows Web Server 2008 R2 7600</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Vista (SP)</description>
     <example os.edition="Home Premium" os.version="Service Pack 2">Windows Vista (TM) Home Premium 6002 Service Pack 2</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Vista</description>
     <example os.edition="Home Premium">Windows Vista (TM) Home Premium 6000</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows 7/8 (SP + Edition)</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows 7 Enterprise 7601 Service Pack 1</example>
     <example os.edition="Starter" os.version="Service Pack 1">Windows 7 Starter 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.edition"/>
     <param pos="3" name="os.build"/>
     <param pos="4" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\d+) (Service Pack \d+)$">
     <description>Windows 7/8 (SP)</description>
     <example os.version="Service Pack 1">Windows 7 7601 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.build"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows 7/8 (Edition)</description>
     <example os.edition="Enterprise">Windows 7 Enterprise 7600</example>
     <example os.edition="Enterprise">Windows 8.1 Enterprise 9600</example>
     <example os.edition="Enterprise">Windows 8 Enterprise 9200</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.edition"/>
     <param pos="3" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\d+)$">
     <description>Windows 7/8</description>
     <example>Windows 8 9200</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- Windows 2012 R2 matches go first to simplify the regular expressions -->
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows Server 2012 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2012 R2 (SP)</description>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2012 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2012 R2</description>
     <example os.edition="Standard">Windows Server 2012 R2 Standard 9600</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- TODO: Need an example string -->
   <fingerprint pattern="^Windows Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2012 (SP)</description>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2012</description>
     <example>Windows Server 2012 Standard 9200</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows MultiPoint Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows MultiPoint Server 2012 (SP)</description>
     <example os.build="9201" os.version="Service Pack 1">Windows MultiPoint Server 2012 Premium 9201 Service Pack 1</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="MultiPoint"/>
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows MultiPoint Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows MultiPoint Server 2012</description>
     <example os.build="9200">Windows MultiPoint Server 2012 Premium 9200</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.edition" value="MultiPoint"/>
     <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <!-- Windows 10 Preview -->
   <fingerprint pattern="^Windows 10 (\w+|\w+ \w+|\w+ \w+ \w+) Insider Preview (\d+)$">
     <description>Windows 10 Enterprise Insider Preview</description>
     <example os.build="10130" os.edition="Enterprise">Windows 10 Enterprise Insider Preview 10130</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 10"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^Windows 10 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows 10</description>
@@ -370,12 +405,13 @@
     <example os.build="10130" os.edition="Home">Windows 10 Home 10130</example>
     <example os.build="10130" os.edition="Education">Windows 10 Education 10130</example>
     <example os.build="10130" os.edition="Professional">Windows 10 Professional 10130</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 10"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^VxWorks">
     <description>VxWorks</description>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -385,6 +385,17 @@
     <param pos="1" name="os.build"/>
     <param pos="0" name="os.device" value="General"/>
   </fingerprint>
+  <fingerprint pattern="^Windows Storage Server 2012 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+    <description>Windows Storage Server 2012</description>
+    <example os.build="9200">Windows Storage Server 2012 Standard 9200</example>
+    <param pos="0" name="os.certainty" value="0.85"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2012"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.edition" value="Storage"/>
+    <param pos="1" name="os.build"/>
+    <param pos="0" name="os.device" value="General"/>
+  </fingerprint>
   <!-- Windows 10 Preview -->
   <fingerprint pattern="^Windows 10 (\w+|\w+ \w+|\w+ \w+ \w+) Insider Preview (\d+)$">
     <description>Windows 10 Enterprise Insider Preview</description>


### PR DESCRIPTION
LM Banners for Windows. This regex is required to maintain current behaviour of Nexpose. We might create more specific banners later on. 