### PR TITLE
Improve validation of fingerprint param values

### DIFF
--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -108,8 +108,11 @@ class Fingerprint
     return if params.empty?
     params.each do |param_name, pos_value|
       pos, value = pos_value
-      next unless pos != 0 && !value.to_s.empty?
-      yield :fail, "'#{@name}'s #{param_name} is a non-zero pos but specifies a value of '#{value}'"
+      if pos > 0 && !value.to_s.empty?
+        yield :fail, "'#{@name}'s #{param_name} is a non-zero pos but specifies a value of '#{value}'"
+      elsif pos == 0 && value.to_s.empty?
+        yield :fail, "'#{@name}'s #{param_name} is at zero pos but doesn't specify a value"
+      end
     end
   end
 

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -111,7 +111,7 @@ class Fingerprint
       if pos > 0 && !value.to_s.empty?
         yield :fail, "'#{@name}'s #{param_name} is a non-zero pos but specifies a value of '#{value}'"
       elsif pos == 0 && value.to_s.empty?
-        yield :fail, "'#{@name}'s #{param_name} is at zero pos but doesn't specify a value"
+        yield :fail, "'#{@name}'s #{param_name} is not a capture (pos=0) but doesn't specify a value"
       end
     end
   end

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -42,7 +42,7 @@ describe Recog::DB do
 
             it "doesn't omit values for non-capture params" do
               if pos == 0 && value.to_s.empty?
-                fail "'#{fp.name}'s #{param_name} is at zero pos but doesn't specify a value"
+                fail "'#{fp.name}'s #{param_name} is not a capture (pos=0) but doesn't specify a value"
               end
             end
           end

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -31,6 +31,23 @@ describe Recog::DB do
       db.fingerprints.each_index do |i|
         fp = db.fingerprints[i]
 
+        context "#{fp.name}" do
+          fp.params.each do |param_name, pos_value|
+            pos, value = pos_value
+            it "doesn't have param values for capture params" do
+              if pos > 0 && !value.to_s.empty?
+                fail "'#{fp.name}'s #{param_name} is a non-zero pos but specifies a value of '#{value}'"
+              end
+            end
+
+            it "doesn't omit values for non-capture params" do
+              if pos == 0 && value.to_s.empty?
+                fail "'#{fp.name}'s #{param_name} is at zero pos but doesn't specify a value"
+              end
+            end
+          end
+        end
+
         context "#{fp.regex}" do
 
           it "has a name" do

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -308,8 +308,7 @@ more text</example>
     <example>OOPS: vsftpd: root is not mounted.</example>
     <example>OOPS: cannot read user list file:/etc/vsftpd.user_list</example>
     <param pos="0" name="service.family" value="vsFTPd"/>
-    <param pos="0" name="service.product" value="vsFTPd Extended"/>
-    <param pos="0" name="service.version"/>
+    <param pos="0" name="service.product" value="vsFTPd"/>
   </fingerprint>
   <fingerprint pattern="^FileZilla Server(?: version)? (?:v)?(\d\.[\w.]+(?: beta)?).*$">
     <description>FileZilla FTP Server</description>
@@ -1070,7 +1069,7 @@ more text</example>
     <param pos="0" name="service.vendor" value="GNU"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="hw.vendor" value="ZyXEL"/>
-    <param pos="1" name="hw.family" value="WiMax"/>
+    <param pos="0" name="hw.family" value="WiMax"/>
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
   <fingerprint pattern="^Speedport W ?(\S+) (?:Typ [A|B] )?FTP Server v([\d.]+) ready$$">
@@ -1080,7 +1079,7 @@ more text</example>
     <example hw.product="722V" os.version="1.18.000">Speedport W722V FTP Server v1.18.000 ready</example>
     <param pos="0" name="hw.vendor" value="Deutsche Telekom"/>
     <param pos="0" name="hw.device" value="WAP"/>
-    <param pos="1" name="hw.family" value="Speedport"/>
+    <param pos="0" name="hw.family" value="Speedport"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>


### PR DESCRIPTION
An internal source pointed out that one of the `vsftpd` fingerprints had a param with a position of 0 (indicating that it wasn't a capture) but which didn't have a value either.

` <param pos="0" name="service.version"/>`

I've added support for detecting this issue with `bin/recog_verify`.  I've also added support for detecting this as well as the issue where a param is a capture but has a value to Recog's RSpec tests.

Example output from `bin/recog_verify`
```bash
$ bin/recog_verify xml/ftp_banners.xml 
WARN: 'ProFTPD on a wired Linksys device' has no test cases
FAIL: 'vsFTPd (Very Secure FTP Daemon) error message's service.version is at zero pos but doesn't specify a value
WARN: 'Nepenthes honeypot' has no test cases
FAIL: 'FTPD on a ZyXEL (Huawei rebrand) WiMax WAP's hw.family is a non-zero pos but specifies a value of 'WiMax'
FAIL: 'FTPD on Speedport WLAN/ADSL routers (Deutsche Telekom mfg by misc)'s hw.family is a non-zero pos but specifies a value of 'Speedport'
SUMMARY: Test completed with 254 successful, 2 warnings, and 3 failures
```

Example output from RSpec
```bash
Failures:

  1) Recog::DB#ftp_banners.xml FTPD on a ZyXEL (Huawei rebrand) WiMax WAP doesn't have param values for capture params
     Failure/Error: fail "'#{fp.name}'s #{param_name} is a non-zero pos but specifies a value of '#{value}'"
     
     RuntimeError:
       'FTPD on a ZyXEL (Huawei rebrand) WiMax WAP's hw.family is a non-zero pos but specifies a value of 'WiMax'
     # ./spec/lib/fingerprint_self_test_spec.rb:39:in `block (7 levels) in <top (required)>'

  2) Recog::DB#ftp_banners.xml FTPD on Speedport WLAN/ADSL routers (Deutsche Telekom mfg by misc) doesn't have param values for capture params
     Failure/Error: fail "'#{fp.name}'s #{param_name} is a non-zero pos but specifies a value of '#{value}'"
     
     RuntimeError:
       'FTPD on Speedport WLAN/ADSL routers (Deutsche Telekom mfg by misc)'s hw.family is a non-zero pos but specifies a value of 'Speedport'
     # ./spec/lib/fingerprint_self_test_spec.rb:39:in `block (7 levels) in <top (required)>'

  3) Recog::DB#ftp_banners.xml vsFTPd (Very Secure FTP Daemon) error message doesn't omit values for non-capture params
     Failure/Error: fail "'#{fp.name}'s #{param_name} is at zero pos but doesn't specify a value"
     
     RuntimeError:
       'vsFTPd (Very Secure FTP Daemon) error message's service.version is at zero pos but doesn't specify a value
     # ./spec/lib/fingerprint_self_test_spec.rb:45:in `block (7 levels) in <top (required)>'

Finished in 1 minute 8.04 seconds (files took 4.6 seconds to load)
37526 examples, 3 failures

Failed examples:

rspec ./spec/lib/fingerprint_self_test_spec.rb[1:3:194:11] # Recog::DB#ftp_banners.xml FTPD on a ZyXEL (Huawei rebrand) WiMax WAP doesn't have param values for capture params
rspec ./spec/lib/fingerprint_self_test_spec.rb[1:3:196:5] # Recog::DB#ftp_banners.xml FTPD on Speedport WLAN/ADSL routers (Deutsche Telekom mfg by misc) doesn't have param values for capture params
rspec ./spec/lib/fingerprint_self_test_spec.rb[1:3:62:6] # Recog::DB#ftp_banners.xml vsFTPd (Very Secure FTP Daemon) error message doesn't omit values for non-capture params
```