### PR TITLE
[WIP] Add support for matching against all XML databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Matches can be tested on the command-line in a similar fashion:
 
 ```
     $ echo 'OpenSSH_6.6p1 Ubuntu-2ubuntu1' | bin/recog_match xml/ssh_banners.xml -
-    MATCH: {"service.version"=>"6.6p1", "openssh.comment"=>"Ubuntu-2ubuntu1", "service.vendor"=>"OpenBSD", "service.family"=>"OpenSSH", "service.product"=>"OpenSSH", "data"=>"OpenSSH_6.6p1 Ubuntu-2ubuntu1"}
+    MATCH: {"matched"=>"OpenSSH running on Ubuntu 14.04", "service.version"=>"6.6p1", "openssh.comment"=>"Ubuntu-2ubuntu1", "service.vendor"=>"OpenBSD", "service.family"=>"OpenSSH", "service.product"=>"OpenSSH", "os.vendor"=>"Ubuntu", "os.device"=>"General", "os.family"=>"Linux", "os.product"=>"Linux", "os.version"=>"14.04", "service.protocol"=>"ssh", "fingerprint_db"=>"ssh.banner", "data"=>"OpenSSH_6.6p1 Ubuntu-2ubuntu1"}
 ```
 
 ### Best Practices

--- a/features/data/matching_banners_fingerprints.xml
+++ b/features/data/matching_banners_fingerprints.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<fingerprints protocol="ftp" type="service">
+<fingerprints protocol="ftp" database_type="service">
   <fingerprint pattern="^-{10} Welcome to Pure-FTPd (.*)-{10}$">
     <example>---------- Welcome to Pure-FTPd ----------</example>
     <description>Pure-FTPd

--- a/features/data/matching_banners_fingerprints.xml
+++ b/features/data/matching_banners_fingerprints.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<fingerprints>
+<fingerprints protocol="ftp" type="service">
   <fingerprint pattern="^-{10} Welcome to Pure-FTPd (.*)-{10}$">
     <example>---------- Welcome to Pure-FTPd ----------</example>
     <description>Pure-FTPd

--- a/features/data/matching_banners_fingerprints.xml
+++ b/features/data/matching_banners_fingerprints.xml
@@ -8,10 +8,12 @@
     <param pos="1" name="pureftpd.config"/>
     <param pos="0" name="service.family" value="Pure-FTPd"/>
     <param pos="0" name="service.product" value="Pure-FTPd"/>
+    <param pos="0" name="service.protocol" value="ftp"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP Server \(SunOS (\S+)\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
     <example>example.com FTP server (SunOS 5.7) ready.</example>
+    <param pos="0" name="service.protocol" value="ftp"/>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/features/data/matching_banners_fingerprints.xml
+++ b/features/data/matching_banners_fingerprints.xml
@@ -13,7 +13,6 @@
   <fingerprint pattern="^(\S+) FTP Server \(SunOS (\S+)\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
     <example>example.com FTP server (SunOS 5.7) ready.</example>
-    <param pos="0" name="service.protocol" value="ftp"/>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/features/data/multiple_banners_fingerprints.xml
+++ b/features/data/multiple_banners_fingerprints.xml
@@ -16,10 +16,12 @@
     <param pos="1" name="pureftpd.config"/>
     <param pos="0" name="service.family" value="Pure-FTPd"/>
     <param pos="0" name="service.product" value="Pure-FTPd"/>
+    <param pos="0" name="service.protocol" value="ftp"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP Server \(SunOS (\S+)\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
     <example>example.com FTP server (SunOS 5.7) ready.</example>
+    <param pos="0" name="service.protocol" value="ftp"/>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/features/match.feature
+++ b/features/match.feature
@@ -3,8 +3,8 @@ Feature: Match
     When I run `recog_match matching_banners_fingerprints.xml sample_banner.txt`
     Then it should pass with:
       """
-      MATCH: {"matched"=>"Pure-FTPd Config data can be zero or more of: [privsep] [TLS]", "pureftpd.config"=>"[privsep] [TLS] ", "service.family"=>"Pure-FTPd", "service.product"=>"Pure-FTPd", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
-      MATCH: {"matched"=>"SunOS/Solaris", "os.vendor"=>"Sun", "os.family"=>"Solaris", "os.product"=>"Solaris", "os.device"=>"General", "host.name"=>"polaris", "os.version"=>"5.8", "data"=>"polaris FTP server (SunOS 5.8) ready."}
+      MATCH: {"matched"=>"Pure-FTPd Config data can be zero or more of: [privsep] [TLS]", "pureftpd.config"=>"[privsep] [TLS] ", "service.family"=>"Pure-FTPd", "service.product"=>"Pure-FTPd", "service.protocol"=>"ftp", "fingerprint_db"=>"matching_banners_fingerprints", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
+      MATCH: {"matched"=>"SunOS/Solaris", "service.protocol"=>"ftp", "os.vendor"=>"Sun", "os.family"=>"Solaris", "os.product"=>"Solaris", "os.device"=>"General", "host.name"=>"polaris", "os.version"=>"5.8", "fingerprint_db"=>"matching_banners_fingerprints", "data"=>"polaris FTP server (SunOS 5.8) ready."}
       """
 
   Scenario: Fails at finding matches
@@ -19,14 +19,14 @@ Feature: Match
     When I run `recog_match multiple_banners_fingerprints.xml sample_banner.txt --multi-match`
     Then it should pass with:
       """
-      MATCHES: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"},{"matched"=>"Pure-FTPd Config data can be zero or more of: [privsep] [TLS]", "pureftpd.config"=>"[privsep] [TLS] ", "service.family"=>"Pure-FTPd", "service.product"=>"Pure-FTPd", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
-      MATCHES: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "data"=>"polaris FTP server (SunOS 5.8) ready."},{"matched"=>"SunOS/Solaris", "os.vendor"=>"Sun", "os.family"=>"Solaris", "os.product"=>"Solaris", "os.device"=>"General", "host.name"=>"polaris", "os.version"=>"5.8", "data"=>"polaris FTP server (SunOS 5.8) ready."}
+      MATCHES: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "service.protocol"=>"", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"},{"matched"=>"Pure-FTPd Config data can be zero or more of: [privsep] [TLS]", "pureftpd.config"=>"[privsep] [TLS] ", "service.family"=>"Pure-FTPd", "service.product"=>"Pure-FTPd", "service.protocol"=>"ftp", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
+      MATCHES: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "service.protocol"=>"", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"polaris FTP server (SunOS 5.8) ready."},{"matched"=>"SunOS/Solaris", "service.protocol"=>"ftp", "os.vendor"=>"Sun", "os.family"=>"Solaris", "os.product"=>"Solaris", "os.device"=>"General", "host.name"=>"polaris", "os.version"=>"5.8", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"polaris FTP server (SunOS 5.8) ready."}
       """
 
   Scenario: Finds first matches using no-multi-match flag
     When I run `recog_match multiple_banners_fingerprints.xml sample_banner.txt --no-multi-match`
     Then it should pass with:
     """
-    MATCH: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
-    MATCH: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "data"=>"polaris FTP server (SunOS 5.8) ready."}
+    MATCH: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "service.protocol"=>"", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
+    MATCH: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "service.protocol"=>"", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"polaris FTP server (SunOS 5.8) ready."}
     """

--- a/features/match.feature
+++ b/features/match.feature
@@ -4,7 +4,7 @@ Feature: Match
     Then it should pass with:
       """
       MATCH: {"matched"=>"Pure-FTPd Config data can be zero or more of: [privsep] [TLS]", "pureftpd.config"=>"[privsep] [TLS] ", "service.family"=>"Pure-FTPd", "service.product"=>"Pure-FTPd", "service.protocol"=>"ftp", "fingerprint_db"=>"matching_banners_fingerprints", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
-      MATCH: {"matched"=>"SunOS/Solaris", "service.protocol"=>"ftp", "os.vendor"=>"Sun", "os.family"=>"Solaris", "os.product"=>"Solaris", "os.device"=>"General", "host.name"=>"polaris", "os.version"=>"5.8", "fingerprint_db"=>"matching_banners_fingerprints", "data"=>"polaris FTP server (SunOS 5.8) ready."}
+      MATCH: {"matched"=>"SunOS/Solaris", "os.vendor"=>"Sun", "os.family"=>"Solaris", "os.product"=>"Solaris", "os.device"=>"General", "host.name"=>"polaris", "os.version"=>"5.8", "service.protocol"=>"ftp", "fingerprint_db"=>"matching_banners_fingerprints", "data"=>"polaris FTP server (SunOS 5.8) ready."}
       """
 
   Scenario: Fails at finding matches

--- a/lib/recog/db.rb
+++ b/lib/recog/db.rb
@@ -13,19 +13,19 @@ class DB
   #   against strings that make sense for the {#match_key}
   attr_reader :fingerprints
 
-  # @return [String] Taken from the `fingerprints/matches` element, or
+  # @return [String] Taken from the `fingerprints/matches` attribute, or
   #   defaults to the basename of {#path} without the `.xml` extension.
   attr_reader :match_key
 
-  # @return [String] Taken from the `fingerprints/protocol` element, or
+  # @return [String] Taken from the `fingerprints/protocol` attribute, or
   #   defaults to an empty string
   attr_reader :protocol
 
-  # @return [String] Taken from the `fingerprints/database_type` element
+  # @return [String] Taken from the `fingerprints/database_type` attribute
   #   defaults to an empty string
   attr_reader :database_type
 
-  # @return [Float] Taken from the `fingerprints/preference` element,
+  # @return [Float] Taken from the `fingerprints/preference` attribute,
   #   defaults to 0.10.  Used when ordering databases, highest numbers
   #   are given priority and are processed first.
   attr_reader :preference

--- a/lib/recog/db.rb
+++ b/lib/recog/db.rb
@@ -25,20 +25,22 @@ class DB
   #   defaults to an empty string
   attr_reader :database_type
 
-  # @return [Integer] Taken from the `fingerprints/priority` element,
-  #   defaults to 100.  Used when ordering databases, lowest numbers
-  #   first.
-  attr_reader :priority
+  # @return [Float] Taken from the `fingerprints/preference` element,
+  #   defaults to 0.10.  Used when ordering databases, highest numbers
+  #   are given priority and are processed first.
+  attr_reader :preference
 
-  # Default Fingerprint database priority when it isn't specified in file
-  DEFAULT_FP_DB_PRIORITY = 100
+  # Default Fingerprint database preference when it isn't specified in file
+  # Do not use a value below 0.10 so as to allow users to specify lower
+  # values in their own custom XML that will always run last.
+  DEFAULT_FP_PREFERENCE = 0.10
 
   # @param path [String]
   def initialize(path)
     @match_key = nil
     @protocol = ''
     @database_type = ''
-    @priority = DEFAULT_FP_DB_PRIORITY
+    @preference = DEFAULT_FP_PREFERENCE.to_f
     @path = path
     @fingerprints = []
 
@@ -60,7 +62,7 @@ class DB
       @match_key = fbase['matches'].to_s if fbase['matches']
       @protocol = fbase['protocol'].to_s if fbase['protocol']
       @database_type = fbase['database_type'].to_s if fbase['database_type']
-      @priority = fbase['priority'].to_i if fbase['priority']
+      @preference = fbase['preference'].to_f if fbase['preference']
 
     end
 

--- a/lib/recog/db.rb
+++ b/lib/recog/db.rb
@@ -19,12 +19,23 @@ class DB
 
   # @return [String] Taken from the `fingerprints/protocol` element, or
   #   defaults to an empty string
-  attr_reader :match_protocol
+  attr_reader :protocol
+
+  # @return [String] Taken from the `fingerprints/type` element
+  #   defaults to an empty string
+  attr_reader :db_type
+
+  # @return [Integer] Taken from the `fingerprints/priority` element,
+  #   defaults to 100.  Used when ordering databases, lowest numbers
+  #   first.
+  attr_reader :priority
 
   # @param path [String]
   def initialize(path)
     @match_key = nil
-    @match_protocol = ''
+    @protocol = ''
+    @db_type = ''
+    @priority = 100
     @path = path
     @fingerprints = []
 
@@ -47,7 +58,15 @@ class DB
       end
 
       if fbase['protocol']
-        @match_protocol = fbase['protocol'].to_s
+        @protocol = fbase['protocol'].to_s
+      end
+
+      if fbase['type']
+        @db_type = fbase['type'].to_s
+      end
+
+      if fbase['priority']
+        @priority = fbase['priority'].to_i
       end
     end
 
@@ -56,7 +75,7 @@ class DB
     end
 
     xml.xpath("/fingerprints/fingerprint").each do |fprint|
-      @fingerprints << Fingerprint.new(fprint, @match_key, @match_protocol)
+      @fingerprints << Fingerprint.new(fprint, @match_key, @protocol)
     end
 
     xml = nil

--- a/lib/recog/db.rb
+++ b/lib/recog/db.rb
@@ -58,9 +58,9 @@ class DB
     xml.xpath('/fingerprints').each do |fbase|
 
       @match_key = fbase['matches'].to_s if fbase['matches']
-      @protocol  = fbase['protocol'].to_s if fbase['protocol']
+      @protocol = fbase['protocol'].to_s if fbase['protocol']
       @database_type = fbase['database_type'].to_s if fbase['database_type']
-      @priority  = fbase['priority'].to_i if fbase['priority']
+      @priority = fbase['priority'].to_i if fbase['priority']
 
     end
 

--- a/lib/recog/db.rb
+++ b/lib/recog/db.rb
@@ -30,12 +30,15 @@ class DB
   #   first.
   attr_reader :priority
 
+  # Default Fingerprint database priority when it isn't specified in file
+  DEFAULT_FP_DB_PRIORITY = 100
+
   # @param path [String]
   def initialize(path)
     @match_key = nil
     @protocol = ''
     @db_type = ''
-    @priority = 100
+    @priority = DEFAULT_FP_DB_PRIORITY
     @path = path
     @fingerprints = []
 

--- a/lib/recog/db.rb
+++ b/lib/recog/db.rb
@@ -17,9 +17,14 @@ class DB
   #   defaults to the basename of {#path} without the `.xml` extension.
   attr_reader :match_key
 
+  # @return [String] Taken from the `fingerprints/protocol` element, or
+  #   defaults to an empty string
+  attr_reader :match_protocol
+
   # @param path [String]
   def initialize(path)
     @match_key = nil
+    @match_protocol = ''
     @path = path
     @fingerprints = []
 
@@ -40,6 +45,10 @@ class DB
       if fbase['matches']
         @match_key = fbase['matches'].to_s
       end
+
+      if fbase['protocol']
+        @match_protocol = fbase['protocol'].to_s
+      end
     end
 
     unless @match_key
@@ -47,7 +56,7 @@ class DB
     end
 
     xml.xpath("/fingerprints/fingerprint").each do |fprint|
-      @fingerprints << Fingerprint.new(fprint)
+      @fingerprints << Fingerprint.new(fprint, @match_key, @match_protocol)
     end
 
     xml = nil

--- a/lib/recog/db_manager.rb
+++ b/lib/recog/db_manager.rb
@@ -13,8 +13,12 @@ class DBManager
   end
 
   def load_databases
-    Dir[self.path + "/*.xml"].each do |dbxml|
-      self.databases << DB.new(dbxml)
+    if File.directory?(self.path)
+      Dir[self.path + "/*.xml"].each do |dbxml|
+        self.databases << DB.new(dbxml)
+      end
+    elsif File.file?(self.path) && File.readable?(self.path)
+       self.databases << DB.new(self.path)
     end
   end
 

--- a/lib/recog/db_manager.rb
+++ b/lib/recog/db_manager.rb
@@ -17,8 +17,8 @@ class DBManager
       Dir[self.path + "/*.xml"].each do |dbxml|
         self.databases << DB.new(dbxml)
       end
-    elsif File.file?(self.path) && File.readable?(self.path)
-       self.databases << DB.new(self.path)
+    else
+      self.databases << DB.new(self.path)
     end
   end
 

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -43,7 +43,17 @@ class Fingerprint
   # @return [Hash,nil] Keys will be host, service, and os attributes
   def match(match_string)
     # match_string.force_encoding('BINARY') if match_string
-    match_data = @regex.match(match_string)
+    begin
+      match_data = @regex.match(match_string)
+    rescue Encoding::CompatibilityError
+      ## FIXFIX - Determine if this can be addressed
+      return nil
+    rescue Exception => e
+      STDERR.puts e.inspect
+      STDERR.puts e
+      STDERR.puts "Problematic banner:\n#{match_string}"
+      STDERR.puts match_string.length
+    end
     return if match_data.nil?
 
     result = { 'matched' => @name }

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -27,7 +27,10 @@ class Fingerprint
   attr_reader :tests
 
   # @param xml [Nokogiri::XML::Element]
-  def initialize(xml)
+  # @param match_protocol [String] Protocol such as ftp, mssql, http, etc.
+  def initialize(xml, match_key, match_protocol)
+    @match_key = match_key
+    @match_protocol = match_protocol
     @name   = parse_description(xml)
     @regex  = create_regexp(xml)
     @params = {}
@@ -68,6 +71,17 @@ class Fingerprint
         result[k] = match_data[ pos ]
       end
     end
+
+    # Use the protocol specified in the XML database if there isn't one
+    # provided as part of this fingerprint.
+    if @match_protocol
+      unless result['service.protocol']
+        result['service.protocol'] = @match_protocol
+      end
+    end
+
+    result['fingerprint_db'] = @match_key if @match_key
+
     return result
   end
 

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -41,6 +41,15 @@ class Fingerprint
     parse_params(xml)
   end
 
+  def output_diag_data(message, data, exception)
+    STDERR.puts message
+    STDERR.puts exception.inspect
+    STDERR.puts "Length:   #{data.length}"
+    STDERR.puts "Encoding: #{data.encoding}"
+    STDERR.puts "Problematic data:\n#{data}"
+    STDERR.puts "Raw bytes:\n#{data.pretty_inspect}\n"
+  end
+
   # Attempt to match the given string.
   #
   # @param match_string [String]
@@ -55,24 +64,10 @@ class Fingerprint
         encoded_str = match_string.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => '')
         match_data = @regex.match(encoded_str)
       rescue Exception => e
-        STDERR.puts 'Exception while re-encoding match_string to UTF-8'
-        STDERR.puts e.inspect
-        STDERR.puts e
-        STDERR.puts match_string.length
-        STDERR.puts match_string.encoding
-        STDERR.puts "Problematic banner:\n#{match_string}"
-        STDERR.puts
-        STDERR.puts match_string.pretty_inspect
+        output_diag_data('Exception while re-encoding match_string to UTF-8', match_string, e)
       end
     rescue Exception => e
-      STDERR.puts 'Exception while running regex against match_string'
-      STDERR.puts e.inspect
-      STDERR.puts e
-      STDERR.puts match_string.length
-      STDERR.puts match_string.encoding
-      STDERR.puts "Problematic banner:\n#{match_string}"
-      STDERR.puts
-      STDERR.puts match_string.pretty_inspect
+      output_diag_data('Exception while running regex against match_string', match_string, e)
     end
     return if match_data.nil?
 

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -27,10 +27,11 @@ class Fingerprint
   attr_reader :tests
 
   # @param xml [Nokogiri::XML::Element]
-  # @param match_protocol [String] Protocol such as ftp, mssql, http, etc.
-  def initialize(xml, match_key, match_protocol)
+  # @param match_key [String] See Recog::DB
+  # @param protocol [String] Protocol such as ftp, mssql, http, etc.
+  def initialize(xml, match_key=nil, protocol=nil)
     @match_key = match_key
-    @match_protocol = match_protocol
+    @protocol = protocol
     @name   = parse_description(xml)
     @regex  = create_regexp(xml)
     @params = {}
@@ -74,9 +75,9 @@ class Fingerprint
 
     # Use the protocol specified in the XML database if there isn't one
     # provided as part of this fingerprint.
-    if @match_protocol
+    if @protocol
       unless result['service.protocol']
-        result['service.protocol'] = @match_protocol
+        result['service.protocol'] = @protocol
       end
     end
 

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -37,6 +37,7 @@ class Fingerprint
     @params = {}
     @tests = []
 
+    @protocol.downcase! if @protocol
     parse_examples(xml)
     parse_params(xml)
   end

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -49,9 +49,9 @@ class Fingerprint
     # match_string.force_encoding('BINARY') if match_string
     begin
       match_data = @regex.match(match_string)
-    rescue Encoding::CompatibilityError
-      ## FIXFIX - Determine if this can be addressed
-      return nil
+    rescue Encoding::CompatibilityError => e
+      # 'ASCII-8BIT' encoded responses will be caught and fixed here.
+      match_data = @regex.match(match_string.force_encoding('UTF-8'))
     rescue Exception => e
       STDERR.puts e.inspect
       STDERR.puts e

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -50,13 +50,28 @@ class Fingerprint
     begin
       match_data = @regex.match(match_string)
     rescue Encoding::CompatibilityError => e
-      # 'ASCII-8BIT' encoded responses will be caught and fixed here.
-      match_data = @regex.match(match_string.force_encoding('UTF-8'))
+      begin
+        # Replace invalid UTF-8 characters with spaces, just as DAP does.
+        encoded_str = match_string.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => '')
+        match_data = @regex.match(encoded_str)
+      rescue Exception => e
+        STDERR.puts "Broke when re-encoding"
+        STDERR.puts e.inspect
+        STDERR.puts e
+        STDERR.puts match_string.length
+        STDERR.puts match_string.encoding
+        STDERR.puts "Problematic banner:\n#{match_string}"
+        STDERR.puts
+        STDERR.puts match_string.pretty_inspect
+      end
     rescue Exception => e
       STDERR.puts e.inspect
       STDERR.puts e
-      STDERR.puts "Problematic banner:\n#{match_string}"
       STDERR.puts match_string.length
+      STDERR.puts match_string.encoding
+      STDERR.puts "Problematic banner:\n#{match_string}"
+      STDERR.puts
+      STDERR.puts match_string.pretty_inspect
     end
     return if match_data.nil?
 

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -55,7 +55,7 @@ class Fingerprint
         encoded_str = match_string.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => '')
         match_data = @regex.match(encoded_str)
       rescue Exception => e
-        STDERR.puts "Broke when re-encoding"
+        STDERR.puts 'Exception while re-encoding match_string to UTF-8'
         STDERR.puts e.inspect
         STDERR.puts e
         STDERR.puts match_string.length
@@ -65,6 +65,7 @@ class Fingerprint
         STDERR.puts match_string.pretty_inspect
       end
     rescue Exception => e
+      STDERR.puts 'Exception while running regex against match_string'
       STDERR.puts e.inspect
       STDERR.puts e
       STDERR.puts match_string.length

--- a/lib/recog/nizer.rb
+++ b/lib/recog/nizer.rb
@@ -27,7 +27,7 @@ class Nizer
   # Load fingerprints from a specific file or directory
   # This will not preserve any fingerprints that have already been loaded
   # @param path [String] Path to file or directory of XML fingerprints
-  def self.load_db(path=nil)
+  def self.load_db(path = nil)
     if path
       @@db_manager = Recog::DBManager.new(path)
     else
@@ -36,7 +36,7 @@ class Nizer
 
     # Sort the databases, no behavior or result change for those calling
     # Nizer.match or Nizer.multi_match as they have a single DB
-    @@db_manager.databases.sort! { |a,b| a.priority <=> b.priority }
+    @@db_manager.databases.sort! { |a, b| a.priority <=> b.priority }
     @@db_sorted = true
   end
 
@@ -56,8 +56,8 @@ class Nizer
 
   #
   # Locate a database that corresponds with the `match_key` and attempt to
-  # find a matching {Fingerprint fingerprint}, stopping at the first hit. Returns `nil`
-  # when no matching database or fingerprint is found.
+  # find a matching {Fingerprint fingerprint}, stopping at the first hit.
+  # Returns `nil` when no matching database or fingerprint is found.
   #
   # @param match_key [String] Fingerprint DB name, e.g. 'smb.native_os'
   # @return (see Fingerprint#match)
@@ -82,24 +82,28 @@ class Nizer
   # @param match_string [String] Service banner to match
   # @param [Hash] filters This hash contains filters used to limit the
   #   results to just those from specific types of fingerprints.
-  #   The matched values are derived from the 'fingerprints' top level
-  #   element in the fingerprint DB XML or, in the case of 'protocol',
-  #   this value can be overridden at the individual fingerprint level.
+  #   The values that these filters match come from the 'fingerprints' top
+  #   level element in the fingerprint DB XML or, in the case of 'protocol',
+  #   this value can be overridden at the individual fingerprint level by
+  #   setting a value for 'service.protocol'
+  #
+  #   With the exception of 'match_key', the filters below match the
+  #   'fingerprints' attributes with the same name.
   # @option filters [String] :match_key Value from XML 'matches' or file name
-  # @option filters [String] :fp_type  Fingerprint type (service, os, etc.)
+  # @option filters [String] :database_type  Fingerprint type (service, util.os, etc.)
   # @option filters [String] :protocol Protocol (ftp, smtp, etc.)
-  # @return (see Fingerprint#match)
+  # @return (see Fingerprint#match) or nil
   def self.match_all_db(match_string, filters = {})
     match_string = match_string.to_s.unpack("C*").pack("C*")
     @@db_manager ||= Recog::DBManager.new
     unless @@db_sorted
-      @@db_manager.databases.sort! { |a,b| a.priority <=> b.priority }
+      @@db_manager.databases.sort! { |a, b| a.priority <=> b.priority }
       @@db_sorted = true
     end
 
     @@db_manager.databases.each do |db|
       next if filters[:match_key] && !filters[:match_key].include?(db.match_key)
-      next if filters[:type] && !filters[:type].include?(db.db_type)
+      next if filters[:database_type] && !filters[:database_type].include?(db.database_type)
       db.fingerprints.each do |fprint|
         m = fprint.match(match_string)
         if m
@@ -117,7 +121,7 @@ class Nizer
     match_string = match_string.to_s.unpack("C*").pack("C*")
     @@db_manager ||= Recog::DBManager.new
 
-    matches = Array.new #array to hold all fingerprint matches
+    matches = Array.new # array to hold all fingerprint matches
 
     @@db_manager.databases.each do |db|
       next unless db.match_key == match_key
@@ -139,26 +143,30 @@ class Nizer
   # @param match_string [String] Service banner to match
   # @param [Hash] filters This hash contains filters used to limit the
   #   results to just those from specific types of fingerprints.
-  #   The matched values are derived from the 'fingerprints' top level
-  #   element in the fingerprint DB XML or, in the case of 'protocol',
-  #   this value can be overridden at the individual fingerprint level.
+  #   The values that these filters match come from the 'fingerprints' top
+  #   level element in the fingerprint DB XML or, in the case of 'protocol',
+  #   this value can be overridden at the individual fingerprint level by
+  #   setting a value for 'service.protocol'
+  #
+  #   With the exception of 'match_key', the filters below match the
+  #   'fingerprints' attributes with the same name.
   # @option filters [String] :match_key Value from XML 'matches' or file name
-  # @option filters [String] :fp_type  Fingerprint type (service, os, etc.)
+  # @option filters [String] :database_type  Fingerprint type (service, util.os, etc.)
   # @option filters [String] :protocol Protocol (ftp, smtp, etc.)
-  # @return [Array] Array of Fingerprint#match
+  # @return [Array] Array of Fingerprint#match or empty array
   def self.multi_match_all_db(match_string, filters = {})
     match_string = match_string.to_s.unpack("C*").pack("C*")
     @@db_manager ||= Recog::DBManager.new
     unless @@db_sorted
-      @@db_manager.databases.sort! { |a,b| a.priority <=> b.priority }
+      @@db_manager.databases.sort! { |a, b| a.priority <=> b.priority }
       @@db_sorted = true
     end
 
-    matches = Array.new #array to hold all fingerprint matches
+    matches = Array.new # array to hold all fingerprint matches
 
     @@db_manager.databases.each do |db|
       next if filters[:match_key] && !filters[:match_key].include?(db.match_key)
-      next if filters[:type] && !filters[:type].include?(db.db_type)
+      next if filters[:database_type] && !filters[:database_type].include?(db.database_type)
       db.fingerprints.each do |fp|
         m = fp.match(match_string)
         if m

--- a/lib/recog/nizer.rb
+++ b/lib/recog/nizer.rb
@@ -36,7 +36,7 @@ class Nizer
 
     # Sort the databases, no behavior or result change for those calling
     # Nizer.match or Nizer.multi_match as they have a single DB
-    @@db_manager.databases.sort! { |a, b| a.priority <=> b.priority }
+    @@db_manager.databases.sort! { |a, b| b.preference <=> a.preference }
     @@db_sorted = true
   end
 
@@ -44,19 +44,19 @@ class Nizer
   # Destroy the current DBManager object
   def self.unload_db
     @@db_manager = nil
+    @@db_sorted = false
   end
 
   #
   # Display the fingerprint databases in the order in which they will be used
   # to match banners.  This is useful for fingerprint tuning and debugging.
   def self.display_db_order
-    unless @@db_manager
-      @@db_manager = Recog::DBManager.new
-      @@db_manager.databases.sort! { |a, b| a.priority <=> b.priority }
-    end
+    self.load_db unless @@db_manager
 
+    puts format('%s  %-22s  %s ', 'Preference', 'Database', 'Type')
     @@db_manager.databases.each do |db|
-      puts format('Priority: %4d   Name: %s ', db.priority, db.match_key)
+      puts format('%10.3f  %-22s  %s ', db.preference, db.match_key,
+                  db.database_type)
     end
   end
 

--- a/lib/recog/nizer.rb
+++ b/lib/recog/nizer.rb
@@ -60,6 +60,25 @@ class Nizer
   end
 
   #
+  # Search all fingerprint dbs and attempt to find a matching
+  # {Fingerprint fingerprint}, stopping at the first hit. Returns `nil`
+  # when no matching database or fingerprint is found.
+  #
+  # @param match_string [String] Service banner to match
+  # @return (see Fingerprint#match)
+  def self.match_all_db(match_string)
+    match_string = match_string.to_s.unpack("C*").pack("C*")
+    @@db_manager ||= Recog::DBManager.new
+    @@db_manager.databases.each do |db|
+      db.fingerprints.each do |fprint|
+        m = fprint.match(match_string)
+        return m if m
+      end
+    end
+    nil
+  end
+
+  #
   # Consider an array of match outputs, choose the best result, taking into
   # account the granularity of OS vs Version vs SP vs Language. Only consider
   # fields relevant to the host (OS, name, mac address, etc).

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -21,6 +21,13 @@ describe Recog::DB do
         expect(db.match_key).not_to be_empty
       end
 
+      it "has valid 'preference' value" do
+          # Reserve values below 0.10 and above 0.90 for users
+          # See xml/fingerprints.xsd
+          expect(db.preference.class).to be ::Float
+          expect(db.preference).to be_between(0.10, 0.90)
+      end
+
       db.fingerprints.each_index do |i|
         fp = db.fingerprints[i]
 

--- a/spec/lib/recog/nizer_spec.rb
+++ b/spec/lib/recog/nizer_spec.rb
@@ -2,10 +2,10 @@ require 'recog'
 require 'yaml'
 
 
-VALID_FILTER = {match_key: 'smb.native_os', protocol: 'smb', type: 'service'}
-NOMATCH_MATCH_KEY = {match_key: 'no_such_987', protocol: 'smb', type: 'service'}
-NOMATCH_PROTO = {match_key: 'smb.native_os', protocol: 'no_such_987', type: 'service'}
-NOMATCH_TYPE = {match_key: 'smb.native_os', protocol: 'smb', type: 'no_such_987'}
+VALID_FILTER = {match_key: 'smb.native_os', protocol: 'smb', database_type: 'util.os'}
+NOMATCH_MATCH_KEY = {match_key: 'no_such_987', protocol: 'smb', database_type: 'util.os'}
+NOMATCH_PROTO = {match_key: 'smb.native_os', protocol: 'no_such_987', database_type: 'util.os'}
+NOMATCH_TYPE = {match_key: 'smb.native_os', protocol: 'smb', database_type: 'no_such_987'}
 
 describe Recog::Nizer do
   subject { described_class }

--- a/spec/lib/recog/nizer_spec.rb
+++ b/spec/lib/recog/nizer_spec.rb
@@ -30,6 +30,11 @@ describe Recog::Nizer do
           end
         end
 
+        let(:nomatch_result) { subject.match('smb.native_os', 'no_such_987_76tgklh') }
+        it "returns a nil when data cannot be matched" do
+          expect(nomatch_result).to be_nil
+        end
+
         let(:invalid_db_result) { subject.match('no_such_987', data) }
         it "returns a nil when match_key search doesn't match" do
           expect(invalid_db_result).to be_nil
@@ -57,7 +62,7 @@ describe Recog::Nizer do
         end
 
         it "returns a successful match" do
-          expect(match_all_result[0]['matched'].to_s).to match(/^[A-Z]/)
+          expect(match_all_result[0]['matched']).to match(/^[A-Z]/)
         end
 
         it "correctly matches service or os" do
@@ -76,7 +81,7 @@ describe Recog::Nizer do
         end
 
         it "returns a successful match when searching without a filter" do
-          expect(no_filter_result[0]['matched'].to_s).to match(/^[A-Z]/)
+          expect(no_filter_result[0]['matched']).to match(/^[A-Z]/)
         end
 
         it "correctly matches service or os when searching without a filter" do
@@ -100,7 +105,6 @@ describe Recog::Nizer do
         it "returns an empty array when protocol search doesn't match" do
           expect(nomatch_proto_result).to be_empty
         end
-
 
         let(:nomatch_type_result) { subject.match_all_db(data, NOMATCH_TYPE) }
         it "returns an array when database_type search doesn't match" do
@@ -296,6 +300,21 @@ describe Recog::Nizer do
       let(:fp_db) { subject.load_db(file_path) }
       it "loads without error" do
         expect(fp_db).to  be true
+        subject.unload_db()
+      end
+    end
+
+    context "with no path specified" do
+      let(:fp_db) { subject.load_db }
+      it "loads without error" do
+        expect(fp_db).to  be true
+        subject.unload_db()
+      end
+    end
+
+    context "with empty file path" do
+      it "raises an error" do
+        expect { subject.load_db('') }.to raise_error(Errno::ENOENT)
         subject.unload_db()
       end
     end

--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -4,7 +4,7 @@ When an HTTP server is fingerprinted as Apache, a 2nd analysis pass is done
 on the server headers HTTPProtocolHelper.SERVER_HEADERS: they are matched
 against the following patterns to extract OS information.
 -->
-<fingerprints matches="apache_os" database_type="util.os" priority="90">
+<fingerprints matches="apache_os" database_type="util.os" preference="0.10">
   <fingerprint pattern=".*\(iSeries\).*">
     <description>IBM i5/OS iSeries (OS/400)</description>
     <param pos="0" name="os.vendor" value="IBM"/>

--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -4,7 +4,7 @@ When an HTTP server is fingerprinted as Apache, a 2nd analysis pass is done
 on the server headers HTTPProtocolHelper.SERVER_HEADERS: they are matched
 against the following patterns to extract OS information.
 -->
-<fingerprints matches="apache_os">
+<fingerprints matches="apache_os" type="os" priority="90">
   <fingerprint pattern=".*\(iSeries\).*">
     <description>IBM i5/OS iSeries (OS/400)</description>
     <param pos="0" name="os.vendor" value="IBM"/>

--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -4,7 +4,7 @@ When an HTTP server is fingerprinted as Apache, a 2nd analysis pass is done
 on the server headers HTTPProtocolHelper.SERVER_HEADERS: they are matched
 against the following patterns to extract OS information.
 -->
-<fingerprints matches="apache_os" type="os" priority="90">
+<fingerprints matches="apache_os" database_type="util.os" priority="90">
   <fingerprint pattern=".*\(iSeries\).*">
     <description>IBM i5/OS iSeries (OS/400)</description>
     <param pos="0" name="os.vendor" value="IBM"/>

--- a/xml/architecture.xml
+++ b/xml/architecture.xml
@@ -2,7 +2,7 @@
 <!--
   Generic rules for matching a machine architecture, platform, or chipset
 -->
-<fingerprints matches="architecture" type="os">
+<fingerprints matches="architecture" database_type="util.os">
   <fingerprint pattern="x64|amd64|x86_64" flags="REG_ICASE">
     <description>x64 (x86_x64)</description>
     <example>Linux claw 3.11.0-15-generic #23-Ubuntu SMP Mon Dec 9 18:17:04 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux</example>

--- a/xml/architecture.xml
+++ b/xml/architecture.xml
@@ -2,7 +2,7 @@
 <!--
   Generic rules for matching a machine architecture, platform, or chipset
 -->
-<fingerprints matches="architecture">
+<fingerprints matches="architecture" type="os">
   <fingerprint pattern="x64|amd64|x86_64" flags="REG_ICASE">
     <description>x64 (x86_x64)</description>
     <example>Linux claw 3.11.0-15-generic #23-Ubuntu SMP Mon Dec 9 18:17:04 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux</example>

--- a/xml/fingerprints.xsd
+++ b/xml/fingerprints.xsd
@@ -7,6 +7,7 @@
       <xsd:element name="fingerprint" type="fingerprint_element" minOccurs="1" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="matches" type="xsd:string" use="optional"/>
+    <xsd:attribute name="protocol" type="xsd:string" use="optional"/>
   </xsd:complexType>
 
   <xsd:complexType name="fingerprint_element" mixed="true">

--- a/xml/fingerprints.xsd
+++ b/xml/fingerprints.xsd
@@ -8,6 +8,8 @@
     </xsd:sequence>
     <xsd:attribute name="matches" type="xsd:string" use="optional"/>
     <xsd:attribute name="protocol" type="xsd:string" use="optional"/>
+    <xsd:attribute name="type" type="xsd:string" use="optional"/>
+    <xsd:attribute name="priority" type="xsd:string" use="optional"/>
   </xsd:complexType>
 
   <xsd:complexType name="fingerprint_element" mixed="true">

--- a/xml/fingerprints.xsd
+++ b/xml/fingerprints.xsd
@@ -17,7 +17,7 @@
             extension. See Recog::DB#parse_fingerprints
             This value is returned as part of any successful match.
 
-        - protocol: indicates the application protocol of the fingerprints
+        - protocol: indicates the name of the service or protocol
             found within the XML fingerprint database. Examples of this would
             be 'ftp', 'smtp', 'ssh', etc. Within Recog this value will be
             superseded by a 'service.protocol' attribute on a specific

--- a/xml/fingerprints.xsd
+++ b/xml/fingerprints.xsd
@@ -23,13 +23,13 @@
             superseded by a 'service.protocol' attribute on a specific
             fingerprint match. See Recog::DB#parse_fingerprints
             This value has two purposes. It can be used for filtering
-            ( See Recog::Nizer#match_all_db and #multi_match_all_db )
-            and is returned as part of any successful match.
+            ( See Recog::Nizer#match_all_db ) and is returned as part of any
+            successful match.
 
         - database_type: indicates the type of fingerprints matches expected
             to be found within the database. These values are used by
-            Recog::Nizer#match_all_db and #multi_match_all_db to filter matches
-            to just the type of database that is relevant to the match string.
+            Recog::Nizer#match_all_db to filter matches to just the type of 
+            database that is relevant to the match string.
             This value is *NOT* returned as part of successful matches.
 
             Current values are:

--- a/xml/fingerprints.xsd
+++ b/xml/fingerprints.xsd
@@ -20,7 +20,7 @@
         - protocol: indicates the application protocol of the fingerprints
             found within the XML fingerprint database. Examples of this would
             be 'ftp', 'smtp', 'ssh', etc. Within Recog this value will be
-            superceded by a 'service.protocol' attribute on a specific
+            superseded by a 'service.protocol' attribute on a specific
             fingerprint match. See Recog::DB#parse_fingerprints
             This value has two purposes. It can be used for filtering
             ( See Recog::Nizer#match_all_db and #multi_match_all_db )

--- a/xml/fingerprints.xsd
+++ b/xml/fingerprints.xsd
@@ -45,29 +45,32 @@
               capacity and may provide for data enrichment via an independent
               call after a service banner match has already be made.
 
-        - priority: indicates the relative priority/ordering that will be used
+        - preference: indicates the relative priority/ordering that will be used
             when Recog::Nizer performs matches against multiple databases.
-            'priority' is an Integer value that current ranges from 1 to 100
-            but there are no limits within that number space. Lower numbers
-            are given greater priority and will be processed first. If this
-            attribute is not present in the fingerprint database it will 
-            be assigned the value of 'DEFAULT_FP_DB_PRIORITY' within Recog::DB
-            which is currently 100.
+            'preference' is a float value that currently ranges from 0.0 to 1.0
+            Higher numbers are given greater priority and will be processed
+            first. If this attribute is not present in the fingerprint database
+            it will be assigned the value of 'DEFAULT_FP_PREFERENCE' within
+            Recog::DB which is currently 0.10
 
             This value is *NOT* returned as part of successful matches.
 
             When determining the priority of a fingerprint database the
             following criterial and rules should be used:
 
-            - Values below 10 should be reserved for end user use with the goal
-              of enabling them to create fingerprint databases that will always
-              take priority over those included in the Recog project.
+            - Values above 0.90 should be reserved for end user use with the
+              goal of enabling them to create fingerprint databases that will
+              always take priority over those included in the Recog project.
+
+            - Values below 0.10 should be reserved for end user use with the
+              goal of enabling them to create fingerprint databases that will
+              always be processed after those included with the Recog project.
 
             - The highest level of preference should be given to those 
               fingerprint databases that have very high quality matches
               (very strict regex, accurate).
 
-            - Preference should be given to those fingerprint databases that
+            - Priority should be given to those fingerprint databases that
               are for very common services.
 
             - Consideration should be given to preferring databases that will
@@ -76,7 +79,7 @@
               HTTP server response, but 'http_header.server' is more likely
               to provide the best data.
 
-            - Values of 10 - 30 should be used for those very high quality,
+            - Values of 0.90 - 0.80 should be used for those very high quality,
               highly common services.
       </xsd:documentation>
     </xsd:annotation>
@@ -87,7 +90,14 @@
     <xsd:attribute name="matches" type="xsd:string" use="optional"/>
     <xsd:attribute name="protocol" type="xsd:string" use="optional"/>
     <xsd:attribute name="database_type" type="xsd:string" use="optional"/>
-    <xsd:attribute name="priority" type="xsd:string" use="optional"/>
+    <xsd:attribute name="preference" use="optional">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:float">
+           <xsd:minInclusive value="0" />
+           <xsd:maxInclusive value="1.0" />
+        </xsd:restriction>
+     </xsd:simpleType>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:complexType name="fingerprint_element" mixed="true">

--- a/xml/fingerprints.xsd
+++ b/xml/fingerprints.xsd
@@ -3,12 +3,90 @@
   <xsd:element name="fingerprints" type="fingerprints_element"/>
 
   <xsd:complexType name="fingerprints_element">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The attributes that follow this documentation help categorize the
+        fingerprint databases and contents as well as enable optimization of
+        their processing.
+
+        - matches: provides a XML fingerprint database identifier. It is
+            intended to be descriptive in nature and often indicates a protocol
+            and function or sub-protocol type. Examples of this would be
+            'mysql.banners' vs 'mysql.errors'. If this attribute is not present
+            in the XML then its value is the base filename without the file
+            extension. See Recog::DB#parse_fingerprints
+            This value is returned as part of any successful match.
+
+        - protocol: indicates the application protocol of the fingerprints
+            found within the XML fingerprint database. Examples of this would
+            be 'ftp', 'smtp', 'ssh', etc. Within Recog this value will be
+            superceded by a 'service.protocol' attribute on a specific
+            fingerprint match. See Recog::DB#parse_fingerprints
+            This value has two purposes. It can be used for filtering
+            ( See Recog::Nizer#match_all_db and #multi_match_all_db )
+            and is returned as part of any successful match.
+
+        - database_type: indicates the type of fingerprints matches expected
+            to be found within the database. These values are used by
+            Recog::Nizer#match_all_db and #multi_match_all_db to filter matches
+            to just the type of database that is relevant to the match string.
+            This value is *NOT* returned as part of successful matches.
+
+            Current values are:
+
+            - service: These fingerprints are intended to match banners or
+              other responses from services. Fingerprint matches in 'service'
+              database do not necessarily have to return 'service.' attributes
+              in the match data.
+
+            - util.os: These fingerprints are intended to be used to identify
+              or extract OS related information from strings that are not
+              responses to service probes. This may be used in a utility
+              capacity and may provide for data enrichment via an independent
+              call after a service banner match has already be made.
+
+        - priority: indicates the relative priority/ordering that will be used
+            when Recog::Nizer performs matches against multiple databases.
+            'priority' is an Integer value that current ranges from 1 to 100
+            but there are no limits within that number space. Lower numbers
+            are given greater priority and will be processed first. If this
+            attribute is not present in the fingerprint database it will 
+            be assigned the value of 'DEFAULT_FP_DB_PRIORITY' within Recog::DB
+            which is currently 100.
+
+            This value is *NOT* returned as part of successful matches.
+
+            When determining the priority of a fingerprint database the
+            following criterial and rules should be used:
+
+            - Values below 10 should be reserved for end user use with the goal
+              of enabling them to create fingerprint databases that will always
+              take priority over those included in the Recog project.
+
+            - The highest level of preference should be given to those 
+              fingerprint databases that have very high quality matches
+              (very strict regex, accurate).
+
+            - Preference should be given to those fingerprint databases that
+              are for very common services.
+
+            - Consideration should be given to preferring databases that will
+              provide the most valuable data. For example, 'http_header.server'
+              and 'http_header.cookie' may both provide matches to the same
+              HTTP server response, but 'http_header.server' is more likely
+              to provide the best data.
+
+            - Values of 10 - 30 should be used for those very high quality,
+              highly common services.
+      </xsd:documentation>
+    </xsd:annotation>
     <xsd:sequence>
       <xsd:element name="fingerprint" type="fingerprint_element" minOccurs="1" maxOccurs="unbounded"/>
     </xsd:sequence>
+
     <xsd:attribute name="matches" type="xsd:string" use="optional"/>
     <xsd:attribute name="protocol" type="xsd:string" use="optional"/>
-    <xsd:attribute name="type" type="xsd:string" use="optional"/>
+    <xsd:attribute name="database_type" type="xsd:string" use="optional"/>
     <xsd:attribute name="priority" type="xsd:string" use="optional"/>
   </xsd:complexType>
 

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -3,7 +3,7 @@
 FTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint FTP servers.
 -->
-<fingerprints matches="ftp.banner" protocol='ftp'>
+<fingerprints matches="ftp.banner" protocol="ftp">
   <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version ([1234]\.\d+)\)\.$">
     <description>Microsoft FTP Server on Windows NT</description>
     <example>xx Microsoft FTP Service (Version 3.0).</example>
@@ -152,7 +152,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD on Debian Linux</description>
     <example>ProFTPD 1.3.0rc2 Server (Debian) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Debian"/>
@@ -165,7 +164,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD on a Linksys Wireless Access Point/Router</description>
     <example>ProFTPD 1.3.0rc2 Server (LinksysWRT350N) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linksys"/>
@@ -176,7 +174,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Linksys(.*)\) \[(.+)\]$">
     <description>ProFTPD on a wired Linksys device</description>
     <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linksys"/>
@@ -190,7 +187,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <example>ProFTPD 1.2.10 Server (ProFTPD) [host]</example>
     <example>ProFTPD 1.2.10rc3 Server (ProFTPD Default Installation) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="2" name="proftpd.server.name"/>
@@ -200,7 +196,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD with only version info</description>
     <example>ProFTPD 1.3.0rc2 Server ready.</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -208,14 +203,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD with no version info</description>
     <example>ProFTPD FTP Server ready.</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
-    <param pos="0" name="service.product" value="ProFTPD"/>
-  </fingerprint>
-  <fingerprint pattern="^ProFTPD Server$">
-    <description>ProFTPD with no version info, short form</description>
-    <example>ProFTPD Server</example>
-    <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
   </fingerprint>
   <fingerprint pattern="^=\(&lt;\*&gt;\)=-\.:\. \(\( Welcome to Pure-FTPd ([\d.]+) \)\) \.:\.-=\(&lt;\*&gt;\)=-" flags="REG_MULTILINE">
@@ -283,24 +270,14 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^ready, dude \(vsFTPd (\d+\..+): beat me, break me\)$">
     <description>vsFTPd (Very Secure FTP Daemon)</description>
-    <example service.version="1.1.0">ready, dude (vsFTPd 1.1.0: beat me, break me)</example>
+    <example>ready, dude (vsFTPd 1.1.0: beat me, break me)</example>
     <param pos="0" name="service.family" value="vsFTPd"/>
     <param pos="0" name="service.product" value="vsFTPd"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^vsFTPd ([\d.]+\+ \(ext\.3\)) ready\.\.\.$">
-    <description>vsFTPd (Very Secure FTP Daemon) extended build (vsftpd.devnet.ru)</description>
-    <example service.version="2.0.4+ (ext.3)">vsFTPd 2.0.4+ (ext.3) ready...</example>
-    <param pos="0" name="service.family" value="vsFTPd"/>
-    <param pos="0" name="service.product" value="vsFTPd Extended"/>
-    <param pos="1" name="service.version"/>
-  </fingerprint>
-  <fingerprint pattern="^FileZilla Server(?: version)? (?:v)?(\d\.[\w.]+(?: beta)?).*$">
+  <fingerprint pattern="^FileZilla Server version (\d\..+)$">
     <description>FileZilla FTP Server</description>
-    <example service.version="0.9.2 beta">FileZilla Server version 0.9.2 beta</example>
-    <example service.version="0.9.13a beta">FileZilla Server version 0.9.13a beta</example>
-    <example service.version="0.9.54 beta">FileZilla Server 0.9.54 beta</example>
-    <example service.version="0.9.33 beta">FileZilla Server v0.9.33 beta</example>
+    <example>FileZilla Server version 0.9.2 beta</example>
     <param pos="0" name="service.family" value="FileZilla FTP Server"/>
     <param pos="0" name="service.product" value="FileZilla FTP Server"/>
     <param pos="1" name="service.version"/>
@@ -312,8 +289,6 @@ more text</example>
     <param pos="0" name="service.product" value="FTP"/>
     <param pos="0" name="os.vendor" value="APC"/>
     <param pos="0" name="os.device" value="Power device"/>
-    <param pos="0" name="hw.vendor" value="APC"/>
-    <param pos="0" name="hw.device" value="Power device"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) Network Management Card AOS v(\d+\..+) FTP server ready\.$">
     <description>APC power/cooling device</description>
@@ -328,8 +303,6 @@ more text</example>
     <param pos="0" name="os.device" value="Power device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="hw.vendor" value="APC"/>
-    <param pos="0" name="hw.device" value="Power device"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP server \(EMC-SNAS: ([^\)]+)\)(?: \S+)?$">
     <description>EMC Celerra</description>
@@ -344,9 +317,6 @@ more text</example>
     <param pos="0" name="os.product" value="Celerra"/>
     <param pos="2" name="os.version"/>
     <param pos="1" name="host.name"/>
-    <param pos="0" name="hw.vendor" value="Celerra"/>
-    <param pos="0" name="hw.device" value="Storage"/>
-    <param pos="0" name="hw.product" value="Celerra"/>
   </fingerprint>
   <fingerprint pattern="^JD FTP Server Ready.*$">
     <description>HP JetDirect printer</description>
@@ -359,10 +329,6 @@ more text</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="JetDirect"/>
     <param pos="0" name="os.product" value="JetDirect"/>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="0" name="hw.family" value="JetDirect"/>
-    <param pos="0" name="hw.product" value="JetDirect"/>
   </fingerprint>
   <fingerprint pattern="^Check Point FireWall-1 Secure FTP server running on (.+)$">
     <description>Check Point FireWall-1</description>
@@ -374,9 +340,6 @@ more text</example>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="Firewall-1"/>
     <param pos="0" name="os.product" value="Firewall-1"/>
-    <param pos="0" name="hw.vendor" value="Check Point"/>
-    <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.family" value="Firewall-1"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^Blue Coat FTP Service$">
@@ -487,10 +450,6 @@ more text</example>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="hw.vendor" value="Ricoh"/>
-    <param pos="0" name="hw.family" value="Aficio"/>
-    <param pos="0" name="hw.device" value="Multifunction Device"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^NRG ((?:[MS]P )?\S+) FTP server \(([0-9\.a-zA-Z]+)\) ready.?$" flags="REG_ICASE">
     <description>Ricoh NRG multifunction device</description>
@@ -509,9 +468,6 @@ more text</example>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="hw.vendor" value="Ricoh"/>
-    <param pos="0" name="hw.device" value="Multifunction Device"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Xerox Phaser (\S+)$" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>
@@ -521,10 +477,6 @@ more text</example>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
-    <param pos="0" name="hw.vendor" value="Xerox"/>
-    <param pos="0" name="hw.family" value="Phaser"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^XEROX (\d+) Wide Format .*$" certainty="1.0">
     <description>Xerox Wide Format Series of Printers</description>
@@ -533,10 +485,6 @@ more text</example>
     <param pos="0" name="os.family" value="Wide Format"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
-    <param pos="0" name="hw.vendor" value="Xerox"/>
-    <param pos="0" name="hw.family" value="Wide Format"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^FUJI XEROX DocuPrint (.*)$" certainty="1.0">
     <description>FUJI XEROX DocuPrint Series of Printers</description>
@@ -556,9 +504,6 @@ more text</example>
     <param pos="1" name="host.mac"/>
     <param pos="2" name="os.product"/>
     <param pos="3" name="os.version"/>
-    <param pos="0" name="hw.vendor" value="Lexmark"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="2" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^.*Lexmark (\S+) FTP Server (\S+) ready\.?$" certainty="1.0" flags="REG_ICASE">
     <description>Lexmark printers</description>
@@ -567,9 +512,6 @@ more text</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="hw.vendor" value="Lexmark"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^.*Lexmark (\S+) FTP Server ready\.?$" certainty="1.0" flags="REG_ICASE">
     <description>Lexmark printers</description>
@@ -577,9 +519,6 @@ more text</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
-    <param pos="0" name="hw.vendor" value="Lexmark"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^(?:Tornado-)?VxWorks \((?:VxWorks)?([^\)]+)\) FTP server(?: ready)?$" flags="REG_ICASE">
     <description>VxWorks with version information</description>
@@ -612,10 +551,6 @@ more text</example>
     <param pos="0" name="os.family" value="TASKalfa"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
-    <param pos="0" name="hw.vendor" value="Kyocera"/>
-    <param pos="0" name="hw.family" value="TASKalfa"/>
-    <param pos="0" name="hw.device" value="Multifunction Device"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^SAVIN (\S+) FTP server \((.*)\) ready.$" certainty="1.0">
     <description>SAVIN Printer FTP Server</description>
@@ -915,7 +850,6 @@ more text</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="TelePresence"/>
     <param pos="1" name="os.device"/>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="2" name="hw.series"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
@@ -946,217 +880,6 @@ more text</example>
     <param pos="0" name="os.product" value="RouterOS"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
-  </fingerprint>
-    <fingerprint pattern="^MikroTik FTP server \(MikroTik ([\w.]+)\) ready\.?$">
-    <description>MikroTik w/o hostname</description>
-    <example os.version="6.0rc14">MikroTik FTP server (MikroTik 6.0rc14) ready</example>
-    <param pos="0" name="os.vendor" value="MikroTik"/>
-    <param pos="0" name="os.product" value="RouterOS"/>
-    <param pos="1" name="os.version"/>
-  </fingerprint>
-  <fingerprint pattern="^Welcome to ASUS (B?RT-[\w.-]+) FTP service\.$">
-    <description>FTPD on an Asus Wireless Access Point/Router</description>
-    <example hw.product="RT-AC68U">Welcome to ASUS RT-AC68U FTP service.</example>
-    <example hw.product="RT-N13U.B1">Welcome to ASUS RT-N13U.B1 FTP service.</example>
-    <example hw.product="BRT-AC828">Welcome to ASUS BRT-AC828 FTP service.</example>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.vendor" value="Asus"/>
-    <param pos="0" name="hw.device" value="WAP"/>
-    <param pos="1" name="hw.product"/>
-  </fingerprint>
-  <fingerprint pattern="^Welcome to ASUS (DSL-[\w.-]+) FTP service\.$">
-    <description>FTPD on a ADSL/VDSL Modem/Wireless Access Point/Router</description>
-    <example hw.product="DSL-AC68U">Welcome to ASUS DSL-AC68U FTP service.</example>
-    <example hw.product="DSL-N55U-D1">Welcome to ASUS DSL-N55U-D1 FTP service.</example>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.vendor" value="Asus"/>
-    <param pos="0" name="hw.device" value="DSL Modem"/>
-    <param pos="1" name="hw.product"/>
-  </fingerprint>
-  <fingerprint pattern="^Welcome to ASUS (TM-\w+) FTP service\.$">
-    <description>FTPD on a T-Mobile branded Asus Wireless Access Point/Router</description>
-    <example hw.product="TM-AC1900">Welcome to ASUS TM-AC1900 FTP service.</example>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.vendor" value="Asus"/>
-    <param pos="0" name="hw.device" value="WAP"/>
-    <param pos="1" name="hw.product"/>
-  </fingerprint>
-  <fingerprint pattern="^(FRITZ!Box[\w()]+) FTP server ready\.$">
-    <description>FTPD on an AWM multifunction Modem/Wireless Access Point/Router/VoIP device</description>
-    <example hw.product="FRITZ!Box7490">FRITZ!Box7490 FTP server ready.</example>
-    <example hw.product="FRITZ!BoxFonWLAN7390">FRITZ!BoxFonWLAN7390 FTP server ready.</example>
-    <example hw.product="FRITZ!Box7490(UI)">FRITZ!Box7490(UI) FTP server ready.</example>
-    <example hw.product="FRITZ!Box7362SL(UI)">FRITZ!Box7362SL(UI) FTP server ready.</example>
-    <example hw.product="FRITZ!BoxFonWLAN7270v3">FRITZ!BoxFonWLAN7270v3 FTP server ready.</example>
-    <example hw.product="FRITZ!Box6490Cable(kdg)">FRITZ!Box6490Cable(kdg) FTP server ready.</example>
-    <param pos="0" name="service.family" value="FTPD"/>
-    <param pos="0" name="service.product" value="FTPD"/>
-    <param pos="0" name="service.vendor" value="AVM"/>
-    <param pos="0" name="hw.vendor" value="AVM"/>
-    <param pos="0" name="hw.device" value="WAP"/>
-    <param pos="1" name="hw.product"/>
-  </fingerprint>
-  <fingerprint pattern="^HES_CPE FTP server \(GNU inetutils ([\w.]+)\) ready\.$">
-    <description>FTPD on a ZyXEL (Huawei rebrand) WiMax WAP</description>
-    <example service.version="1.4.1">HES_CPE FTP server (GNU inetutils 1.4.1) ready.</example>
-    <param pos="0" name="service.family" value="inetutils"/>
-    <param pos="0" name="service.product" value="inetutils ftpd"/>
-    <param pos="0" name="service.vendor" value="GNU"/>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="hw.vendor" value="ZyXEL"/>
-    <param pos="0" name="hw.device" value="WAP"/>
-  </fingerprint>
-  <fingerprint pattern="^DiskStation FTP server ready\.$">
-    <description>FTPD on a Synology DiskStation NAS</description>
-    <example>DiskStation FTP server ready.</example>
-    <param pos="0" name="service.family" value="SmbFTPD"/>
-    <param pos="0" name="service.product" value="SmbFTPD"/>
-    <param pos="0" name="service.vendor" value="GNU"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.vendor" value="Synology"/>
-    <param pos="0" name="hw.product" value="DiskStation"/>
-    <param pos="0" name="hw.device" value="NAS"/>
-  </fingerprint>
-  <fingerprint pattern="^Synology FTP server ready\.$" flags="REG_ICASE">
-    <description>FTPD on a Synology device</description>
-    <example>Synology FTP server ready.</example>
-    <example>SYNOLOGY FTP server ready.</example>
-    <param pos="0" name="service.family" value="SmbFTPD"/>
-    <param pos="0" name="service.product" value="SmbFTPD"/>
-    <param pos="0" name="service.vendor" value="GNU"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.vendor" value="Synology"/>
-  </fingerprint>
-  <fingerprint pattern="^Multicraft ([\w.-]+) FTP server$">
-    <description>Multicraft FTPD Server</description>
-    <example service.version="2.0.2">Multicraft 2.0.2 FTP server</example>
-    <example service.version="2.0.0-pre19">Multicraft 2.0.0-pre19 FTP server</example>
-    <param pos="0" name="service.family" value="Multicraft"/>
-    <param pos="0" name="service.product" value="Multicraft"/>
-    <param pos="0" name="service.vendor" value="Multicraft"/>
-    <param pos="1" name="service.version"/>
-  </fingerprint>
-  <fingerprint pattern="^bftpd ([\d.]+) at ([\h.:]+) ready\.$">
-    <description>Bftpd FTPD Server</description>
-    <example service.version="2.2.1" host.ip="192.168.0.1">bftpd 2.2.1 at 192.168.0.1 ready.</example>
-    <example service.version="2.2" host.ip="::ffff:192.168.1.1">bftpd 2.2 at ::ffff:192.168.1.1 ready.</example>
-    <param pos="0" name="service.family" value="Bftpd"/>
-    <param pos="0" name="service.product" value="Bftpd"/>
-    <param pos="0" name="service.vendor" value="Bftpd Project"/>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="host.ip"/>
-  </fingerprint>
-  <fingerprint pattern="^NASFTPD Turbo station ([\w.]+) Server \(ProFTPD\) \[([\h.:]+)\]$">
-    <description>ProFTPD on QNAP Turbo Station NAS</description>
-    <example service.version="1.3.5a" host.ip="192.168.1.100">NASFTPD Turbo station 1.3.5a Server (ProFTPD) [192.168.1.100]</example>
-    <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
-    <param pos="0" name="service.product" value="ProFTPD"/>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="hw.vendor" value="QNAP"/>
-    <param pos="0" name="hw.family" value="Turbo Station"/>
-    <param pos="0" name="hw.device" value="NAS"/>
-    <param pos="2" name="host.ip"/>
-  </fingerprint>
-  <fingerprint pattern="^Twisted ([\w.]+) FTP Server$">
-    <description>Twisted (Python) FTP Server</description>
-    <example service.version="14.0.0" >Twisted 14.0.0 FTP Server</example>
-    <example service.version="16.5.0rc2">Twisted 16.5.0rc2 FTP Server</example>
-    <param pos="0" name="service.family" value="Twisted"/>
-    <param pos="0" name="service.product" value="Twisted FTPD"/>
-    <param pos="0" name="service.vendor" value="Twisted Matrix Labs"/>
-    <param pos="1" name="service.version"/>
-  </fingerprint>
-  <fingerprint pattern="^Gene6 FTP Server v(\d{1,2}\.\d{1,2}\.\d{1,2}\s{,2}\(Build \d{1,2}\)) ready\.\.\.$">
-    <description>Gene6 FTP Server on Windows</description>
-    <example service.version="3.10.0 (Build 2)">Gene6 FTP Server v3.10.0 (Build 2) ready...</example>
-    <example service.version="3.7.0  (Build 24)">Gene6 FTP Server v3.7.0  (Build 24) ready...</example>
-    <param pos="0" name="service.family" value="Gene6"/>
-    <param pos="0" name="service.product" value="FTP Server"/>
-    <param pos="0" name="service.vendor" value="Gene6"/>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
-    <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.product" value="Windows"/>
-  </fingerprint>
-  <fingerprint pattern="^([\w.-]+) X2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
-    <description>WS_FTP FTP Server on Windows - X2 variant</description>
-    <example service.version="7.7(50012467)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 7.7(50012467)</example>
-    <example service.version="5.0.5 (1989540204)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 5.0.5 (1989540204)</example>
-    <param pos="0" name="service.family" value="WS_FTP"/>
-    <param pos="0" name="service.product" value="WS_FTP"/>
-    <param pos="0" name="service.vendor" value="Ipswitch"/>
-    <param pos="2" name="service.version"/>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
-    <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.product" value="Windows"/>
-    <param pos="1" name="host.name"/>
-  </fingerprint>
-  <fingerprint pattern="^V2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
-    <description>WS_FTP FTP Server on Windows - V2 variant</description>
-    <example service.version="6.1(05544322)">V2 WS_FTP Server 6.1(05544322)</example>
-    <param pos="0" name="service.family" value="WS_FTP"/>
-    <param pos="0" name="service.product" value="WS_FTP"/>
-    <param pos="0" name="service.vendor" value="Ipswitch"/>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
-    <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.product" value="Windows"/>
-  </fingerprint>
-  <fingerprint pattern="^FTP Server \(ZyWALL (USG\s?[\w-]+)\) \[([\h:.]+)\]$">
-    <description>ZyXEL Unified Security Gateway</description>
-    <example hw.product="USG 20" host.ip="::ffff:192.168.0.2">FTP Server (ZyWALL USG 20) [::ffff:192.168.0.2]</example>
-    <example hw.product="USG100-PLUS" host.ip="::ffff:192.168.5.101">FTP Server (ZyWALL USG100-PLUS) [::ffff:192.168.5.101]</example>
-    <example hw.product="USG 20" host.ip="10.0.0.2">FTP Server (ZyWALL USG 20) [10.0.0.2]</example>
-    <param pos="0" name="service.vendor" value="ZyXEL"/>
-    <param pos="0" name="service.family" value="Unified Security Gateway"/>
-    <param pos="0" name="service.product" value="FTPD"/>
-    <param pos="2" name="host.ip"/>
-    <param pos="0" name="hw.vendor" value="ZyXEL"/>
-    <param pos="0" name="hw.family" value="Unified Security Gateway"/>
-    <param pos="1" name="hw.product"/>
-  </fingerprint>
-  <fingerprint pattern="^Welcome to TP-LINK FTP server$">
-    <description>FTPD on a TP-LINK device (no version/host info)</description>
-    <example>Welcome to TP-LINK FTP server</example>
-    <param pos="0" name="hw.vendor" value="TP-LINK"/>
-  </fingerprint>
-   <fingerprint pattern="^ucftpd\((\w{3}  \d{,2} \d{4}-\d\d:\d\d:\d\d)\) FTP server ready\.$">
-    <description>ucftpd with version</description>
-    <example service.version="Jul  2 2012-22:13:49">ucftpd(Jul  2 2012-22:13:49) FTP server ready.</example>
-    <param pos="0" name="service.family" value="ucftpd"/>
-    <param pos="0" name="service.product" value="ucftpd"/>
-    <param pos="1" name="service.version"/>
-  </fingerprint>
-  <fingerprint pattern="^ucftpd FTP server ready\.$">
-    <description>ucftpd without version</description>
-    <example>ucftpd FTP server ready.</example>
-    <param pos="0" name="service.family" value="ucftpd"/>
-    <param pos="0" name="service.product" value="ucftpd"/>
-  </fingerprint>
-  <fingerprint pattern="^Welcome to TBS FTP Server\.$">
-    <description>TBS FTP Server</description>
-    <example>Welcome to TBS FTP Server.</example>
-    <param pos="0" name="service.family" value="TBS FTP Server"/>
-    <param pos="0" name="service.product" value="TBS FTP Server"/>
-  </fingerprint>
-  <fingerprint pattern="^Sofrel (S5[\w]+) SN ([\d-]+)  ready. Time is (\d{2}:\d{2}:\d{2} \d{2}\/\d{2}\/\d{2})\.$">
-    <description>Sofrel Remote Terminal Unit</description>
-    <example hw.device="S500" host.id="01-499-00427" system.time="00:11:39 01/11/16">Sofrel S500 SN 01-499-00427  ready. Time is 00:11:39 01/11/16.</example>
-    <param pos="0" name="hw.vendor" value="Sofrel"/>
-    <param pos="0" name="hw.family" value="S500 Range"/>
-    <param pos="1" name="hw.device"/>
-    <param pos="2" name="host.id"/>
-    <param pos="0" name="system.time.format" value="HH:mm::ss dd/MM/yy"/>
-    <param pos="3" name="system.time"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP server ready\.?$" flags="REG_ICASE">
     <description>Generic FTP fingerprint with a hostname</description>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -3,7 +3,7 @@
 FTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint FTP servers.
 -->
-<fingerprints matches="ftp.banner" protocol="ftp" type="service" priority="10">
+<fingerprints matches="ftp.banner" protocol="ftp" database_type="service" priority="10">
   <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version ([1234]\.\d+)\)\.$">
     <description>Microsoft FTP Server on Windows NT</description>
     <example>xx Microsoft FTP Service (Version 3.0).</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -3,7 +3,7 @@
 FTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint FTP servers.
 -->
-<fingerprints matches="ftp.banner" protocol="ftp">
+<fingerprints matches="ftp.banner" protocol="ftp" type="service" priority="10">
   <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version ([1234]\.\d+)\)\.$">
     <description>Microsoft FTP Server on Windows NT</description>
     <example>xx Microsoft FTP Service (Version 3.0).</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -3,7 +3,7 @@
 FTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint FTP servers.
 -->
-<fingerprints matches="ftp.banner" protocol="ftp" database_type="service" priority="10">
+<fingerprints matches="ftp.banner" protocol="ftp" database_type="service" preference="0.90">
   <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version ([1234]\.\d+)\)\.$">
     <description>Microsoft FTP Server on Windows NT</description>
     <example>xx Microsoft FTP Service (Version 3.0).</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -3,7 +3,7 @@
 FTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint FTP servers.
 -->
-<fingerprints matches="ftp.banner">
+<fingerprints matches="ftp.banner" protocol='ftp'>
   <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version ([1234]\.\d+)\)\.$">
     <description>Microsoft FTP Server on Windows NT</description>
     <example>xx Microsoft FTP Service (Version 3.0).</example>
@@ -152,6 +152,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD on Debian Linux</description>
     <example>ProFTPD 1.3.0rc2 Server (Debian) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Debian"/>
@@ -164,6 +165,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD on a Linksys Wireless Access Point/Router</description>
     <example>ProFTPD 1.3.0rc2 Server (LinksysWRT350N) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linksys"/>
@@ -174,6 +176,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Linksys(.*)\) \[(.+)\]$">
     <description>ProFTPD on a wired Linksys device</description>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linksys"/>
@@ -187,6 +190,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <example>ProFTPD 1.2.10 Server (ProFTPD) [host]</example>
     <example>ProFTPD 1.2.10rc3 Server (ProFTPD Default Installation) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="2" name="proftpd.server.name"/>
@@ -196,6 +200,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD with only version info</description>
     <example>ProFTPD 1.3.0rc2 Server ready.</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -203,6 +208,14 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD with no version info</description>
     <example>ProFTPD FTP Server ready.</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+  </fingerprint>
+  <fingerprint pattern="^ProFTPD Server$">
+    <description>ProFTPD with no version info, short form</description>
+    <example>ProFTPD Server</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
   </fingerprint>
   <fingerprint pattern="^=\(&lt;\*&gt;\)=-\.:\. \(\( Welcome to Pure-FTPd ([\d.]+) \)\) \.:\.-=\(&lt;\*&gt;\)=-" flags="REG_MULTILINE">
@@ -270,14 +283,24 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^ready, dude \(vsFTPd (\d+\..+): beat me, break me\)$">
     <description>vsFTPd (Very Secure FTP Daemon)</description>
-    <example>ready, dude (vsFTPd 1.1.0: beat me, break me)</example>
+    <example service.version="1.1.0">ready, dude (vsFTPd 1.1.0: beat me, break me)</example>
     <param pos="0" name="service.family" value="vsFTPd"/>
     <param pos="0" name="service.product" value="vsFTPd"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^FileZilla Server version (\d\..+)$">
+  <fingerprint pattern="^vsFTPd ([\d.]+\+ \(ext\.3\)) ready\.\.\.$">
+    <description>vsFTPd (Very Secure FTP Daemon) extended build (vsftpd.devnet.ru)</description>
+    <example service.version="2.0.4+ (ext.3)">vsFTPd 2.0.4+ (ext.3) ready...</example>
+    <param pos="0" name="service.family" value="vsFTPd"/>
+    <param pos="0" name="service.product" value="vsFTPd Extended"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^FileZilla Server(?: version)? (?:v)?(\d\.[\w.]+(?: beta)?).*$">
     <description>FileZilla FTP Server</description>
-    <example>FileZilla Server version 0.9.2 beta</example>
+    <example service.version="0.9.2 beta">FileZilla Server version 0.9.2 beta</example>
+    <example service.version="0.9.13a beta">FileZilla Server version 0.9.13a beta</example>
+    <example service.version="0.9.54 beta">FileZilla Server 0.9.54 beta</example>
+    <example service.version="0.9.33 beta">FileZilla Server v0.9.33 beta</example>
     <param pos="0" name="service.family" value="FileZilla FTP Server"/>
     <param pos="0" name="service.product" value="FileZilla FTP Server"/>
     <param pos="1" name="service.version"/>
@@ -289,6 +312,8 @@ more text</example>
     <param pos="0" name="service.product" value="FTP"/>
     <param pos="0" name="os.vendor" value="APC"/>
     <param pos="0" name="os.device" value="Power device"/>
+    <param pos="0" name="hw.vendor" value="APC"/>
+    <param pos="0" name="hw.device" value="Power device"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) Network Management Card AOS v(\d+\..+) FTP server ready\.$">
     <description>APC power/cooling device</description>
@@ -303,6 +328,8 @@ more text</example>
     <param pos="0" name="os.device" value="Power device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="APC"/>
+    <param pos="0" name="hw.device" value="Power device"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP server \(EMC-SNAS: ([^\)]+)\)(?: \S+)?$">
     <description>EMC Celerra</description>
@@ -317,6 +344,9 @@ more text</example>
     <param pos="0" name="os.product" value="Celerra"/>
     <param pos="2" name="os.version"/>
     <param pos="1" name="host.name"/>
+    <param pos="0" name="hw.vendor" value="Celerra"/>
+    <param pos="0" name="hw.device" value="Storage"/>
+    <param pos="0" name="hw.product" value="Celerra"/>
   </fingerprint>
   <fingerprint pattern="^JD FTP Server Ready.*$">
     <description>HP JetDirect printer</description>
@@ -329,6 +359,10 @@ more text</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="JetDirect"/>
     <param pos="0" name="os.product" value="JetDirect"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.family" value="JetDirect"/>
+    <param pos="0" name="hw.product" value="JetDirect"/>
   </fingerprint>
   <fingerprint pattern="^Check Point FireWall-1 Secure FTP server running on (.+)$">
     <description>Check Point FireWall-1</description>
@@ -340,6 +374,9 @@ more text</example>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="Firewall-1"/>
     <param pos="0" name="os.product" value="Firewall-1"/>
+    <param pos="0" name="hw.vendor" value="Check Point"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.family" value="Firewall-1"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^Blue Coat FTP Service$">
@@ -450,6 +487,10 @@ more text</example>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Ricoh"/>
+    <param pos="0" name="hw.family" value="Aficio"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^NRG ((?:[MS]P )?\S+) FTP server \(([0-9\.a-zA-Z]+)\) ready.?$" flags="REG_ICASE">
     <description>Ricoh NRG multifunction device</description>
@@ -468,6 +509,9 @@ more text</example>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Ricoh"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Xerox Phaser (\S+)$" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>
@@ -477,6 +521,10 @@ more text</example>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Phaser"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^XEROX (\d+) Wide Format .*$" certainty="1.0">
     <description>Xerox Wide Format Series of Printers</description>
@@ -485,6 +533,10 @@ more text</example>
     <param pos="0" name="os.family" value="Wide Format"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Wide Format"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^FUJI XEROX DocuPrint (.*)$" certainty="1.0">
     <description>FUJI XEROX DocuPrint Series of Printers</description>
@@ -504,6 +556,9 @@ more text</example>
     <param pos="1" name="host.mac"/>
     <param pos="2" name="os.product"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="2" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^.*Lexmark (\S+) FTP Server (\S+) ready\.?$" certainty="1.0" flags="REG_ICASE">
     <description>Lexmark printers</description>
@@ -512,6 +567,9 @@ more text</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^.*Lexmark (\S+) FTP Server ready\.?$" certainty="1.0" flags="REG_ICASE">
     <description>Lexmark printers</description>
@@ -519,6 +577,9 @@ more text</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^(?:Tornado-)?VxWorks \((?:VxWorks)?([^\)]+)\) FTP server(?: ready)?$" flags="REG_ICASE">
     <description>VxWorks with version information</description>
@@ -551,6 +612,10 @@ more text</example>
     <param pos="0" name="os.family" value="TASKalfa"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Kyocera"/>
+    <param pos="0" name="hw.family" value="TASKalfa"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^SAVIN (\S+) FTP server \((.*)\) ready.$" certainty="1.0">
     <description>SAVIN Printer FTP Server</description>
@@ -850,6 +915,7 @@ more text</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="TelePresence"/>
     <param pos="1" name="os.device"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="2" name="hw.series"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
@@ -880,6 +946,217 @@ more text</example>
     <param pos="0" name="os.product" value="RouterOS"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
+  </fingerprint>
+    <fingerprint pattern="^MikroTik FTP server \(MikroTik ([\w.]+)\) ready\.?$">
+    <description>MikroTik w/o hostname</description>
+    <example os.version="6.0rc14">MikroTik FTP server (MikroTik 6.0rc14) ready</example>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to ASUS (B?RT-[\w.-]+) FTP service\.$">
+    <description>FTPD on an Asus Wireless Access Point/Router</description>
+    <example hw.product="RT-AC68U">Welcome to ASUS RT-AC68U FTP service.</example>
+    <example hw.product="RT-N13U.B1">Welcome to ASUS RT-N13U.B1 FTP service.</example>
+    <example hw.product="BRT-AC828">Welcome to ASUS BRT-AC828 FTP service.</example>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Asus"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to ASUS (DSL-[\w.-]+) FTP service\.$">
+    <description>FTPD on a ADSL/VDSL Modem/Wireless Access Point/Router</description>
+    <example hw.product="DSL-AC68U">Welcome to ASUS DSL-AC68U FTP service.</example>
+    <example hw.product="DSL-N55U-D1">Welcome to ASUS DSL-N55U-D1 FTP service.</example>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Asus"/>
+    <param pos="0" name="hw.device" value="DSL Modem"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to ASUS (TM-\w+) FTP service\.$">
+    <description>FTPD on a T-Mobile branded Asus Wireless Access Point/Router</description>
+    <example hw.product="TM-AC1900">Welcome to ASUS TM-AC1900 FTP service.</example>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Asus"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^(FRITZ!Box[\w()]+) FTP server ready\.$">
+    <description>FTPD on an AWM multifunction Modem/Wireless Access Point/Router/VoIP device</description>
+    <example hw.product="FRITZ!Box7490">FRITZ!Box7490 FTP server ready.</example>
+    <example hw.product="FRITZ!BoxFonWLAN7390">FRITZ!BoxFonWLAN7390 FTP server ready.</example>
+    <example hw.product="FRITZ!Box7490(UI)">FRITZ!Box7490(UI) FTP server ready.</example>
+    <example hw.product="FRITZ!Box7362SL(UI)">FRITZ!Box7362SL(UI) FTP server ready.</example>
+    <example hw.product="FRITZ!BoxFonWLAN7270v3">FRITZ!BoxFonWLAN7270v3 FTP server ready.</example>
+    <example hw.product="FRITZ!Box6490Cable(kdg)">FRITZ!Box6490Cable(kdg) FTP server ready.</example>
+    <param pos="0" name="service.family" value="FTPD"/>
+    <param pos="0" name="service.product" value="FTPD"/>
+    <param pos="0" name="service.vendor" value="AVM"/>
+    <param pos="0" name="hw.vendor" value="AVM"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^HES_CPE FTP server \(GNU inetutils ([\w.]+)\) ready\.$">
+    <description>FTPD on a ZyXEL (Huawei rebrand) WiMax WAP</description>
+    <example service.version="1.4.1">HES_CPE FTP server (GNU inetutils 1.4.1) ready.</example>
+    <param pos="0" name="service.family" value="inetutils"/>
+    <param pos="0" name="service.product" value="inetutils ftpd"/>
+    <param pos="0" name="service.vendor" value="GNU"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="hw.vendor" value="ZyXEL"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+  </fingerprint>
+  <fingerprint pattern="^DiskStation FTP server ready\.$">
+    <description>FTPD on a Synology DiskStation NAS</description>
+    <example>DiskStation FTP server ready.</example>
+    <param pos="0" name="service.family" value="SmbFTPD"/>
+    <param pos="0" name="service.product" value="SmbFTPD"/>
+    <param pos="0" name="service.vendor" value="GNU"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Synology"/>
+    <param pos="0" name="hw.product" value="DiskStation"/>
+    <param pos="0" name="hw.device" value="NAS"/>
+  </fingerprint>
+  <fingerprint pattern="^Synology FTP server ready\.$" flags="REG_ICASE">
+    <description>FTPD on a Synology device</description>
+    <example>Synology FTP server ready.</example>
+    <example>SYNOLOGY FTP server ready.</example>
+    <param pos="0" name="service.family" value="SmbFTPD"/>
+    <param pos="0" name="service.product" value="SmbFTPD"/>
+    <param pos="0" name="service.vendor" value="GNU"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Synology"/>
+  </fingerprint>
+  <fingerprint pattern="^Multicraft ([\w.-]+) FTP server$">
+    <description>Multicraft FTPD Server</description>
+    <example service.version="2.0.2">Multicraft 2.0.2 FTP server</example>
+    <example service.version="2.0.0-pre19">Multicraft 2.0.0-pre19 FTP server</example>
+    <param pos="0" name="service.family" value="Multicraft"/>
+    <param pos="0" name="service.product" value="Multicraft"/>
+    <param pos="0" name="service.vendor" value="Multicraft"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^bftpd ([\d.]+) at ([\h.:]+) ready\.$">
+    <description>Bftpd FTPD Server</description>
+    <example service.version="2.2.1" host.ip="192.168.0.1">bftpd 2.2.1 at 192.168.0.1 ready.</example>
+    <example service.version="2.2" host.ip="::ffff:192.168.1.1">bftpd 2.2 at ::ffff:192.168.1.1 ready.</example>
+    <param pos="0" name="service.family" value="Bftpd"/>
+    <param pos="0" name="service.product" value="Bftpd"/>
+    <param pos="0" name="service.vendor" value="Bftpd Project"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="host.ip"/>
+  </fingerprint>
+  <fingerprint pattern="^NASFTPD Turbo station ([\w.]+) Server \(ProFTPD\) \[([\h.:]+)\]$">
+    <description>ProFTPD on QNAP Turbo Station NAS</description>
+    <example service.version="1.3.5a" host.ip="192.168.1.100">NASFTPD Turbo station 1.3.5a Server (ProFTPD) [192.168.1.100]</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="hw.vendor" value="QNAP"/>
+    <param pos="0" name="hw.family" value="Turbo Station"/>
+    <param pos="0" name="hw.device" value="NAS"/>
+    <param pos="2" name="host.ip"/>
+  </fingerprint>
+  <fingerprint pattern="^Twisted ([\w.]+) FTP Server$">
+    <description>Twisted (Python) FTP Server</description>
+    <example service.version="14.0.0" >Twisted 14.0.0 FTP Server</example>
+    <example service.version="16.5.0rc2">Twisted 16.5.0rc2 FTP Server</example>
+    <param pos="0" name="service.family" value="Twisted"/>
+    <param pos="0" name="service.product" value="Twisted FTPD"/>
+    <param pos="0" name="service.vendor" value="Twisted Matrix Labs"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Gene6 FTP Server v(\d{1,2}\.\d{1,2}\.\d{1,2}\s{,2}\(Build \d{1,2}\)) ready\.\.\.$">
+    <description>Gene6 FTP Server on Windows</description>
+    <example service.version="3.10.0 (Build 2)">Gene6 FTP Server v3.10.0 (Build 2) ready...</example>
+    <example service.version="3.7.0  (Build 24)">Gene6 FTP Server v3.7.0  (Build 24) ready...</example>
+    <param pos="0" name="service.family" value="Gene6"/>
+    <param pos="0" name="service.product" value="FTP Server"/>
+    <param pos="0" name="service.vendor" value="Gene6"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="^([\w.-]+) X2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
+    <description>WS_FTP FTP Server on Windows - X2 variant</description>
+    <example service.version="7.7(50012467)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 7.7(50012467)</example>
+    <example service.version="5.0.5 (1989540204)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 5.0.5 (1989540204)</example>
+    <param pos="0" name="service.family" value="WS_FTP"/>
+    <param pos="0" name="service.product" value="WS_FTP"/>
+    <param pos="0" name="service.vendor" value="Ipswitch"/>
+    <param pos="2" name="service.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+  <fingerprint pattern="^V2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
+    <description>WS_FTP FTP Server on Windows - V2 variant</description>
+    <example service.version="6.1(05544322)">V2 WS_FTP Server 6.1(05544322)</example>
+    <param pos="0" name="service.family" value="WS_FTP"/>
+    <param pos="0" name="service.product" value="WS_FTP"/>
+    <param pos="0" name="service.vendor" value="Ipswitch"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="^FTP Server \(ZyWALL (USG\s?[\w-]+)\) \[([\h:.]+)\]$">
+    <description>ZyXEL Unified Security Gateway</description>
+    <example hw.product="USG 20" host.ip="::ffff:192.168.0.2">FTP Server (ZyWALL USG 20) [::ffff:192.168.0.2]</example>
+    <example hw.product="USG100-PLUS" host.ip="::ffff:192.168.5.101">FTP Server (ZyWALL USG100-PLUS) [::ffff:192.168.5.101]</example>
+    <example hw.product="USG 20" host.ip="10.0.0.2">FTP Server (ZyWALL USG 20) [10.0.0.2]</example>
+    <param pos="0" name="service.vendor" value="ZyXEL"/>
+    <param pos="0" name="service.family" value="Unified Security Gateway"/>
+    <param pos="0" name="service.product" value="FTPD"/>
+    <param pos="2" name="host.ip"/>
+    <param pos="0" name="hw.vendor" value="ZyXEL"/>
+    <param pos="0" name="hw.family" value="Unified Security Gateway"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to TP-LINK FTP server$">
+    <description>FTPD on a TP-LINK device (no version/host info)</description>
+    <example>Welcome to TP-LINK FTP server</example>
+    <param pos="0" name="hw.vendor" value="TP-LINK"/>
+  </fingerprint>
+   <fingerprint pattern="^ucftpd\((\w{3}  \d{,2} \d{4}-\d\d:\d\d:\d\d)\) FTP server ready\.$">
+    <description>ucftpd with version</description>
+    <example service.version="Jul  2 2012-22:13:49">ucftpd(Jul  2 2012-22:13:49) FTP server ready.</example>
+    <param pos="0" name="service.family" value="ucftpd"/>
+    <param pos="0" name="service.product" value="ucftpd"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^ucftpd FTP server ready\.$">
+    <description>ucftpd without version</description>
+    <example>ucftpd FTP server ready.</example>
+    <param pos="0" name="service.family" value="ucftpd"/>
+    <param pos="0" name="service.product" value="ucftpd"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to TBS FTP Server\.$">
+    <description>TBS FTP Server</description>
+    <example>Welcome to TBS FTP Server.</example>
+    <param pos="0" name="service.family" value="TBS FTP Server"/>
+    <param pos="0" name="service.product" value="TBS FTP Server"/>
+  </fingerprint>
+  <fingerprint pattern="^Sofrel (S5[\w]+) SN ([\d-]+)  ready. Time is (\d{2}:\d{2}:\d{2} \d{2}\/\d{2}\/\d{2})\.$">
+    <description>Sofrel Remote Terminal Unit</description>
+    <example hw.device="S500" host.id="01-499-00427" system.time="00:11:39 01/11/16">Sofrel S500 SN 01-499-00427  ready. Time is 00:11:39 01/11/16.</example>
+    <param pos="0" name="hw.vendor" value="Sofrel"/>
+    <param pos="0" name="hw.family" value="S500 Range"/>
+    <param pos="1" name="hw.device"/>
+    <param pos="2" name="host.id"/>
+    <param pos="0" name="system.time.format" value="HH:mm::ss dd/MM/yy"/>
+    <param pos="3" name="system.time"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP server ready\.?$" flags="REG_ICASE">
     <description>Generic FTP fingerprint with a hostname</description>

--- a/xml/h323_callresp.xml
+++ b/xml/h323_callresp.xml
@@ -3,7 +3,7 @@
 Responses to H.323 call SETUP messages are matched against these patterns
 to fingerprint H.323 servers.
 -->
-<fingerprints>
+<fingerprints protocol="h.323">
   <fingerprint pattern="^0x000b2d00\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
     <description>Sony H.323 Server</description>
     <param pos="0" name="service.vendor" value="Sony"/>

--- a/xml/h323_callresp.xml
+++ b/xml/h323_callresp.xml
@@ -3,7 +3,7 @@
 Responses to H.323 call SETUP messages are matched against these patterns
 to fingerprint H.323 servers.
 -->
-<fingerprints protocol="h.323" type="service" priority="20">
+<fingerprints protocol="h.323" database_type="service" priority="20">
   <fingerprint pattern="^0x000b2d00\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
     <description>Sony H.323 Server</description>
     <param pos="0" name="service.vendor" value="Sony"/>

--- a/xml/h323_callresp.xml
+++ b/xml/h323_callresp.xml
@@ -3,7 +3,7 @@
 Responses to H.323 call SETUP messages are matched against these patterns
 to fingerprint H.323 servers.
 -->
-<fingerprints protocol="h.323">
+<fingerprints protocol="h.323" type="service" priority="20">
   <fingerprint pattern="^0x000b2d00\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
     <description>Sony H.323 Server</description>
     <param pos="0" name="service.vendor" value="Sony"/>

--- a/xml/h323_callresp.xml
+++ b/xml/h323_callresp.xml
@@ -3,7 +3,7 @@
 Responses to H.323 call SETUP messages are matched against these patterns
 to fingerprint H.323 servers.
 -->
-<fingerprints protocol="h.323" database_type="service" priority="20">
+<fingerprints protocol="h.323" database_type="service" preference="0.80">
   <fingerprint pattern="^0x000b2d00\:(.*)\:.*?(\d*\.*\d*\.*\d*).*$" flags="REG_ICASE">
     <description>Sony H.323 Server</description>
     <param pos="0" name="service.vendor" value="Sony"/>

--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -4,7 +4,7 @@ For printers running the PJL protocol (usually on 9100/tcp), their type can be r
 by the INFO ID command. The printer types (strings surrounded by double quotes) are
 matched against these patterns to fingerprint the printer.
 -->
-<fingerprints protocol="pjl">
+<fingerprints protocol="pjl" type="service">
   <!--
    LaserJet and Designjet are registered trademarks of HP. Therefore matching for the keywords
    is sufficient for asserting all relevant information

--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -3,8 +3,11 @@
 For printers running the PJL protocol (usually on 9100/tcp), their type can be requested
 by the INFO ID command. The printer types (strings surrounded by double quotes) are
 matched against these patterns to fingerprint the printer.
+
+'priority' notes: The value has been explicitly set to 100 due to the very loose
+regex that is used here.
 -->
-<fingerprints protocol="pjl" type="service">
+<fingerprints protocol="pjl" database_type="service" priority="100">
   <!--
    LaserJet and Designjet are registered trademarks of HP. Therefore matching for the keywords
    is sufficient for asserting all relevant information

--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -4,10 +4,10 @@ For printers running the PJL protocol (usually on 9100/tcp), their type can be r
 by the INFO ID command. The printer types (strings surrounded by double quotes) are
 matched against these patterns to fingerprint the printer.
 
-'priority' notes: The value has been explicitly set to 100 due to the very loose
+'preference' notes: The value has been explicitly set to 0.10 due to the very loose
 regex that is used here.
 -->
-<fingerprints protocol="pjl" database_type="service" priority="100">
+<fingerprints protocol="pjl" database_type="service" preference="0.10">
   <!--
    LaserJet and Designjet are registered trademarks of HP. Therefore matching for the keywords
    is sufficient for asserting all relevant information

--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -4,7 +4,7 @@ For printers running the PJL protocol (usually on 9100/tcp), their type can be r
 by the INFO ID command. The printer types (strings surrounded by double quotes) are
 matched against these patterns to fingerprint the printer.
 -->
-<fingerprints>
+<fingerprints protocol="pjl">
   <!--
    LaserJet and Designjet are registered trademarks of HP. Therefore matching for the keywords
    is sufficient for asserting all relevant information

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -3,7 +3,7 @@
 Set-Cookie HTTP header values are matched against these patterns to fingerprint HTTP
 servers.
 -->
-<fingerprints matches="http_header.cookie">
+<fingerprints matches="http_header.cookie" protocol="http">
   <fingerprint pattern="^(CFCLIENT_[^=]+|CFGLOBALS|CFID|CFTOKEN)=.*">
     <description>
          Adobe (Macromedia) ColdFusion uses various cookies.

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -3,7 +3,7 @@
 Set-Cookie HTTP header values are matched against these patterns to fingerprint HTTP
 servers.
 -->
-<fingerprints matches="http_header.cookie" protocol="http">
+<fingerprints matches="http_header.cookie" protocol="http" type="service">
   <fingerprint pattern="^(CFCLIENT_[^=]+|CFGLOBALS|CFID|CFTOKEN)=.*">
     <description>
          Adobe (Macromedia) ColdFusion uses various cookies.

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -3,7 +3,7 @@
 Set-Cookie HTTP header values are matched against these patterns to fingerprint HTTP
 servers.
 -->
-<fingerprints matches="http_header.cookie" protocol="http" type="service">
+<fingerprints matches="http_header.cookie" protocol="http" database_type="service">
   <fingerprint pattern="^(CFCLIENT_[^=]+|CFGLOBALS|CFID|CFTOKEN)=.*">
     <description>
          Adobe (Macromedia) ColdFusion uses various cookies.

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.server">
+<fingerprints matches="http_header.server" protocol="http">
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
     <example>Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.server" protocol="http" database_type="service" priority="10">
+<fingerprints matches="http_header.server" protocol="http" database_type="service" preference="0.90">
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
     <example>Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.server" protocol="http" type="service" priority="10">
+<fingerprints matches="http_header.server" protocol="http" database_type="service" priority="10">
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
     <example>Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.server" protocol="http">
+<fingerprints matches="http_header.server" protocol="http" type="service" priority="10">
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
     <example>Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP WWW-Authenticate headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.wwwauth">
+<fingerprints matches="http_header.wwwauth" protocol="http">
   <fingerprint pattern="^(?:Basic|Digest) realm=.[iI]RMC(?:@(IRMC[0-9a-fA-F]{6}))?..*$">
     <description>Fujitsu Siemens Primergy with BMC RemoteView on an iRMC card</description>
     <param pos="0" name="service.vendor" value="Fujitsu Siemens"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP WWW-Authenticate headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.wwwauth" protocol="http" database_type="service" preference="0.20">
+<fingerprints matches="http_header.wwwauth" protocol="http" database_type="service" preference="0.85">
   <fingerprint pattern="^(?:Basic|Digest) realm=.[iI]RMC(?:@(IRMC[0-9a-fA-F]{6}))?..*$">
     <description>Fujitsu Siemens Primergy with BMC RemoteView on an iRMC card</description>
     <param pos="0" name="service.vendor" value="Fujitsu Siemens"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP WWW-Authenticate headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.wwwauth" protocol="http" database_type="service" priority="90">
+<fingerprints matches="http_header.wwwauth" protocol="http" database_type="service" preference="0.20">
   <fingerprint pattern="^(?:Basic|Digest) realm=.[iI]RMC(?:@(IRMC[0-9a-fA-F]{6}))?..*$">
     <description>Fujitsu Siemens Primergy with BMC RemoteView on an iRMC card</description>
     <param pos="0" name="service.vendor" value="Fujitsu Siemens"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP WWW-Authenticate headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.wwwauth" protocol="http" type="service" priority="90">
+<fingerprints matches="http_header.wwwauth" protocol="http" database_type="service" priority="90">
   <fingerprint pattern="^(?:Basic|Digest) realm=.[iI]RMC(?:@(IRMC[0-9a-fA-F]{6}))?..*$">
     <description>Fujitsu Siemens Primergy with BMC RemoteView on an iRMC card</description>
     <param pos="0" name="service.vendor" value="Fujitsu Siemens"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- HTTP WWW-Authenticate headers are matched against these patterns to fingerprint HTTP servers. -->
-<fingerprints matches="http_header.wwwauth" protocol="http">
+<fingerprints matches="http_header.wwwauth" protocol="http" type="service" priority="90">
   <fingerprint pattern="^(?:Basic|Digest) realm=.[iI]RMC(?:@(IRMC[0-9a-fA-F]{6}))?..*$">
     <description>Fujitsu Siemens Primergy with BMC RemoteView on an iRMC card</description>
     <param pos="0" name="service.vendor" value="Fujitsu Siemens"/>

--- a/xml/imap_banners.xml
+++ b/xml/imap_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- IMAP banners are matched against these patterns to fingerprint IMAP servers. -->
-<fingerprints matches="imap4.banner">
+<fingerprints matches="imap4.banner" protocol="imap">
   <fingerprint pattern="^Microsoft Exchange IMAP4rev1 server version (5\.5\.\d{4}\.\d+) \((.*)\) ready$">
     <description>Microsoft Exchange Server 5.5</description>
     <param pos="0" name="service.vendor" value="Microsoft"/>

--- a/xml/imap_banners.xml
+++ b/xml/imap_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- IMAP banners are matched against these patterns to fingerprint IMAP servers. -->
-<fingerprints matches="imap4.banner" protocol="imap" type="service" priority="10">
+<fingerprints matches="imap4.banner" protocol="imap" database_type="service" priority="10">
   <fingerprint pattern="^Microsoft Exchange IMAP4rev1 server version (5\.5\.\d{4}\.\d+) \((.*)\) ready$">
     <description>Microsoft Exchange Server 5.5</description>
     <param pos="0" name="service.vendor" value="Microsoft"/>

--- a/xml/imap_banners.xml
+++ b/xml/imap_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- IMAP banners are matched against these patterns to fingerprint IMAP servers. -->
-<fingerprints matches="imap4.banner" protocol="imap" database_type="service" priority="10">
+<fingerprints matches="imap4.banner" protocol="imap" database_type="service" preference="0.90">
   <fingerprint pattern="^Microsoft Exchange IMAP4rev1 server version (5\.5\.\d{4}\.\d+) \((.*)\) ready$">
     <description>Microsoft Exchange Server 5.5</description>
     <param pos="0" name="service.vendor" value="Microsoft"/>

--- a/xml/imap_banners.xml
+++ b/xml/imap_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- IMAP banners are matched against these patterns to fingerprint IMAP servers. -->
-<fingerprints matches="imap4.banner" protocol="imap">
+<fingerprints matches="imap4.banner" protocol="imap" type="service" priority="10">
   <fingerprint pattern="^Microsoft Exchange IMAP4rev1 server version (5\.5\.\d{4}\.\d+) \((.*)\) ready$">
     <description>Microsoft Exchange Server 5.5</description>
     <param pos="0" name="service.vendor" value="Microsoft"/>

--- a/xml/ldap_searchresult.xml
+++ b/xml/ldap_searchresult.xml
@@ -3,7 +3,7 @@
   Notes: Ruby will fail to build the RegExp if it contains \x84 which is a standard
          byte in ASN.1 Sequence length fields.
 -->
-<fingerprints matches="ldap.search_result" protocol="ldap" type="service" priority="20">
+<fingerprints matches="ldap.search_result" protocol="ldap" database_type="service" priority="20">
 
   <!--
     Samba - position prior to Windows entries due to regex. When testing new

--- a/xml/ldap_searchresult.xml
+++ b/xml/ldap_searchresult.xml
@@ -3,7 +3,7 @@
   Notes: Ruby will fail to build the RegExp if it contains \x84 which is a standard
          byte in ASN.1 Sequence length fields.
 -->
-<fingerprints matches="ldap.search_result" protocol="ldap">
+<fingerprints matches="ldap.search_result" protocol="ldap" type="service" priority="20">
 
   <!--
     Samba - position prior to Windows entries due to regex. When testing new

--- a/xml/ldap_searchresult.xml
+++ b/xml/ldap_searchresult.xml
@@ -3,7 +3,7 @@
   Notes: Ruby will fail to build the RegExp if it contains \x84 which is a standard
          byte in ASN.1 Sequence length fields.
 -->
-<fingerprints matches="ldap.search_result">
+<fingerprints matches="ldap.search_result" protocol="ldap">
 
   <!--
     Samba - position prior to Windows entries due to regex. When testing new

--- a/xml/ldap_searchresult.xml
+++ b/xml/ldap_searchresult.xml
@@ -3,7 +3,7 @@
   Notes: Ruby will fail to build the RegExp if it contains \x84 which is a standard
          byte in ASN.1 Sequence length fields.
 -->
-<fingerprints matches="ldap.search_result" protocol="ldap" database_type="service" priority="20">
+<fingerprints matches="ldap.search_result" protocol="ldap" database_type="service" preference=".80">
 
   <!--
     Samba - position prior to Windows entries due to regex. When testing new

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -6,7 +6,7 @@
   to the domain name for a server to respond with the record:
   e.g. 'host-name._device-info._tcp.local'.
 -->
-<fingerprints matches="mdns.device-info.txt" protocol="mdns" type="os">
+<fingerprints matches="mdns.device-info.txt" protocol="mdns" database_type="util.os">
   <!--
      OS X versions:
      The number specified after osxvers= is equivalent to the major

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -6,7 +6,7 @@
   to the domain name for a server to respond with the record:
   e.g. 'host-name._device-info._tcp.local'.
 -->
-<fingerprints matches="mdns.device-info.txt" protocol="mdns">
+<fingerprints matches="mdns.device-info.txt" protocol="mdns" type="os">
   <!--
      OS X versions:
      The number specified after osxvers= is equivalent to the major

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -6,7 +6,7 @@
   to the domain name for a server to respond with the record:
   e.g. 'host-name._device-info._tcp.local'.
 -->
-<fingerprints matches="mdns.device-info.txt">
+<fingerprints matches="mdns.device-info.txt" protocol="mdns">
   <!--
      OS X versions:
      The number specified after osxvers= is equivalent to the major

--- a/xml/mdns_workstation_txt.xml
+++ b/xml/mdns_workstation_txt.xml
@@ -6,7 +6,7 @@
   to the domain name for a server to respond with the record:
   e.g. 'host-name._workstation._tcp.local'.
 -->
-<fingerprints matches="mdns.workstation.txt">
+<fingerprints matches="mdns.workstation.txt" protocol="mdns">
   <fingerprint pattern="^org\.freedesktop\.Avahi\.cookie=\S+$">
     <description>Avahi</description>
     <example>org.freedesktop.Avahi.cookie=1023312927</example>

--- a/xml/mdns_workstation_txt.xml
+++ b/xml/mdns_workstation_txt.xml
@@ -6,7 +6,7 @@
   to the domain name for a server to respond with the record:
   e.g. 'host-name._workstation._tcp.local'.
 -->
-<fingerprints matches="mdns.workstation.txt" protocol="mdns" type="service">
+<fingerprints matches="mdns.workstation.txt" protocol="mdns" database_type="service">
   <fingerprint pattern="^org\.freedesktop\.Avahi\.cookie=\S+$">
     <description>Avahi</description>
     <example>org.freedesktop.Avahi.cookie=1023312927</example>

--- a/xml/mdns_workstation_txt.xml
+++ b/xml/mdns_workstation_txt.xml
@@ -6,7 +6,7 @@
   to the domain name for a server to respond with the record:
   e.g. 'host-name._workstation._tcp.local'.
 -->
-<fingerprints matches="mdns.workstation.txt" protocol="mdns">
+<fingerprints matches="mdns.workstation.txt" protocol="mdns" type="service">
   <fingerprint pattern="^org\.freedesktop\.Avahi\.cookie=\S+$">
     <description>Avahi</description>
     <example>org.freedesktop.Avahi.cookie=1023312927</example>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -10,7 +10,7 @@
      the TCP payload and the fingerprints below are used to match and extract
      from this version.
 -->
-<fingerprints matches="mysql.banners" protocol="mysql" type="service" priority="20">
+<fingerprints matches="mysql.banners" protocol="mysql" database_type="service" priority="20">
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?max)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL (common)</description>
     <example service.version="4.1.20">4.1.20</example>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -10,7 +10,7 @@
      the TCP payload and the fingerprints below are used to match and extract
      from this version.
 -->
-<fingerprints matches="mysql.banners">
+<fingerprints matches="mysql.banners" protocol="mysql">
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?max)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL (common)</description>
     <example service.version="4.1.20">4.1.20</example>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -10,7 +10,7 @@
      the TCP payload and the fingerprints below are used to match and extract
      from this version.
 -->
-<fingerprints matches="mysql.banners" protocol="mysql">
+<fingerprints matches="mysql.banners" protocol="mysql" type="service" priority="20">
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?max)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL (common)</description>
     <example service.version="4.1.20">4.1.20</example>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -10,7 +10,7 @@
      the TCP payload and the fingerprints below are used to match and extract
      from this version.
 -->
-<fingerprints matches="mysql.banners" protocol="mysql" database_type="service" priority="20">
+<fingerprints matches="mysql.banners" protocol="mysql" database_type="service" preference="0.75">
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}(?:[.-]\d{1,2})?(?:[.-]\d{1})?)(?:-m\d{1,2})?(?:-rc)?(?:-alpha)?(?:-beta)?(?:-gamma)?(?:-?max)?(?:-rs)?(?:-modified)?(?:-debug)?(?:-log)?$" flags="REG_ICASE">
     <description>Oracle MySQL (common)</description>
     <example service.version="4.1.20">4.1.20</example>

--- a/xml/mysql_error.xml
+++ b/xml/mysql_error.xml
@@ -23,7 +23,7 @@
      http://osxr.org/mysql/source/sql/share/errmsg-utf8.txt or
      https://github.com/twitter/mysql/blob/master/sql/share/errmsg-utf8.txt
 -->
-<fingerprints matches="mysql.error">
+<fingerprints matches="mysql.error" protocol="mysql">
   <!-- ER_HOST_NOT_PRIVILEGED -->
   <fingerprint pattern="^Stroj '[^']+' nemá povoleno se k tomuto MySQL serveru připojit$">
     <description>Oracle MySQL error ER_HOST_NOT_PRIVILEGED (cze)</description>

--- a/xml/mysql_error.xml
+++ b/xml/mysql_error.xml
@@ -23,7 +23,7 @@
      http://osxr.org/mysql/source/sql/share/errmsg-utf8.txt or
      https://github.com/twitter/mysql/blob/master/sql/share/errmsg-utf8.txt
 -->
-<fingerprints matches="mysql.error" protocol="mysql" type="service" priority="20">
+<fingerprints matches="mysql.error" protocol="mysql" database_type="service" priority="20">
   <!-- ER_HOST_NOT_PRIVILEGED -->
   <fingerprint pattern="^Stroj '[^']+' nemá povoleno se k tomuto MySQL serveru připojit$">
     <description>Oracle MySQL error ER_HOST_NOT_PRIVILEGED (cze)</description>

--- a/xml/mysql_error.xml
+++ b/xml/mysql_error.xml
@@ -23,7 +23,7 @@
      http://osxr.org/mysql/source/sql/share/errmsg-utf8.txt or
      https://github.com/twitter/mysql/blob/master/sql/share/errmsg-utf8.txt
 -->
-<fingerprints matches="mysql.error" protocol="mysql" database_type="service" priority="20">
+<fingerprints matches="mysql.error" protocol="mysql" database_type="service" preference=".80">
   <!-- ER_HOST_NOT_PRIVILEGED -->
   <fingerprint pattern="^Stroj '[^']+' nemá povoleno se k tomuto MySQL serveru připojit$">
     <description>Oracle MySQL error ER_HOST_NOT_PRIVILEGED (cze)</description>

--- a/xml/mysql_error.xml
+++ b/xml/mysql_error.xml
@@ -23,7 +23,7 @@
      http://osxr.org/mysql/source/sql/share/errmsg-utf8.txt or
      https://github.com/twitter/mysql/blob/master/sql/share/errmsg-utf8.txt
 -->
-<fingerprints matches="mysql.error" protocol="mysql">
+<fingerprints matches="mysql.error" protocol="mysql" type="service" priority="20">
   <!-- ER_HOST_NOT_PRIVILEGED -->
   <fingerprint pattern="^Stroj '[^']+' nemá povoleno se k tomuto MySQL serveru připojit$">
     <description>Oracle MySQL error ER_HOST_NOT_PRIVILEGED (cze)</description>

--- a/xml/nntp_banners.xml
+++ b/xml/nntp_banners.xml
@@ -3,7 +3,7 @@
 NNTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint NNTP servers.
 -->
-<fingerprints matches="nntp.banner" protocol="nntp">
+<fingerprints matches="nntp.banner" protocol="nntp" type="service">
   <fingerprint pattern="^NNTP Service (?:.*) Version: (5.0.2195.[0-9]+) .*$">
     <description>Microsoft IIS NNTP Server on Windows 2000</description>
     <example>NNTP Service 5.00.0984 Version: 5.0.2195.7034 Posting Allowed</example>

--- a/xml/nntp_banners.xml
+++ b/xml/nntp_banners.xml
@@ -3,7 +3,7 @@
 NNTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint NNTP servers.
 -->
-<fingerprints matches="nntp.banner" protocol="nntp" type="service">
+<fingerprints matches="nntp.banner" protocol="nntp" database_type="service">
   <fingerprint pattern="^NNTP Service (?:.*) Version: (5.0.2195.[0-9]+) .*$">
     <description>Microsoft IIS NNTP Server on Windows 2000</description>
     <example>NNTP Service 5.00.0984 Version: 5.0.2195.7034 Posting Allowed</example>

--- a/xml/nntp_banners.xml
+++ b/xml/nntp_banners.xml
@@ -3,7 +3,7 @@
 NNTP greeting messages (part of the banner after the response code) are matched
 against these patterns to fingerprint NNTP servers.
 -->
-<fingerprints matches="nntp.banner">
+<fingerprints matches="nntp.banner" protocol="nntp">
   <fingerprint pattern="^NNTP Service (?:.*) Version: (5.0.2195.[0-9]+) .*$">
     <description>Microsoft IIS NNTP Server on Windows 2000</description>
     <example>NNTP Service 5.00.0984 Version: 5.0.2195.7034 Posting Allowed</example>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -2,7 +2,7 @@
 <!--
 NTP "banners", taken from a readvar response
 -->
-<fingerprints matches="ntp.readvar" protocol="ntp">
+<fingerprints matches="ntp.readvar" protocol="ntp" type="service" priority="20">
   <fingerprint pattern="^.*version=Domain Time II (\S+),hostname=([^,]+),.*system=Win2003.*,processor=(\S+)" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>Greyware Automation Products, Inc. Domain Time II on Windows Server 2003</description>
     <example service.version="5.1.b.20100331R" os.arch="x64" host.name="blah">

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -2,7 +2,7 @@
 <!--
 NTP "banners", taken from a readvar response
 -->
-<fingerprints matches="ntp.readvar" protocol="ntp" type="service" priority="20">
+<fingerprints matches="ntp.readvar" protocol="ntp" database_type="service" priority="20">
   <fingerprint pattern="^.*version=Domain Time II (\S+),hostname=([^,]+),.*system=Win2003.*,processor=(\S+)" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>Greyware Automation Products, Inc. Domain Time II on Windows Server 2003</description>
     <example service.version="5.1.b.20100331R" os.arch="x64" host.name="blah">

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -2,7 +2,7 @@
 <!--
 NTP "banners", taken from a readvar response
 -->
-<fingerprints matches="ntp.readvar" protocol="ntp" database_type="service" priority="20">
+<fingerprints matches="ntp.readvar" protocol="ntp" database_type="service" preference="0.80">
   <fingerprint pattern="^.*version=Domain Time II (\S+),hostname=([^,]+),.*system=Win2003.*,processor=(\S+)" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>Greyware Automation Products, Inc. Domain Time II on Windows Server 2003</description>
     <example service.version="5.1.b.20100331R" os.arch="x64" host.name="blah">

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -2,7 +2,7 @@
 <!--
 NTP "banners", taken from a readvar response
 -->
-<fingerprints matches="ntp.readvar">
+<fingerprints matches="ntp.readvar" protocol="ntp">
   <fingerprint pattern="^.*version=Domain Time II (\S+),hostname=([^,]+),.*system=Win2003.*,processor=(\S+)" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>Greyware Automation Products, Inc. Domain Time II on Windows Server 2003</description>
     <example service.version="5.1.b.20100331R" os.arch="x64" host.name="blah">

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -2,7 +2,7 @@
 <!--
   Patterns for common names of various operating systems.
 -->
-<fingerprints matches="operating_system.name">
+<fingerprints matches="operating_system.name" type="os" priority="10">
   <!-- Windows begin -->
   <fingerprint pattern="^(?i:(?:Microsoft )?(Windows (?:[a-z]+\s[a-z]+\s|[a-z]+\s)?Server (?:\d{4} R2|\d{4}))(?:,\s|\s)?([a-z]+)?(?: Edition)?(?:\s)?(SP\d|SP \d|Service Pack \d)?)$">
     <description>Windows Server 2003 and later</description>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -2,7 +2,7 @@
 <!--
   Patterns for common names of various operating systems.
 -->
-<fingerprints matches="operating_system.name" type="os" priority="10">
+<fingerprints matches="operating_system.name" database_type="util.os" priority="10">
   <!-- Windows begin -->
   <fingerprint pattern="^(?i:(?:Microsoft )?(Windows (?:[a-z]+\s[a-z]+\s|[a-z]+\s)?Server (?:\d{4} R2|\d{4}))(?:,\s|\s)?([a-z]+)?(?: Edition)?(?:\s)?(SP\d|SP \d|Service Pack \d)?)$">
     <description>Windows Server 2003 and later</description>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -2,7 +2,7 @@
 <!--
   Patterns for common names of various operating systems.
 -->
-<fingerprints matches="operating_system.name" database_type="util.os" priority="10">
+<fingerprints matches="operating_system.name" database_type="util.os" preference="0.80">
   <!-- Windows begin -->
   <fingerprint pattern="^(?i:(?:Microsoft )?(Windows (?:[a-z]+\s[a-z]+\s|[a-z]+\s)?Server (?:\d{4} R2|\d{4}))(?:,\s|\s)?([a-z]+)?(?: Edition)?(?:\s)?(SP\d|SP \d|Service Pack \d)?)$">
     <description>Windows Server 2003 and later</description>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -3,7 +3,7 @@
 POP3 greeting messages (part of the banner after the status indicator +OK or -ERR) are
 matched against these patterns to fingerprint POP3 servers.
 -->
-<fingerprints matches="pop3.banner" protocol="pop3">
+<fingerprints matches="pop3.banner" protocol="pop3" type="service" priority="10">
   <fingerprint pattern="^([^ ]+) +Cyrus POP3 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready">
     <description>OSX Cyrus POP</description>
     <example host.domain="8.8.8.8" service.version="2.3.8" os.version="10.5">8.8.8.8 Cyrus POP3 v2.3.8-OS X Server 10.5: 9A562 server ready &lt;1999107648.1324502155@8.8.8.8&gt;</example>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -3,7 +3,7 @@
 POP3 greeting messages (part of the banner after the status indicator +OK or -ERR) are
 matched against these patterns to fingerprint POP3 servers.
 -->
-<fingerprints matches="pop3.banner" protocol="pop3" database_type="service" priority="10">
+<fingerprints matches="pop3.banner" protocol="pop3" database_type="service" preference="0.90">
   <fingerprint pattern="^([^ ]+) +Cyrus POP3 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready">
     <description>OSX Cyrus POP</description>
     <example host.domain="8.8.8.8" service.version="2.3.8" os.version="10.5">8.8.8.8 Cyrus POP3 v2.3.8-OS X Server 10.5: 9A562 server ready &lt;1999107648.1324502155@8.8.8.8&gt;</example>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -3,7 +3,7 @@
 POP3 greeting messages (part of the banner after the status indicator +OK or -ERR) are
 matched against these patterns to fingerprint POP3 servers.
 -->
-<fingerprints matches="pop3.banner" protocol="pop3" type="service" priority="10">
+<fingerprints matches="pop3.banner" protocol="pop3" database_type="service" priority="10">
   <fingerprint pattern="^([^ ]+) +Cyrus POP3 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready">
     <description>OSX Cyrus POP</description>
     <example host.domain="8.8.8.8" service.version="2.3.8" os.version="10.5">8.8.8.8 Cyrus POP3 v2.3.8-OS X Server 10.5: 9A562 server ready &lt;1999107648.1324502155@8.8.8.8&gt;</example>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -3,7 +3,7 @@
 POP3 greeting messages (part of the banner after the status indicator +OK or -ERR) are
 matched against these patterns to fingerprint POP3 servers.
 -->
-<fingerprints matches="pop3.banner">
+<fingerprints matches="pop3.banner" protocol="pop3">
   <fingerprint pattern="^([^ ]+) +Cyrus POP3 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready">
     <description>OSX Cyrus POP</description>
     <example host.domain="8.8.8.8" service.version="2.3.8" os.version="10.5">8.8.8.8 Cyrus POP3 v2.3.8-OS X Server 10.5: 9A562 server ready &lt;1999107648.1324502155@8.8.8.8&gt;</example>

--- a/xml/rsh_resp.xml
+++ b/xml/rsh_resp.xml
@@ -2,7 +2,7 @@
 <!--
 Rservices responses to requests are matched against these patterns to fingerprint the OSes of servers.
 -->
-<fingerprints>
+<fingerprints protocol="rsh">
   <fingerprint pattern="^.Permission denied: Error 0$">
     <description>Digital Unix rlogind</description>
     <example>xPermission denied: Error 0</example>

--- a/xml/rsh_resp.xml
+++ b/xml/rsh_resp.xml
@@ -2,7 +2,7 @@
 <!--
 Rservices responses to requests are matched against these patterns to fingerprint the OSes of servers.
 -->
-<fingerprints protocol="rsh">
+<fingerprints protocol="rsh" type="service">
   <fingerprint pattern="^.Permission denied: Error 0$">
     <description>Digital Unix rlogind</description>
     <example>xPermission denied: Error 0</example>

--- a/xml/rsh_resp.xml
+++ b/xml/rsh_resp.xml
@@ -2,7 +2,7 @@
 <!--
 Rservices responses to requests are matched against these patterns to fingerprint the OSes of servers.
 -->
-<fingerprints protocol="rsh" type="service">
+<fingerprints protocol="rsh" database_type="service">
   <fingerprint pattern="^.Permission denied: Error 0$">
     <description>Digital Unix rlogind</description>
     <example>xPermission denied: Error 0</example>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -2,7 +2,7 @@
 <!--
 SIP Server header values are matched against these patterns to fingerprint SIP devices.
 -->
-<fingerprints matches="sip_header.server" protocol="sip">
+<fingerprints matches="sip_header.server" protocol="sip" type="service">
   <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
     <description>Cisco SIPGateway</description>
     <example>Cisco-SIPGateway/IOS-12.x</example>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -2,7 +2,7 @@
 <!--
 SIP Server header values are matched against these patterns to fingerprint SIP devices.
 -->
-<fingerprints matches="sip_header.server">
+<fingerprints matches="sip_header.server" protocol="sip">
   <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
     <description>Cisco SIPGateway</description>
     <example>Cisco-SIPGateway/IOS-12.x</example>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -2,7 +2,7 @@
 <!--
 SIP Server header values are matched against these patterns to fingerprint SIP devices.
 -->
-<fingerprints matches="sip_header.server" protocol="sip" type="service">
+<fingerprints matches="sip_header.server" protocol="sip" database_type="service">
   <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
     <description>Cisco SIPGateway</description>
     <example>Cisco-SIPGateway/IOS-12.x</example>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -2,7 +2,7 @@
 <!--
 SIP User Agent header values are matched against these patterns to fingerprint SIP devices.
 -->
-<fingerprints matches="sip_header.user_agent" protocol="sip" type="service">
+<fingerprints matches="sip_header.user_agent" protocol="sip" database_type="service">
   <!-- Cisco Devices -->
   <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
     <description>Cisco SIPGateway</description>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -2,7 +2,7 @@
 <!--
 SIP User Agent header values are matched against these patterns to fingerprint SIP devices.
 -->
-<fingerprints matches="sip_header.user_agent">
+<fingerprints matches="sip_header.user_agent" protocol="sip">
   <!-- Cisco Devices -->
   <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
     <description>Cisco SIPGateway</description>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -2,7 +2,7 @@
 <!--
 SIP User Agent header values are matched against these patterns to fingerprint SIP devices.
 -->
-<fingerprints matches="sip_header.user_agent" protocol="sip">
+<fingerprints matches="sip_header.user_agent" protocol="sip" type="service">
   <!-- Cisco Devices -->
   <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
     <description>Cisco SIPGateway</description>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -3,7 +3,7 @@
   SMB fingerprints obtained from the Native LM (LAN manager) field of SMB
   negotations
 -->
-<fingerprints matches="smb.native_lm" protocol="smb" type="service">
+<fingerprints matches="smb.native_lm" protocol="smb" database_type="service">
   <!-- Mac OS X -->
   <fingerprint pattern="^Samba (3\.0\.28a-apple)$">
     <description>Samba on OS X 10.6</description>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -3,7 +3,7 @@
   SMB fingerprints obtained from the Native LM (LAN manager) field of SMB
   negotations
 -->
-<fingerprints matches="smb.native_lm">
+<fingerprints matches="smb.native_lm" protocol="smb">
   <!-- Mac OS X -->
   <fingerprint pattern="^Samba (3\.0\.28a-apple)$">
     <description>Samba on OS X 10.6</description>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -3,7 +3,7 @@
   SMB fingerprints obtained from the Native LM (LAN manager) field of SMB
   negotations
 -->
-<fingerprints matches="smb.native_lm" protocol="smb">
+<fingerprints matches="smb.native_lm" protocol="smb" type="service">
   <!-- Mac OS X -->
   <fingerprint pattern="^Samba (3\.0\.28a-apple)$">
     <description>Samba on OS X 10.6</description>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -2,7 +2,7 @@
 <!--
   SMB fingerprints obtained from the Native OS field of SMB negotations
 -->
-<fingerprints matches="smb.native_os" protocol="smb">
+<fingerprints matches="smb.native_os" protocol="smb" type="service">
   <fingerprint pattern="^(Windows NT \d\.\d+)$">
     <description>Windows NT</description>
     <example os.product="Windows NT 4.0">Windows NT 4.0</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -2,7 +2,7 @@
 <!--
   SMB fingerprints obtained from the Native OS field of SMB negotations
 -->
-<fingerprints matches="smb.native_os" protocol="smb" type="service">
+<fingerprints matches="smb.native_os" protocol="smb" database_type="util.os">
   <fingerprint pattern="^(Windows NT \d\.\d+)$">
     <description>Windows NT</description>
     <example os.product="Windows NT 4.0">Windows NT 4.0</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -2,7 +2,7 @@
 <!--
   SMB fingerprints obtained from the Native OS field of SMB negotations
 -->
-<fingerprints matches="smb.native_os">
+<fingerprints matches="smb.native_os" protocol="smb">
   <fingerprint pattern="^(Windows NT \d\.\d+)$">
     <description>Windows NT</description>
     <example os.product="Windows NT 4.0">Windows NT 4.0</example>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -18,7 +18,7 @@ These XML files are used in this order:
 
 The system or service fingerprint with the highest certainty overwrites the others.
 -->
-<fingerprints matches="smtp.banner">
+<fingerprints matches="smtp.banner" protocol="smtp">
   <fingerprint pattern="^X1 NT-ESMTP Server ([^ ]+) \(IMail (\d+\.[^ ]+) EVAL \d+-\d+\)$">
     <description>IMail EVAL version</description>
     <param pos="0" name="service.vendor" value="Ipswitch"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -18,11 +18,11 @@ These XML files are used in this order:
 
 The system or service fingerprint with the highest certainty overwrites the others.
 
-'priority' notes: This value has been impacted by the poor quality of the 'Cisco PIX' match.
-  Additionally, the 'priority' value for the other databases mentioned above has been set so
+'preference' notes: This value has been impacted by the poor quality of the 'Cisco PIX' match.
+  Additionally, the 'preference' value for the other databases mentioned above has been set so
   as to implement their preference as described.
 -->
-<fingerprints matches="smtp.banner" protocol="smtp" database_type="service" priority="90">
+<fingerprints matches="smtp.banner" protocol="smtp" database_type="service" preference="0.20">
   <fingerprint pattern="^X1 NT-ESMTP Server ([^ ]+) \(IMail (\d+\.[^ ]+) EVAL \d+-\d+\)$">
     <description>IMail EVAL version</description>
     <param pos="0" name="service.vendor" value="Ipswitch"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -17,8 +17,12 @@ These XML files are used in this order:
    smtp_quit.xml
 
 The system or service fingerprint with the highest certainty overwrites the others.
+
+'priority' notes: This value has been impacted by the poor quality of the 'Cisco PIX' match.
+  Additionally, the 'priority' value for the other databases mentioned above has been set so
+  as to implement their preference as described.
 -->
-<fingerprints matches="smtp.banner" protocol="smtp" type="service" priority="20">
+<fingerprints matches="smtp.banner" protocol="smtp" database_type="service" priority="90">
   <fingerprint pattern="^X1 NT-ESMTP Server ([^ ]+) \(IMail (\d+\.[^ ]+) EVAL \d+-\d+\)$">
     <description>IMail EVAL version</description>
     <param pos="0" name="service.vendor" value="Ipswitch"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -18,7 +18,7 @@ These XML files are used in this order:
 
 The system or service fingerprint with the highest certainty overwrites the others.
 -->
-<fingerprints matches="smtp.banner" protocol="smtp">
+<fingerprints matches="smtp.banner" protocol="smtp" type="service" priority="20">
   <fingerprint pattern="^X1 NT-ESMTP Server ([^ ]+) \(IMail (\d+\.[^ ]+) EVAL \d+-\d+\)$">
     <description>IMail EVAL version</description>
     <param pos="0" name="service.vendor" value="Ipswitch"/>

--- a/xml/smtp_debug.xml
+++ b/xml/smtp_debug.xml
@@ -5,7 +5,7 @@ SMTP response lines to the DEBUG command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^500 No way!$">
     <description>
          Exim

--- a/xml/smtp_debug.xml
+++ b/xml/smtp_debug.xml
@@ -4,8 +4,11 @@ SMTP response lines to the DEBUG command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="96">
   <fingerprint pattern="^500 No way!$">
     <description>
          Exim

--- a/xml/smtp_debug.xml
+++ b/xml/smtp_debug.xml
@@ -5,10 +5,10 @@ SMTP response lines to the DEBUG command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="96">
+<fingerprints protocol="smtp" database_type="service" preference="0.14">
   <fingerprint pattern="^500 No way!$">
     <description>
          Exim

--- a/xml/smtp_debug.xml
+++ b/xml/smtp_debug.xml
@@ -5,7 +5,7 @@ SMTP response lines to the DEBUG command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^500 No way!$">
     <description>
          Exim

--- a/xml/smtp_ehlo.xml
+++ b/xml/smtp_ehlo.xml
@@ -5,7 +5,7 @@ SMTP response lines to the EHLO command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_ehlo.xml
+++ b/xml/smtp_ehlo.xml
@@ -5,7 +5,7 @@ SMTP response lines to the EHLO command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_ehlo.xml
+++ b/xml/smtp_ehlo.xml
@@ -5,10 +5,10 @@ SMTP response lines to the EHLO command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority='91'>
+<fingerprints protocol="smtp" database_type="service" preference='0.19'>
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_ehlo.xml
+++ b/xml/smtp_ehlo.xml
@@ -4,8 +4,11 @@ SMTP response lines to the EHLO command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority='91'>
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_expn.xml
+++ b/xml/smtp_expn.xml
@@ -5,10 +5,10 @@ SMTP response lines to the EXPN command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="94">
+<fingerprints protocol="smtp" database_type="service" preference="0.16">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_expn.xml
+++ b/xml/smtp_expn.xml
@@ -5,7 +5,7 @@ SMTP response lines to the EXPN command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_expn.xml
+++ b/xml/smtp_expn.xml
@@ -5,7 +5,7 @@ SMTP response lines to the EXPN command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_expn.xml
+++ b/xml/smtp_expn.xml
@@ -4,8 +4,11 @@ SMTP response lines to the EXPN command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="94">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -5,7 +5,7 @@ SMTP response lines to the HELP command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^214[ -]This is ArGoSoft Mail Server, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
     <description>
          ArgoSoft mail server HELP response

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -5,7 +5,7 @@ SMTP response lines to the HELP command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^214[ -]This is ArGoSoft Mail Server, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
     <description>
          ArgoSoft mail server HELP response

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -4,8 +4,11 @@ SMTP response lines to the HELP command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="92">
   <fingerprint pattern="^214[ -]This is ArGoSoft Mail Server, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
     <description>
          ArgoSoft mail server HELP response

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -5,10 +5,10 @@ SMTP response lines to the HELP command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="92">
+<fingerprints protocol="smtp" database_type="service" preference="0.18">
   <fingerprint pattern="^214[ -]This is ArGoSoft Mail Server, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
     <description>
          ArgoSoft mail server HELP response

--- a/xml/smtp_mailfrom.xml
+++ b/xml/smtp_mailfrom.xml
@@ -2,7 +2,7 @@
 <!--
 This file is currently unused.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="250 .* is syntactically correct *">
     <description>exim</description>
     <example>250 &lt;nosuchuser@rapid7.com&gt; is syntactically correct</example>

--- a/xml/smtp_mailfrom.xml
+++ b/xml/smtp_mailfrom.xml
@@ -2,7 +2,7 @@
 <!--
 This file is currently unused.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service">
   <fingerprint pattern="250 .* is syntactically correct *">
     <description>exim</description>
     <example>250 &lt;nosuchuser@rapid7.com&gt; is syntactically correct</example>

--- a/xml/smtp_mailfrom.xml
+++ b/xml/smtp_mailfrom.xml
@@ -2,7 +2,7 @@
 <!--
 This file is currently unused.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="250 .* is syntactically correct *">
     <description>exim</description>
     <example>250 &lt;nosuchuser@rapid7.com&gt; is syntactically correct</example>

--- a/xml/smtp_noop.xml
+++ b/xml/smtp_noop.xml
@@ -5,10 +5,10 @@ SMTP response lines to the NOOP command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="93">
+<fingerprints protocol="smtp" database_type="service" preference="0.17">
   <fingerprint pattern="^220 OK.*$">
     <description>
          CheckPoint FireWall-1 returns code 220 for NOOP command (instead of 250)

--- a/xml/smtp_noop.xml
+++ b/xml/smtp_noop.xml
@@ -5,7 +5,7 @@ SMTP response lines to the NOOP command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^220 OK.*$">
     <description>
          CheckPoint FireWall-1 returns code 220 for NOOP command (instead of 250)

--- a/xml/smtp_noop.xml
+++ b/xml/smtp_noop.xml
@@ -4,8 +4,11 @@ SMTP response lines to the NOOP command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="93">
   <fingerprint pattern="^220 OK.*$">
     <description>
          CheckPoint FireWall-1 returns code 220 for NOOP command (instead of 250)

--- a/xml/smtp_noop.xml
+++ b/xml/smtp_noop.xml
@@ -5,7 +5,7 @@ SMTP response lines to the NOOP command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^220 OK.*$">
     <description>
          CheckPoint FireWall-1 returns code 220 for NOOP command (instead of 250)

--- a/xml/smtp_quit.xml
+++ b/xml/smtp_quit.xml
@@ -8,7 +8,7 @@ See comment at the top of smtp_banners.xml for additional info.
 'priority' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="89">
+<fingerprints protocol="smtp" database_type="service" priority="99">
   <fingerprint pattern="^221[ -]See ya in cyberspace$">
     <description>
          221 See ya in cyberspace

--- a/xml/smtp_quit.xml
+++ b/xml/smtp_quit.xml
@@ -5,10 +5,10 @@ SMTP response lines to the QUIT command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="99">
+<fingerprints protocol="smtp" database_type="service" preference="0.11">
   <fingerprint pattern="^221[ -]See ya in cyberspace$">
     <description>
          221 See ya in cyberspace

--- a/xml/smtp_quit.xml
+++ b/xml/smtp_quit.xml
@@ -4,8 +4,11 @@ SMTP response lines to the QUIT command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="89">
   <fingerprint pattern="^221[ -]See ya in cyberspace$">
     <description>
          221 See ya in cyberspace

--- a/xml/smtp_quit.xml
+++ b/xml/smtp_quit.xml
@@ -5,7 +5,7 @@ SMTP response lines to the QUIT command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^221[ -]See ya in cyberspace$">
     <description>
          221 See ya in cyberspace

--- a/xml/smtp_quit.xml
+++ b/xml/smtp_quit.xml
@@ -5,7 +5,7 @@ SMTP response lines to the QUIT command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^221[ -]See ya in cyberspace$">
     <description>
          221 See ya in cyberspace

--- a/xml/smtp_rcptto.xml
+++ b/xml/smtp_rcptto.xml
@@ -2,7 +2,7 @@
 <!--
 This file is currently unused.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <!--
    <fingerprint pattern="501[ -]Invalid domain *">
       <description>

--- a/xml/smtp_rcptto.xml
+++ b/xml/smtp_rcptto.xml
@@ -2,7 +2,7 @@
 <!--
 This file is currently unused.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <!--
    <fingerprint pattern="501[ -]Invalid domain *">
       <description>

--- a/xml/smtp_rcptto.xml
+++ b/xml/smtp_rcptto.xml
@@ -2,7 +2,7 @@
 <!--
 This file is currently unused.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service">
   <!--
    <fingerprint pattern="501[ -]Invalid domain *">
       <description>

--- a/xml/smtp_rset.xml
+++ b/xml/smtp_rset.xml
@@ -5,7 +5,7 @@ SMTP response lines to the RSET command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^250[ -]RSET\?  Well, OK\.$">
     <description>
          500 What? I don't understand that.

--- a/xml/smtp_rset.xml
+++ b/xml/smtp_rset.xml
@@ -5,10 +5,10 @@ SMTP response lines to the RSET command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="98">
+<fingerprints protocol="smtp" database_type="service" preference="0.12">
   <fingerprint pattern="^250[ -]RSET\?  Well, OK\.$">
     <description>
          500 What? I don't understand that.

--- a/xml/smtp_rset.xml
+++ b/xml/smtp_rset.xml
@@ -5,7 +5,7 @@ SMTP response lines to the RSET command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^250[ -]RSET\?  Well, OK\.$">
     <description>
          500 What? I don't understand that.

--- a/xml/smtp_rset.xml
+++ b/xml/smtp_rset.xml
@@ -4,8 +4,11 @@ SMTP response lines to the RSET command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="98">
   <fingerprint pattern="^250[ -]RSET\?  Well, OK\.$">
     <description>
          500 What? I don't understand that.

--- a/xml/smtp_turn.xml
+++ b/xml/smtp_turn.xml
@@ -5,7 +5,7 @@ SMTP response lines to the TURN command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^502[ -]Hey!  I don't let remote systems TURN on me\.$">
     <description>
          502 Hey!  I don't let remote systems TURN on me.

--- a/xml/smtp_turn.xml
+++ b/xml/smtp_turn.xml
@@ -5,7 +5,7 @@ SMTP response lines to the TURN command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^502[ -]Hey!  I don't let remote systems TURN on me\.$">
     <description>
          502 Hey!  I don't let remote systems TURN on me.

--- a/xml/smtp_turn.xml
+++ b/xml/smtp_turn.xml
@@ -4,8 +4,11 @@ SMTP response lines to the TURN command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="97">
   <fingerprint pattern="^502[ -]Hey!  I don't let remote systems TURN on me\.$">
     <description>
          502 Hey!  I don't let remote systems TURN on me.

--- a/xml/smtp_turn.xml
+++ b/xml/smtp_turn.xml
@@ -5,10 +5,10 @@ SMTP response lines to the TURN command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="97">
+<fingerprints protocol="smtp" database_type="service" preference="0.13">
   <fingerprint pattern="^502[ -]Hey!  I don't let remote systems TURN on me\.$">
     <description>
          502 Hey!  I don't let remote systems TURN on me.

--- a/xml/smtp_vrfy.xml
+++ b/xml/smtp_vrfy.xml
@@ -4,8 +4,11 @@ SMTP response lines to the VRFY command are matched against these patterns
 (1 line at a time) to fingerprint SMTP servers.
 
 See comment at the top of smtp_banners.xml for additional info.
+
+'priority' note: This value has been set so as to implement the ordering
+  of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" type="service">
+<fingerprints protocol="smtp" database_type="service" priority="95">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_vrfy.xml
+++ b/xml/smtp_vrfy.xml
@@ -5,10 +5,10 @@ SMTP response lines to the VRFY command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 
-'priority' note: This value has been set so as to implement the ordering
+'preference' note: This value has been set so as to implement the ordering
   of SMTP related fingerprint databases as described in 'smtp_banners.xml'.
 -->
-<fingerprints protocol="smtp" database_type="service" priority="95">
+<fingerprints protocol="smtp" database_type="service" preference="0.15">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_vrfy.xml
+++ b/xml/smtp_vrfy.xml
@@ -5,7 +5,7 @@ SMTP response lines to the VRFY command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints>
+<fingerprints protocol="smtp">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/smtp_vrfy.xml
+++ b/xml/smtp_vrfy.xml
@@ -5,7 +5,7 @@ SMTP response lines to the VRFY command are matched against these patterns
 
 See comment at the top of smtp_banners.xml for additional info.
 -->
-<fingerprints protocol="smtp">
+<fingerprints protocol="smtp" type="service">
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX.*&quot; unrecognized$">
     <description>
          Cisco PIX changes the command letters to 'X' before passing

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -4,7 +4,7 @@
   SNMP fingerprint definitions. These are matched against the value of the
   'sysDescr' (OID 1.3.6.1.2.1.1.1) variable.
 -->
-<fingerprints matches="snmp.sys_description">
+<fingerprints matches="snmp.sys_description" protocol="snmp">
   <!--======================================================================
                               3COM
    =======================================================================-->

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -4,7 +4,7 @@
   SNMP fingerprint definitions. These are matched against the value of the
   'sysDescr' (OID 1.3.6.1.2.1.1.1) variable.
 -->
-<fingerprints matches="snmp.sys_description" protocol="snmp" database_type="service">
+<fingerprints matches="snmp.sys_description" protocol="snmp" database_type="service" preference="0.20">
   <!--======================================================================
                               3COM
    =======================================================================-->

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -4,7 +4,7 @@
   SNMP fingerprint definitions. These are matched against the value of the
   'sysDescr' (OID 1.3.6.1.2.1.1.1) variable.
 -->
-<fingerprints matches="snmp.sys_description" protocol="snmp">
+<fingerprints matches="snmp.sys_description" protocol="snmp" type="service">
   <!--======================================================================
                               3COM
    =======================================================================-->

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -4,7 +4,7 @@
   SNMP fingerprint definitions. These are matched against the value of the
   'sysDescr' (OID 1.3.6.1.2.1.1.1) variable.
 -->
-<fingerprints matches="snmp.sys_description" protocol="snmp" type="service">
+<fingerprints matches="snmp.sys_description" protocol="snmp" database_type="service">
   <!--======================================================================
                               3COM
    =======================================================================-->

--- a/xml/snmp_sysobjid.xml
+++ b/xml/snmp_sysobjid.xml
@@ -3,7 +3,7 @@
   SNMP fingerprint definitions for SysObjectIDs. These are matched against the value of the
   'sysObjectID' (OID 1.3.6.1.2.1.1.2) variable.
 -->
-<fingerprints matches="snmp.sys_object_id">
+<fingerprints matches="snmp.sys_object_id" protocol="snmp">
   <!--======================================================================
                               MICROSOFT
    =======================================================================-->

--- a/xml/snmp_sysobjid.xml
+++ b/xml/snmp_sysobjid.xml
@@ -3,7 +3,7 @@
   SNMP fingerprint definitions for SysObjectIDs. These are matched against the value of the
   'sysObjectID' (OID 1.3.6.1.2.1.1.2) variable.
 -->
-<fingerprints matches="snmp.sys_object_id" protocol="snmp" type="service">
+<fingerprints matches="snmp.sys_object_id" protocol="snmp" database_type="service">
   <!--======================================================================
                               MICROSOFT
    =======================================================================-->

--- a/xml/snmp_sysobjid.xml
+++ b/xml/snmp_sysobjid.xml
@@ -3,7 +3,7 @@
   SNMP fingerprint definitions for SysObjectIDs. These are matched against the value of the
   'sysObjectID' (OID 1.3.6.1.2.1.1.2) variable.
 -->
-<fingerprints matches="snmp.sys_object_id" protocol="snmp">
+<fingerprints matches="snmp.sys_object_id" protocol="snmp" type="service">
   <!--======================================================================
                               MICROSOFT
    =======================================================================-->

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -4,7 +4,7 @@ SSH "software revision and comment" strings (official RFC nomenclature for the p
 the identification string after "SSH-x.x-") are matched against these patterns to
 fingerprint SSH servers.
 -->
-<fingerprints matches="ssh.banner" protocol="ssh">
+<fingerprints matches="ssh.banner" protocol="ssh" type="service" priority="10">
   <!-- Honeypot SSH server banners are useless for fingerprinting -->
   <fingerprint pattern="honeypot" flags="REG_ICASE">
     <description>Honeypot SSH</description>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -4,7 +4,7 @@ SSH "software revision and comment" strings (official RFC nomenclature for the p
 the identification string after "SSH-x.x-") are matched against these patterns to
 fingerprint SSH servers.
 -->
-<fingerprints matches="ssh.banner" protocol="ssh" database_type="service" priority="10">
+<fingerprints matches="ssh.banner" protocol="ssh" database_type="service" preference="0.90">
   <!-- Honeypot SSH server banners are useless for fingerprinting -->
   <fingerprint pattern="honeypot" flags="REG_ICASE">
     <description>Honeypot SSH</description>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -4,7 +4,7 @@ SSH "software revision and comment" strings (official RFC nomenclature for the p
 the identification string after "SSH-x.x-") are matched against these patterns to
 fingerprint SSH servers.
 -->
-<fingerprints matches="ssh.banner">
+<fingerprints matches="ssh.banner" protocol="ssh">
   <!-- Honeypot SSH server banners are useless for fingerprinting -->
   <fingerprint pattern="honeypot" flags="REG_ICASE">
     <description>Honeypot SSH</description>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -4,7 +4,7 @@ SSH "software revision and comment" strings (official RFC nomenclature for the p
 the identification string after "SSH-x.x-") are matched against these patterns to
 fingerprint SSH servers.
 -->
-<fingerprints matches="ssh.banner" protocol="ssh" type="service" priority="10">
+<fingerprints matches="ssh.banner" protocol="ssh" database_type="service" priority="10">
   <!-- Honeypot SSH server banners are useless for fingerprinting -->
   <fingerprint pattern="honeypot" flags="REG_ICASE">
     <description>Honeypot SSH</description>

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- UPnP Server headers are matched against these patterns to fingerprint UPnP servers. -->
-<fingerprints matches="ssdp_header.server" protocol="upnp">
+<fingerprints matches="ssdp_header.server" protocol="ssdp" type="service">
   <fingerprint pattern="^Linux/(\S+) UPnP/[\d\.]+ miniupnpd/([\d\.]+)$" flags="REG_ICASE">
     <description>Linux MiniUPnPd UPnP Server</description>
     <example>Linux/Cross_compiled UPnP/1.0 miniupnpd/1.0</example>

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- UPnP Server headers are matched against these patterns to fingerprint UPnP servers. -->
-<fingerprints matches="ssdp_header.server" protocol="ssdp" type="service">
+<fingerprints matches="ssdp_header.server" protocol="ssdp" database_type="service">
   <fingerprint pattern="^Linux/(\S+) UPnP/[\d\.]+ miniupnpd/([\d\.]+)$" flags="REG_ICASE">
     <description>Linux MiniUPnPd UPnP Server</description>
     <example>Linux/Cross_compiled UPnP/1.0 miniupnpd/1.0</example>

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- UPnP Server headers are matched against these patterns to fingerprint UPnP servers. -->
-<fingerprints matches="ssdp_header.server">
+<fingerprints matches="ssdp_header.server" protocol="upnp">
   <fingerprint pattern="^Linux/(\S+) UPnP/[\d\.]+ miniupnpd/([\d\.]+)$" flags="REG_ICASE">
     <description>Linux MiniUPnPd UPnP Server</description>
     <example>Linux/Cross_compiled UPnP/1.0 miniupnpd/1.0</example>

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- UPnP Server headers are matched against these patterns to fingerprint UPnP servers. -->
-<fingerprints matches="ssdp_header.server" protocol="ssdp" database_type="service">
+<fingerprints matches="ssdp_header.server" protocol="ssdp" database_type="service" preference="0.70">
   <fingerprint pattern="^Linux/(\S+) UPnP/[\d\.]+ miniupnpd/([\d\.]+)$" flags="REG_ICASE">
     <description>Linux MiniUPnPd UPnP Server</description>
     <example>Linux/Cross_compiled UPnP/1.0 miniupnpd/1.0</example>


### PR DESCRIPTION
The goal of this PR is to enable the use of Recog to search **all** fingerprint databases for a match for a given string.  To do this effectively Recog must support filtering of the results in order to tailor them to the caller's needs.   It must allow prioritization of the databases to ensure that those containing the highest quality matches are processed first.  These changes **must** not impact the parameters of existing functions or materially change the results that they currently provide.

The changes here were written with an eye towards existing use cases.  They **should** be able to drop in w/o breakage for any environment where the XML XSD has not been modified or isn't being overwritten by a build process.

###  Code Changes

* Add `Nizer#match_all_db` to support matching a string against multiple databases.
  * Allow filtering of the above searches by providing a Hash of filter options
    * `:match_key` - Same as the `match_key` used in the `Nizer#match` search. This
                      value is set at the top level `fingerprints` element in an XML fingerprints DB file. If 
                      this value isn't set then it will be the name of the XML file without the extension.
                      This value in the XML file and it's related auto-population were in the existing code.

    * `:datbase_type` - Allows filtering by fingerprint type such as `service`, `util.os`, etc with the goal of
                      limiting undesirable matches.  An example of this would be matching against an 
                      `util.os` fingerprint database just because it has `Windows 2008` in the name. This
                      is a **NEW** value set at the top level `fingerprints` element in an XML fingerprints
                      DB file.

    * `:protocol` - Allows filtering by protocol such as `smtp`, `ftp`, etc.  This is a **NEW**
                      value set at the top level `fingerprints` element in an XML fingerprints DB
                      file **but** can be over written by specifying a `service.protocol` element in an 
                      individual fingerprint match definition.

    * `:multi_match` - Allows `Nizer#match_all_db` to return multiple matches.  This allows 
                      `Nizer#match_all_db` to replace the functionality of `Nizer#multi_match`.

    Example use of `Nizer#match_all_db` with filters:

```Ruby
    result_filter = { database_type: 'service', protocol: ‘smtp’  }
    fp_match = Recog::Nizer.match_all_db(banner_to_match, result_filter)
```


* Add `Nizer#load_db` which allows using `Nizer` to load a specific XML fingerprint file or directory of files.  Previously it would, via DBManager, only load the databases in the `xml` directory under the `Recog` directory in use.  It will automatically sort the databases when they are loaded by `Nizer#load_db`.

* Add `Nizer#unload_db` which destroys the `Nizer::DBManager` class level object in the variable.

* Add `Nizer#display_db_order` which outputs the currently loaded fingerprints in the order in which they will be queried. It also displays their priority and database type.  This is useful for debugging issues related to matching across multiple databases. An example of the output has been provided at the end of this description.

* Modify `DBManager#load_databases` so as to permit loading an individual file.  Previously it would attempt to load all XML files in the specified directory. Now it will detect if the specified path is a file or directory and handle as appropriate.

* `Fingerprint#initialize` now supports passing in **optional** parameters `match_key` and `protocol` so the fingerprint definitions will contain this information.  By doing it this way it provides this information to any applications that are using the fingerprinting but not doing so via `Recog::Nizer`.  `recog_match` is an example of this.

**NOTE**:

* `Nizer#match` and `Nizer#multi_match` have been rewritten as wrappers around 
  `Nizer#match_all_db`. The former calling syntax is still in place and the parameters are
  mapped to filters.  The wrappers still pass all of the original RSpec tests as well as some
  new tests.

* `rspec` tests have been written to handle new code and some tests for existing code were expanded.

### XML Changes

* Added support for specifying a `preference` at the top level `fingerprints` of a database. This 
   is used by `Nizer#match_all_db`  to determine the order in which databases will be used to
   process a banner string. Preference is a float value between 0 and 1.0 with the highest number
   being given priority (processed first). If an XML database doesn't have a priority value set then
   it will be set to the value of `DEFAULT_FP_PREFERENCE` as  defined in `Recog::DB`. This value
  is currently 0.10.  I've set the values on certain current databases based on the likelihood that 
   the db will provide a quality match. If databases were thought to have similar quality then in 
  some cases priority was given to a database that covered a more common service. The highest
  `preference` value currently set is 0.90 and the lowest is 0.10.  The intent is to allow users to
   always have room to create/modify databases that will have priority over existing databases by
   setting #'s above 0.90 and to set catch-all/low preference databases by setting #'s
   below 0.10.  The XML schema in `xml/fingerprints.xsd` limits `preference` to values between
   0.0 and 1.0 inclusive.  RSpec tests limit the `preference` values for XML databases that
   are included in this project to values between 0.10 and 0.90 inclusive.

  **Obviously these values will be the subject of discussion and will be tuned over time.**

* Add support for specifying a `protocol` at the top level `fingerprints` of a database and at the individual fingerprint level. This value indicates the application protocol of the fingerprints found within the XML fingerprint database. Examples of this would be 'ftp', 'smtp', 'ssh', etc. Within Recog this value will be superseded by a `service.protocol` attribute on a specific  fingerprint match. See `Recog::DB#parse_fingerprints`.  This value has two purposes. It can be used for filtering  ( See Recog::Nizer#match_all_db and #multi_match_all_db ) and is also returned as part of any successful match.
  * Top level XML example:
    ```xml
    <fingerprints matches="ldap.search_result" protocol="ldap">
    ```
  * Within an individual fingerprint
    ```xml
    <param pos="0" name="service.protocol" value="ldap"/>
    ```
* Added support for specifying a `database_type` at the top level `fingerprints` of a database. This is used to indicates the type of fingerprints matches expected to be found within the database. These values are used by `Recog::Nizer#match_all_db` to filter matches to just the type of database that is relevant to the match string.

  This value is **NOT** returned as part of successful matches.

   Current values are:

    * **service**: These fingerprints are intended to match banners or other responses from services. Fingerprint matches in 'service' database do not necessarily have to return 'service.' attributes in the match data.

    * **util.os**: These fingerprints are intended to be used to identify or extract OS related information from strings that are not responses to service probes. This may be used in a utility capacity and may provide for data enrichment via an independent all after a service banner match has already be made.

* Updated `xml/fingerprints.xsd` to support the new `fingerprints` attributes for protocol, type, and priority.

### Results output changes

All output, even that which doesn't call new methods, will contain values for `fingerprint_db` and `service.protocol` when a match is made and if the data is populated in the source XML.  The logic in `Recog::DB` will ensure that `fingerprint_db` is always populated.

```bash
echo 'OpenSSH_6.6p1 Ubuntu-2ubuntu1' | bin/recog_match xml/ssh_banners.xml -

MATCH: {
  "matched"=>"OpenSSH running on Ubuntu 14.04", 
  "service.version"=>"6.6p1", 
  "openssh.comment"=>"Ubuntu-2ubuntu1", 
  "service.vendor"=>"OpenBSD", 
  "service.family"=>"OpenSSH", 
  "service.product"=>"OpenSSH", 
  "os.vendor"=>"Ubuntu", 
  "os.device"=>"General", "os.family"=>"Linux", 
  "os.product"=>"Linux", "os.version"=>"14.04", 
  "service.protocol"=>"ssh", 
  "fingerprint_db"=>"ssh.banner", 
  "data"=>"OpenSSH_6.6p1 Ubuntu-2ubuntu1"}
```

Current fingerprint database priority, highest priority first:
```
Preference  Database                Type 
     0.900  http_header.server      service 
     0.900  ftp.banner              service 
     0.900  imap4.banner            service 
     0.900  pop3.banner             service 
     0.900  ssh.banner              service 
     0.800  h323_callresp           service 
     0.800  mysql.error             service 
     0.800  ntp.readvar             service 
     0.800  operating_system.name   util.os 
     0.800  ldap.search_result      service 
     0.750  mysql.banners           service 
     0.200  http_header.wwwauth     service 
     0.200  smtp.banner             service 
     0.190  smtp_ehlo               service 
     0.180  smtp_help               service 
     0.170  smtp_noop               service 
     0.160  smtp_expn               service 
     0.150  smtp_vrfy               service 
     0.140  smtp_debug              service 
     0.130  smtp_turn               service 
     0.120  smtp_rset               service 
     0.110  smtp_quit               service 
     0.100  ssdp_header.server      service 
     0.100  architecture            util.os 
     0.100  hp_pjl_id               service 
     0.100  http_header.cookie      service 
     0.100  mdns.device-info.txt    util.os 
     0.100  mdns.workstation.txt    service 
     0.100  nntp.banner             service 
     0.100  rsh_resp                service 
     0.100  sip_header.server       service 
     0.100  sip_header.user_agent   service 
     0.100  smb.native_lm           service 
     0.100  smb.native_os           util.os 
     0.100  smtp_mailfrom           service 
     0.100  smtp_rcptto             service 
     0.100  snmp.sys_description    service 
     0.100  snmp.sys_object_id      service 
     0.100  apache_os               util.os 
```