### PR TITLE
Small regexp fixes for Go compatibility

### DIFF
--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -304,7 +304,7 @@
     <param pos="0" name="service.family" value="PowerDNS"/>
     <param pos="0" name="service.product" value="Recursor"/>
   </fingerprint>
-  <fingerprint pattern="^PowerDNS Authoritative Server (\d\.[\d.]++(?:-rc\d)?) \(\w+@[\w.]+ built [\d\s]+\w*@[\w.-]*\)$">
+  <fingerprint pattern="^PowerDNS Authoritative Server (\d\.[\d\.]+(?:-rc\d)?) \(\w+@[\w.]+ built [\d\s]+\w*@[\w.-]*\)$">
     <description>PowerDNS Authoritative Server</description>
     <example service.version="3.4.19">PowerDNS Authoritative Server 3.4.19 (jenkins@autotest.powerdns.com built 20160102220341 root@)</example>
     <example service.version="3.4.10">PowerDNS Authoritative Server 3.4.10 (jenkins@autotest.powerdns.com built 20170306160718 root@foo-bar.foo.baz)</example>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -24,7 +24,17 @@
     <param pos="2" name="os.edition"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^(?i:(?:Microsoft )?(Windows (?:XP|Vista|7|8|8.1|10))(?:\s)?((?!Mobile)(?:[a-z]+|[a-z]+, )?(?:[a-z]+|[a-z]+\s[a-z]+)?)?(?: Edition)?(?:\s)?(SP\d|SP \d|Service Pack \d)?)$">
+  <fingerprint pattern="^(?i:(?:Microsoft )?Windows 10 Mobile(?:\s([a-z]+))?(?: Edition)?)$">
+    <description>Windows 10 Mobile</description>
+    <example os.product="Windows 10 Mobile">Windows 10 Mobile Edition</example>
+    <example os.product="Windows 10 Mobile" os.edition="Enterprise">Windows 10 Mobile Enterprise Edition</example>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows 10 Mobile"/>
+    <param pos="1" name="os.edition"/>
+    <param pos="0" name="os.device" value="Mobile"/>
+  </fingerprint>
+  <fingerprint pattern="^(?i:(?:Microsoft )?(Windows (?:XP|Vista|7|8|8.1|10))(?:\s)?((?:[a-z]+|[a-z]+, )?(?:[a-z]+|[a-z]+\s[a-z]+)?)?(?: Edition)?(?:\s)?(SP\d|SP \d|Service Pack \d)?)$">
     <description>Windows Desktop XP and later</description>
     <example os.product="Windows XP" os.edition="Professional">Windows XP Professional</example>
     <example os.product="Windows XP" os.edition="Tablet PC">Windows XP Tablet PC Edition</example>
@@ -62,16 +72,6 @@
     <param pos="0" name="os.product" value="NT"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.edition"/>
-  </fingerprint>
-  <fingerprint pattern="^(?i:(?:Microsoft )?Windows 10 Mobile(?:\s(?!Edition)([a-z]+))?(?: Edition)?)$">
-    <description>Windows 10 Mobile</description>
-    <example os.product="Windows 10 Mobile">Windows 10 Mobile Edition</example>
-    <example os.product="Windows 10 Mobile" os.edition="Enterprise">Windows 10 Mobile Enterprise Edition</example>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.product" value="Windows 10 Mobile"/>
-    <param pos="1" name="os.edition"/>
-    <param pos="0" name="os.device" value="Mobile"/>
   </fingerprint>
   <fingerprint pattern="^(?i:(?:Microsoft )?Windows Phone (\d|\d\.\d)?)$">
     <description>Windows Phone 7 and later</description>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -1150,7 +1150,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
     <param pos="3" name="sendmail.config.version"/>
     <param pos="4" name="system.time"/>
   </fingerprint>
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d(?:\.\d)?(?:build\d)?+; (.+); .*$">
+  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d(?:\.\d)?(?:build\d)?;+ (.+); .*$">
     <description>Sendmail - Debian patch only</description>
     <example service.version="8.15.2">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-3; Thu, 30 Nov 2017 10:55:50 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <example service.version="8.14.3">foo.bar ESMTP Sendmail 8.14.3/8.14.3/Debian-9.4; Thu, 30 Nov 2017 10:11:54 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -877,7 +877,7 @@ The system or service fingerprint with the highest certainty overwrites the othe
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
   </fingerprint>
-  <fingerprint pattern="^(?i)((?!ESMTP)[^ ]+) POSTFIX$">
+  <fingerprint pattern="^(?i)([^ ]+) POSTFIX$">
     <description>Postfix - generic w/o ESMTP</description>
     <example host.name="foo.bar">foo.bar Postfix</example>
     <param pos="0" name="service.family" value="Postfix"/>


### PR DESCRIPTION
This change corrects two typos and removes two negative look aheads, allowing these expressions to be parsed by the Go standard library 'regexp' engine.