### PR TITLE
Adding banner detection for Intel AMT

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3283,4 +3283,12 @@
     <param pos="0" name="service.product" value="Symantec Endpoint Protection Manager"/>
     <param pos="0" name="service.family" value="Symantec Endpoint Protection Manager"/>
   </fingerprint>
+  <fingerprint pattern="^Intel\(R\) Active Management Technology\s(\d+\.\d+\.\d+\.\d+|\d+\.\d+\.\d+|\d+\.\d+)">
+    <description>Intel(R) Active Management Technology</description>
+    <example>Intel(R) Active Management Technology 7.1.86</example>
+    <param pos="0" name="service.vendor" value="Intel"/>
+    <param pos="0" name="service.product" value="Intel(R) Active Management Technology"/>
+    <param pos="0" name="service.family" value="Intel(R) Active Management Technology"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
 </fingerprints>


### PR DESCRIPTION
## Description
Adding banner detection from Intel AMT's HTTP web management console running on `tcp/16992` and `tcp/16993` (HTTPS)

## How Has This Been Tested?
- [x] Run rspec
- [x] Run `bin/recog_verify xml/http_servers.xml`