### PR TITLE
DCA-6545: Added Vermillion FTPD fingerprint

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -906,4 +906,12 @@ more text</example>
     <param pos="0" name="service.vendor" value="Pro Group"/>
     <param pos="0" name="service.product" value="ProRat"/>
   </fingerprint>
+  <fingerprint pattern="FTP Server \(vftpd ([\d\.]+)\) ready\.?$">
+    <description>Vermillion FTP Daemon</description>
+    <example service.vendor="Vermillion" service.product="FTP Daemon" service.version="1.23">itsme FTP Server (vftpd 1.23) ready.</example>
+    <example service.vendor="Vermillion" service.product="FTP Daemon" service.version="1.31">FTP Server (vftpd 1.31) ready.</example>
+    <param pos="0" name="service.vendor" value="Vermillion"/>
+    <param pos="0" name="service.product" value="FTP Daemon"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
 </fingerprints>


### PR DESCRIPTION
This PR adds banner detection from Vermillion FTP Daemon - this is to allow 2 new vuln checks to fire: https://github.com/rapid7/nexpose-content/pull/1248