### PR TITLE
Fix solaris version matches from ntp

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -129,15 +129,24 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="2" name="service.version"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="^(\S+) FTP Server \(SunOS (\S+)\) ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.([789]|\d{2,})\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
-    <example>example.com FTP server (SunOS 5.7) ready.</example>
+    <example host.name="example.com" os.version="7">example.com FTP server (SunOS 5.7) ready.</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
+  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.6\) ready\." flags="REG_ICASE">
+    <description>SunOS 5.6 (Solaris 2.6)</description>
+    <example host.name="example.com">example.com FTP Server (SunOS 5.6) ready.</example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="os.version" value="2.6"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>  
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Debian\) \[(.+)\]$">
     <description>ProFTPD on Debian Linux</description>
     <example>ProFTPD 1.3.0rc2 Server (Debian) [host]</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -132,7 +132,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
   <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.(1[1-9])\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
     <example host.name="example.com" os.version="11">example.com FTP server (SunOS 5.11) ready.</example>
-    <example host.name="example.com" os.version="12">example.com FTP server (SunOS 5.12) ready.</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -129,8 +129,19 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="2" name="service.version"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.([789]|\d{2,})\) ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.(1[1-9]|[2-9]\d{1,}|\d{3,})\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
+    <example host.name="example.com" os.version="11">example.com FTP server (SunOS 5.11) ready.</example>
+    <example host.name="example.com" os.version="21">example.com FTP server (SunOS 5.21) ready.</example>
+    <example host.name="example.com" os.version="123">example.com FTP server (SunOS 5.123) ready.</example>
+    <param pos="0" name="os.vendor" value="Oracle"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="1" name="host.name"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.([789]|10)\) ready\.?$" flags="REG_ICASE">
+    <description>SunOS/Solaris 5.7-5.10</description>
     <example host.name="example.com" os.version="7">example.com FTP server (SunOS 5.7) ready.</example>
     <example host.name="example.com" os.version="10">example.com FTP server (SunOS 5.10) ready.</example>
     <param pos="0" name="os.vendor" value="Sun"/>
@@ -138,7 +149,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
-  </fingerprint>
+  </fingerprint>  
   <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.6\) ready\." flags="REG_ICASE">
     <description>SunOS 5.6 (Solaris 2.6)</description>
     <example host.name="example.com">example.com FTP Server (SunOS 5.6) ready.</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -129,11 +129,10 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="2" name="service.version"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.(1[1-9]|[2-9]\d{1,}|\d{3,})\) ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.(1[1-9])\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
     <example host.name="example.com" os.version="11">example.com FTP server (SunOS 5.11) ready.</example>
-    <example host.name="example.com" os.version="21">example.com FTP server (SunOS 5.21) ready.</example>
-    <example host.name="example.com" os.version="123">example.com FTP server (SunOS 5.123) ready.</example>
+    <example host.name="example.com" os.version="12">example.com FTP server (SunOS 5.12) ready.</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -132,6 +132,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
   <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.([789]|\d{2,})\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
     <example host.name="example.com" os.version="7">example.com FTP server (SunOS 5.7) ready.</example>
+    <example host.name="example.com" os.version="10">example.com FTP server (SunOS 5.10) ready.</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -419,11 +419,120 @@ NTP "banners", taken from a readvar response
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description>ntpd running on Solaris</description>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.0&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 2.0 (SunOS/5.0) </description>
     <example>
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS/5.9", leap=00, stratum=2,
+      processor="sun4u", system="SunOS/5.0", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="0" name="os.version" value="2.0"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.1&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 2.1 (SunOS/5.1) </description>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.1", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="0" name="os.version" value="2.1"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.2&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 2.2 (SunOS/5.2) </description>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.2", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="0" name="os.version" value="2.2"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.3&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 2.3 (SunOS/5.3) </description>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.3", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="0" name="os.version" value="2.3"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.4&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 2.4 (SunOS/5.4) </description>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.4", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="0" name="os.version" value="2.4"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.5&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 2.5 (SunOS/5.5) </description>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.5", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="0" name="os.version" value="2.5"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.6&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 2.6 (SunOS/5.6) </description>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.6", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="0" name="os.version" value="2.6"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description> ntpd running on Solaris 7 or above (SunOS/5.7 and above) </description>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.7", leap=00, stratum=2,
+    </example>
+    <example>
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.11", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -434,34 +543,123 @@ NTP "banners", taken from a readvar response
     <param pos="2" name="os.arch"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description>Solaris with no ntp version</description>
-    <example>
-      processor="sun4m", system="SunOS5.6"
-    </example>
-    <example>
-      processor="sun4m", system="SunOS5.8"
-    </example>
-    <example>
-      processor="sun4u", system="SunOS5.10"
-    </example>
-    <example>
-      processor="sun4u", system="SunOS5.6"
-    </example>
-    <example>
-      processor="sun4u", system="SunOS5.7"
-    </example>
-    <example>
-      processor="sun4u", system="SunOS5.8"
-    </example>
-    <example>
-      processor="sun4u", system="SunOS5.9"
-    </example>
-    <param pos="0" name="os.vendor" value="Sun"/>
-    <param pos="0" name="os.family" value="Solaris"/>
-    <param pos="0" name="os.product" value="Solaris"/>
-    <param pos="1" name="os.arch"/>
-    <param pos="2" name="os.version"/>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.0&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 2.0 (SunOS/5.0) with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.0"
+   </example>
+   <example>
+    processor="sun4u",system="SunOS/5.0"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.version" value="2.0" />
+   <param pos="1" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.1&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 2.1 (SunOS/5.1) with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.1"
+   </example>
+   <example>
+    processor="sun4u",system="SunOS/5.1"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.version" value="2.1" />
+   <param pos="1" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.2&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 2.2 (SunOS/5.2) with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.2"
+   </example>
+   <example>
+    processor="sun4u",system="SunOS/5.2"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.version" value="2.2" />
+   <param pos="1" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.3&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 2.3 (SunOS/5.3) with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.3"
+   </example>
+   <example>
+    processor="sun4u",system="SunOS/5.3"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.version" value="2.3" />
+   <param pos="1" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.4&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 2.4 (SunOS/5.4) with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.4"
+   </example>
+   <example>
+    processor="sun4u",system="SunOS/5.4"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.version" value="2.4" />
+   <param pos="1" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.5&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 2.5 (SunOS/5.5) with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.5"
+   </example>
+   <example>
+    processor="sun4u",system="SunOS/5.5"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.version" value="2.5" />
+   <param pos="1" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.6&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 2.6 (SunOS/5.6) with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.6"
+   </example>
+   <example>
+    processor="sun4u",system="SunOS/5.6"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.version" value="2.6" />
+   <param pos="1" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description> Solaris 7 (SunOS/5.7) and above with no ntp version</description>
+   <example>
+     processor="sun4m",system="SunOS/5.7"
+   </example>
+   <example>
+     processor="sun4u",system="SunOS/5.7"
+   </example>
+   <example>
+     processor="sun4m",system="SunOS/5.10"
+   </example>
+   <example>
+     processor="sun4u",system="SunOS/5.10"
+   </example>
+   <param pos="0" name="os.vendor" value="Sun"/>
+   <param pos="0" name="os.family" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="1" name="os.arch"/>
+   <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^.*system=&quot;UNIX/SunOS ([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>SunOS with no ntp version</description>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -562,14 +562,6 @@ NTP "banners", taken from a readvar response
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS5.11", leap=00,stratum=2,
     </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="12">
-      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS/5.12", leap=00, stratum=2,
-    </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="12">
-      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS5.12", leap=00, stratum=2,
-    </example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
@@ -611,14 +603,8 @@ NTP "banners", taken from a readvar response
    <example os.arch="sun4m">
      processor="sun4m", system="SunOS/5.0"
    </example>
-   <example os.arch="sun4u">
-    processor="sun4u", system="SunOS/5.0"
-   </example>
    <example os.arch="sun4m">
      processor="sun4m", system="SunOS5.0"
-   </example>
-   <example os.arch="sun4u">
-     processor="sun4u", system="SunOS5.0"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
    <param pos="0" name="os.family" value="Solaris"/>
@@ -630,12 +616,6 @@ NTP "banners", taken from a readvar response
    <description>Solaris 2.1 (SunOS/5.1) with no ntp version</description>
    <example os.arch="sun4m">
      processor="sun4m", system="SunOS/5.1"
-   </example>
-   <example os.arch="sun4u">
-    processor="sun4u", system="SunOS/5.1"
-   </example>
-   <example os.arch="sun4m">
-    processor="sun4m", system="SunOS5.1"
    </example>
    <example os.arch="sun4u">
     processor="sun4u", system="SunOS5.1"
@@ -652,12 +632,6 @@ NTP "banners", taken from a readvar response
      processor="sun4m", system="SunOS/5.2"
    </example>
    <example os.arch="sun4u">
-    processor="sun4u", system="SunOS/5.2"
-   </example>
-   <example os.arch="sun4m">
-    processor="sun4m", system="SunOS5.2"
-   </example>
-   <example os.arch="sun4u">
     processor="sun4u", system="SunOS5.2"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
@@ -670,12 +644,6 @@ NTP "banners", taken from a readvar response
    <description>Solaris 2.3 (SunOS/5.3) with no ntp version</description>
    <example os.arch="sun4m">
      processor="sun4m", system="SunOS/5.3"
-   </example>
-   <example os.arch="sun4u">
-    processor="sun4u", system="SunOS/5.3"
-   </example>
-   <example os.arch="sun4m">
-    processor="sun4m", system="SunOS5.3"
    </example>
    <example os.arch="sun4u">
     processor="sun4u", system="SunOS5.3"
@@ -692,12 +660,6 @@ NTP "banners", taken from a readvar response
      processor="sun4m", system="SunOS/5.4"
    </example>
    <example os.arch="sun4u">
-    processor="sun4u", system="SunOS/5.4"
-   </example>
-   <example os.arch="sun4m">
-    processor="sun4m", system="SunOS5.4"
-   </example>
-   <example os.arch="sun4u">
     processor="sun4u", system="SunOS5.4"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
@@ -710,12 +672,6 @@ NTP "banners", taken from a readvar response
    <description>Solaris 2.5 (SunOS/5.5) with no ntp version</description>
    <example os.arch="sun4m">
      processor="sun4m", system="SunOS/5.5"
-   </example>
-   <example os.arch="sun4u">
-    processor="sun4u", system="SunOS/5.5"
-   </example>
-   <example os.arch="sun4m">
-    processor="sun4m", system="SunOS5.5"
    </example>
    <example os.arch="sun4u">
     processor="sun4u", system="SunOS5.5"
@@ -732,12 +688,6 @@ NTP "banners", taken from a readvar response
      processor="sun4m", system="SunOS/5.6"
    </example>
    <example os.arch="sun4u">
-    processor="sun4u", system="SunOS/5.6"
-   </example>
-   <example os.arch="sun4m">
-    processor="sun4m", system="SunOS5.6"
-   </example>
-   <example os.arch="sun4u">
     processor="sun4u", system="SunOS5.6"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
@@ -751,14 +701,8 @@ NTP "banners", taken from a readvar response
    <example os.arch="sun4m" os.version="7">
      processor="sun4m", system="SunOS/5.7"
    </example>
-   <example os.arch="sun4u" os.version="7">
-     processor="sun4u", system="SunOS/5.7"
-   </example>
    <example os.arch="sun4m" os.version="10">
      processor="sun4m", system="SunOS/5.10"
-   </example>
-   <example os.arch="sun4u" os.version="10">
-     processor="sun4u", system="SunOS/5.10"
    </example>
    <example os.arch="sun4u" os.version="7">
     processor="sun4u", system="SunOS5.7"
@@ -777,17 +721,8 @@ NTP "banners", taken from a readvar response
    <example os.arch="sun4m" os.version="11">
     processor="sun4m", system="SunOS/5.11"
    </example>
-   <example os.arch="sun4u" os.version="11">
-     processor="sun4u", system="SunOS/5.11"
-   </example>
-   <example os.arch="sun4u" os.version="12">
-     processor="sun4u", system="SunOS/5.12"
-   </example>
-   <example os.arch="sun4m" os.version="12">
-     processor="sun4m", system="SunOS/5.12"
-   </example>
-   <example os.arch="sun4u" os.version="12">
-     processor="sun4u", system="SunOS5.12"
+   <example os.arch="sun4m" os.version="11">
+     processor="sun4m", system="SunOS5.11"
    </example>
    <param pos="0" name="os.vendor" value="Oracle"/>
    <param pos="0" name="os.family" value="Solaris"/>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -419,11 +419,15 @@ NTP "banners", taken from a readvar response
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.0&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description> ntpd running on Solaris 2.0 (SunOS/5.0) </description>
-    <example>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.0&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>ntpd running on Solaris 2.0 (SunOS/5.0) </description>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.0", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u",system="SunOS5.0", leap=00,stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -434,11 +438,15 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.1&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.1&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description> ntpd running on Solaris 2.1 (SunOS/5.1) </description>
-    <example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.1", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.1", leap=00,stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -449,11 +457,15 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.2&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.2&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description> ntpd running on Solaris 2.2 (SunOS/5.2) </description>
-    <example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.2", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.2", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -464,11 +476,15 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.3&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.3&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description> ntpd running on Solaris 2.3 (SunOS/5.3) </description>
-    <example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.3", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.3", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -479,11 +495,15 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.4&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description> ntpd running on Solaris 2.4 (SunOS/5.4) </description>
-    <example>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.4&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>ntpd running on Solaris 2.4 (SunOS/5.4) </description>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.4", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
+      version="ntpd 4.2.0@1.1161-r WEd Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.4", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -494,11 +514,15 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.5&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description> ntpd running on Solaris 2.5 (SunOS/5.5) </description>
-    <example>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.5&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>ntpd running on Solaris 2.5 (SunOS/5.5) </description>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.5", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDt 2005 (1)",
+      processor="sun4u", system="SunOS5.5", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -509,12 +533,16 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.6&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description> ntpd running on Solaris 2.6 (SunOS/5.6) </description>
-    <example>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.6&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>ntpd running on Solaris 2.6 (SunOS/5.6) </description>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.6", leap=00, stratum=2,
     </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.6", leap=00, stratum=2,
+    </example>    
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
@@ -524,15 +552,23 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description> ntpd running on Solaris 7 or above (SunOS/5.7 and above) </description>
-    <example>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>ntpd running on Solaris 7 or above (SunOS/5.7 and above) </description>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="7">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.7", leap=00, stratum=2,
     </example>
-    <example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.11", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="7">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.7", leap=00,stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.11", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -543,117 +579,165 @@ NTP "banners", taken from a readvar response
     <param pos="2" name="os.arch"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.0&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 2.0 (SunOS/5.0) with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.0"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.0&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 2.0 (SunOS/5.0) with no ntp version</description>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS/5.0"
    </example>
-   <example>
-    processor="sun4u",system="SunOS/5.0"
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS/5.0"
+   </example>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS5.0"
+   </example>
+   <example os.arch="sun4u">
+     processor="sun4u", system="SunOS5.0"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
-   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>
    <param pos="0" name="os.version" value="2.0" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.1&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 2.1 (SunOS/5.1) with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.1"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.1&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 2.1 (SunOS/5.1) with no ntp version</description>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS/5.1"
    </example>
-   <example>
-    processor="sun4u",system="SunOS/5.1"
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS/5.1"
+   </example>
+   <example os.arch="sun4m">
+    processor="sun4m", system="SunOS5.1"
+   </example>
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS5.1"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
-   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>
    <param pos="0" name="os.version" value="2.1" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.2&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 2.2 (SunOS/5.2) with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.2"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.2&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 2.2 (SunOS/5.2) with no ntp version</description>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS/5.2"
    </example>
-   <example>
-    processor="sun4u",system="SunOS/5.2"
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS/5.2"
+   </example>
+   <example os.arch="sun4m">
+    processor="sun4m", system="SunOS5.2"
+   </example>
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS5.2"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
-   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>
    <param pos="0" name="os.version" value="2.2" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.3&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 2.3 (SunOS/5.3) with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.3"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.3&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 2.3 (SunOS/5.3) with no ntp version</description>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS/5.3"
    </example>
-   <example>
-    processor="sun4u",system="SunOS/5.3"
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS/5.3"
+   </example>
+   <example os.arch="sun4m">
+    processor="sun4m", system="SunOS5.3"
+   </example>
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS5.3"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
-   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>
    <param pos="0" name="os.version" value="2.3" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.4&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 2.4 (SunOS/5.4) with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.4"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.4&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 2.4 (SunOS/5.4) with no ntp version</description>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS/5.4"
    </example>
-   <example>
-    processor="sun4u",system="SunOS/5.4"
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS/5.4"
+   </example>
+   <example os.arch="sun4m">
+    processor="sun4m", system="SunOS5.4"
+   </example>
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS5.4"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
-   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>
    <param pos="0" name="os.version" value="2.4" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.5&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 2.5 (SunOS/5.5) with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.5"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.5&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 2.5 (SunOS/5.5) with no ntp version</description>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS/5.5"
    </example>
-   <example>
-    processor="sun4u",system="SunOS/5.5"
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS/5.5"
+   </example>
+   <example os.arch="sun4m">
+    processor="sun4m", system="SunOS5.5"
+   </example>
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS5.5"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
-   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>
    <param pos="0" name="os.version" value="2.5" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.6&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 2.6 (SunOS/5.6) with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.6"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.6&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 2.6 (SunOS/5.6) with no ntp version</description>
+   <example os.arch="sun4m">
+     processor="sun4m", system="SunOS/5.6"
    </example>
-   <example>
-    processor="sun4u",system="SunOS/5.6"
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS/5.6"
+   </example>
+   <example os.arch="sun4m">
+    processor="sun4m", system="SunOS5.6"
+   </example>
+   <example os.arch="sun4u">
+    processor="sun4u", system="SunOS5.6"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
-   <param pos="0" name="os.vendor" value="Solaris"/>
+   <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>
    <param pos="0" name="os.version" value="2.6" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description> Solaris 7 (SunOS/5.7) and above with no ntp version</description>
-   <example>
-     processor="sun4m",system="SunOS/5.7"
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 7 (SunOS/5.7) and above with no ntp version</description>
+   <example os.arch="sun4m" os.version="7">
+     processor="sun4m", system="SunOS/5.7"
    </example>
-   <example>
-     processor="sun4u",system="SunOS/5.7"
+   <example os.arch="sun4u" os.version="7">
+     processor="sun4u", system="SunOS/5.7"
    </example>
-   <example>
-     processor="sun4m",system="SunOS/5.10"
+   <example os.arch="sun4m" os.version="10">
+     processor="sun4m", system="SunOS/5.10"
    </example>
-   <example>
-     processor="sun4u",system="SunOS/5.10"
+   <example os.arch="sun4u" os.version="10">
+     processor="sun4u", system="SunOS/5.10"
+   </example>
+   <example os.arch="sun4u" os.version="7">
+    processor="sun4u", system="SunOS5.7"
+   </example>
+   <example os.arch="sun4m" os.version="10">
+    processor="sun4m", system="SunOS5.10"
    </example>
    <param pos="0" name="os.vendor" value="Sun"/>
    <param pos="0" name="os.family" value="Solaris"/>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -552,31 +552,23 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.(1[1-9]|[2-9]\d{1,}|\d{3,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.(1[1-9])&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Solaris 11 or above (SunOS/5.11 and above) </description>
     <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.11", leap=00, stratum=2,
     </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="20">
-      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS/5.20", leap=00, stratum=2,
-    </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="123">
-      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS/5.123", leap=00, stratum=2,
-    </example>
     <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS5.11", leap=00,stratum=2,
     </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="20">
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="12">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS5.20", leap=00, stratum=2,
+      processor="sun4u", system="SunOS/5.12", leap=00, stratum=2,
     </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="123">
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="12">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS5.123", leap=00, stratum=2,
+      processor="sun4u", system="SunOS5.12", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -780,7 +772,7 @@ NTP "banners", taken from a readvar response
    <param pos="1" name="os.arch"/>
    <param pos="2" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.(1[1-9]|[2-9]\d{1,}|\d{3,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.(1[1-9])&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
    <description>Solaris 11 and up with no ntp version</description>
    <example os.arch="sun4m" os.version="11">
     processor="sun4m", system="SunOS/5.11"
@@ -788,20 +780,14 @@ NTP "banners", taken from a readvar response
    <example os.arch="sun4u" os.version="11">
      processor="sun4u", system="SunOS/5.11"
    </example>
-   <example os.arch="sun4u" os.version="20">
-     processor="sun4u", system="SunOS/5.20"
+   <example os.arch="sun4u" os.version="12">
+     processor="sun4u", system="SunOS/5.12"
    </example>
-   <example os.arch="sun4m" os.version="20">
-     processor="sun4m", system="SunOS/5.20"
+   <example os.arch="sun4m" os.version="12">
+     processor="sun4m", system="SunOS/5.12"
    </example>
-   <example os.arch="sun4u" os.version="20">
-     processor="sun4u", system="SunOS5.20"
-   </example>
-   <example os.arch="sun4u" os.version="123">
-     processor="sun4u", system="SunOS/5.123"
-   </example>
-   <example os.arch="sun4u" os.version="123">
-     processor="sun4u", system="SunOS5.123"
+   <example os.arch="sun4u" os.version="12">
+     processor="sun4u", system="SunOS5.12"
    </example>
    <param pos="0" name="os.vendor" value="Oracle"/>
    <param pos="0" name="os.family" value="Solaris"/>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -552,23 +552,58 @@ NTP "banners", taken from a readvar response
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-    <description>ntpd running on Solaris 7 or above (SunOS/5.7 and above) </description>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.(1[1-9]|[2-9]\d{1,}|\d{3,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>ntpd running on Solaris 11 or above (SunOS/5.11 and above) </description>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.11", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="20">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.20", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="123">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS/5.123", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.11", leap=00,stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="20">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.20", leap=00, stratum=2,
+    </example>
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="123">
+      version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
+      processor="sun4u", system="SunOS5.123", leap=00, stratum=2,
+    </example>
+    <param pos="0" name="os.vendor" value="Oracle"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="service.family" value="NTP"/>
+    <param pos="0" name="service.product" value="NTP"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="os.arch"/>
+    <param pos="3" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.([789]|10)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+    <description>ntpd running on Solaris 7-Solaris 10 (SunOS/5.7 - SunOS/5.10) </description>
     <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="7">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS/5.7", leap=00, stratum=2,
     </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="10">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS/5.11", leap=00, stratum=2,
+      processor="sun4u", system="SunOS/5.10", leap=00, stratum=2,
     </example>
     <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="7">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
       processor="sun4u", system="SunOS5.7", leap=00,stratum=2,
     </example>
-    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="11">
+    <example service.version="4.2.0@1.1161-r" os.arch="sun4u" os.version="10">
       version="ntpd 4.2.0@1.1161-r Wed Apr 20 11:28:05 EDT 2005 (1)",
-      processor="sun4u", system="SunOS5.11", leap=00, stratum=2,
+      processor="sun4u", system="SunOS5.10", leap=00, stratum=2,
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -719,8 +754,8 @@ NTP "banners", taken from a readvar response
    <param pos="0" name="os.version" value="2.6" />
    <param pos="1" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
-   <description>Solaris 7 (SunOS/5.7) and above with no ntp version</description>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.([789]|10)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 7-10 (SunOS/5.7 - SunOS/5.10) with no ntp version</description>
    <example os.arch="sun4m" os.version="7">
      processor="sun4m", system="SunOS/5.7"
    </example>
@@ -745,6 +780,35 @@ NTP "banners", taken from a readvar response
    <param pos="1" name="os.arch"/>
    <param pos="2" name="os.version"/>
   </fingerprint>
+  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/?5.(1[1-9]|[2-9]\d{1,}|\d{3,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+   <description>Solaris 11 and up with no ntp version</description>
+   <example os.arch="sun4m" os.version="11">
+    processor="sun4m", system="SunOS/5.11"
+   </example>
+   <example os.arch="sun4u" os.version="11">
+     processor="sun4u", system="SunOS/5.11"
+   </example>
+   <example os.arch="sun4u" os.version="20">
+     processor="sun4u", system="SunOS/5.20"
+   </example>
+   <example os.arch="sun4m" os.version="20">
+     processor="sun4m", system="SunOS/5.20"
+   </example>
+   <example os.arch="sun4u" os.version="20">
+     processor="sun4u", system="SunOS5.20"
+   </example>
+   <example os.arch="sun4u" os.version="123">
+     processor="sun4u", system="SunOS/5.123"
+   </example>
+   <example os.arch="sun4u" os.version="123">
+     processor="sun4u", system="SunOS5.123"
+   </example>
+   <param pos="0" name="os.vendor" value="Oracle"/>
+   <param pos="0" name="os.family" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="1" name="os.arch"/>
+   <param pos="2" name="os.version"/>
+  </fingerprint> 
   <fingerprint pattern="^.*system=&quot;UNIX/SunOS ([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>SunOS with no ntp version</description>
     <example>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -514,7 +514,6 @@
   <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?SunOS\s?5.(1[1-9])?)$">
     <description>Oracle/Solaris 5.11 and upwards</description>
     <example os.version="11">SunOS 5.11</example>
-    <example os.version="12">SunOS 5.12</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -482,10 +482,21 @@
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?Solaris\s?(\d+?(?:\.\d+?)*?)?)$">
-    <description>Solaris</description>
+  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?Solaris\s?(1[1-9]?(?:\.\d+?)*?)?)$">
+    <description>Solaris 11 and up</description>
     <example os.version="11.3">Solaris 11.3</example>
     <example os.version="11">Solaris 11</example>
+    <param pos="0" name="os.vendor" value="Oracle"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?Solaris\s?((?:[789]|10)+?(?:\.\d+?)*?)?)$">
+    <description>Solaris 7-10</description>
+    <example os.version="7">Solaris 7</example>
+    <example os.version="7.3">Solaris 7.3</example>
+    <example os.version="10">Solaris 10</example>
+    <example os.version="10.3">Solaris 10.3</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
@@ -495,7 +506,7 @@
     <description>SunOS/Solaris 5.7-5.10</description>
     <example os.version="7">SunOS 5.7</example>
     <example os.version="10">SunOS 5.10</example>
-    <param pos="0" name="os.vendor" value="SunOS"/>
+    <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -482,11 +482,30 @@
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?(?:Solaris|SunOS)\s?(\d+?(?:\.\d+?)*?)?)$">
+  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?Solaris\s?(\d+?(?:\.\d+?)*?)?)$">
     <description>Solaris</description>
     <example os.version="11.3">Solaris 11.3</example>
-    <example os.version="5.11">SunOS 5.11</example>
+    <example os.version="11">Solaris 11</example>
     <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?SunOS\s?5.([789]|10)?)$">
+    <description>SunOS/Solaris 5.7-5.10</description>
+    <example os.version="7">SunOS 5.7</example>
+    <example os.version="10">SunOS 5.10</example>
+    <param pos="0" name="os.vendor" value="SunOS"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?SunOS\s?5.(1[1-9]|[2-9]\d{1,}|\d{3,})?)$">
+    <description>Oracle/Solaris 5.11 and upwards</description>
+    <example os.version="11">SunOS 5.11</example>
+    <example os.version="20">SunOS 5.20</example>
+    <example os.version="123">SunOS 5.123</example>
+    <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -500,11 +500,10 @@
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?SunOS\s?5.(1[1-9]|[2-9]\d{1,}|\d{3,})?)$">
+  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?SunOS\s?5.(1[1-9])?)$">
     <description>Oracle/Solaris 5.11 and upwards</description>
     <example os.version="11">SunOS 5.11</example>
-    <example os.version="20">SunOS 5.20</example>
-    <example os.version="123">SunOS 5.123</example>
+    <example os.version="12">SunOS 5.12</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -7257,11 +7257,10 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="2" name="os.arch"/>
     <param pos="3" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS 5\.(1[1-9]||[2-9]\d{1,}|\d{3,}) (\S+) sparc SUNW,([^,]+),.*$">
+  <fingerprint pattern="^SunOS 5\.(1[1-9]) (\S+) sparc SUNW,([^,]+),.*$">
    <description>Oracle/Solaris 5.11 and upwards</description>
    <example os.version="11" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.11 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
-   <example os.version="20" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.20 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
-   <example os.version="123" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.123 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
+   <example os.version="12" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.12 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
    <param pos="0" name="os.vendor" value="Oracle"/>
    <param pos="0" name="os.certainty" value="0.9"/>
    <param pos="0" name="os.family" value="Solaris"/>
@@ -7290,11 +7289,10 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="3" name="os.arch"/>
     <param pos="4" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS (\S+) 5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) \S+ (\S+) \S+ SUNW,([^,]+).*$">
+  <fingerprint pattern="^SunOS (\S+) 5\.(1[1-9]) \S+ (\S+) \S+ SUNW,([^,]+).*$">
     <description>Oracle/Solaris 5.11 and upwards</description>
     <example host.name="integra01" os.version="11" os.arch="sun4v" hw.product="T5240">SunOS integra01 5.11 Generic_127127-11 sun4v sparc SUNW,T5240</example>
-    <example host.name="integra01" os.version="20" os.arch="sun4v" hw.product="T5240">SunOS integra01 5.20 Generic_127127-11 sun4v sparc SUNW,T5240</example>
-    <example host.name="magppg01" os.version="123" os.arch="sun4v" hw.product="T5240">SunOS magppg01 5.123 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+    <example host.name="integra01" os.version="12" os.arch="sun4v" hw.product="T5240">SunOS integra01 5.12 Generic_127127-11 sun4v sparc SUNW,T5240</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -7325,11 +7323,10 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS 5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) \S+ (\S+)$">
+  <fingerprint pattern="^SunOS 5\.(1[1-9]) \S+ (\S+)$">
     <description>Oracle/Solaris 5.11 and upwards</description>
     <example os.version="11" os.arch="sun4u">SunOS 5.11 Generic sun4u</example>
-    <example os.version="20" os.arch="sun4u">SunOS 5.20 Generic sun4u</example>
-    <example os.version="123" os.arch="sun4u">SunOS 5.123 Generic sun4u</example>
+    <example os.version="12" os.arch="sun4u">SunOS 5.12 Generic sun4u</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -7352,11 +7349,10 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS release:5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) version:\S+ machine:(\S+)$">
+  <fingerprint pattern="^SunOS release:5\.(1[1-9]) version:\S+ machine:(\S+)$">
     <description>SunOS/Solaris 5.11 and upwards</description>
     <example os.version="11" os.arch="sun4u">SunOS release:5.11 version:Generic_125100-07 machine:sun4u</example>
-    <example os.version="20" os.arch="sun4u">SunOS release:5.20 version:Generic_125100-07 machine:sun4u</example>
-    <example os.version="123" os.arch="sun4u">SunOS release:5.123 version:Generic_125100-07 machine:sun4u</example>
+    <example os.version="12" os.arch="sun4u">SunOS release:5.12 version:Generic_125100-07 machine:sun4u</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.vertainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -7061,7 +7061,6 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^SunOS (\S+) 5\.(1[1-9]) \S+ (\S+)$">
    <description>Oracle/Solaris 5.11 and upwards</description>
    <example host.name="sysname" os.version="11" os.arch="sun4u">SunOS sysname 5.11 Generic_118833-33 sun4u</example>
-   <example host.name="sysname" os.version="12" os.arch="sun4u">SunOS sysname 5.12 Generic_118833-33 sun4u</example>
    <param pos="0" name="os.vendor" value="Oracle"/>
    <param pos="0" name="os.certainty" value="0.9"/>
    <param pos="0" name="os.family" value="Solaris"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -7058,12 +7058,11 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SUN
    =======================================================================-->
-  <fingerprint pattern="^SunOS (\S+) 5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) \S+ (\S+)$">
+  <fingerprint pattern="^SunOS (\S+) 5\.(1[1-9]) \S+ (\S+)$">
    <description>Oracle/Solaris 5.11 and upwards</description>
    <example host.name="sysname" os.version="11" os.arch="sun4u">SunOS sysname 5.11 Generic_118833-33 sun4u</example>
-   <example host.name="sysname" os.version="20" os.arch="sun4u">SunOS sysname 5.20 Generic_118833-33 sun4u</example>
-   <example host.name="sysname" os.version="123" os.arch="sun4u">SunOS sysname 5.123 Generic_118833-33 sun4u</example>
-   <param pos="0" name="os.vendor" value="oracle"/>
+   <example host.name="sysname" os.version="12" os.arch="sun4u">SunOS sysname 5.12 Generic_118833-33 sun4u</example>
+   <param pos="0" name="os.vendor" value="Oracle"/>
    <param pos="0" name="os.certainty" value="0.9"/>
    <param pos="0" name="os.family" value="Solaris"/>
    <param pos="0" name="os.product" value="Solaris"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -7058,9 +7058,24 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SUN
    =======================================================================-->
-  <fingerprint pattern="^SunOS (\S+) 5\.(\S+) \S+ (\S+)$">
-    <description>SunOS/Solaris</description>
-    <example>SunOS sysname 5.10 Generic_118833-33 sun4u</example>
+  <fingerprint pattern="^SunOS (\S+) 5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) \S+ (\S+)$">
+   <description>Oracle/Solaris 5.11 and upwards</description>
+   <example host.name="sysname" os.version="11" os.arch="sun4u">SunOS sysname 5.11 Generic_118833-33 sun4u</example>
+   <example host.name="sysname" os.version="20" os.arch="sun4u">SunOS sysname 5.20 Generic_118833-33 sun4u</example>
+   <example host.name="sysname" os.version="123" os.arch="sun4u">SunOS sysname 5.123 Generic_118833-33 sun4u</example>
+   <param pos="0" name="os.vendor" value="oracle"/>
+   <param pos="0" name="os.certainty" value="0.9"/>
+   <param pos="0" name="os.family" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.device" value="General"/>
+   <param pos="1" name="host.name"/>
+   <param pos="2" name="os.version"/>
+   <param pos="3" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^SunOS (\S+) 5\.([789]|10) \S+ (\S+)$">
+    <description>SunOS/Solaris 5.7-5.10</description>
+    <example host.name="sysname" os.arch="sun4u" os.version="10">SunOS sysname 5.10 Generic_118833-33 sun4u</example>
+    <example host.name="sysname" os.arch="sun4u" os.version="7">SunOS sysname 5.7 Generic_118833-33 sun4u</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -7221,15 +7236,15 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="Storage"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS 5\.(\S+) (\S+) sparc SUNW,([^,]+),.*$">
-    <description>SunOS/Solaris</description>
-    <example>SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
+  <fingerprint pattern="^SunOS 5\.([789]|10) (\S+) sparc SUNW,([^,]+),.*$">
+    <description>SunOS/Solaris 5.7-5.10</description>
+    <example os.version="10" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
     <example>SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V210, Class 5 Call Manager</example>
     <example>SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V215, CommandCenter</example>
     <example>SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V240, Class 5 Call Manager</example>
     <example>SunOS 5.10 sun4u sparc SUNW,Ultra-250, Class 5 Call Manager</example>
     <example>SunOS 5.10 sun4u sparc SUNW,UltraAX-i2, Class 5 Call Manager</example>
-    <example>SunOS 5.8 sun4u sparc SUNW,Sun-Fire-V210, Class 5 Call Manager</example>
+    <example os.version="8" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.8 sun4u sparc SUNW,Sun-Fire-V210, Class 5 Call Manager</example>
     <example>SunOS 5.8 sun4u sparc SUNW,Ultra-60, Class 5 Call Manager</example>
     <example>SunOS 5.8 sun4u sparc SUNW,UltraAX-i2, Class 4 Call Manager</example>
     <example>SunOS 5.8 sun4u sparc SUNW,UltraAX-i2, Class 5 Call Manager</example>
@@ -7242,14 +7257,29 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="2" name="os.arch"/>
     <param pos="3" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS (\S+) 5\.(\S+) \S+ (\S+) \S+ SUNW,([^,]+).*$">
-    <description>SunOS/Solaris</description>
-    <example>SunOS integra01 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+  <fingerprint pattern="^SunOS 5\.(1[1-9]||[2-9]\d{1,}|\d{3,}) (\S+) sparc SUNW,([^,]+),.*$">
+   <description>Oracle/Solaris 5.11 and upwards</description>
+   <example os.version="11" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.11 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
+   <example os.version="20" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.20 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
+   <example os.version="123" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.123 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
+   <param pos="0" name="os.vendor" value="Oracle"/>
+   <param pos="0" name="os.certainty" value="0.9"/>
+   <param pos="0" name="os.family" value="Solaris"/>
+   <param pos="0" name="os.product" value="Solaris"/>
+   <param pos="0" name="os.device" value="General"/>
+   <param pos="1" name="os.version"/>
+   <param pos="2" name="os.arch"/>
+   <param pos="3" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^SunOS (\S+) 5\.([789]|10) \S+ (\S+) \S+ SUNW,([^,]+).*$">
+    <description>SunOS/Solaris 5.7-5.10</description>
+    <example host.name="integra01" os.version="10" os.arch="sun4v" hw.product="T5240">SunOS integra01 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
     <example>SunOS integra02 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
     <example>SunOS magppg01 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
     <example>SunOS magppg02 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
     <example>SunOS rs1-s3 5.10 Generic_142900-09 sun4v sparc SUNW,Netra-CP3260</example>
     <example hw.product="Sun-Fire-T200">SunOS sn 5.10 Generic_118833-36 sun4v sparc SUNW,Sun-Fire-T200</example>
+    <example hw.product="Sun-Fire-T200" host.name="sn" os.arch="sun4v" os.version="8">SunOS sn 5.8 Generic_118833-36 sun4v sparc SUNW,Sun-Fire-T200</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -7260,17 +7290,32 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="3" name="os.arch"/>
     <param pos="4" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS 5\.(\S+) \S+ (\S+)$">
-    <description>SunOS/Solaris</description>
-    <example>SunOS 5.10 Generic sun4u</example>
+  <fingerprint pattern="^SunOS (\S+) 5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) \S+ (\S+) \S+ SUNW,([^,]+).*$">
+    <description>Oracle/Solaris 5.11 and upwards</description>
+    <example host.name="integra01" os.version="11" os.arch="sun4v" hw.product="T5240">SunOS integra01 5.11 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+    <example host.name="integra01" os.version="20" os.arch="sun4v" hw.product="T5240">SunOS integra01 5.20 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+    <example host.name="magppg01" os.version="123" os.arch="sun4v" hw.product="T5240">SunOS magppg01 5.123 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+    <param pos="0" name="os.vendor" value="Oracle"/>
+    <param pos="0" name="os.certainty" value="0.9"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="1" name="host.name"/>
+    <param pos="2" name="os.version"/>
+    <param pos="3" name="os.arch"/>
+    <param pos="4" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="^SunOS 5\.([789]|10) \S+ (\S+)$">
+    <description>SunOS/Solaris 5.7-5.10</description>
+    <example os.version="10" os.arch="sun4u">SunOS 5.10 Generic sun4u</example>
     <example>SunOS 5.10 Generic_137111-07 sun4v</example>
     <example>SunOS 5.10 Generic_142900-11 sun4v</example>
-    <example>SunOS 5.8 Generic_108528-16 sun4u</example>
+    <example os.version="8" os.arch="sun4u">SunOS 5.8 Generic_108528-16 sun4u</example>
     <example>SunOS 5.8 Generic_108528-27 sun4u</example>
     <example>SunOS 5.8 Generic_108528-29 sun4u</example>
     <example>SunOS 5.8 Generic_117350-25 sun4u</example>
     <example>SunOS 5.8 Generic_117350-62 sun4u</example>
-    <example>SunOS 5.9 Generic_118558-24 sun4u</example>
+    <example os.version="9" os.arch="sun4u">SunOS 5.9 Generic_118558-24 sun4u</example>
     <example>SunOS 5.9 Generic_118558-36 sun4u</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.certainty" value="0.9"/>
@@ -7280,12 +7325,25 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^SunOS release:5\.(\S+) version:\S+ machine:(\S+)$">
-    <description>SunOS/Solaris</description>
-    <example>SunOS release:5.10 version:Generic_125100-07 machine:sun4u</example>
-    <example>SunOS release:5.10 version:Generic_139555-08 machine:sun4v</example>
-    <example>SunOS release:5.8 version:Generic_117350-62 machine:sun4u</example>
-    <example>SunOS release:5.9 version:Generic_122300-22 machine:sun4u</example>
+  <fingerprint pattern="^SunOS 5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) \S+ (\S+)$">
+    <description>Oracle/Solaris 5.11 and upwards</description>
+    <example os.version="11" os.arch="sun4u">SunOS 5.11 Generic sun4u</example>
+    <example os.version="20" os.arch="sun4u">SunOS 5.20 Generic sun4u</example>
+    <example os.version="123" os.arch="sun4u">SunOS 5.123 Generic sun4u</example>
+    <param pos="0" name="os.vendor" value="Oracle"/>
+    <param pos="0" name="os.certainty" value="0.9"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>  
+  <fingerprint pattern="^SunOS release:5\.([789]|10) version:\S+ machine:(\S+)$">
+    <description>SunOS/Solaris 5.7-5.10</description>
+    <example os.version="10" os.arch="sun4u">SunOS release:5.10 version:Generic_125100-07 machine:sun4u</example>
+    <example os.version="10" os.arch="sun4v">SunOS release:5.10 version:Generic_139555-08 machine:sun4v</example>
+    <example os.version="8" os.arch="sun4u">SunOS release:5.8 version:Generic_117350-62 machine:sun4u</example>
+    <example os.version="9" os.arch="sun4u">SunOS release:5.9 version:Generic_122300-22 machine:sun4u</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -7294,6 +7352,19 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
   </fingerprint>
+  <fingerprint pattern="^SunOS release:5\.(1[1-9]|[2-9]\d{1,}|\d{3,}) version:\S+ machine:(\S+)$">
+    <description>SunOS/Solaris 5.11 and upwards</description>
+    <example os.version="11" os.arch="sun4u">SunOS release:5.11 version:Generic_125100-07 machine:sun4u</example>
+    <example os.version="20" os.arch="sun4u">SunOS release:5.20 version:Generic_125100-07 machine:sun4u</example>
+    <example os.version="123" os.arch="sun4u">SunOS release:5.123 version:Generic_125100-07 machine:sun4u</example>
+    <param pos="0" name="os.vendor" value="Oracle"/>
+    <param pos="0" name="os.vertainty" value="0.9"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.arch"/>
+   </fingerprint> 
   <!--======================================================================
                               SYMANTEC
    =======================================================================-->


### PR DESCRIPTION
Previously ntp banners for Solaris had their os.product value set to 'Solaris' , however the version was being set to the SunOS version which is different from the Solaris version, see: https://en.wikipedia.org/wiki/Solaris_(operating_system)#Version_history

Due to the first digit of the Solaris version being different from the SunOS version I have created  separate fingerprints for all regex matching SunOS/5.0 -> SunOS/5.6, as their versions have to be hard coded, for example the following regex pattern:
`  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.1&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
`

Has its os.version set :


`<param pos="0" name="os.version" value="2.1" />
`

From SunOS/5.7 and upwards the Solaris version is just the final digit from the SunOS version so it was possible to capture this within the regex :

`  <fingerprint pattern="^.*processor=&quot;([^ ]+)&quot;,.*system=&quot;SunOS/5.([789]|\d{2,})&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
`

Has its os.version set:

`   <param pos="2" name="os.version"/>
`

**Testing:**

`bin/recog_verify xml/ssh_banners.xml` completes with 0 failures against new example cases
`Rake tests` passed with 0 failures




