### PR TITLE
Added fingerprinting of pfSense (and bsnmpd) via SNMP

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5970,9 +5970,8 @@ Copyright (c) 1995-2005 by Cisco Systems
    =======================================================================-->
   <fingerprint pattern="^pfSense\s(\S+)\s(\d+\.\d+(?:\.\d+)?)-RELEASE.*(FreeBSD)\s([\d\.]+-(?:STABLE|RELEASE)(?:-p\d+)?).*\s(\w+)$">
     <description>pfSense</description>
-    <example service.vendor="FreeBSD" service.product="bsnmpd" service.component.vendor="pfSense" service.component.product="pfSense" service.component.version="2.3.4" os.vendor="FreeBSD" os.family="FreeBSD" os.product="FreeBSD" os.version="10.3-RELEASE-p19" os.arch="amd64" os.certainty="0.9" host.name="pfSense.localdomain">pfSense pfSense.localdomain 2.3.4-RELEASE pfSense FreeBSD 10.3-RELEASE-p19 amd64</example>
-    <example service.vendor="FreeBSD" service.product="bsnmpd" service.component.vendor="pfSense" service.component.product="pfSense" service.component.version="2.1" os.vendor="FreeBSD" os.family="FreeBSD" os.product="FreeBSD" os.version="8.3-RELEASE-p11" os.arch="i386" os.certainty="0.9" host.name="example.com">pfSense example.com 2.1-RELEASE nanobsd FreeBSD 8.3-RELEASE-p11 i386</example>
-    <param pos="0" name="service.vendor" value="FreeBSD"/>
+    <example service.vendor="FreeBSD" service.product="bsnmpd" service.component.vendor="pfSense" service.component.product="pfSense" service.component.version="2.3.4" os.vendor="FreeBSD" os.family="FreeBSD" os.product="FreeBSD" os.version="10.3-RELEASE-p19" os.arch="amd64" host.name="pfSense.localdomain">pfSense pfSense.localdomain 2.3.4-RELEASE pfSense FreeBSD 10.3-RELEASE-p19 amd64</example>
+    <example service.vendor="FreeBSD" service.product="bsnmpd" service.component.vendor="pfSense" service.component.product="pfSense" service.component.version="2.1" os.vendor="FreeBSD" os.family="FreeBSD" os.product="FreeBSD" os.version="8.3-RELEASE-p11" os.arch="i386" host.name="example.com">pfSense example.com 2.1-RELEASE nanobsd FreeBSD 8.3-RELEASE-p11 i386</example>
     <param pos="0" name="service.product" value="bsnmpd"/>
     <param pos="0" name="service.component.vendor" value="pfSense"/>
     <param pos="0" name="service.component.product" value="pfSense"/>
@@ -5980,6 +5979,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="host.name"/>
     <param pos="2" name="service.component.version"/>
     <param pos="3" name="os.vendor"/>
+    <param pos="3" name="service.vendor"/>
     <param pos="3" name="os.family"/>
     <param pos="3" name="os.product"/>
     <param pos="4" name="os.version"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5965,6 +5965,26 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
+  <!--======================================================================
+                            pfSense
+   =======================================================================-->
+  <fingerprint pattern="^pfSense\s(\S+)\s(\d+\.\d+(?:\.\d+)?)-RELEASE.*(FreeBSD)\s([\d\.]+-(?:STABLE|RELEASE)(?:-p\d+)?).*\s(\w+)$">
+    <description>pfSense</description>
+    <example service.vendor="FreeBSD" service.product="bsnmpd" service.component.vendor="pfSense" service.component.product="pfSense" service.component.version="2.3.4" os.vendor="FreeBSD" os.family="FreeBSD" os.product="FreeBSD" os.version="10.3-RELEASE-p19" os.arch="amd64" os.certainty="0.9" host.name="pfSense.localdomain">pfSense pfSense.localdomain 2.3.4-RELEASE pfSense FreeBSD 10.3-RELEASE-p19 amd64</example>
+    <example service.vendor="FreeBSD" service.product="bsnmpd" service.component.vendor="pfSense" service.component.product="pfSense" service.component.version="2.1" os.vendor="FreeBSD" os.family="FreeBSD" os.product="FreeBSD" os.version="8.3-RELEASE-p11" os.arch="i386" os.certainty="0.9" host.name="example.com">pfSense example.com 2.1-RELEASE nanobsd FreeBSD 8.3-RELEASE-p11 i386</example>
+    <param pos="0" name="service.vendor" value="FreeBSD"/>
+    <param pos="0" name="service.product" value="bsnmpd"/>
+    <param pos="0" name="service.component.vendor" value="pfSense"/>
+    <param pos="0" name="service.component.product" value="pfSense"/>
+    <param pos="0" name="os.certainty" value="0.9"/>
+    <param pos="1" name="host.name"/>
+    <param pos="2" name="service.component.version"/>
+    <param pos="3" name="os.vendor"/>
+    <param pos="3" name="os.family"/>
+    <param pos="3" name="os.product"/>
+    <param pos="4" name="os.version"/>
+    <param pos="5" name="os.arch"/>
+  </fingerprint>
   <!--
       Currently unmatched fingerprints:
          Vendor:Paradyne Corporation,ProductId:4929


### PR DESCRIPTION
## Description
Adds fingerprinting of pfSense firewall devices/virtual appliances via the SNMP banner

## Motivation and Context
pfSense is a fairly prevalent firewall/gateway device that currently has ~23 CVEs against it

## How Has This Been Tested?
- [x] Run rspec on branch
- [x] Run `bin/recog_verify xml/snmp_sysdescr.xml`:
```
cmccrisken@ciaran-dev:~/rapid7/cmccrisken-r7/recog (git: master)$ bin/recog_verify xml/snmp_sysdescr.xml 
WARN: 'Castelle FaxPress' has no test cases
WARN: 'NetportExpress Print Server' has no test cases
WARN: 'Lexmark C760 Color Laser Printer' has no test cases
WARN: 'Red Hat Enterprise Linux 4 Update 3' has no test cases
SUMMARY: Test completed with 2931 successful, 4 warnings, and 0 failures

```
- [x] Scanned pfSense virtual appliance with InsightVM:
```
2017-06-29T19:43:25 [INFO] [Thread: 10.4.28.201:161/UDP] [Site: pfs2] Asserting SystemFingerprint [[architecture=amd64][certainty=0.9][description=FreeBSD 10.3-RELEASE-p19][deviceClass=null][family=FreeBSD][product=FreeBSD][vendor=FreeBSD][version=10.3-RELEASE-p19]]
2017-06-29T19:43:25 [INFO] [Thread: 10.4.28.201:161/UDP] [Site: pfs2] Asserting Fingerprint [[certainty=0.9][description=pfSense 2.3.4][family=null][product=pfSense][vendor=pfSense][version=2.3.4]]
```