### PR TITLE
Add fingerprint for Moodle

### DIFF
--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -345,6 +345,13 @@ servers.
     <param pos="0" name="service.family" value="SMH"/>
     <param pos="0" name="service.product" value="SMH"/>
   </fingerprint>
+  <fingerprint pattern="^MoodleSession=">
+    <description>Moodle</description>
+    <example>MoodleSession=uohhsgcain708q5l4gqcmmb5s2; path=/</example>
+    <param pos="0" name="service.component.vendor" value="Moodle Pty Ltd"/>
+    <param pos="0" name="service.component.family" value="Moodle"/>
+    <param pos="0" name="service.component.product" value="Moodle"/>
+  </fingerprint>
   <!--
         Ignore various cookies that are very generic cookies for session IDs
         that are not necessarily indicative of any particular


### PR DESCRIPTION
Adds a fingerprint for [Moodle](https://moodle.org/) from the Session cookie returned by the service.