### PR TITLE
Limit branch builds to master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ env:
   global:
     - CI="travis"
     - JRUBY_OPTS="--server -J-Xms512m -J-Xmx2G"
+branches:
+  only:
+    - master


### PR DESCRIPTION
Avoid duplicating travis builds on tag pushes and PRs from origin branches. This doesn't really do anything for us directly, but it is nice to not spend extra cycles unnecessarily on a free service.