### PR TITLE
Adding maria db max scale banner support

### DIFF
--- a/.rake_tasks~
+++ b/.rake_tasks~
@@ -1,0 +1,9 @@
+build
+clean
+clobber
+features
+install
+install:local
+release[remote]
+spec
+yard

--- a/.rake_tasks~
+++ b/.rake_tasks~
@@ -1,9 +1,0 @@
-build
-clean
-clobber
-features
-install
-install:local
-release[remote]
-spec
-yard

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -998,13 +998,13 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,2}\.[\d]{1,2})(?:-\d{1,2}\.\d{1,2}\.[\d]{1,2})?\s(\d{1,2}\.\d{1,2}\.\d{1,2})-maxscale$">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,2}\.[a-f\d]{1,2})(?:-\d{1,2}\.\d{1,2}\.[a-f\d]{1,2})?\s(\d{1,2}\.\d{1,2}\.\d{1,2})-maxscale$">
     <description>MariaDB MaxScale</description>
     <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example> 
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="Maxscale"/>
+    <param pos="0" name="service.product" value="MaxScale"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha-community-nt" flags="REG_ICASE">
     <description>Oracle MySQL with defunct Falcon Storage Engine with Named Pipes (Windows)</description>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1000,8 +1000,14 @@
   </fingerprint>
   <fingerprint pattern="(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-maxscale">
     <description>MariaDB MaxScale</description>
-    <example service.version="02.0.3">5.5.5-10.0.02.0.3-maxscale</example>
-    <example service.version="01.4.5">5.5.5-10.0.01.4.5-maxscale</example>
+    <example service.version="2.0.3">5.5.5-10.0.0 2.0.3-maxscale</example>
+    <example service.version="1.4.5">5.5.5-10.0.0 1.4.5-maxscale</example>
+    <example service.version="1.4.3">5.5.5-10.0.0 1.4.3-maxscale</example>
+    <example service.version="2.1.9">5.5.5-10.0.0 2.1.9-maxscale</example>
+    <example service.version="2.2.5">5.5.5-10.2.12 2.2.5-maxscale</example>
+    <example service.version="2.0.1">5.5.5-10.0.0 2.0.1-maxscale</example>
+    <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example>
+ 
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -998,12 +998,10 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
-  <fingerprint pattern="(\d{1,2}\.\d{1,2}\.\d{1,2})-maxscale">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,2}\.[\d]{1,2})(?:-\d{1,2}\.\d{1,2}\.[\d]{1,2})?\s(\d{1,2}\.\d{1,2}\.\d{1,2})-maxscale$">
     <description>MariaDB MaxScale</description>
-    <example service.version="2.0.3">5.5.5-10.0.0 2.0.3-maxscale</example>
     <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example> 
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB Maxscale"/>
   </fingerprint>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1002,8 +1002,9 @@
     <description>MariaDB MaxScale</description>
     <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example> 
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB Maxscale"/>
+    <param pos="0" name="service.product" value="Maxscale"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha-community-nt" flags="REG_ICASE">
     <description>Oracle MySQL with defunct Falcon Storage Engine with Named Pipes (Windows)</description>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -998,7 +998,7 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
-  <fingerprint pattern="(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-maxscale">
+  <fingerprint pattern="(\d{1,2}\.\d{1,2}\.\d{1,2})-maxscale">
     <description>MariaDB MaxScale</description>
     <example service.version="2.0.3">5.5.5-10.0.0 2.0.3-maxscale</example>
     <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example> 

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -998,6 +998,15 @@
     <param pos="0" name="service.product" value="MariaDB"/>
     <param pos="0" name="service.edition" value="Enterprise Edition"/>
   </fingerprint>
+  <fingerprint pattern="(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-maxscale">
+    <description>MariaDB MaxScale</description>
+    <example service.version="02.0.3">5.5.5-10.0.02.0.3-maxscale</example>
+    <example service.version="01.4.5">5.5.5-10.0.01.4.5-maxscale</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB-maxscale"/>
+  </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha-community-nt" flags="REG_ICASE">
     <description>Oracle MySQL with defunct Falcon Storage Engine with Named Pipes (Windows)</description>
     <example service.version="5.2.0">5.2.0-falcon-alpha-community-nt</example>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1001,16 +1001,11 @@
   <fingerprint pattern="(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-maxscale">
     <description>MariaDB MaxScale</description>
     <example service.version="2.0.3">5.5.5-10.0.0 2.0.3-maxscale</example>
-    <example service.version="1.4.5">5.5.5-10.0.0 1.4.5-maxscale</example>
-    <example service.version="1.4.3">5.5.5-10.0.0 1.4.3-maxscale</example>
-    <example service.version="2.1.9">5.5.5-10.0.0 2.1.9-maxscale</example>
-    <example service.version="2.2.5">5.5.5-10.2.12 2.2.5-maxscale</example>
-    <example service.version="2.0.1">5.5.5-10.0.0 2.0.1-maxscale</example>
     <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example> 
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB-maxscale"/>
+    <param pos="0" name="service.product" value="MariaDB Maxscale"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha-community-nt" flags="REG_ICASE">
     <description>Oracle MySQL with defunct Falcon Storage Engine with Named Pipes (Windows)</description>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1006,8 +1006,7 @@
     <example service.version="2.1.9">5.5.5-10.0.0 2.1.9-maxscale</example>
     <example service.version="2.2.5">5.5.5-10.2.12 2.2.5-maxscale</example>
     <example service.version="2.0.1">5.5.5-10.0.0 2.0.1-maxscale</example>
-    <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example>
- 
+    <example service.version="2.1.14">5.5.5-10.0.0 2.1.14-maxscale</example> 
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>


### PR DESCRIPTION
### Description
Adds fingerprinting support for MariaDB MaxScale 

### Motivation and context
MariaDB Maxscale is a popular database proxy and adding it will increase coverage of the MariaDB line of products

### How Has This Been Tested?

- [x] Run rspec on branch
- [x] Run `bin/recog_verify xml/mysql_banners.xml`:
