### PR TITLE
Add fingerprint for QPC Software QVT/Net FTP Server

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1288,4 +1288,17 @@ more text</example>
     <param pos="2" name="service.version"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
+  <fingerprint pattern="^(?:(\S+) )?FTP server \(QVT\/Net ([\d.]+)\) ready\.?$">
+    <description>QVT/Net FTP Server</description>
+    <example host.name="siren" service.version="5.1">siren FTP server (QVT/Net 5.1) ready.</example>
+    <example host.name="qpc-qvtnet" service.version="4.1">qpc-qvtnet FTP server (QVT/Net 4.1) ready.</example>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="service.vendor" value="QPC Software"/>
+    <param pos="0" name="service.product" value="QVT/Term"/>
+    <param pos="2" name="service.version"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1279,7 +1279,6 @@ more text</example>
     <example host.name="srv.name" service.version="1.23">srv.name FTP Server (vftpd 1.23) ready.</example>
     <example service.version="1.31">FTP Server (vftpd 1.31) ready.</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="service.vendor" value="Vermillion"/>
@@ -1292,7 +1291,6 @@ more text</example>
     <example host.name="siren" service.version="5.1">siren FTP server (QVT/Net 5.1) ready.</example>
     <example host.name="qpc-qvtnet" service.version="4.1">qpc-qvtnet FTP server (QVT/Net 4.1) ready.</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="service.vendor" value="QPC Software"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1296,7 +1296,7 @@ more text</example>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="service.vendor" value="QPC Software"/>
-    <param pos="0" name="service.product" value="QVT/Term"/>
+    <param pos="0" name="service.product" value="QVT/Net"/>
     <param pos="2" name="service.version"/>
     <param pos="1" name="host.name"/>
   </fingerprint>


### PR DESCRIPTION
This PR adds a fingerprint for QPC Software's FTP Server which was bundled with the following utility packages for Windows systems:

- QVT/Net
- QVT/Term
- AVT/Term

The contents of the packages differs but the FTP Server is common across all of them. Could not obtain the AVT/Term utility package as these programs have been obsolete for many years and this flavour seemed rare/non-existent, however the FTP Daemon bundled with QVT/Net 4.1 and QVT/Term 5.1 responded with the banners:

`qpc-qvtnet FTP server (QVT/Net 4.1) ready.`
`qpc-qvtnet FTP server (QVT/Net 5.1) ready.`

...respectively (`qpc-qvtnet` being the host name of the Windows XP VM). 