### PR TITLE
Add missing OpenSSH and HipServ SSH fingerprints

### DIFF
--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -479,9 +479,9 @@ fingerprint SSH servers.
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
     <param pos="0" name="os.vendor" value="HipServ"/>
-    <param pos="0" name="os.device" value="Router"/>
-    <param pos="0" name="os.family" value="RouterOS"/>
-    <param pos="0" name="os.product" value="RouterOS"/>
+    <param pos="0" name="os.device" value="NAS"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="HipServ"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(.*) in DesktopAuthority (?:.*)$">
     <description>DesktopAuthority SSH</description>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -349,6 +349,38 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-5(?:\+deb8u\d+)?)$">
+    <description>OpenSSH running on Debian 8.x (jessie)</description>
+    <example service.version="6.7p1" openssh.comment="Debian-5">OpenSSH_6.7p1 Debian-5</example>
+    <example service.version="6.7p1" openssh.comment="Debian-5+deb8u1">OpenSSH_6.7p1 Debian-5+deb8u1</example>
+    <example service.version="6.7p1" openssh.comment="Debian-5+deb8u2">OpenSSH_6.7p1 Debian-5+deb8u2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="8.0"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-5(?:\+deb8u\d+)?)$">
+    <description>OpenSSH running on Raspbian 8.x (jessie)</description>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5">OpenSSH_6.7p1 Raspbian-5</example>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u1">OpenSSH_6.7p1 Raspbian-5+deb8u1</example>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u2">OpenSSH_6.7p1 Raspbian-5+deb8u2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="os.vendor" value="Raspbian"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="8.0"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+squeeze.*)$">
     <description>OpenSSH running on Debian 6.0 (squeeze)</description>
     <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>
@@ -435,6 +467,18 @@ fingerprint SSH servers.
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
     <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.family" value="RouterOS"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(.*)-HipServ$">
+    <description>OpenSSH on HipServ</description>
+    <example service.version="4.3">OpenSSH_4.3-HipServ</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="os.vendor" value="HipServ"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="RouterOS"/>
     <param pos="0" name="os.product" value="RouterOS"/>


### PR DESCRIPTION
This is just a start, will push more missing SSH banners as I go.  Current questions: 

- Rasbian is for the Raspberry Pi but as-is this isn't mentioned in the fingerprint.  Where should it go?  And should we add a new "IoT" category or family? 
- HipServ is a home NAS to store media is there a better family for that?  Otherwise I've called it a Router... 