### PR TITLE
Improve SMB fingerprints

### DIFF
--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -42,4 +42,18 @@
     <param pos="0" name="service.product" value="Samba"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
+  <!-- this isn't perfect.  it will match anything that is exactly
+       8 characters including at least one upper case and one lowercase digit.
+       dionaea generates a random upper/lowercase string of exactly
+       8 characters.  so this will miss all upper case or all lowercase, and
+       will false-positive on things like "Sambaaaa", which could be a legit
+       dionaea string or someone's messing with us
+      -->
+  <fingerprint pattern="^^(?=.*[a-z])(?=.*[A-Z]).{8}$">
+    <description>dionaea and derivative honeypots</description>
+    <example>ZElOmCSA</example>
+    <param pos="0" name="service.vendor" value="DinoTools"/>
+    <param pos="0" name="service.product" value="dionaea"/>
+    <param pos="0" name="service.certainty" value="0.50"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -42,18 +42,4 @@
     <param pos="0" name="service.product" value="Samba"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <!-- this isn't perfect.  it will match anything that is exactly
-       8 characters including at least one upper case and one lowercase digit.
-       dionaea generates a random upper/lowercase string of exactly
-       8 characters.  so this will miss all upper case or all lowercase, and
-       will false-positive on things like "Sambaaaa", which could be a legit
-       dionaea string or someone's messing with us
-      -->
-  <fingerprint pattern="^^(?=.*[a-z])(?=.*[A-Z]).{8}$">
-    <description>dionaea and derivative honeypots</description>
-    <example>ZElOmCSA</example>
-    <param pos="0" name="service.vendor" value="DinoTools"/>
-    <param pos="0" name="service.product" value="dionaea"/>
-    <param pos="0" name="service.certainty" value="0.50"/>
-  </fingerprint>
 </fingerprints>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -49,6 +49,15 @@
     <param pos="0" name="os.product" value="Windows XP"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
+  <fingerprint pattern="^Windows XP (Home|Professional)(?: Edition)?$">
+    <description>Windows XP without a version</description>
+    <example os.edition="Home">Windows XP Home Edition</example>
+    <example os.edition="Professional">Windows XP Professional</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows XP"/>
+    <param pos="1" name="os.edition"/>
+  </fingerprint>
   <fingerprint pattern="^Windows \.NET">
     <description>Windows Server 2003 Beta</description>
     <param pos="0" name="os.certainty" value="1.0"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -552,4 +552,19 @@
     <param pos="0" name="service.vendor" value="Samba"/>
   </fingerprint>
 
+  <!-- this isn't perfect.  it will match anything that is exactly
+       8 characters including at least one upper case and one lowercase digit.
+       dionaea generates a random upper/lowercase string of exactly
+       8 characters.  so this will miss all upper case or all lowercase, and
+       will false-positive on things like "Sambaaaa", which could be a legit
+       dionaea string or someone's messing with us
+      -->
+  <fingerprint pattern="^^(?=.*[a-z])(?=.*[A-Z]).{8}$">
+    <description>dionaea and derivative honeypots</description>
+    <example>ZElOmCSA</example>
+    <param pos="0" name="service.vendor" value="DinoTools"/>
+    <param pos="0" name="service.product" value="dionaea"/>
+    <param pos="0" name="service.certainty" value="0.50"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -275,10 +275,11 @@
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
   </fingerprint>
-  <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
+  <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows 7/8 (SP + Edition)</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows 7 Enterprise 7601 Service Pack 1</example>
     <example os.edition="Starter" os.version="Service Pack 1">Windows 7 Starter 7601 Service Pack 1</example>
+    <example os.edition="Ultimate" os.build="7601" os.version="Service Pack 1">Windows 7 Ultimate 7601 Service Pack 1, v.178</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -72,9 +72,10 @@
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
-  <fingerprint pattern="^Windows Server 2003 R2 (\d+) (Service Pack \d+)$">
+  <fingerprint pattern="^Windows Server 2003 R2 (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2003 R2 (SP)</description>
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 R2 3790 Service Pack 2</example>
+    <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 R2 3790 Service Pack 2, v.2825</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
@@ -82,16 +83,23 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Windows Server 2003 (\d+)$">
-    <description>Windows Server 2003</description>
+    <description>Windows Server 2003 with a build</description>
     <example os.build="3790">Windows Server 2003 3790</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
-  <fingerprint pattern="^Windows Server 2003 (\d+) (Service Pack \d+)$">
+  <fingerprint pattern="^Windows Server 2003$">
+    <description>Windows Server 2003 without a build</description>
+    <example>Windows Server 2003</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2003"/>
+  </fingerprint>
+  <fingerprint pattern="^Windows Server 2003 (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2003 (SP)</description>
-    <example os.build="3790" os.version="Service Pack 1">Windows Server 2003 3790 Service Pack 1</example>
+    <example os.build="3790" os.version="Service Pack 1">Windows Server 2003 3790 Service Pack 1, v.3309</example>
     <example os.build="3790" os.version="Service Pack 2">Windows Server 2003 3790 Service Pack 2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -554,19 +554,4 @@
     <param pos="0" name="service.vendor" value="Samba"/>
   </fingerprint>
 
-  <!-- this isn't perfect.  it will match anything that is exactly
-       8 characters including at least one upper case and one lowercase digit.
-       dionaea generates a random upper/lowercase string of exactly
-       8 characters.  so this will miss all upper case or all lowercase, and
-       will false-positive on things like "Sambaaaa", which could be a legit
-       dionaea string or someone's messing with us
-      -->
-  <fingerprint pattern="^^(?=.*[a-z])(?=.*[A-Z]).{8}$">
-    <description>dionaea and derivative honeypots</description>
-    <example>ZElOmCSA</example>
-    <param pos="0" name="service.vendor" value="DinoTools"/>
-    <param pos="0" name="service.product" value="dionaea"/>
-    <param pos="0" name="service.certainty" value="0.50"/>
-  </fingerprint>
-
 </fingerprints>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -207,6 +207,17 @@
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
   </fingerprint>
+  <fingerprint pattern="^Windows Server 2016(?: Technical Preview \d+)? (\w+|\w+ \w+|\w+ \w+ \w+)(?: Evaluation)? (\d+)$">
+    <description>Windows Server 2016 with a build, without service pack</description>
+    <example os.edition="Datacenter" os.build="14393">Windows Server 2016 Datacenter 14393</example>
+    <example os.edition="Standard" os.build="14393">Windows Server 2016 Standard Evaluation 14393</example>
+    <example os.edition="Essentials" os.build="10586">Windows Server 2016 Technical Preview 4 Essentials 10586</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2016"/>
+    <param pos="1" name="os.edition"/>
+    <param pos="2" name="os.build"/>
+  </fingerprint>
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 R2 Web</description>
     <example os.version="Service Pack 1">Windows Web Server 2008 R2 7601 Service Pack 1</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -108,7 +108,7 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
   <!-- Note that 2008 SP1 is technically "2008 Gold" according to Microsoft -->
-  <fingerprint pattern="^Windows Server \(R\) 2008 (\w+|\w+ \w+|\w+ \w+ \w+)(?: (?:with|without) Hyper-V|) (\d+) (Service Pack \d+)$">
+  <fingerprint pattern="^Windows Server \(R\) 2008 (\w+|\w+ \w+|\w+ \w+ \w+)(?: (?:with|without) Hyper-V|) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2008</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows Server (R) 2008 Enterprise without Hyper-V 6001 Service Pack 1</example>
     <example os.edition="Enterprise" os.version="Service Pack 2">Windows Server (R) 2008 Enterprise 6002 Service Pack 2</example>
@@ -178,7 +178,7 @@
     <param pos="1" name="os.build"/>
   </fingerprint>
   <!-- 2008 R2 -->
-  <fingerprint pattern="^Windows Server 2008 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
+  <fingerprint pattern="^Windows Server 2008 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2008</description>
     <example>Windows Server 2008 R2 Enterprise 7601 Service Pack 1</example>
     <example>Windows Server 2008 R2 Standard 7601 Service Pack 1</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -219,6 +219,16 @@
     <param pos="0" name="os.edition" value="Web"/>
     <param pos="1" name="os.build"/>
   </fingerprint>
+  <fingerprint pattern="^Windows Storage Server 2008 R2 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
+    <description>Windows Server 2008 Storage R2 (SP)</description>
+    <example os.version="Service Pack 1" os.build="7601">Windows Storage Server 2008 R2 Essentials 7601 Service Pack 1</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
+    <param pos="0" name="os.edition" value="Storage"/>
+    <param pos="1" name="os.build"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Vista (SP)</description>
     <example os.edition="Home Premium" os.version="Service Pack 2">Windows Vista (TM) Home Premium 6002 Service Pack 2</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -328,7 +328,7 @@
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
   </fingerprint>
-  <fingerprint pattern="^Windows 10 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+  <fingerprint pattern="^Windows 10 ((?:\w+|\w+ \w+|\w+ \w+ \w+)(?: LTSB(?: Evaluation)?)?) (\d+)$">
     <description>Windows 10</description>
     <example os.build="10130" os.edition="Enterprise">Windows 10 Enterprise 10130</example>
     <example os.build="10130" os.edition="Mobile Enterprise">Windows 10 Mobile Enterprise 10130</example>
@@ -336,6 +336,8 @@
     <example os.build="10130" os.edition="Home">Windows 10 Home 10130</example>
     <example os.build="10130" os.edition="Education">Windows 10 Education 10130</example>
     <example os.build="10130" os.edition="Professional">Windows 10 Professional 10130</example>
+    <example os.build="10240" os.edition="Enterprise N 2015 LTSB">Windows 10 Enterprise N 2015 LTSB 10240</example>
+    <example os.build="14393" os.edition="Enterprise 2016 LTSB Evaluation">Windows 10 Enterprise 2016 LTSB Evaluation 14393</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows 10"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -108,6 +108,13 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
   <!-- Note that 2008 SP1 is technically "2008 Gold" according to Microsoft -->
+  <fingerprint pattern="^Windows Server 2008$">
+    <description>Windows Server 2008 without a build</description>
+    <example>Windows Server 2008</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2008"/>
+  </fingerprint>
   <fingerprint pattern="^Windows Server \(R\) 2008 (\w+|\w+ \w+|\w+ \w+ \w+)(?: (?:with|without) Hyper-V|) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2008</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows Server (R) 2008 Enterprise without Hyper-V 6001 Service Pack 1</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -218,6 +218,15 @@
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
   </fingerprint>
+  <fingerprint pattern="^Windows Storage Server 2016 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+    <description>Windows Server 2016 Storage</description>
+    <example os.build="14393">Windows Storage Server 2016 Standard 14393</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2016"/>
+    <param pos="0" name="os.edition" value="Storage"/>
+    <param pos="1" name="os.build"/>
+  </fingerprint>
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 R2 Web</description>
     <example os.version="Service Pack 1">Windows Web Server 2008 R2 7601 Service Pack 1</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -111,7 +111,7 @@
   <fingerprint pattern="^Windows Server \(R\) 2008 (\w+|\w+ \w+|\w+ \w+ \w+)(?: (?:with|without) Hyper-V|) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2008</description>
     <example os.edition="Enterprise" os.version="Service Pack 1">Windows Server (R) 2008 Enterprise without Hyper-V 6001 Service Pack 1</example>
-    <example os.edition="Enterprise" os.version="Service Pack 2">Windows Server (R) 2008 Enterprise 6002 Service Pack 2</example>
+    <example os.edition="Enterprise" os.version="Service Pack 2">Windows Server (R) 2008 Enterprise 6002 Service Pack 2, v.275</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -543,4 +543,13 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?i:unix)$">
+    <description>Generally some Samba variant, which reports Unix</description>
+    <example>Unix</example>
+    <param pos="0" name="os.family" value="Unix"/>
+    <param pos="0" name="os.certainty" value="0.75"/>
+    <param pos="0" name="service.product" value="Samba"/>
+    <param pos="0" name="service.vendor" value="Samba"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
This improves Recog's ability to fingerprint Samba and Windows-based SMB endpoints via the native LM and OS responses.