### PR TITLE
Convert hex regex patterns to be language-agnostic and fix bad Windows OS catch-all regex

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -216,7 +216,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \((.*)\) \[[\h.:\]]*$">
+  <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \((.*)\) \[[[a-f\d].:\]]*$">
     <description>ProFTPD with version info - truncated</description>
     <example service.version="1.3.2c">ProFTPD 1.3.2c Server (ProFTPD Default Installation) [</example>
     <example proftpd.server.name="svrname.hosting.com">ProFTPD 1.3.0 Server (svrname.hosting.com) [10.10.10.</example>
@@ -1123,7 +1123,7 @@ more text</example>
     <param pos="0" name="service.vendor" value="Multicraft"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^bftpd ([\d.]+) at ([\h.:]+) ready\.$">
+  <fingerprint pattern="^bftpd ([\d.]+) at ([[a-f\d].:]+) ready\.$">
     <description>Bftpd FTPD Server</description>
     <example service.version="2.2.1" host.ip="192.168.0.1">bftpd 2.2.1 at 192.168.0.1 ready.</example>
     <example service.version="2.2" host.ip="::ffff:192.168.1.1">bftpd 2.2 at ::ffff:192.168.1.1 ready.</example>
@@ -1133,7 +1133,7 @@ more text</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="host.ip"/>
   </fingerprint>
-  <fingerprint pattern="^NASFTPD Turbo station (?:2.x )?([\w.]+) Server \(ProFTPD\) \[([\h.:]+)\]$">
+  <fingerprint pattern="^NASFTPD Turbo station (?:2.x )?([\w.]+) Server \(ProFTPD\) \[([[a-f\d].:]+)\]$">
     <description>ProFTPD on QNAP Turbo Station NAS</description>
     <example service.version="1.3.5a" host.ip="192.168.1.100">NASFTPD Turbo station 1.3.5a Server (ProFTPD) [192.168.1.100]</example>
     <example service.version="1.3.1rc2" host.ip="192.168.1.100">NASFTPD Turbo station 2.x 1.3.1rc2 Server (ProFTPD) [192.168.1.100]</example>
@@ -1191,7 +1191,7 @@ more text</example>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
-  <fingerprint pattern="^FTP Server \(ZyWALL (USG\s?[\w-]+)\) \[([\h:.]+)\]$">
+  <fingerprint pattern="^FTP Server \(ZyWALL (USG\s?[\w-]+)\) \[([[a-f\d]:.]+)\]$">
     <description>ZyXEL Unified Security Gateway</description>
     <example hw.product="USG 20" host.ip="::ffff:192.168.0.2">FTP Server (ZyWALL USG 20) [::ffff:192.168.0.2]</example>
     <example hw.product="USG100-PLUS" host.ip="::ffff:192.168.5.101">FTP Server (ZyWALL USG100-PLUS) [::ffff:192.168.5.101]</example>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -89,15 +89,14 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^(?i:(?:Microsoft )?Windows(?:\s?\w+?)*?\s?(\d+?(?:\.\d+?)*?)?)$">
+  <fingerprint pattern="^(?i:(?:Microsoft )?Windows.*)$">
     <description>Windows catch-all</description>
-    <example os.version="3.11">Windows for Workgroups 3.11</example>
+    <example>Windows for Workgroups 3.11</example>
     <example>Microsoft Windows</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="os.certainty" value="0.5"/>
-    <param pos="1" name="os.version"/>
   </fingerprint>
   <!-- Windows end -->
 


### PR DESCRIPTION
As indicated in #138 the use of `\h` is a special feature of Ruby's regex engine. For other languages and runtimes it causes the matches to fail since it has a different meaning. I replaced all occurrences that I could find.

Additionally I fixed the Windows OS catch-all regex which had really bad backtracking performance, especially in Java where it would take 20-30 seconds to match (or not match) for a single string. Since it is super generic anyway I got rid of the attempt at capturing a version for it as well.