### PR TITLE
Correct F5 fingerprints

### DIFF
--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -119,7 +119,7 @@
       </description>
     <param pos="1" name="cookie"/>
     <param pos="2" name="loadbalancer.poolname"/>
-    <param pos="0" name="service.vendor" value="F5 Labs"/>
+    <param pos="0" name="service.vendor" value="F5"/>
     <param pos="0" name="service.family" value="BIG-IP"/>
     <param pos="0" name="service.product" value="BIG-IP LTM"/>
   </fingerprint>
@@ -129,7 +129,7 @@
       http://www.f5.com/solutions/deployment/pdfs/SAP_v94_dg.pdf
       </description>
     <param pos="1" name="cookie"/>
-    <param pos="0" name="service.vendor" value="F5 Labs"/>
+    <param pos="0" name="service.vendor" value="F5"/>
     <param pos="0" name="service.family" value="BIG-IP"/>
     <param pos="0" name="service.product" value="BIG-IP LTM"/>
   </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2536,12 +2536,8 @@
   <fingerprint pattern="^(?:BigIP|BIG-IP)$">
     <description>F5 BIG-IP</description>
     <param pos="0" name="service.vendor" value="F5"/>
-    <param pos="0" name="service.product" value="BIG-IP"/>
+    <param pos="0" name="service.product" value="BIG-IP LTM"/>
     <param pos="0" name="service.family" value="BIG-IP"/>
-    <param pos="0" name="os.vendor" value="F5"/>
-    <param pos="0" name="os.device" value="Load balancer"/>
-    <param pos="0" name="os.family" value="BIG-IP"/>
-    <param pos="0" name="os.product" value="BIG-IP"/>
   </fingerprint>
   <fingerprint pattern="^Foundry Networks(?:/(\d+\.\d+))?$">
     <description>Foundry Networks device (though not sure which)</description>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2535,10 +2535,10 @@
   </fingerprint>
   <fingerprint pattern="^(?:BigIP|BIG-IP)$">
     <description>F5 BIG-IP</description>
-    <param pos="0" name="service.vendor" value="F5 Labs"/>
+    <param pos="0" name="service.vendor" value="F5"/>
     <param pos="0" name="service.product" value="BIG-IP"/>
     <param pos="0" name="service.family" value="BIG-IP"/>
-    <param pos="0" name="os.vendor" value="F5 Labs"/>
+    <param pos="0" name="os.vendor" value="F5"/>
     <param pos="0" name="os.device" value="Load balancer"/>
     <param pos="0" name="os.family" value="BIG-IP"/>
     <param pos="0" name="os.product" value="BIG-IP"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -287,8 +287,9 @@
   <fingerprint pattern="^.*(?:Basic|Digest) .*realm=&quot;BIG-IP&quot;.*$">
     <description>Generic F5 Big-IP</description>
     <example>Basic realm="BIG-IP"</example>
-    <param pos="0" name="os.vendor" value="F5"/>
-    <param pos="0" name="os.product" value="BIG-IP"/>
+    <param pos="0" name="servicevendor" value="F5"/>
+    <param pos="0" name="service.family" value="BIG-IP"/>
+    <param pos="0" name="service.product" value="BIG-IP LTM"/>
   </fingerprint>
   <!-- HP ProCurve -->
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(?:HP|ProCurve) (J[3]\d{3}A)&quot;$" flags="REG_ICASE">

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -1152,10 +1152,9 @@
       clock=0xd20533b8.903aa79b, state=1, offset=0.000, frequency=0.000,
       jitter=0.015, stability=0.000
     </example>
-    <param pos="0" name="service.family" value="NTP"/>
-    <param pos="0" name="service.product" value="NTP"/>
-    <param pos="0" name="os.vendor" value="F5"/>
-    <param pos="0" name="os.product" value="BIG-IP"/>
+    <param pos="0" name="service.vendor" value="F5"/>
+    <param pos="0" name="service.family" value="BIG-IP"/>
+    <param pos="0" name="service.product" value="BIG-IP LTM"/>
     <param pos="1" name="service.version"/>
     <param pos="2" name="os.arch"/>
     <param pos="3" name="os.version"/>


### PR DESCRIPTION
In other fingerprints the vendor is F5, which is more correct.  This makes the vendor name consistent.

This also uses the BIG-IP family and BIG-IP LTM product consistently, and corrects a handful of `os` fingerprints that should be `service`.