### PR TITLE
Fix inconsistency in Moodle fingerprint vendor

### DIFF
--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -348,7 +348,7 @@ servers.
   <fingerprint pattern="^MoodleSession=">
     <description>Moodle</description>
     <example>MoodleSession=uohhsgcain708q5l4gqcmmb5s2; path=/</example>
-    <param pos="0" name="service.component.vendor" value="Moodle Pty Ltd"/>
+    <param pos="0" name="service.component.vendor" value="Moodle"/>
     <param pos="0" name="service.component.family" value="Moodle"/>
     <param pos="0" name="service.component.product" value="Moodle"/>
   </fingerprint>


### PR DESCRIPTION
## Description
Authenticated HTTP and Cookie HTTP Moodle fingerprints' vendor updated to "Moodle" to be consistent across all 3 methods of fingerprinting Moodle Web App.

## Motivation and Context
Moodle fingerprint vendor was inconsistent across the 3 fingerprinting threads for Moodle. The Authenticated Web App fingerprinter was also asserting a component FP, rather than a Software FP and therefore, the Moodle content would not fire (as it was looking for a Product fingerprint)

## How Has This Been Tested?
- [x] Run rspec on branch
- [x] Pass banner from Moodle to recog and ensure fingerprint is extracted:
```
2017-04-21T15:38:28 [INFO] [Thread: moodle-linux-u.vuln.lax.rapid7.com:80/TCP] [Site: a] Asserting Fingerprint [[certainty=0.9][description=Moodle][family=Moodle][product=Moodle][vendor=Moodle][version=null]]
```