### PR TITLE
Correct duplicate params in SMTP banner fingerprints

### DIFF
--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -32,6 +32,7 @@ describe Recog::DB do
         fp = db.fingerprints[i]
 
         context "#{fp.name}" do
+          param_names = []
           fp.params.each do |param_name, pos_value|
             pos, value = pos_value
             it "doesn't have param values for capture params" do
@@ -43,6 +44,14 @@ describe Recog::DB do
             it "doesn't omit values for non-capture params" do
               if pos == 0 && value.to_s.empty?
                 fail "'#{fp.name}'s #{param_name} is not a capture (pos=0) but doesn't specify a value"
+              end
+            end
+
+            it "doesn't have duplicate params" do
+              if param_names.include? param_name
+                fail "'#{fp.name}'s has duplicate #{param_name}"
+              else
+                param_names << param_name
               end
             end
           end

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -48,7 +48,7 @@ describe Recog::DB do
             end
 
             it "doesn't have duplicate params" do
-              if param_names.include? param_name
+              if param_names.include?(param_name)
                 fail "'#{fp.name}'s has duplicate #{param_name}"
               else
                 param_names << param_name

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -1294,7 +1294,6 @@ The system or service fingerprint with the highest certainty overwrites the othe
     <example host.name="foo.bar">foo.bar ESMTP Sendmail</example>
     <example host.name="foo.bar">foo.bar Sendmail ready. </example>
     <param pos="0" name="service.family" value="Sendmail"/>
-    <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="system.time"/>
@@ -1396,7 +1395,6 @@ The system or service fingerprint with the highest certainty overwrites the othe
     <description>SonicWall Email Security</description>
     <example host.name="foo.bar" service.version="9.0.5.2077">foo.bar ESMTP SonicWALL (9.0.5.2077)</example>
     <example host.name="foo.bar" service.version="9.1.1.3113">foo.bar ESMTP SonicWall (9.1.1.3113)</example>
-    <param pos="0" name="service.vendor" value="SonicWall"/>
     <param pos="0" name="service.vendor" value="SonicWall"/>
     <param pos="0" name="service.family" value="Email Security"/>
     <param pos="0" name="service.product" value="Email Security"/>


### PR DESCRIPTION
Working on something else recog related and it tripped over duplicate `param` attributes.  This addresses the specific issue.  I added a unit test too, however it doesn't seem to detect the problem when used against current `master`.