### PR TITLE
Amazon Linux AMI fingerprinting via ftp banner

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1317,7 +1317,7 @@ more text</example>
     <param pos="2" name="service.version"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="^Amazon Linux AMI release (.*)">
+  <fingerprint pattern="Amazon\sLinux\sAMI\srelease\s(\d+\.\d+)">
     <description>Amazon Linux AMI</description>
     <example os.version="2016.09">Amazon Linux AMI release 2016.09</example>
     <param pos="0" name="os.vendor" value="Amazon"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1317,4 +1317,12 @@ more text</example>
     <param pos="2" name="service.version"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
+  <fingerprint pattern="^Amazon Linux AMI release (.*)">
+    <description>Amazon Linux AMI</description>
+    <example os.version="2016.09">Amazon Linux AMI release 2016.09</example>
+    <param pos="0" name="os.vendor" value="Amazon"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux AMI"/>
+    <param pos="1" name="os.version"/> 
+  </fingerprint>
 </fingerprints>


### PR DESCRIPTION
Comes from an FTP banner seen on shodan here is the full output (with response codes)
`
220-Amazon Linux AMI release 2016.09
220-Kernel \r on an \m
220-
220
530 Permission denied.
530 Please login with USER and PASS.
211-Features:
 EPRT
 EPSV
 MDTM
 PASV
 REST STREAM
 SIZE
 TVFS
 UTF8
211 End`
nexpose PR - https://github.com/rapid7/nexpose/pull/5573