### PR TITLE
Add family for Cisco NX-OS and SAN fingerprint

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1598,6 +1598,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Switch"/>
+    <param pos="1" name="os.family"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="hw.series"/>
     <param pos="3" name="os.version"/>


### PR DESCRIPTION
## Description
Adding family to Cisco NX-OS and SAN fingerprint

## Motivation and Context
SNMP fingerprinting is missing os.family for Cisco NX-OS and SAN.

## How Has This Been Tested?
- [x] Run rspec on branch
- [x] Pass banner from Cisco NX & SAN system to recog and ensure fingerprint is extracted:
```
SystemFingerprint [[architecture=null][certainty=0.85][description=Cisco NX-OS 4.1(3a)][deviceClass=Switch][family=NX-OS][product=NX-OS][vendor=Cisco][version=4.1(3a)]] source: SNMP
```