### PR TITLE
Correct Cisco PIX fingerprints to use OS rather than service fingerprint

### DIFF
--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -119,10 +119,10 @@
   <fingerprint pattern="^SMTP/cmap ready_+$">
     <description>Cisco Pix v4.x</description>
     <example>SMTP/cmap ready________________________________________________________________________</example>
-    <param pos="0" name="service.vendor" value="Cisco"/>
-    <param pos="0" name="service.family" value="PIX"/>
-    <param pos="0" name="service.product" value="PIX"/>
-    <param pos="0" name="service.version" value="4"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="PIX"/>
+    <param pos="0" name="os.product" value="PIX"/>
+    <param pos="0" name="os.version" value="4"/>
   </fingerprint>
   <fingerprint pattern="CCProxy (\S+) SMTP Service Ready(?:\(Unregistered\))?$">
     <description>Youngzsoft CCProxy SMTP</description>
@@ -143,10 +143,10 @@
 
          Search Cisco's documentation for "fixup protocol SMTP" for more information.
       </description>
-    <example service.product="PIX">***************************</example>
-    <param pos="0" name="service.vendor" value="Cisco"/>
-    <param pos="0" name="service.family" value="PIX"/>
-    <param pos="0" name="service.product" value="PIX"/>
+    <example os.product="PIX">***************************</example>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="PIX"/>
+    <param pos="0" name="os.product" value="PIX"/>
   </fingerprint>
   <fingerprint pattern="^([^ ]+) +ESMTP CPMTA-([^ ]+)_([^ ]+)_([^ ]+)_([^ ]+) - NO UCE *$">
     <description>Critical Path (aka InScribe) Messaging Server

--- a/xml/smtp_ehlo.xml
+++ b/xml/smtp_ehlo.xml
@@ -14,9 +14,9 @@
          Cisco PIX changes the command letters to 'X' before passing
          them to the real SMTP server.
       </description>
-    <param pos="0" name="service.vendor" value="Cisco"/>
-    <param pos="0" name="service.family" value="PIX"/>
-    <param pos="0" name="service.product" value="PIX"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="PIX"/>
+    <param pos="0" name="os.product" value="PIX"/>
   </fingerprint>
   <!--
    Don't try to infer a fingerprint from XEXCH50, because if we do, it might overwrite

--- a/xml/smtp_expn.xml
+++ b/xml/smtp_expn.xml
@@ -14,9 +14,9 @@
          Cisco PIX changes the command letters to 'X' before passing
          them to the real SMTP server.
       </description>
-    <param pos="0" name="service.vendor" value="Cisco"/>
-    <param pos="0" name="service.family" value="PIX"/>
-    <param pos="0" name="service.product" value="PIX"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="PIX"/>
+    <param pos="0" name="os.product" value="PIX"/>
   </fingerprint>
   <fingerprint pattern="^550[ -]EXPN not available to \(.+\) \[.+\] *$">
     <description>

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -33,9 +33,9 @@
          Cisco PIX changes the command letters to 'X' before passing
          them to the real SMTP server.
       </description>
-    <param pos="0" name="service.vendor" value="Cisco"/>
-    <param pos="0" name="service.family" value="PIX"/>
-    <param pos="0" name="service.product" value="PIX"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="PIX"/>
+    <param pos="0" name="os.product" value="PIX"/>
   </fingerprint>
   <fingerprint pattern="^500[ -]5.5.1 unrecognised command HELP$">
     <description>

--- a/xml/smtp_vrfy.xml
+++ b/xml/smtp_vrfy.xml
@@ -14,9 +14,9 @@
          Cisco PIX changes the command letters to 'X' before passing
          them to the real SMTP server.
       </description>
-    <param pos="0" name="service.vendor" value="Cisco"/>
-    <param pos="0" name="service.family" value="PIX"/>
-    <param pos="0" name="service.product" value="PIX"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="PIX"/>
+    <param pos="0" name="os.product" value="PIX"/>
   </fingerprint>
   <!-- XXX: Why is EXPN mentionned here ? Is this a mistake ? -->
   <fingerprint pattern="^550[ -]EXPN not available *$">


### PR DESCRIPTION
The original code from which these recog fingerprints were derived expects Cisco PIX fingerprints to be for OS rather than service, which aligns with what is done in CPE.  Why these were done with service looks like to be an oversight.