### PR TITLE
Fingerprint update: 2016.11 - ftp.banner

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -12,7 +12,6 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows NT"/>
     <param pos="1" name="host.name"/>
@@ -25,7 +24,6 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
     <param pos="1" name="host.name"/>
@@ -37,7 +35,6 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="1" name="host.name"/>
@@ -49,7 +46,6 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="1" name="host.name"/>
@@ -61,7 +57,6 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
@@ -74,7 +69,6 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.product" value="FTPD"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="HP-UX"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.product" value="HP-UX"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="service.version"/>
@@ -88,7 +82,6 @@ against these patterns to fingerprint FTP servers.
     <param pos="0" name="service.product" value="WU-FTPD"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="HP-UX"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.product" value="HP-UX"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="service.version"/>
@@ -113,7 +106,6 @@ example.com FTP server (Version:  Mac OS X Server 10.3 - +GSSAPI) ready.</exampl
     <param pos="0" name="service.product" value="FTP"/>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.product" value="Mac OS X Server"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
@@ -127,7 +119,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.product" value="FTP"/>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.product" value="Mac OS X Server"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
@@ -144,7 +135,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -156,7 +146,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Debian"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="2" name="host.name"/>
@@ -278,7 +267,6 @@ more text</example>
     <param pos="0" name="service.family" value="Serv-U"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
@@ -289,7 +277,6 @@ more text</example>
     <param pos="0" name="service.product" value="zFTPServer"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
@@ -1005,7 +992,6 @@ more text</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="Unix"/>
     <param pos="0" name="os.product" value="Tru64 Unix"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1015,7 +1001,6 @@ more text</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="Unix"/>
     <param pos="0" name="os.product" value="Digital Unix"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1180,7 +1165,6 @@ more text</example>
     <param pos="0" name="service.vendor" value="Gene6"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
@@ -1193,7 +1177,6 @@ more text</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="1" name="host.name"/>
@@ -1206,7 +1189,6 @@ more text</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -368,12 +368,12 @@ more text</example>
     <param pos="0" name="service.vendor" value="EMC"/>
     <param pos="0" name="service.product" value="Celerra"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="os.vendor" value="Celerra"/>
+    <param pos="0" name="os.vendor" value="EMC"/>
     <param pos="0" name="os.device" value="Storage"/>
     <param pos="0" name="os.product" value="Celerra"/>
     <param pos="2" name="os.version"/>
     <param pos="1" name="host.name"/>
-    <param pos="0" name="hw.vendor" value="Celerra"/>
+    <param pos="0" name="hw.vendor" value="EMC"/>
     <param pos="0" name="hw.device" value="Storage"/>
     <param pos="0" name="hw.product" value="Celerra"/>
   </fingerprint>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1228,9 +1228,10 @@ more text</example>
     <example>Welcome to TP-LINK FTP server</example>
     <param pos="0" name="hw.vendor" value="TP-LINK"/>
   </fingerprint>
-   <fingerprint pattern="^ucftpd\((\w{3}  \d{,2} \d{4}-\d\d:\d\d:\d\d)\) FTP server ready\.$">
+   <fingerprint pattern="^ucftpd\((\w{3}\s+\d{,2} \d{4}-\d\d:\d\d:\d\d)\) FTP server ready\.$">
     <description>ucftpd with version</description>
     <example service.version="Jul  2 2012-22:13:49">ucftpd(Jul  2 2012-22:13:49) FTP server ready.</example>
+    <example service.version="Sep 10 2010-17:23:34">ucftpd(Sep 10 2010-17:23:34) FTP server ready.</example>
     <param pos="0" name="service.family" value="ucftpd"/>
     <param pos="0" name="service.product" value="ucftpd"/>
     <param pos="1" name="service.version"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -152,6 +152,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD on Debian Linux</description>
     <example>ProFTPD 1.3.0rc2 Server (Debian) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Debian"/>
@@ -164,6 +165,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD on a Linksys Wireless Access Point/Router</description>
     <example>ProFTPD 1.3.0rc2 Server (LinksysWRT350N) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linksys"/>
@@ -174,6 +176,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Linksys(.*)\) \[(.+)\]$">
     <description>ProFTPD on a wired Linksys device</description>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linksys"/>
@@ -183,10 +186,11 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
   </fingerprint>
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \((.*)\) \[(.+)\]$">
     <description>ProFTPD with version info but no obvious OS info</description>
-    <example>ProFTPD 1.2.10 Server (Main FTP Server) [host]</example>
-    <example>ProFTPD 1.2.10 Server (ProFTPD) [host]</example>
-    <example>ProFTPD 1.2.10rc3 Server (ProFTPD Default Installation) [host]</example>
+    <example service.version="1.2.10">ProFTPD 1.2.10 Server (Main FTP Server) [host]</example>
+    <example proftpd.server.name="ProFTPD">ProFTPD 1.2.10 Server (ProFTPD) [host]</example>
+    <example host.name="host">ProFTPD 1.2.10rc3 Server (ProFTPD Default Installation) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
     <param pos="2" name="proftpd.server.name"/>
@@ -194,8 +198,9 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
   </fingerprint>
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server ready\.$">
     <description>ProFTPD with only version info</description>
-    <example>ProFTPD 1.3.0rc2 Server ready.</example>
+    <example service.version="1.3.0rc2">ProFTPD 1.3.0rc2 Server ready.</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -203,7 +208,35 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <description>ProFTPD with no version info</description>
     <example>ProFTPD FTP Server ready.</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
+  </fingerprint>
+  <fingerprint pattern="^ProFTPD Server$">
+    <description>ProFTPD with no version info, short form</description>
+    <example>ProFTPD Server</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+  </fingerprint>
+  <fingerprint pattern="^(?:\d{4}\-\d\d\-\d\d \d\d:\d\d:\d\d,\d\d\d )?(\S+) proftpd\[\d+\]: error: no valid servers configured">
+    <description>ProFTPD no valid servers configured</description>
+    <example host.name="ftp.host.com">ftp.host.com proftpd[40312]: error: no valid servers configured\n</example>
+    <example host.name="hostname.com">2016-10-31 12:14:35,524 hostname.com proftpd[26992]: error: no valid servers configured\n</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+  <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \((.*)\) \[[\h.:\]]*$">
+    <description>ProFTPD with version info - truncated</description>
+    <example service.version="1.3.2c">ProFTPD 1.3.2c Server (ProFTPD Default Installation) [</example>
+    <example proftpd.server.name="svrname.hosting.com">ProFTPD 1.3.0 Server (svrname.hosting.com) [10.10.10.</example>
+    <example>ProFTPD 1.3.3a Server (randomstring) [::ff</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="proftpd.server.name"/>
   </fingerprint>
   <fingerprint pattern="^=\(&lt;\*&gt;\)=-\.:\. \(\( Welcome to Pure-FTPd ([\d.]+) \)\) \.:\.-=\(&lt;\*&gt;\)=-" flags="REG_MULTILINE">
     <description>Pure-FTPd versions &lt;= 1.0.13 (at least as far back as 1.0.11)</description>
@@ -235,11 +268,11 @@ more text</example>
     <param pos="0" name="service.product" value="Pure-FTPd"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^Serv-U FTP[ -]Server v(\d+\..+)(?: for WinSock)? ready\.*$">
+  <fingerprint pattern="^Serv-U FTP[ -]Server v(\d+\.\S+)(?: for WinSock)? ready\.*$">
     <description>Serv-U (only runs on Windows)</description>
-    <example>Serv-U FTP-Server v2.5n for WinSock ready...</example>
-    <example>Serv-U FTP Server v6.0 for WinSock ready</example>
-    <example>Serv-U FTP Server v7.2 ready...</example>
+    <example service.version="2.5n">Serv-U FTP-Server v2.5n for WinSock ready...</example>
+    <example service.version="6.0">Serv-U FTP Server v6.0 for WinSock ready</example>
+    <example service.version="7.2">Serv-U FTP Server v7.2 ready...</example>
     <param pos="0" name="service.vendor" value="Rhino Software"/>
     <param pos="0" name="service.product" value="Serv-U"/>
     <param pos="0" name="service.family" value="Serv-U"/>
@@ -251,7 +284,8 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^zFTPServer v?(\S+), .*ready\.$" flags="REG_ICASE">
     <description>zftpserver (only runs on Windows)</description>
-    <example>zFTPServer v4.0, build 2008-12-24 01:41 ready.</example>
+    <example service.version="4.0">zFTPServer v4.0, build 2008-12-24 01:41 ready.</example>
+    <param pos="0" name="service.vendor" value="Västgöta-Data AB" />
     <param pos="0" name="service.product" value="zFTPServer"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
@@ -261,8 +295,8 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^\(vsFTPd (\d+\..+)\)(?: (.+))?$">
     <description>vsFTPd (Very Secure FTP Daemon)</description>
-    <example>(vsFTPd 1.1.3) host</example>
-    <example>(vsFTPd 2.0.5)</example>
+    <example service.version="1.1.3">(vsFTPd 1.1.3) host</example>
+    <example service.version="2.0.5">(vsFTPd 2.0.5)</example>
     <param pos="0" name="service.family" value="vsFTPd"/>
     <param pos="0" name="service.product" value="vsFTPd"/>
     <param pos="1" name="service.version"/>
@@ -270,14 +304,32 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^ready, dude \(vsFTPd (\d+\..+): beat me, break me\)$">
     <description>vsFTPd (Very Secure FTP Daemon)</description>
-    <example>ready, dude (vsFTPd 1.1.0: beat me, break me)</example>
+    <example service.version="1.1.0">ready, dude (vsFTPd 1.1.0: beat me, break me)</example>
     <param pos="0" name="service.family" value="vsFTPd"/>
     <param pos="0" name="service.product" value="vsFTPd"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^FileZilla Server version (\d\..+)$">
+  <fingerprint pattern="^vsFTPd ([\d.]+\+ \(ext\.3\)) ready\.\.\.$">
+    <description>vsFTPd (Very Secure FTP Daemon) extended build (vsftpd.devnet.ru)</description>
+    <example service.version="2.0.4+ (ext.3)">vsFTPd 2.0.4+ (ext.3) ready...</example>
+    <param pos="0" name="service.family" value="vsFTPd"/>
+    <param pos="0" name="service.product" value="vsFTPd Extended"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+    <fingerprint pattern="^OOPS: .*vsftp.*$">
+    <description>vsFTPd (Very Secure FTP Daemon) error message</description>
+    <example>OOPS: vsftpd: root is not mounted.</example>
+    <example>OOPS: cannot read user list file:/etc/vsftpd.user_list</example>
+    <param pos="0" name="service.family" value="vsFTPd"/>
+    <param pos="0" name="service.product" value="vsFTPd Extended"/>
+    <param pos="0" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^FileZilla Server(?: version)? (?:v)?(\d\.[\w.]+(?: beta)?).*$">
     <description>FileZilla FTP Server</description>
-    <example>FileZilla Server version 0.9.2 beta</example>
+    <example service.version="0.9.2 beta">FileZilla Server version 0.9.2 beta</example>
+    <example service.version="0.9.13a beta">FileZilla Server version 0.9.13a beta</example>
+    <example service.version="0.9.54 beta">FileZilla Server 0.9.54 beta</example>
+    <example service.version="0.9.33 beta">FileZilla Server v0.9.33 beta</example>
     <param pos="0" name="service.family" value="FileZilla FTP Server"/>
     <param pos="0" name="service.product" value="FileZilla FTP Server"/>
     <param pos="1" name="service.version"/>
@@ -289,12 +341,14 @@ more text</example>
     <param pos="0" name="service.product" value="FTP"/>
     <param pos="0" name="os.vendor" value="APC"/>
     <param pos="0" name="os.device" value="Power device"/>
+    <param pos="0" name="hw.vendor" value="APC"/>
+    <param pos="0" name="hw.device" value="Power device"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) Network Management Card AOS v(\d+\..+) FTP server ready\.$">
     <description>APC power/cooling device</description>
-    <example>AP7932 Network Management Card AOS v3.3.4 FTP server ready.</example>
-    <example>ACRC103 Network Management Card AOS v3.6.1 FTP server ready.</example>
-    <example>0G-9354-01 Network Management Card AOS v3.6.1 FTP server ready.</example>
+    <example service.version="3.3.4">AP7932 Network Management Card AOS v3.3.4 FTP server ready.</example>
+    <example os.version="3.6.1">ACRC103 Network Management Card AOS v3.6.1 FTP server ready.</example>
+    <example os.product="0G-9354-01">0G-9354-01 Network Management Card AOS v3.6.1 FTP server ready.</example>
     <param pos="0" name="service.vendor" value="APC"/>
     <param pos="0" name="service.product" value="AOS"/>
     <param pos="0" name="service.family" value="AOS"/>
@@ -303,12 +357,14 @@ more text</example>
     <param pos="0" name="os.device" value="Power device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="APC"/>
+    <param pos="0" name="hw.device" value="Power device"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP server \(EMC-SNAS: ([^\)]+)\)(?: \S+)?$">
     <description>EMC Celerra</description>
-    <example>foo2 FTP server (EMC-SNAS: 5.6.47.11)</example>
-    <example>foo2 FTP server (EMC-SNAS: 5.6.50.203) ready.</example>
-    <example>foo4 FTP server (EMC-SNAS: 5.5.31.6) r</example>
+    <example service.version="5.6.47.11">foo2 FTP server (EMC-SNAS: 5.6.47.11)</example>
+    <example service.version="5.6.50.203">foo2 FTP server (EMC-SNAS: 5.6.50.203) ready.</example>
+    <example service.version="5.5.31.6">foo4 FTP server (EMC-SNAS: 5.5.31.6) r</example>
     <param pos="0" name="service.vendor" value="EMC"/>
     <param pos="0" name="service.product" value="Celerra"/>
     <param pos="2" name="service.version"/>
@@ -317,6 +373,9 @@ more text</example>
     <param pos="0" name="os.product" value="Celerra"/>
     <param pos="2" name="os.version"/>
     <param pos="1" name="host.name"/>
+    <param pos="0" name="hw.vendor" value="Celerra"/>
+    <param pos="0" name="hw.device" value="Storage"/>
+    <param pos="0" name="hw.product" value="Celerra"/>
   </fingerprint>
   <fingerprint pattern="^JD FTP Server Ready.*$">
     <description>HP JetDirect printer</description>
@@ -329,10 +388,14 @@ more text</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="JetDirect"/>
     <param pos="0" name="os.product" value="JetDirect"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.family" value="JetDirect"/>
+    <param pos="0" name="hw.product" value="JetDirect"/>
   </fingerprint>
   <fingerprint pattern="^Check Point FireWall-1 Secure FTP server running on (.+)$">
     <description>Check Point FireWall-1</description>
-    <example>Check Point FireWall-1 Secure FTP server running on host</example>
+    <example host.name="host">Check Point FireWall-1 Secure FTP server running on host</example>
     <param pos="0" name="service.vendor" value="Check Point"/>
     <param pos="0" name="service.product" value="Firewall-1"/>
     <param pos="0" name="service.family" value="Firewall-1"/>
@@ -340,6 +403,9 @@ more text</example>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="Firewall-1"/>
     <param pos="0" name="os.product" value="Firewall-1"/>
+    <param pos="0" name="hw.vendor" value="Check Point"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.family" value="Firewall-1"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^Blue Coat FTP Service$">
@@ -423,18 +489,23 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^AXIS (\S+) Video (?:Encoder Blade|Server|Decoder) ([\d\.]+) .* ready\.?$" flags="REG_ICASE">
     <description>Axis Video encoders/servers</description>
-    <example>AXIS Q7406 Video Encoder Blade 5.01 (Aug 01 2008) ready.</example>
-    <example>AXIS 241Q Video Server 4.47.2 (Dec 11 2008) ready.</example>
-    <example>AXIS P7701 Video Decoder 5.07.2 (Apr 20 2010) ready.</example>
+    <example hw.product="Q7406">AXIS Q7406 Video Encoder Blade 5.01 (Aug 01 2008) ready.</example>
+    <example os.product="241Q">AXIS 241Q Video Server 4.47.2 (Dec 11 2008) ready.</example>
+    <example os.version="5.07.2">AXIS P7701 Video Decoder 5.07.2 (Apr 20 2010) ready.</example>
+    <param pos="0" name="hw.vendor" value="Axis"/>
+    <param pos="1" name="hw.product"/>
     <param pos="0" name="os.vendor" value="Axis"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^AXIS (\S+) .*FTP Network Print Server V?([\d\.]+\S+) .* ready\.?$" flags="REG_ICASE">
     <description>Axis print servers</description>
-    <example>AXIS 5600+ (rev 3) FTP Network Print Server V7.00 Sep 10 2004 ready.</example>
-    <example>AXIS 560 FTP Network Print Server V6.00 Jul 7 1999 ready.</example>
-    <example>AXIS 5470e FTP Network Print Server V6.30.beta2 Sep 25 2002 ready.</example>
+    <example hw.product="5600+">AXIS 5600+ (rev 3) FTP Network Print Server V7.00 Sep 10 2004 ready.</example>
+    <example os.product="560">AXIS 560 FTP Network Print Server V6.00 Jul 7 1999 ready.</example>
+    <example os.version="6.30.beta2">AXIS 5470e FTP Network Print Server V6.30.beta2 Sep 25 2002 ready.</example>
+    <param pos="0" name="hw.vendor" value="Axis"/>
+    <param pos="0" name="hw.device" value="Print server"/>
+    <param pos="1" name="hw.product"/>
     <param pos="0" name="os.vendor" value="Axis"/>
     <param pos="0" name="os.device" value="Print server"/>
     <param pos="1" name="os.product"/>
@@ -442,9 +513,13 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^RICOH Aficio ((?:[MS]P )?\S+) FTP server \(([0-9\.a-zA-Z]+)\) ready.?$" flags="REG_ICASE">
     <description>Ricoh Aficio multifunction device</description>
-    <example>RICOH Aficio 2045e FTP server (4.12) ready.</example>
-    <example>RICOH Aficio SP 4210N FTP server (8.63) ready.</example>
-    <example>RICOH Aficio MP C3000 FTP server (5.11) ready.</example>
+    <example os.product="2045e">RICOH Aficio 2045e FTP server (4.12) ready.</example>
+    <example os.version="8.63">RICOH Aficio SP 4210N FTP server (8.63) ready.</example>
+    <example hw.product="MP C3000">RICOH Aficio MP C3000 FTP server (5.11) ready.</example>
+    <param pos="0" name="hw.vendor" value="Ricoh"/>
+    <param pos="0" name="hw.family" value="Aficio"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Aficio"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -468,6 +543,9 @@ more text</example>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Ricoh"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Xerox Phaser (\S+)$" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>
@@ -477,6 +555,10 @@ more text</example>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Phaser"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^XEROX (\d+) Wide Format .*$" certainty="1.0">
     <description>Xerox Wide Format Series of Printers</description>
@@ -485,6 +567,10 @@ more text</example>
     <param pos="0" name="os.family" value="Wide Format"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Wide Format"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^FUJI XEROX DocuPrint (.*)$" certainty="1.0">
     <description>FUJI XEROX DocuPrint Series of Printers</description>
@@ -504,27 +590,36 @@ more text</example>
     <param pos="1" name="host.mac"/>
     <param pos="2" name="os.product"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="2" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^.*Lexmark (\S+) FTP Server (\S+) ready\.?$" certainty="1.0" flags="REG_ICASE">
     <description>Lexmark printers</description>
-    <example>ET0021718 Lexmark T654 FTP Server NR.APS.F368 ready.</example>
+    <example os.product="T654" os.version="NR.APS.F368">ET0021718 Lexmark T654 FTP Server NR.APS.F368 ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^.*Lexmark (\S+) FTP Server ready\.?$" certainty="1.0" flags="REG_ICASE">
     <description>Lexmark printers</description>
-    <example>Lexmark X500 FTP server ready</example>
+    <example os.product="X500">Lexmark X500 FTP server ready</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^(?:Tornado-)?VxWorks \((?:VxWorks)?([^\)]+)\) FTP server(?: ready)?$" flags="REG_ICASE">
     <description>VxWorks with version information</description>
-    <example>VxWorks (5.3.1) FTP server ready</example>
-    <example>VxWorks (VxWorks5.5.1) FTP server ready</example>
-    <example>Tornado-vxWorks (VxWorks5.5.1) FTP server</example>
+    <example os.version="5.3.1">VxWorks (5.3.1) FTP server ready</example>
+    <example os.version="5.5.1">VxWorks (VxWorks5.5.1) FTP server ready</example>
+    <example os.version="5.5.1">Tornado-vxWorks (VxWorks5.5.1) FTP server</example>
     <param pos="0" name="os.vendor" value="Wind River"/>
     <param pos="0" name="os.product" value="VxWorks"/>
     <param pos="1" name="os.version"/>
@@ -551,13 +646,17 @@ more text</example>
     <param pos="0" name="os.family" value="TASKalfa"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Kyocera"/>
+    <param pos="0" name="hw.family" value="TASKalfa"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^SAVIN (\S+) FTP server \((.*)\) ready.$" certainty="1.0">
     <description>SAVIN Printer FTP Server</description>
-    <example>SAVIN 4075 FTP server (4.08) ready.</example>
-    <example>SAVIN 9025 FTP server (7.23) ready.</example>
-    <example>SAVIN 9050 FTP server (7.30) ready.</example>
-    <example>SAVIN 917 FTP server (9.03) ready.</example>
+    <example os.product="4075">SAVIN 4075 FTP server (4.08) ready.</example>
+    <example hw.product="9025">SAVIN 9025 FTP server (7.23) ready.</example>
+    <example os.version="7.30">SAVIN 9050 FTP server (7.30) ready.</example>
+    <example os.version="9.03">SAVIN 917 FTP server (9.03) ready.</example>
     <example>SAVIN 917 FTP server (9.05.2) ready.</example>
     <example>SAVIN C2525 FTP server (5.14) ready.</example>
     <example>SAVIN C3528 FTP server (4.08.3) ready.</example>
@@ -568,6 +667,9 @@ more text</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Savin"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Oce (im\d+) Ver (\S+) FTP server\.$" certainty="1.0">
     <description>OCE IM series Printer</description>
@@ -668,41 +770,55 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^ET(\S+) Lexmark Forms Printer (\d+) Ethernet FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Lexmark Forms Printer</description>
-    <example>ET0020004F54EE Lexmark Forms Printer 2590 Ethernet FTP Server LCL.CU.P012c ready.</example>
+    <example os.product="2590">ET0020004F54EE Lexmark Forms Printer 2590 Ethernet FTP Server LCL.CU.P012c ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="Forms Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="host.mac"/>
     <param pos="2" name="os.product"/>
     <param pos="3" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.family" value="Forms Printer"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="2" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^ET(\S+) TOSHIBA e-STUDIO500S FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Toshiba Printer</description>
-    <example>ET0004001E9C00 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N221 ready.</example>
+    <example os.version="NC2.NPS.N221">ET0004001E9C00 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N221 ready.</example>
     <example>ET00040089BE42 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N211 ready.</example>
     <param pos="0" name="os.vendor" value="Toshiba"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.product" value="e-STUDIO"/>
     <param pos="1" name="host.mac"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Toshiba"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="0" name="hw.product" value="e-STUDIO"/>
   </fingerprint>
   <fingerprint pattern="^\S+ TOSHIBA e-STUDIO500S FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Toshiba Printer</description>
-    <example>JHBPRN13 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N211 ready.</example>
+    <example os.version="NC2.NPS.N211">JHBPRN13 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N211 ready.</example>
     <param pos="0" name="os.vendor" value="Toshiba"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.product" value="e-STUDIO"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Toshiba"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="0" name="hw.product" value="e-STUDIO"/>
   </fingerprint>
   <fingerprint pattern="^.*Lexmark Optra (\S+) FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Lexmark Optra Printer</description>
-    <example>lex142785470853 Lexmark Optra T612 FTP Server 3.20.30 ready.</example>
-    <example>oppr1.s02504.us Lexmark Optra T610 FTP Server 3.20.20 ready.</example>
+    <example os.product="T612">lex142785470853 Lexmark Optra T612 FTP Server 3.20.30 ready.</example>
+    <example os.version="3.20.20">oppr1.s02504.us Lexmark Optra T610 FTP Server 3.20.20 ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="Optra"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Lexmark"/>
+    <param pos="0" name="hw.family" value="Optra"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^SHARP (MX-\S+) Ver (\S+) FTP server\.$" certainty="1.0">
     <description>Sharp Printer/Copier/Scanne</description>
@@ -720,15 +836,22 @@ more text</example>
     <param pos="0" name="os.family" value="MX Series"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Sharp"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.family" value="MX Series"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^(FS-\S+MFP\S*?) FTP server\.?$" certainty="1.0">
     <description>Kyocera Printers</description>
-    <example>FS-C2126MFP FTP server</example>
-    <example>FS-C2026MFP+ FTP server</example>
-    <example>FS-1128MFP FTP server</example>
+    <example os.product="FS-C2126MFP">FS-C2126MFP FTP server</example>
+    <example hw.product="FS-C2026MFP+">FS-C2026MFP+ FTP server</example>
+    <example hw.product="FS-1128MFP">FS-1128MFP FTP server</example>
     <param pos="0" name="os.vendor" value="Kyocera"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Kyocera"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^(FS-\S+(?:DN|D|N)) FTP server\.?$" certainty="1.0">
     <description>Kyocera Printers</description>
@@ -738,12 +861,16 @@ more text</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="FS"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Kyocera"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.family" value="FS"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^(ESI-\S+) Version (\S+) ready\.$" certainty="1.0">
     <description>Extended Systems ExtendNet Print Server</description>
-    <example>ESI-2941B Version 6.34 ready.</example>
-    <example>ESI-2941A Version 6.03 ready.</example>
-    <example>ESI-2933A Version 6.40 ready.</example>
+    <example os.product="ESI-2941B">ESI-2941B Version 6.34 ready.</example>
+    <example os.version="6.03">ESI-2941A Version 6.03 ready.</example>
+    <example hw.product="ESI-2933A">ESI-2933A Version 6.40 ready.</example>
     <example>ESI-2831 Version 2.1 ready.</example>
     <example>ESI-2833A Version 6.3 ready.</example>
     <example>ESI-2900A Version 6.31 ready.</example>
@@ -756,19 +883,24 @@ more text</example>
     <param pos="0" name="os.device" value="Print server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.family" value="Extended Systems ExtendNet"/>
+    <param pos="0" name="hw.device" value="Print server"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^SATO SATO PRINTER Ver (\S+) FTP server\.$" certainty="1.0">
     <description>SATO Printer</description>
-    <example>SATO SATO PRINTER Ver A1.2.3 FTP server.</example>
+    <example os.version="A1.2.3">SATO SATO PRINTER Ver A1.2.3 FTP server.</example>
     <example>SATO SATO PRINTER Ver A2.3.0 FTP server.</example>
     <param pos="0" name="os.vendor" value="SATO"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="SATO"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^Printer FTP (\d+\.\d+\.\d+) ready at (\w{3} \d{2} \d{2}:\d{2}:\d{2})$" certainty="1.0">
     <description>AMTDatasouth Fastmark M5</description>
-    <example>Printer FTP 4.8.7 ready at Apr 30 20:13:23</example>
-    <example>Printer FTP 4.8.7 ready at Aug 31 16:43:22</example>
+    <example os.version="4.8.7">Printer FTP 4.8.7 ready at Apr 30 20:13:23</example>
+    <example system.time="Aug 31 16:43:22">Printer FTP 4.8.7 ready at Aug 31 16:43:22</example>
     <example>Printer FTP 4.8.7 ready at Feb 28 11:27:46</example>
     <example>Printer FTP 4.8.7 ready at Jan 31 00:40:04</example>
     <example>Printer FTP 4.8.7 ready at Mar 31 06:28:25</example>
@@ -778,6 +910,9 @@ more text</example>
     <param pos="1" name="os.version"/>
     <param pos="0" name="system.time.format" value="MMM dd HH:mm::ss"/>
     <param pos="2" name="system.time"/>
+    <param pos="0" name="hw.vendor" value="AMTDatasouth"/>
+    <param pos="0" name="hw.product" value="Fastmark M5"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^EFI FTP Print server ready\.$" certainty="0.8">
     <description>EFI FTP Print Server</description>
@@ -791,12 +926,16 @@ more text</example>
   <!-- Conjectured based on known MX FTP fingerprints -->
   <fingerprint pattern="^SHARP (AR-\S+) Ver (\S+) FTP server">
     <description>Sharp AR Series multifunction device</description>
-    <example>SHARP AR-M450 Ver 01.05.00.0k FTP server.</example>
+    <example os.product="AR-M450">SHARP AR-M450 Ver 01.05.00.0k FTP server.</example>
     <param pos="0" name="os.vendor" value="Sharp"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.family" value="AR Series"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Sharp"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="0" name="hw.family" value="AR Series"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^KONICA MINOLTA FTP server ready\.?$">
     <description>Konica Minolta FTP Server</description>
@@ -806,6 +945,9 @@ more text</example>
     <param pos="0" name="os.product" value="Printer"/>
     <param pos="0" name="service.vendor" value="Konica Minolta"/>
     <param pos="0" name="service.product" value="KM FTPD"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Konica Minolta"/>
+    <param pos="0" name="hw.product" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^(KM\S+) FTP server \(KM FTPD version (\d*(?:\.\d*))\) ready\.?$">
     <description>Konica Minolta FTP Server</description>
@@ -826,13 +968,16 @@ more text</example>
   </fingerprint>
   <fingerprint pattern="^(ZBR-\d+) Version (\S+) ready\.?$">
     <description>ZebraNet Print Server FTP</description>
-    <example>ZBR-46686 Version 7.02 ready.</example>
-    <example>ZBR-79071 Version V56.17.5Z ready.</example>
-    <example>ZBR-46687 Version 7.02 ready.</example>
+    <example os.product="ZBR-46686">ZBR-46686 Version 7.02 ready.</example>
+    <example os.version="V56.17.5Z">ZBR-79071 Version V56.17.5Z ready.</example>
+    <example os.version="7.02">ZBR-46687 Version 7.02 ready.</example>
     <param pos="0" name="os.vendor" value="ZebraNet"/>
     <param pos="0" name="os.device" value="Print server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="ZebraNet"/>
+    <param pos="0" name="hw.device" value="Print server"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP server \(Version \S+ \w+ \w+ \d{1,2} \d{1,2}:\d{1,2}:\d{1,2} [A-Z]+ (?:1|2)\d{3}\) ready\.?$">
     <description>Generic/unknown FTP Server found on HP-UX and AIX systems</description>
@@ -850,6 +995,7 @@ more text</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="TelePresence"/>
     <param pos="1" name="os.device"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="2" name="hw.series"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
@@ -880,6 +1026,246 @@ more text</example>
     <param pos="0" name="os.product" value="RouterOS"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
+  </fingerprint>
+    <fingerprint pattern="^MikroTik FTP server \(MikroTik ([\w.]+)\) ready\.?$">
+    <description>MikroTik w/o hostname</description>
+    <example os.version="6.0rc14">MikroTik FTP server (MikroTik 6.0rc14) ready</example>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to ASUS (B?RT-[\w.-]+) FTP service\.$">
+    <description>FTPD on an Asus Wireless Access Point/Router</description>
+    <example hw.product="RT-AC68U">Welcome to ASUS RT-AC68U FTP service.</example>
+    <example hw.product="RT-N13U.B1">Welcome to ASUS RT-N13U.B1 FTP service.</example>
+    <example hw.product="BRT-AC828">Welcome to ASUS BRT-AC828 FTP service.</example>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Asus"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to ASUS (DSL-[\w.-]+) FTP service\.$">
+    <description>FTPD on a ADSL/VDSL Modem/Wireless Access Point/Router</description>
+    <example hw.product="DSL-AC68U">Welcome to ASUS DSL-AC68U FTP service.</example>
+    <example hw.product="DSL-N55U-D1">Welcome to ASUS DSL-N55U-D1 FTP service.</example>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Asus"/>
+    <param pos="0" name="hw.device" value="DSL Modem"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to ASUS (TM-\w+) FTP service\.$">
+    <description>FTPD on a T-Mobile branded Asus Wireless Access Point/Router</description>
+    <example hw.product="TM-AC1900">Welcome to ASUS TM-AC1900 FTP service.</example>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Asus"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^(FRITZ!Box[\w()]+) FTP server ready\.$">
+    <description>FTPD on an AWM multifunction Modem/Wireless Access Point/Router/VoIP device</description>
+    <example hw.product="FRITZ!Box7490">FRITZ!Box7490 FTP server ready.</example>
+    <example hw.product="FRITZ!BoxFonWLAN7390">FRITZ!BoxFonWLAN7390 FTP server ready.</example>
+    <example hw.product="FRITZ!Box7490(UI)">FRITZ!Box7490(UI) FTP server ready.</example>
+    <example hw.product="FRITZ!Box7362SL(UI)">FRITZ!Box7362SL(UI) FTP server ready.</example>
+    <example hw.product="FRITZ!BoxFonWLAN7270v3">FRITZ!BoxFonWLAN7270v3 FTP server ready.</example>
+    <example hw.product="FRITZ!Box6490Cable(kdg)">FRITZ!Box6490Cable(kdg) FTP server ready.</example>
+    <param pos="0" name="hw.vendor" value="AVM"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="hw.family" value="FRITZ!Box"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^HES_CPE FTP server \(GNU inetutils ([\w.]+)\) ready\.$">
+    <description>FTPD on a ZyXEL (Huawei rebrand) WiMax WAP</description>
+    <example service.version="1.4.1">HES_CPE FTP server (GNU inetutils 1.4.1) ready.</example>
+    <param pos="0" name="service.family" value="inetutils"/>
+    <param pos="0" name="service.product" value="inetutils ftpd"/>
+    <param pos="0" name="service.vendor" value="GNU"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="hw.vendor" value="ZyXEL"/>
+    <param pos="1" name="hw.family" value="WiMax"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+  </fingerprint>
+  <fingerprint pattern="^Speedport W ?(\S+) (?:Typ [A|B] )?FTP Server v([\d.]+) ready$$">
+    <description>FTPD on Speedport WLAN/ADSL routers (Deutsche Telekom mfg by misc)</description>
+    <example hw.product="723V" os.version="1.40.000">Speedport W 723V Typ B FTP Server v1.40.000 ready</example>
+    <example hw.product="921V" os.version="1.39.000">Speedport W 921V FTP Server v1.39.000 ready</example>
+    <example hw.product="722V" os.version="1.18.000">Speedport W722V FTP Server v1.18.000 ready</example>
+    <param pos="0" name="hw.vendor" value="Deutsche Telekom"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="1" name="hw.family" value="Speedport"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^DiskStation FTP server ready\.$">
+    <description>FTPD on a Synology DiskStation NAS</description>
+    <example>DiskStation FTP server ready.</example>
+    <param pos="0" name="service.family" value="SmbFTPD"/>
+    <param pos="0" name="service.product" value="SmbFTPD"/>
+    <param pos="0" name="service.vendor" value="GNU"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Synology"/>
+    <param pos="0" name="hw.family" value="DiskStation"/>
+    <param pos="0" name="hw.device" value="NAS"/>
+  </fingerprint>
+  <fingerprint pattern="^Synology FTP server ready\.$" flags="REG_ICASE">
+    <description>FTPD on a Synology device</description>
+    <example>Synology FTP server ready.</example>
+    <example>SYNOLOGY FTP server ready.</example>
+    <param pos="0" name="service.family" value="SmbFTPD"/>
+    <param pos="0" name="service.product" value="SmbFTPD"/>
+    <param pos="0" name="service.vendor" value="GNU"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.vendor" value="Synology"/>
+  </fingerprint>
+  <fingerprint pattern="^.Welcome to MyBookLive.$">
+    <description>FTPD on Western Digital My Book Live NAS</description>
+    <example>"Welcome to MyBookLive"</example>
+    <param pos="0" name="hw.vendor" value="Western Digital"/>
+    <param pos="0" name="hw.family" value="My Book"/>
+    <param pos="0" name="hw.product" value="My Book Live"/>
+    <param pos="0" name="hw.device" value="NAS"/>
+  </fingerprint>
+  <fingerprint pattern="^Multicraft ([\w.-]+) FTP server$">
+    <description>Multicraft FTPD Server</description>
+    <example service.version="2.0.2">Multicraft 2.0.2 FTP server</example>
+    <example service.version="2.0.0-pre19">Multicraft 2.0.0-pre19 FTP server</example>
+    <param pos="0" name="service.family" value="Multicraft"/>
+    <param pos="0" name="service.product" value="Multicraft"/>
+    <param pos="0" name="service.vendor" value="Multicraft"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^bftpd ([\d.]+) at ([\h.:]+) ready\.$">
+    <description>Bftpd FTPD Server</description>
+    <example service.version="2.2.1" host.ip="192.168.0.1">bftpd 2.2.1 at 192.168.0.1 ready.</example>
+    <example service.version="2.2" host.ip="::ffff:192.168.1.1">bftpd 2.2 at ::ffff:192.168.1.1 ready.</example>
+    <param pos="0" name="service.family" value="Bftpd"/>
+    <param pos="0" name="service.product" value="Bftpd"/>
+    <param pos="0" name="service.vendor" value="Bftpd Project"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="host.ip"/>
+  </fingerprint>
+  <fingerprint pattern="^NASFTPD Turbo station (?:2.x )?([\w.]+) Server \(ProFTPD\) \[([\h.:]+)\]$">
+    <description>ProFTPD on QNAP Turbo Station NAS</description>
+    <example service.version="1.3.5a" host.ip="192.168.1.100">NASFTPD Turbo station 1.3.5a Server (ProFTPD) [192.168.1.100]</example>
+    <example service.version="1.3.1rc2" host.ip="192.168.1.100">NASFTPD Turbo station 2.x 1.3.1rc2 Server (ProFTPD) [192.168.1.100]</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="hw.vendor" value="QNAP"/>
+    <param pos="0" name="hw.family" value="Turbo Station"/>
+    <param pos="0" name="hw.device" value="NAS"/>
+    <param pos="2" name="host.ip"/>
+  </fingerprint>
+  <fingerprint pattern="^Twisted ([\w.]+) FTP Server$">
+    <description>Twisted (Python) FTP Server</description>
+    <example service.version="14.0.0" >Twisted 14.0.0 FTP Server</example>
+    <example service.version="16.5.0rc2">Twisted 16.5.0rc2 FTP Server</example>
+    <param pos="0" name="service.family" value="Twisted"/>
+    <param pos="0" name="service.product" value="Twisted FTPD"/>
+    <param pos="0" name="service.vendor" value="Twisted Matrix Labs"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Gene6 FTP Server v(\d{1,2}\.\d{1,2}\.\d{1,2}\s{,2}\(Build \d{1,2}\)) ready\.\.\.$">
+    <description>Gene6 FTP Server on Windows</description>
+    <example service.version="3.10.0 (Build 2)">Gene6 FTP Server v3.10.0 (Build 2) ready...</example>
+    <example service.version="3.7.0  (Build 24)">Gene6 FTP Server v3.7.0  (Build 24) ready...</example>
+    <param pos="0" name="service.family" value="Gene6"/>
+    <param pos="0" name="service.product" value="FTP Server"/>
+    <param pos="0" name="service.vendor" value="Gene6"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="^([\w.-]+) X2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
+    <description>WS_FTP FTP Server on Windows - X2 variant</description>
+    <example service.version="7.7(50012467)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 7.7(50012467)</example>
+    <example service.version="5.0.5 (1989540204)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 5.0.5 (1989540204)</example>
+    <param pos="0" name="service.family" value="WS_FTP"/>
+    <param pos="0" name="service.product" value="WS_FTP"/>
+    <param pos="0" name="service.vendor" value="Ipswitch"/>
+    <param pos="2" name="service.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+  <fingerprint pattern="^V2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
+    <description>WS_FTP FTP Server on Windows - V2 variant</description>
+    <example service.version="6.1(05544322)">V2 WS_FTP Server 6.1(05544322)</example>
+    <param pos="0" name="service.family" value="WS_FTP"/>
+    <param pos="0" name="service.product" value="WS_FTP"/>
+    <param pos="0" name="service.vendor" value="Ipswitch"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="^FTP Server \(ZyWALL (USG\s?[\w-]+)\) \[([\h:.]+)\]$">
+    <description>ZyXEL Unified Security Gateway</description>
+    <example hw.product="USG 20" host.ip="::ffff:192.168.0.2">FTP Server (ZyWALL USG 20) [::ffff:192.168.0.2]</example>
+    <example hw.product="USG100-PLUS" host.ip="::ffff:192.168.5.101">FTP Server (ZyWALL USG100-PLUS) [::ffff:192.168.5.101]</example>
+    <example hw.product="USG 20" host.ip="10.0.0.2">FTP Server (ZyWALL USG 20) [10.0.0.2]</example>
+    <param pos="0" name="service.vendor" value="ZyXEL"/>
+    <param pos="0" name="service.family" value="Unified Security Gateway"/>
+    <param pos="0" name="service.product" value="FTPD"/>
+    <param pos="2" name="host.ip"/>
+    <param pos="0" name="hw.vendor" value="ZyXEL"/>
+    <param pos="0" name="hw.family" value="Unified Security Gateway"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to TP-LINK FTP server$">
+    <description>FTPD on a TP-LINK device (no version/host info)</description>
+    <example>Welcome to TP-LINK FTP server</example>
+    <param pos="0" name="hw.vendor" value="TP-LINK"/>
+  </fingerprint>
+   <fingerprint pattern="^ucftpd\((\w{3}  \d{,2} \d{4}-\d\d:\d\d:\d\d)\) FTP server ready\.$">
+    <description>ucftpd with version</description>
+    <example service.version="Jul  2 2012-22:13:49">ucftpd(Jul  2 2012-22:13:49) FTP server ready.</example>
+    <param pos="0" name="service.family" value="ucftpd"/>
+    <param pos="0" name="service.product" value="ucftpd"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^ucftpd FTP server ready\.$">
+    <description>ucftpd without version</description>
+    <example>ucftpd FTP server ready.</example>
+    <param pos="0" name="service.family" value="ucftpd"/>
+    <param pos="0" name="service.product" value="ucftpd"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to TBS FTP Server\.$">
+    <description>TBS FTP Server</description>
+    <example>Welcome to TBS FTP Server.</example>
+    <param pos="0" name="service.family" value="TBS FTP Server"/>
+    <param pos="0" name="service.product" value="TBS FTP Server"/>
+  </fingerprint>
+  <fingerprint pattern="^Sofrel (S5[\w]+) SN ([\d-]+)  ready. Time is (\d{2}:\d{2}:\d{2} \d{2}\/\d{2}\/\d{2})\.$">
+    <description>Sofrel Remote Terminal Unit</description>
+    <example hw.device="S500" host.id="01-499-00427" system.time="00:11:39 01/11/16">Sofrel S500 SN 01-499-00427  ready. Time is 00:11:39 01/11/16.</example>
+    <param pos="0" name="hw.vendor" value="Sofrel"/>
+    <param pos="0" name="hw.family" value="S500 Range"/>
+    <param pos="1" name="hw.device"/>
+    <param pos="2" name="host.id"/>
+    <param pos="0" name="system.time.format" value="HH:mm::ss dd/MM/yy"/>
+    <param pos="3" name="system.time"/>
+  </fingerprint>
+  <fingerprint pattern="^TiMOS-[CB]-([\S]+) cpm\/[\w]+ ALCATEL (SR [\S]+) Copyright .{,4}$">
+    <description>ALCATEL Service Router running TiMOS</description>
+    <example os.version="13.0.R9">TiMOS-C-13.0.R9 cpm/hops64 ALCATEL SR 7750 Copyright (</example>
+    <example hw.device="SR 7750">TiMOS-C-9.0.R8 cpm/hops ALCATEL SR 7750 Copyright (c) </example>
+    <param pos="0" name="os.vendor" value="ALCATEL"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="ALCATEL"/>
+    <param pos="0" name="hw.family" value="Service Router"/>
+    <param pos="2" name="hw.device"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) FTP server ready\.?$" flags="REG_ICASE">
     <description>Generic FTP fingerprint with a hostname</description>


### PR DESCRIPTION
This update is based on processing the Scans.io database for ftp banners fro 2016.10.31.  It also includes adjustments to existing fingerprints to add additional example tests and/or additional data.