### PR TITLE
Banner update: HTTP - 2018.08.13

### DIFF
--- a/remap.json
+++ b/remap.json
@@ -10,6 +10,7 @@
         "weblogic": "weblogic_server"
       }
     },
+    {"r7_vendor": "blue_coat", "cpe_vendor": "bluecoat"},
     {"r7_vendor": "centos", "cpe_vendor": "centos", "products":
       {
         "linux": "centos"
@@ -92,6 +93,7 @@
       }
     },
     {"r7_vendor": "proftpd_project", "cpe_vendor": "proftpd"},
+    {"r7_vendor": "realvnc_ltd.", "cpe_vendor": "realvnc"},
     {"r7_vendor": "red_hat", "cpe_vendor": "redhat", "products":
       {
         "cygwin_x_server_project": "cygwin",

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -10,20 +10,20 @@
     <example>Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.component.vendor" value="Red Hat"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:redhat:stronghold:{service.component.version}"/>
     <param pos="0" name="service.component.product" value="Stronghold"/>
     <param pos="0" name="service.component.family" value="Stronghold"/>
     <param pos="1" name="service.component.version"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:redhat:stronghold:{service.component.version}"/>
     <param pos="3" name="apache.info"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:linux:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:linux:-"/>
   </fingerprint>
   <fingerprint pattern="^Apache/\d$" flags="REG_ICASE">
     <description>Apache returning only its major version number</description>
@@ -31,8 +31,8 @@
     <example>Apache/2</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
+    <param pos="0" name="service.family" value="Apache"/>
   </fingerprint>
   <fingerprint pattern="^Apache$" flags="REG_ICASE">
     <description>Apache returning no version information</description>
@@ -40,8 +40,8 @@
     <example>apache</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
+    <param pos="0" name="service.family" value="Apache"/>
   </fingerprint>
   <fingerprint pattern="^Apache(?:-AdvancedExtranetServer)?(?:/([012][\d.]*)\s*(.*))?$" flags="REG_ICASE">
     <description>Apache</description>
@@ -1462,9 +1462,9 @@
     <example>APACHE/1.3.9</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
   </fingerprint>
   <fingerprint pattern="^Check Point SVN foundation$">
@@ -1472,142 +1472,147 @@
     <example>Check Point SVN foundation</example>
     <param pos="0" name="service.vendor" value="Check Point"/>
     <param pos="0" name="service.product" value="Firewall-1"/>
-    <param pos="0" name="service.family" value="Firewall-1"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:checkpoint:firewall-1:-"/>
+    <param pos="0" name="service.family" value="Firewall-1"/>
     <param pos="0" name="os.vendor" value="Check Point"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:checkpoint:gaia_os:-"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="Firewall-1"/>
-    <param pos="0" name="os.product" value="Firewall-1"/>
+    <param pos="0" name="os.product" value="GAiA OS"/>
+    <param pos="0" name="hw.vendor" value="Check Point"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.family" value="Firewall-1"/>
+    <param pos="0" name="hw.product" value="Firewall-1"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/([1234]\.0)$">
     <description>Microsoft IIS 1.0 - 4.0 runs on Windows NT 4.0</description>
     <example>Microsoft-IIS/4.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_nt:4.0"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows NT"/>
     <param pos="0" name="os.version" value="4.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_nt:4.0"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/5.0$">
     <description>Microsoft IIS 5.0 runs on Windows 2000</description>
     <example>Microsoft-IIS/5.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_2000:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_2000:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/5.1$">
     <description>Microsoft IIS 5.1 runs on Windows XP</description>
     <example>Microsoft-IIS/5.1</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.1"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.1"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.1"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_xp:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_xp:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/6.0$">
     <description>Microsoft IIS 6.0 runs on Windows Server 2003 (and Windows XP x64)</description>
     <example>Microsoft-IIS/6.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:6.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="6.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:6.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2003:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2003:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/7.0$">
     <description>Microsoft IIS 7.0 runs on Windows Server 2008 (and Windows Vista)</description>
     <example>Microsoft-IIS/7.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="7.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/7.5$">
     <description>Microsoft IIS 7.5 runs on Windows Server 2008 R2 (and Windows 7)</description>
     <example>Microsoft-IIS/7.5</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.5"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="7.5"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.5"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/8.0$">
     <description>Microsoft IIS 8.0 runs on Windows Server 2012 (and Windows 8)</description>
     <example>Microsoft-IIS/8.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="8.0"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/8.5$">
     <description>Microsoft IIS 8.5 runs on Windows Server 2012 R2 (and Windows 8.1)</description>
     <example>Microsoft-IIS/8.5</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.5"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="8.5"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.5"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/([\d\.]+)$">
     <description>Microsoft IIS new, unknown version</description>
     <example>Microsoft-IIS/9.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS$">
     <description>Microsoft IIS, no version information</description>
     <example>Microsoft-IIS</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
+    <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -1623,10 +1628,10 @@
     <param pos="0" name="service.component.family" value=".NET"/>
     <param pos="1" name="service.component.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-WinCE/(\d\.\d+)$">
     <description>Windows CE embedded devices, including HP iPAQ,
@@ -1643,8 +1648,8 @@
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows CE"/>
-    <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_ce:{os.version}"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-PWS/(\d\.\d+)$">
     <description>Microsoft Personal Web Server runs on Windows 9x, ME, etc.</description>
@@ -1652,13 +1657,13 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="PWS"/>
     <param pos="0" name="service.product" value="PWS"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:personal_web_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-PWS-95/(\d\.\d+)$">
     <description>Microsoft Personal Web Server for Windows 95</description>
@@ -1666,13 +1671,13 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="PWS"/>
     <param pos="0" name="service.product" value="PWS"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:personal_web_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_95:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 95"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_95:-"/>
   </fingerprint>
   <fingerprint pattern="^Apache[ -]Coyote/(\d\.\d)$">
     <description>HTTP connector for Apache Tomcat to run as a standalone
@@ -1681,8 +1686,8 @@
     <example>Apache Coyote/1.0</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
-    <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:-"/>
+    <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
     <param pos="0" name="service.component.product" value="Coyote"/>
     <param pos="0" name="service.component.family" value="Coyote"/>
@@ -1693,26 +1698,26 @@
     <example service.version="4.0.4.GA" service.component.version="5.5">Servlet 2.4; JBoss-4.0.4.GA (build: CVSTag=JBoss_4_0_4_GA date=200605151000)/Tomcat-5.5</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
+    <param pos="1" name="service.version"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
     <param pos="0" name="service.component.product" value="Tomcat"/>
     <param pos="0" name="service.component.family" value="Tomcat"/>
     <param pos="2" name="service.component.version"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
   </fingerprint>
   <fingerprint pattern="^Servlet [\d\.]+; Tomcat-(\S+)/JBoss-(\S+) \(build: .*\)$">
     <description>JBoss with embedded tomcat</description>
     <example service.version="4.0.1sp1" service.component.version="5.0.28">Servlet 2.4; Tomcat-5.0.28/JBoss-4.0.1sp1 (build: CVSTag=JBoss_4_0_1_SP1 date=200502160314)</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="2" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
+    <param pos="2" name="service.version"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
     <param pos="0" name="service.component.product" value="Tomcat"/>
     <param pos="0" name="service.component.family" value="Tomcat"/>
     <param pos="1" name="service.component.version"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
   </fingerprint>
   <fingerprint pattern="^Servlet [\d\.]+; JBoss-([\S]+)(?: \(build.*)?/JBossWeb-(\S+)$">
     <description>JBoss with JBossweb</description>
@@ -1720,8 +1725,8 @@
     <example service.version="5.0" service.component.version="2.1">Servlet 2.5; JBoss-5.0/JBossWeb-2.1</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
+    <param pos="1" name="service.version"/>
     <param pos="0" name="service.component.vendor" value="RedHat"/>
     <param pos="0" name="service.component.product" value="JBossWeb"/>
     <param pos="2" name="service.component.version"/>
@@ -1731,8 +1736,8 @@
     <example service.version="6">Servlet/3.0; JBossAS-6</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss AS"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_wildfly_application_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^JBoss-EAP\/(\d+)$">
     <description>JBoss EAP</description>
@@ -1740,8 +1745,8 @@
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.family" value="JBoss"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Apache Tomcat/(\d\.[\d.]+)(?:-LE-jdk14)? \(HTTP/1.1 Connector\)$">
     <description>HTTP connector for Apache Tomcat to run as a standalone
@@ -1752,8 +1757,8 @@
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="0" name="service.product" value="Tomcat"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
+    <param pos="1" name="service.version"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
     <param pos="0" name="service.component.family" value="Apache Tomcat HTTP Connector"/>
     <param pos="0" name="service.component.product" value="Apache Tomcat HTTP Connector"/>
@@ -1767,9 +1772,9 @@
     <example>Tomcat Web Server/3.3.1 Final ( JSP 1.1; Servlet 2.2 )</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="2" name="tomcat.info"/>
   </fingerprint>
   <fingerprint pattern="^Tomcat/(\S+)$">
@@ -1777,9 +1782,9 @@
     <example>Tomcat/2.1</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^PHP/(\S+)$">
     <description>PHP</description>
@@ -1815,9 +1820,9 @@
     <example>Oracle Application Server/10g (10.1.2) Apache/1.3.34 (Unix) mod_perl/1.29 mod_jk/1.2.14 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=119642322340,0)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="3" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
     <param pos="1" name="apache.variant.version"/>
@@ -1833,8 +1838,8 @@
     <example>Oracle-Application-Server-10g/9.0.4.1.0 Oracle-HTTP-Server</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
+    <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
     <param pos="1" name="apache.variant.version"/>
@@ -1845,8 +1850,8 @@
     <example>Oracle9iAS/9.0.3.1 Oracle HTTP Server Oracle9iAS-Web-Cache/9.0.3.1.0 (N)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
+    <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
     <param pos="1" name="apache.variant.version"/>
@@ -1858,9 +1863,9 @@
     <example>Oracle HTTP Server Powered by Apache/1.3.19 (Win32) mod_ssl/2.8.1 OpenSSL/0.9.5a mod_fastcgi/2.2.10 mod_oprocmgr/1.0 mod_perl/1.25</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
   </fingerprint>
@@ -1869,8 +1874,8 @@
     <example>Oracle HTTP Server Powered by Apache</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
+    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
   </fingerprint>
   <fingerprint pattern="^HP Apache-based Web Server/([012][\d.]*)\s*\(Unix\)\s*(.*)$">
@@ -1879,16 +1884,16 @@
     <example>HP Apache-based Web Server/1.3.26 (Unix)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="HP-UX"/>
     <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:hp-ux:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="HP-UX"/>
     <param pos="0" name="os.product" value="HP-UX"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:hp:hp-ux:-"/>
   </fingerprint>
   <fingerprint pattern="^CompaqHTTPServer/([0-9.]*)(?: HP System Management Homepage(?:/.*)?)?$">
     <description>HP/Compaq HTTP Server</description>
@@ -1993,15 +1998,110 @@
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="TippingPoint"/>
     <param pos="0" name="os.device" value="IPS"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="TippingPoint"/>
+    <param pos="0" name="hw.device" value="IPS"/>
+  </fingerprint>
+  <fingerprint pattern="^uc-httpd[ \/]([\d.]+)$">
+    <description>Xiongmai Tech uc-httpd</description>
+    <example service.version="1.0.0">uc-httpd 1.0.0</example>
+    <example service.version="1.0.0">uc-httpd/1.0.0</example>
+    <param pos="0" name="service.vendor" value="Xiongmai Tech"/>
+    <param pos="0" name="service.product" value="uc-httpd"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^micro_httpd$">
+    <description>ACME micro_httpd</description>
+    <example>micro_httpd</example>
+    <param pos="0" name="service.vendor" value="ACME"/>
+    <param pos="0" name="service.product" value="micro_httpd"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:acme:micro_httpd:-"/>
+  </fingerprint>
+  <fingerprint pattern="^mini_httpd$">
+    <description>ACME mini_httpd</description>
+    <example>mini_httpd</example>
+    <param pos="0" name="service.vendor" value="ACME"/>
+    <param pos="0" name="service.product" value="mini_httpd"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:acme:mini_httpd:-"/>
+  </fingerprint>
+  <fingerprint pattern="^LiteSpeed\/?(:?[\d.]+)?(?: \S+)?">
+    <description>LiteSpeed</description>
+    <example>LiteSpeed</example>
+    <example>LiteSpeed/5.2.8 Enterprise</example>
+    <param pos="0" name="service.vendor" value="LiteSpeed Technologies"/>
+    <param pos="0" name="service.product" value="LiteSpeed Web Server"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^IdeaWebServer\/v?([\d.]+)$">
+    <description>Idea Web Server</description>
+    <example>IdeaWebServer/0.83</example>
+    <example service.version="0.83.74">IdeaWebServer/0.83.74</example>
+    <example service.version="0.70">IdeaWebServer/v0.70</example>
+    <param pos="0" name="service.vendor" value="home.pl"/>
+    <param pos="0" name="service.product" value="Idea Web Server"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^openresty\/?(:?[\d.]+)?$">
+    <description>OpenResty OpenResty</description>
+    <example>openresty</example>
+    <example service.version="1.13.6.2">openresty/1.13.6.2</example>
+    <param pos="0" name="service.vendor" value="OpenResty"/>
+    <param pos="0" name="service.product" value="OpenResty"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^gunicorn\/([\d.]+)+$">
+    <description>Gunicorn Gunicorn</description>
+    <example service.version="19.7.1">gunicorn/19.7.1</example>
+    <param pos="0" name="service.vendor" value="Gunicorn"/>
+    <param pos="0" name="service.product" value="Gunicorn"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Serv-U\/([\d.]+)$">
+    <description>Serv-U HTTP interface</description>
+    <example service.version="15.1.6.31">Serv-U/15.1.6.31</example>
+    <param pos="0" name="service.vendor" value="SolarWinds"/>
+    <param pos="0" name="service.family" value="Serv-U"/>
+    <param pos="0" name="service.product" value="FTP Server"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Varnish(?:[- ]Cache)?$">
+    <description>Varnish Cache</description>
+    <example>Varnish</example>
+    <example>Varnish-Cache</example>
+    <param pos="0" name="service.vendor" value="Varnish-cache"/>
+    <param pos="0" name="service.family" value="Varnish"/>
+    <param pos="0" name="service.product" value="Varnish"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:varnish-cache:varnish:-"/>
+  </fingerprint>
+  <fingerprint pattern="^Tengine\/?(:?[\d.]+)?$">
+    <description>Tengine</description>
+    <example>Tengine</example>
+    <example service.version="2.0.0">Tengine/2.0.0</example>
+    <param pos="0" name="service.vendor" value="Taobao"/>
+    <param pos="0" name="service.family" value="Tengine"/>
+    <param pos="0" name="service.product" value="Tengine"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Mikrotik HttpProxy$">
+    <description>MikroTik RouterOS - Proxy service</description>
+    <example>Mikrotik HttpProxy</example>
+    <param pos="0" name="service.vendor" value="MikroTik"/>
+    <param pos="0" name="service.product" value="HttpProxy"/>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:mikrotik:routeros:-"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+    <param pos="0" name="hw.vendor" value="MikroTik"/>
+    <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>
   <fingerprint pattern="^Helix Server Version ([0-9.]*) \(win32\) \(RealServer compatible\)$">
     <description>RealMedia Helix Server</description>
     <example>Helix Server Version 9.0.4.960 (win32) (RealServer compatible)</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="service.vendor" value="RealMedia"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="Helix Server"/>
@@ -2021,10 +2121,10 @@
     <description>Windows Media Services (older versions)</description>
     <example>Cougar/9.01.01.3841</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="Windows Media Services"/>
@@ -2034,10 +2134,10 @@
     <description>Windows Media Services (newer versions)</description>
     <example>WMServer/9.1.1.3841</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="Windows Media Services"/>
@@ -2047,20 +2147,20 @@
     <description>Generic Microsoft HTTP service</description>
     <example>Microsoft-HTTPAPI/2.0</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^ASP.NET$">
     <description>Something written in ASP.NET</description>
     <example>ASP.NET</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="os.certainty" value="0.6"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^[Xx]itami$">
     <description>Xitami web server</description>
@@ -2073,16 +2173,20 @@
     <description>Bosch VCS VIDOS-NVR network video recorder</description>
     <example>VCS-VIDOS-NVR</example>
     <param pos="0" name="os.vendor" value="Bosch"/>
-    <param pos="0" name="os.device" value="Video"/>
+    <param pos="0" name="os.device" value="DVR"/>
     <param pos="0" name="os.product" value="VIDOS-NVR"/>
+    <param pos="0" name="hw.vendor" value="Bosch"/>
+    <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
   <fingerprint pattern="^HeiTel GmbH Web Server \[\S+\]$">
     <description>HeiTel Digital Video Recorder</description>
     <example>HeiTel GmbH Web Server [V1.15/V1.14/V1.3]</example>
     <example>HeiTel GmbH Web Server [V1.26/V1.15/V1.7]</example>
     <param pos="0" name="os.vendor" value="HeiTel"/>
-    <param pos="0" name="os.device" value="Video"/>
+    <param pos="0" name="os.device" value="DVR"/>
     <param pos="0" name="os.product" value="Unknown"/>
+    <param pos="0" name="hw.vendor" value="HeiTel"/>
+    <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
   <fingerprint pattern="^MiniServ/([0-9.]*)$">
     <description>mini_httpd</description>
@@ -2096,8 +2200,8 @@
     <example>IBM HTTP Server/V5R3M0</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="HTTP Server"/>
-    <param pos="0" name="service.family" value="HTTP Server"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:ibm:http_server:-"/>
+    <param pos="0" name="service.family" value="HTTP Server"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.device" value="General"/>
@@ -2119,9 +2223,9 @@
     <example>IBM_HTTP_Server/6.1 Apache/2.0.47 (Win32) PHP/5.1.1</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="3" name="apache.info"/>
     <param pos="0" name="apache.variant" value="IBM"/>
     <param pos="1" name="apache.variant.version"/>
@@ -2132,8 +2236,8 @@
     <example>IBM_HTTP_Server/7.0.0.9 (Unix)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
+    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="apache.variant" value="IBM"/>
     <param pos="1" name="apache.variant.version"/>
   </fingerprint>
@@ -2143,8 +2247,8 @@
     <example>IBM_HTTP_Server</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
+    <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="apache.variant" value="IBM"/>
   </fingerprint>
   <!--
@@ -2157,8 +2261,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Application Server"/>
     <param pos="0" name="service.product" value="Java System Application Server"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_application_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Sun[ -]Java[ -]System[ /]Application[ -]Server Platform Edition( \d\.[\d_]+)?$">
     <description>Sun Java System Application Server (formerly iPlanet Application Server,
@@ -2195,8 +2299,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Server"/>
     <param pos="0" name="service.product" value="Java System Web Server"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^(?:Sun-Java-System-Web-Server|Sun-ONE-Web-Server)/(?:\d\.[\d_]+)$">
     <description>Sun Java System Web Server (formerly Netscape Enterprise Server, iPlanet Web
@@ -2229,8 +2333,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Sun-ONE-Web-Proxy-Server/(.*)$">
     <description>Sun ONE WebProxy Server (formerly iPlanet WebProxy Server,
@@ -2239,8 +2343,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/([^.]+\.[^.]+\.[^.]+)$">
     <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server,
@@ -2249,8 +2353,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/(?:4\.\d+)$">
     <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server,
@@ -2280,9 +2384,10 @@
     <example>HP-iLO-Server/1.30</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="iLO"/>
-    <param pos="0" name="service.family" value="iLO"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:hp:integrated_lights_out:-"/>
+    <param pos="0" name="service.family" value="iLO"/>
     <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.product" value="iLO"/>
     <param pos="0" name="os.family" value="iLO"/>
@@ -2300,9 +2405,9 @@
     <example>Jetty/5.1.10 (Linux/2.6.12 i386 java/1.5.0_05)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="2" name="jetty.info"/>
   </fingerprint>
   <!-- Catch-all for Jetty versions using the Jetty/version format. -->
@@ -2311,18 +2416,18 @@
     <example>Jetty/4.2.x (VxWorks/WIND version 2.9 ppc java/1.1-rr-std-b12)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Jetty\((\S+)\)$">
     <description>Mort Bay Jetty</description>
     <example>Jetty(6.1.7)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^[Ss]quid/(\d+\.[\w.]+)$">
     <description>Squid Web </description>
@@ -2362,23 +2467,25 @@
     <param pos="0" name="service.family" value="lighttpd"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^nginx/(\S+)">
-    <description>nginx with version info</description>
-    <example>nginx/0.8.53 + Phusion Passenger 3.0.0 (mod_rails/mod_rack)</example>
-    <example>nginx/0.8.53</example>
-    <param pos="0" name="service.product" value="nginx"/>
-    <param pos="0" name="service.family" value="nginx"/>
-    <param pos="0" name="service.vendor" value="nginx"/>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:{service.version}"/>
-  </fingerprint>
   <fingerprint pattern="^nginx$">
     <description>nginx without version info</description>
     <example>nginx</example>
     <param pos="0" name="service.product" value="nginx"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
+  </fingerprint>
+  <fingerprint pattern="^nginx\/?(:?[\d.]+)?">
+    <description>nginx with version info and/or mods</description>
+    <example service.version="0.8.53">nginx/0.8.53 + Phusion Passenger 3.0.0 (mod_rails/mod_rack)</example>
+    <example>nginx/0.8.53</example>
+    <example>nginx + Phusion Passenger 5.1.11</example>
+    <example>nginx + Phusion Passenger</example>
+    <param pos="0" name="service.product" value="nginx"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:{service.version}"/>
+    <param pos="0" name="service.family" value="nginx"/>
+    <param pos="0" name="service.vendor" value="nginx"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Lotus(?:-Domino)?(?:/|/0|/Release)?$">
     <description>IBM Lotus Notes/Domino with no useful version info</description>
@@ -2388,8 +2495,8 @@
     <example>Lotus-Domino/Release</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
-    <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:-"/>
+    <param pos="0" name="service.family" value="Lotus Domino"/>
   </fingerprint>
   <fingerprint pattern="^Lotus(?:-Domino)?/(?:Release-?)?([4-7][\d.]+)\s*(?:.*)$">
     <description>IBM Lotus Notes/Domino with version info</description>
@@ -2397,9 +2504,9 @@
     <example>Lotus-Domino/Release-4.6.7(Intl)</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:{service.version}"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^WebLogic (?:WebLogic )?Server (\d+\.\d+(?:\s+SP\d+)?)\s+.*$">
     <description>BEA WebLogic</description>
@@ -2408,9 +2515,9 @@
     <example>WebLogic WebLogic Server 6.1 SP4  11/08/2002 21:50:43 #221641</example>
     <param pos="0" name="service.vendor" value="BEA"/>
     <param pos="0" name="service.product" value="WebLogic"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:bea:weblogic_server:{service.version}"/>
     <param pos="0" name="service.family" value="WebLogic"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:bea:weblogic_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^WebSphere Application Server/(\d+\.\d+)$">
     <description>IBM WebSphere</description>
@@ -2428,9 +2535,9 @@
     <example>Resin/2.1.s030827</example>
     <param pos="0" name="service.vendor" value="Caucho"/>
     <param pos="0" name="service.product" value="Resin"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:caucho:resin:{service.version}"/>
     <param pos="0" name="service.family" value="Resin"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:caucho:resin:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Ipswitch-IMail/(\d\.\d+)$">
     <description>Ipswitch IMail Server</description>
@@ -2439,14 +2546,14 @@
     <example>Ipswitch-IMail/8.05</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="0" name="service.product" value="IMail Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ipswitch:imail_server:{service.version}"/>
     <param pos="0" name="service.family" value="IMail Server"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:ipswitch:imail_server:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Abyss/(\d\.[\d.]+)-X1-Win32 AbyssLib/(?:\d\.[\d.]+)$">
     <description>Aprelium Technologies Abyss Web Server X1
@@ -2458,10 +2565,10 @@
     <param pos="0" name="service.family" value="Abyss Web Server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Abyss/(\d\.[\d.]+)-X2-Win32 AbyssLib/(?:\d\.[\d.]+)$">
     <description>Aprelium Technologies Abyss Web Server X2
@@ -2471,10 +2578,10 @@
     <param pos="0" name="service.family" value="Abyss Web Server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft (Commerce Server\s*(?:2002|2007)?, (?:Enterprise|Standard|Evaluation|Developer) Edition)$">
     <description>Microsoft Commerce Server</description>
@@ -2482,25 +2589,25 @@
     <param pos="1" name="service.product"/>
     <param pos="0" name="service.family" value="Commerce Server"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^NetWare-Enterprise-Web-Server/(\d+\.\d+)$">
     <description>NetWare Enterprise Web Server (runs on NetWare 5.1)</description>
     <param pos="0" name="service.vendor" value="Novell"/>
     <param pos="0" name="service.product" value="NetWare Enterprise Web Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:novell:netware_enterprise_web_server:{service.version}"/>
     <param pos="0" name="service.family" value="NetWare Enterprise Web Server"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:novell:netware_enterprise_web_server:{service.version}"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="Novell"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
-    <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:{os.version}"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^NetWare HTTP Stack$">
     <description>NetWare HTTP stack (runs on 6.0 and 6.5)</description>
@@ -2508,10 +2615,10 @@
     <param pos="0" name="service.product" value="NetWare HTTP Stack"/>
     <param pos="0" name="service.family" value="NetWare HTTP Stack"/>
     <param pos="0" name="os.vendor" value="Novell"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:-"/>
   </fingerprint>
   <fingerprint pattern="^Novell-HTTP-Server/3.1R1$">
     <description>NetWare HTTP Server (runs on NetWare 4.11)</description>
@@ -2524,8 +2631,8 @@
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
-    <param pos="0" name="os.version" value="4.11"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:4.11"/>
+    <param pos="0" name="os.version" value="4.11"/>
   </fingerprint>
   <fingerprint pattern="^Novell-HTTP-Server/2.51R1$">
     <description>NetWare HTTP Server (runs on NetWare 4.1)</description>
@@ -2538,24 +2645,24 @@
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
-    <param pos="0" name="os.version" value="4.1"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:4.1"/>
+    <param pos="0" name="os.version" value="4.1"/>
   </fingerprint>
   <fingerprint pattern="^Netscape-FastTrack/(\d+\.[\w\s.]+)$">
     <description>Netscape FastTrack Server</description>
     <param pos="0" name="service.vendor" value="Netscape"/>
     <param pos="0" name="service.product" value="FastTrack Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:fasttrack_server:{service.version}"/>
     <param pos="0" name="service.family" value="FastTrack Server"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:fasttrack_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Netscape-Commerce/(\d+\.[\w\s.]+)$">
     <description>Netscape Commerce Server</description>
     <param pos="0" name="service.vendor" value="Netscape"/>
     <param pos="0" name="service.product" value="Commerce Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:commerce_server:{service.version}"/>
     <param pos="0" name="service.family" value="Commerce Server"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:commerce_server:{service.version}"/>
   </fingerprint>
   <!--
       TODO
@@ -2579,6 +2686,8 @@
     <param pos="0" name="os.device" value="VPN"/>
     <param pos="0" name="os.family" value="SSL-VPN"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="SonicWALL"/>
+    <param pos="0" name="hw.device" value="VPN"/>
   </fingerprint>
   <fingerprint pattern="^SonicWALL$">
     <description>SonicWALL device</description>
@@ -2614,9 +2723,9 @@
     <param pos="0" name="os.vendor" value="NetApp"/>
     <param pos="0" name="os.family" value="Data ONTAP"/>
     <param pos="0" name="os.product" value="Data ONTAP"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:netapp:data_ontap:{os.version}"/>
     <param pos="0" name="os.device" value="File server"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:netapp:data_ontap:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^BlueCoat-Security-Appliance$">
     <description>Blue Coat security appliance</description>
@@ -2630,8 +2739,10 @@
     <description>F5 BIG-IP</description>
     <param pos="0" name="service.vendor" value="F5"/>
     <param pos="0" name="service.product" value="BIG-IP LTM"/>
-    <param pos="0" name="service.family" value="BIG-IP"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:f5:big-ip_local_traffic_manager:-"/>
+    <param pos="0" name="service.family" value="BIG-IP"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
   <fingerprint pattern="^Foundry Networks(?:/(\d+\.\d+))?$">
     <description>Foundry Networks device (though not sure which)</description>
@@ -2653,6 +2764,10 @@
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="JetDirect"/>
     <param pos="0" name="os.product" value="JetDirect"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="JetDirect"/>
+    <param pos="0" name="hw.product" value="JetDirect"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^HP HTTP Server; (?:Hewlett-Packard )?HP ((\S+) \S+)">
     <description>HP Printer</description>
@@ -2666,6 +2781,10 @@
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="2" name="os.family"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="JetDirect"/>
+    <param pos="0" name="hw.product" value="JetDirect"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^HTTP/1\.0$">
     <description>Old HP printers identify themselves as "HTTP/1.0"</description>
@@ -2676,6 +2795,10 @@
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="JetDirect"/>
     <param pos="0" name="os.product" value="JetDirect"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="JetDirect"/>
+    <param pos="0" name="hw.product" value="JetDirect"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^(?:Allegro-Software-)?RomPager/\s*(\S+)">
     <description>Embedded HTTP server used by many vendors and device
@@ -2700,20 +2823,24 @@
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="RT"/>
     <param pos="0" name="os.product" value="RT"/>
+    <param pos="0" name="hw.vendor" value="Yamaha"/>
+    <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>
   <fingerprint pattern="^(?:Canon Http|CANON HTTP) Server (?:Ver)?(?:\d+\.\d+)$">
-    <description>Canon device running embedded web server, though
-      not sure if this is a printer or network camera</description>
+    <description>Canon Multifunction Printer/Copiers</description>
     <param pos="0" name="service.vendor" value="Canon"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="os.vendor" value="Canon"/>
-    <param pos="0" name="os.product" value="Unknown"/>
+    <param pos="0" name="hw.vendor" value="Canon"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
   </fingerprint>
   <fingerprint pattern=".*Linksys.*">
     <description>Linksys Wireless Access Point</description>
     <param pos="0" name="os.vendor" value="Linksys"/>
     <param pos="0" name="os.product" value="Unknown"/>
     <param pos="0" name="os.device" value="WAP"/>
+    <param pos="0" name="hw.vendor" value="Linksys"/>
+    <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
   <fingerprint pattern="^cisco-IOS$">
     <description>Cisco IOS</description>
@@ -2723,10 +2850,11 @@
     <param pos="0" name="service.product" value="IOS"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:-"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
     <param pos="0" name="os.certainty" value="0.8"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:-"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
   </fingerprint>
   <fingerprint pattern="^cisco-IOS/([^\s]+) HTTP-server/.*$">
     <description>Cisco IOS with version information</description>
@@ -2736,10 +2864,11 @@
     <param pos="0" name="service.product" value="IOS"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:{os.version}"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
   </fingerprint>
   <fingerprint pattern="^Cisco AWARE (.*)$">
     <description>Cisco ASA</description>
@@ -2750,6 +2879,11 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="ASA"/>
     <param pos="0" name="os.product" value="VPN"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="ASA"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
+    <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
   </fingerprint>
   <fingerprint pattern="^DesktopAuthority/(.*)$">
     <description>ScriptLogic DesktopAuthority</description>
@@ -2758,16 +2892,16 @@
     <param pos="0" name="service.product" value="Desktop Authority"/>
     <param pos="0" name="service.family" value="Desktop Authority"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Agent-ListenServer-HttpSvr/.*$">
     <description>McAfee ePolicy Orchestrator</description>
     <param pos="0" name="service.vendor" value="McAfee"/>
     <param pos="0" name="service.product" value="ePolicy Orchestrator"/>
-    <param pos="0" name="service.family" value="ePolicy Orchestrator"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:mcafee:epolicy_orchestrator:-"/>
+    <param pos="0" name="service.family" value="ePolicy Orchestrator"/>
   </fingerprint>
   <fingerprint pattern="^EWS-NIC\d/(\S+)$">
     <description>Xerox Embedded Web Server (EWS)</description>
@@ -2781,6 +2915,8 @@
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.product" value="Unknown"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^Adaptec ASM (\S+)$">
     <description>Adaptec - Adaptec Storage Manager (runs on Windows Only)</description>
@@ -2789,9 +2925,9 @@
     <param pos="0" name="service.product" value="ASM"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^JRun Web Server$">
     <description>Macromedia (formerly Allaire) JRun</description>
@@ -2823,17 +2959,17 @@
     <description>Rumpus FTP Server, Web File Manager interface</description>
     <example>Rumpus</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
   </fingerprint>
   <fingerprint pattern="^servermgrd$">
     <description>Mac OS X Server administrative daemon</description>
     <example>servermgrd</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
   </fingerprint>
   <fingerprint pattern="^(RMC Webserver|RAC_ONE_HTTP) (\d\.\d)$">
     <description>Dell Remote Access Controller</description>
@@ -2851,6 +2987,10 @@
     <param pos="0" name="os.family" value="Document Centre"/>
     <param pos="0" name="os.product" value="Document Centre"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Document Centre"/>
+    <param pos="0" name="hw.product" value="Document Centre"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^TSM_HTTP/\d\.\d$">
     <description>IBM Tivoli Storage Manager</description>
@@ -2878,15 +3018,16 @@
     <param pos="0" name="service.product" value="TUX web server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linux"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:-"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:-"/>
   </fingerprint>
   <fingerprint pattern="^RealVNC/(?:\S+)$">
     <description>RealVNC built-in webserver</description>
     <example>RealVNC/4.0</example>
     <param pos="0" name="service.vendor" value="RealVNC Ltd."/>
     <param pos="0" name="service.product" value="RealVNC"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:realvnc:realvnc:-"/>
   </fingerprint>
   <fingerprint pattern="(Agranat|Conexant|(?:Globespan)?Virata)-EmWeb/(.*)$">
     <description>EmWeb variants</description>
@@ -2929,9 +3070,10 @@
     <description>Polycom Soundpoint IP Telephone</description>
     <example>Polycom SoundPoint IP Telephone HTTPd</example>
     <param pos="0" name="service.vendor" value="Polycom"/>
-    <param pos="0" name="service.product" value="SoundPoint"/>
-    <param pos="0" name="os.vendor" value="Polycom"/>
-    <param pos="0" name="os.product" value="SoundPoint"/>
+    <param pos="0" name="service.family" value="SoundPoint"/>
+    <param pos="0" name="hw.vendor" value="Polycom"/>
+    <param pos="0" name="hw.family" value="SoundPoint"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
   </fingerprint>
   <!-- 4D WebSTAR was aquired by Kerio but it seems that both
         Kerio and 4D have branched the product. The 4D banners
@@ -3000,15 +3142,16 @@
     <example>CherryPy/3</example>
     <param pos="0" name="service.vendor" value="CherryPy"/>
     <param pos="0" name="service.product" value="CherryPy"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cherrypy:cherrypy:{service.version}"/>
     <param pos="0" name="service.family" value="CherryPy"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cherrypy:cherrypy:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^TornadoServer/((?:\d+\.)*\d+)$" flags="REG_ICASE">
     <description>Tornado Python web framework and asynchronous networking library.</description>
     <example>TornadoServer/4.0.2</example>
-    <param pos="0" name="service.vendor" value="Tornado"/>
+    <param pos="0" name="service.vendor" value="TornadoWeb"/>
     <param pos="0" name="service.product" value="Tornado"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:tornadoweb:tornado:{service.version}"/>
     <param pos="0" name="service.family" value="Tornado"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -3028,10 +3171,10 @@
     <example>HP Web Jetadmin/2 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="apache.variant" value="HP Web Jetadmin"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
   </fingerprint>
   <fingerprint pattern="^HP Web Jetadmin ([\d\.]+)(?: \([^\)]+\))?$">
@@ -3040,8 +3183,8 @@
     <example service.version="10.3.91358">HP Web Jetadmin 10.3.91358 (10.3 SR5)</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="Web Jetadmin"/>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:hp:web_jetadmin:{service.version}"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Citrix Web PN Server$">
     <description>Citrix Web PN (Program Neighborhood) Server is an HTTP server used by Citrix products</description>
@@ -3059,31 +3202,48 @@
     <param pos="0" name="service.family" value="Lotus Expeditor"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^GoAhead-Webs$">
-    <description>An embedded web server developed by GoAhead Software, which was later acquired by Oracle.</description>
+  <!-- GoAhead software was acquired by Oracle in 2011. They later handed this
+       off to (E)Mbedthis. Version 3.0 released in October 2012 appears to be
+       the first version to fully be Mbedthis software.
+  -->
+  <fingerprint pattern="^GoAhead-(?:Webs|http)$">
+    <description>GoAhead-Webs - no version</description>
     <example>GoAhead-Webs</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
     <param pos="0" name="service.product" value="GoAhead Webserver"/>
     <param pos="0" name="service.family" value="GoAhead Webserver"/>
   </fingerprint>
-  <fingerprint pattern="^Mbedthis-Appweb/((?:\d+\.)*\d+)$">
-    <description>An embedded web server for hosting dynamic web applications.</description>
-    <example>Mbedthis-Appweb/2.4.0</example>
+  <fingerprint pattern="^GoAhead-(?:Webs|http)\/([\d.]+)(?: PeerSec-MatrixSSL\/[\d.]+-OPEN)?$">
+    <description>GoAhead-Webs - version</description>
+    <example service.version="2.5.0">GoAhead-Webs/2.5.0 PeerSec-MatrixSSL/3.4.2-OPEN</example>
+    <example>GoAhead-Webs/2.5.0</example>
+    <param pos="0" name="service.vendor" value="Oracle"/>
+    <param pos="0" name="service.product" value="GoAhead Webserver"/>
+    <param pos="0" name="service.family" value="GoAhead Webserver"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <!-- MBedthis changed its name/branding to Embedthis-->
+  <fingerprint pattern="^Mbedthis-App[Ww]eb/([\d.]+)$">
+    <description>Mbedthis Appweb</description>
+    <example service.version="2.4.0">Mbedthis-Appweb/2.4.0</example>
+    <example service.version="2.4.0">Mbedthis-AppWeb/2.4.0</example>
     <example>Mbedthis-Appweb/2.4.2</example>
     <example>Mbedthis-Appweb/2</example>
-    <param pos="0" name="service.vendor" value="Embedthis"/>
+    <param pos="0" name="service.vendor" value="Mbedthis Software"/>
     <param pos="0" name="service.product" value="Appweb"/>
     <param pos="0" name="service.family" value="Appweb"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:embedthis:appweb:{service.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Embedthis-http$">
-    <description>An embedded web server for hosting dynamic web applications.</description>
+  <fingerprint pattern="^Embedthis-(?:Appweb|http)\/?(:?[\d.]+)?$">
+    <description>Embedthis AppWeb</description>
+    <example service.version="3.2.3">Embedthis-Appweb/3.2.3</example>
     <example>Embedthis-http</example>
+    <example service.version="4.0.0">Embedthis-http/4.0.0</example>
     <param pos="0" name="service.vendor" value="Embedthis"/>
     <param pos="0" name="service.product" value="Appweb"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:embedthis:appweb:{service.version}"/>
     <param pos="0" name="service.family" value="Appweb"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:embedthis:appweb:-"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Avaya CMBE/((?:\d+\.)*\d+)$">
     <description>Web server for Avaya Aura Communication Manager Branch, a SIP-based communications platform.</description>
@@ -3122,14 +3282,16 @@
     <example>CUPS/1.1</example>
     <param pos="0" name="service.vendor" value="Apple"/>
     <param pos="0" name="service.product" value="CUPS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apple:cups:{service.version}"/>
     <param pos="0" name="service.family" value="CUPS"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apple:cups:{service.version}"/>
   </fingerprint>
-  <fingerprint pattern="^TwistedWeb/((?:\d\.)+\d+)$">
-    <description>An HTTP server, HTML templating engind, and HTTP client library from Twisted Labs.</description>
+  <fingerprint pattern="^TwistedWeb/([\d.rc]+)$">
+    <description>Twisted Matrix Labs - TwistedWeb</description>
     <example>TwistedWeb/2.5.0</example>
-    <param pos="0" name="service.vendor" value="Twisted Matrix Labs"/>
+    <example service.version="16.4.0">TwistedWeb/16.4.0</example>
+    <example service.version="16.5.0rc2">TwistedWeb/16.5.0rc2</example>
+    <param pos="0" name="service.vendor" value="TwistedMatrix"/>
     <param pos="0" name="service.product" value="Twisted Web"/>
     <param pos="0" name="service.family" value="Twisted Web"/>
     <param pos="1" name="service.version"/>
@@ -3157,9 +3319,9 @@
     <example>Avocent DSView 3/3</example>
     <param pos="0" name="service.vendor" value="Avocent"/>
     <param pos="0" name="service.product" value="DSView"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:avocent:dsview:{service.version}"/>
     <param pos="0" name="service.family" value="DSView"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:avocent:dsview:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Mongrel ((?:\d+\.)*\d+)$">
     <description>Ruby-based web server and HTTP library.</description>
@@ -3231,9 +3393,9 @@
     <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="service.product" value="PA Firewall"/>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
     <param pos="0" name="os.product" value="PA Firewall"/>
     <param pos="0" name="os.device" value="Firewall"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
   </fingerprint>
   <fingerprint pattern="^Ews/((?:\d+\.)*\d+)$">
     <description>IBM Network Printer Manager.</description>
@@ -3244,6 +3406,9 @@
     <param pos="0" name="service.family" value="Network Printer Manager"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
+  <!-- NOTE: '$ProjectRevision: {some version string} $' has been seen in a
+       variety of products including printers, PDUs, etc.
+  -->
   <fingerprint pattern="^\$ProjectRevision: 4.0.2.38 \$$">
     <description>This banner is seen on some HP LaserJet printers.</description>
     <example>$ProjectRevision: 4.0.2.38 $</example>
@@ -3282,6 +3447,7 @@
     <param pos="0" name="service.product" value="Cross Web Server"/>
     <param pos="0" name="os.vendor" value="HiSilicon"/>
     <param pos="0" name="os.device" value="DVR"/>
+    <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
   <!-- Hikvision is OEMd by a number of DVR manufacturers -->
   <fingerprint pattern="^(?:Hikvision|DVRDVS)-Webs$">
@@ -3292,6 +3458,16 @@
     <param pos="0" name="service.product" value="Hikvision Web Server"/>
     <param pos="0" name="os.vendor" value="Hikvision"/>
     <param pos="0" name="os.device" value="DVR"/>
+    <param pos="0" name="hw.device" value="DVR"/>
+  </fingerprint>
+  <fingerprint pattern="^DNVRS-Webs$">
+    <description>Hikvision httpd</description>
+    <example>DNVRS-Webs</example>
+    <param pos="0" name="service.vendor" value="Hikvision"/>
+    <param pos="0" name="service.product" value="Hikvision Web Server"/>
+    <param pos="0" name="os.vendor" value="Hikvision"/>
+    <param pos="0" name="os.device" value="DVR"/>
+    <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
   <fingerprint pattern="^NET-DK[/ ](\d+\.\d+)$">
     <description>Web server found on ARRIS cable modems</description>
@@ -3302,6 +3478,8 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="ARRIS"/>
     <param pos="0" name="os.device" value="Cable Modem"/>
+    <param pos="0" name="hw.vendor" value="ARRIS"/>
+    <param pos="0" name="hw.device" value="Cable Modem"/>
   </fingerprint>
   <!-- junit says,
      "Example pattern '' from http_servers.xml didn't match pattern '^$'"
@@ -3319,6 +3497,10 @@
   <fingerprint pattern="^Web-Server/(?:\d+\.+\d+)$">
     <description>Obfuscated web server -- assert nothing.</description>
     <example>Web-Server/3.0</example>
+  </fingerprint>
+  <fingerprint pattern="^httpd$">
+    <description>httpd - generic -- assert nothing.</description>
+    <example>httpd</example>
   </fingerprint>
   <!-- Service provider equipment (CDNs, etc) -->
   <fingerprint pattern="^AkamaiGHost$">
@@ -3371,11 +3553,11 @@
     <example service.version="5.0">QTSS/5.0 (Build/452; Platform/MacOSX; Release/Panther; )</example>
     <example service.version="5.0.3.3">QTSS/5.0.3.3 (Build/452.22.4; Platform/MacOSX; Release/Panther; Update/Security; )</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.3"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.version" value="10.3"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.3"/>
     <param pos="0" name="service.product" value="QTSS"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -3383,10 +3565,10 @@
     <description>QTSS OS X</description>
     <example service.version="6.1.0">QTSS/6.1.0 (Build/532; Platform/MacOSX; Release/Mac OS X Server; )</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.device" value="General"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="service.product" value="QTSS"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -3421,5 +3603,72 @@
     <param pos="0" name="service.product" value="Intel(R) Standard Manageability"/>
     <param pos="0" name="service.family" value="Intel(R) Active Management Technology"/>
     <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Sunny WebBox$">
+    <description>Sunny WebBox</description>
+    <example>Sunny WebBox</example>
+    <param pos="0" name="service.vendor" value="SMA Solar Technology Ag"/>
+    <param pos="0" name="service.family" value="Sunny"/>
+    <param pos="0" name="service.product" value="WebBox"/>
+    <param pos="0" name="hw.family" value="Sunny"/>
+    <param pos="0" name="hw.product" value="WebBox"/>
+    <param pos="0" name="hw.device" value="Power Management"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_ce:-"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows CE"/>
+  </fingerprint>
+  <fingerprint pattern="^EnergyICT RTU \d+-\w+-\d+$">
+    <description>EnergyICT RTU</description>
+    <example>EnergyICT RTU 101-F25CE1-1524</example>
+    <param pos="0" name="hw.family" value="Honeywell"/>
+    <param pos="0" name="hw.product" value="RTU"/>
+    <param pos="0" name="hw.device" value="Power Management"/>
+  </fingerprint>
+  <fingerprint pattern="^AV-TECH AV787 Video Web Server$">
+    <description>AV-TECH AVC787 Video Web Server</description>
+    <example>AV-TECH AV787 Video Web Server</example>
+    <param pos="0" name="service.vendor" value="AVTECH"/>
+    <param pos="0" name="service.family" value="MPEG4 DVR"/>
+    <param pos="0" name="service.product" value="HTTPD"/>
+    <param pos="0" name="hw.family" value="MPEG4 DVR"/>
+    <param pos="0" name="hw.product" value="AVC787"/>
+    <param pos="0" name="hw.device" value="DVR"/>
+  </fingerprint>
+  <fingerprint pattern="^tivo-httpd-\S+$">
+    <description>Tivo DVR</description>
+    <example>tivo-httpd-1:20.7.4.RC35-D18-6:D18</example>
+    <param pos="0" name="hw.vendor" value="Tivo"/>
+    <param pos="0" name="hw.family" value="DVR"/>
+    <param pos="0" name="hw.device" value="DVR"/>
+  </fingerprint>
+  <!-- Tridium previously had a product with the 'Niagra' spelling -->
+  <fingerprint pattern="^Niagara Web Server\/([\d.]+)$">
+    <description>Tridium Niagara AX Framework</description>
+    <example service.version="3.8.111">Niagara Web Server/3.8.111</example>
+    <param pos="0" name="service.vendor" value="Tridium"/>
+    <param pos="0" name="service.family" value="Niagara"/>
+    <param pos="0" name="service.product" value="Niagara AX"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Microsoft WinCE Fidelix v([\d.]+)$">
+    <description>Fidelix Industrial Control Web Server</description>
+    <example service.version="11.50.29">Microsoft WinCE Fidelix v11.50.29</example>
+    <param pos="0" name="os.certainty" value="0.9"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_ce:-"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows CE"/>
+    <param pos="0" name="service.vendor" value="Fidelix"/>
+    <param pos="0" name="service.product" value="Web Server"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="hw.vendor" value="Fidelix"/>
+    <param pos="0" name="hw.device" value="Industrial Control"/>
+  </fingerprint>
+  <fingerprint pattern="^chainpoint-node$">
+    <description>Chainpoint Node</description>
+    <example>chainpoint-node</example>
+    <param pos="0" name="service.vendor" value="Chainpoint"/>
+    <param pos="0" name="service.product" value="Node"/>
   </fingerprint>
 </fingerprints>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2034,7 +2034,6 @@
   </fingerprint>
   <fingerprint pattern="^IdeaWebServer\/v?([\d.]+)$">
     <description>Idea Web Server</description>
-    <example>IdeaWebServer/0.83</example>
     <example service.version="0.83.74">IdeaWebServer/0.83.74</example>
     <example service.version="0.70">IdeaWebServer/v0.70</example>
     <param pos="0" name="service.vendor" value="home.pl"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -10,20 +10,20 @@
     <example>Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.component.vendor" value="Red Hat"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:redhat:stronghold:{service.component.version}"/>
     <param pos="0" name="service.component.product" value="Stronghold"/>
     <param pos="0" name="service.component.family" value="Stronghold"/>
     <param pos="1" name="service.component.version"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:redhat:stronghold:{service.component.version}"/>
     <param pos="3" name="apache.info"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:linux:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:linux:-"/>
   </fingerprint>
   <fingerprint pattern="^Apache/\d$" flags="REG_ICASE">
     <description>Apache returning only its major version number</description>
@@ -31,8 +31,8 @@
     <example>Apache/2</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="service.family" value="Apache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
   </fingerprint>
   <fingerprint pattern="^Apache$" flags="REG_ICASE">
     <description>Apache returning no version information</description>
@@ -40,8 +40,8 @@
     <example>apache</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="service.family" value="Apache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
   </fingerprint>
   <fingerprint pattern="^Apache(?:-AdvancedExtranetServer)?(?:/([012][\d.]*)\s*(.*))?$" flags="REG_ICASE">
     <description>Apache</description>
@@ -1462,9 +1462,9 @@
     <example>APACHE/1.3.9</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
   </fingerprint>
   <fingerprint pattern="^Check Point SVN foundation$">
@@ -1472,8 +1472,8 @@
     <example>Check Point SVN foundation</example>
     <param pos="0" name="service.vendor" value="Check Point"/>
     <param pos="0" name="service.product" value="Firewall-1"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:checkpoint:firewall-1:-"/>
     <param pos="0" name="service.family" value="Firewall-1"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:checkpoint:firewall-1:-"/>
     <param pos="0" name="os.vendor" value="Check Point"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:checkpoint:gaia_os:-"/>
     <param pos="0" name="os.device" value="Firewall"/>
@@ -1489,130 +1489,130 @@
     <example>Microsoft-IIS/4.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_nt:4.0"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows NT"/>
     <param pos="0" name="os.version" value="4.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_nt:4.0"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/5.0$">
     <description>Microsoft IIS 5.0 runs on Windows 2000</description>
     <example>Microsoft-IIS/5.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_2000:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 2000"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_2000:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/5.1$">
     <description>Microsoft IIS 5.1 runs on Windows XP</description>
     <example>Microsoft-IIS/5.1</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.1"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="5.1"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:5.1"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_xp:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows XP"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_xp:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/6.0$">
     <description>Microsoft IIS 6.0 runs on Windows Server 2003 (and Windows XP x64)</description>
     <example>Microsoft-IIS/6.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:6.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="6.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:6.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2003:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2003"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2003:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/7.0$">
     <description>Microsoft IIS 7.0 runs on Windows Server 2008 (and Windows Vista)</description>
     <example>Microsoft-IIS/7.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="7.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/7.5$">
     <description>Microsoft IIS 7.5 runs on Windows Server 2008 R2 (and Windows 7)</description>
     <example>Microsoft-IIS/7.5</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.5"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="7.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:7.5"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/8.0$">
     <description>Microsoft IIS 8.0 runs on Windows Server 2012 (and Windows 8)</description>
     <example>Microsoft-IIS/8.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.0"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="8.0"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/8.5$">
     <description>Microsoft IIS 8.5 runs on Windows Server 2012 R2 (and Windows 8.1)</description>
     <example>Microsoft-IIS/8.5</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.5"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.version" value="8.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:8.5"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS/([\d\.]+)$">
     <description>Microsoft IIS new, unknown version</description>
     <example>Microsoft-IIS/9.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-IIS$">
     <description>Microsoft IIS, no version information</description>
     <example>Microsoft-IIS</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
     <param pos="0" name="service.family" value="IIS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:-"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -1628,10 +1628,10 @@
     <param pos="0" name="service.component.family" value=".NET"/>
     <param pos="1" name="service.component.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-WinCE/(\d\.\d+)$">
     <description>Windows CE embedded devices, including HP iPAQ,
@@ -1648,8 +1648,8 @@
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows CE"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_ce:{os.version}"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_ce:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-PWS/(\d\.\d+)$">
     <description>Microsoft Personal Web Server runs on Windows 9x, ME, etc.</description>
@@ -1657,13 +1657,13 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="PWS"/>
     <param pos="0" name="service.product" value="PWS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:personal_web_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:personal_web_server:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-PWS-95/(\d\.\d+)$">
     <description>Microsoft Personal Web Server for Windows 95</description>
@@ -1671,13 +1671,13 @@
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="PWS"/>
     <param pos="0" name="service.product" value="PWS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:personal_web_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:personal_web_server:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_95:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows 95"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_95:-"/>
   </fingerprint>
   <fingerprint pattern="^Apache[ -]Coyote/(\d\.\d)$">
     <description>HTTP connector for Apache Tomcat to run as a standalone
@@ -1686,8 +1686,8 @@
     <example>Apache Coyote/1.0</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:-"/>
     <param pos="0" name="service.family" value="Tomcat"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:-"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
     <param pos="0" name="service.component.product" value="Coyote"/>
     <param pos="0" name="service.component.family" value="Coyote"/>
@@ -1698,26 +1698,26 @@
     <example service.version="4.0.4.GA" service.component.version="5.5">Servlet 2.4; JBoss-4.0.4.GA (build: CVSTag=JBoss_4_0_4_GA date=200605151000)/Tomcat-5.5</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
     <param pos="0" name="service.component.product" value="Tomcat"/>
     <param pos="0" name="service.component.family" value="Tomcat"/>
     <param pos="2" name="service.component.version"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
   </fingerprint>
   <fingerprint pattern="^Servlet [\d\.]+; Tomcat-(\S+)/JBoss-(\S+) \(build: .*\)$">
     <description>JBoss with embedded tomcat</description>
     <example service.version="4.0.1sp1" service.component.version="5.0.28">Servlet 2.4; Tomcat-5.0.28/JBoss-4.0.1sp1 (build: CVSTag=JBoss_4_0_1_SP1 date=200502160314)</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
     <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
     <param pos="0" name="service.component.product" value="Tomcat"/>
     <param pos="0" name="service.component.family" value="Tomcat"/>
     <param pos="1" name="service.component.version"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
   </fingerprint>
   <fingerprint pattern="^Servlet [\d\.]+; JBoss-([\S]+)(?: \(build.*)?/JBossWeb-(\S+)$">
     <description>JBoss with JBossweb</description>
@@ -1725,8 +1725,8 @@
     <example service.version="5.0" service.component.version="2.1">Servlet 2.5; JBoss-5.0/JBossWeb-2.1</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
     <param pos="0" name="service.component.vendor" value="RedHat"/>
     <param pos="0" name="service.component.product" value="JBossWeb"/>
     <param pos="2" name="service.component.version"/>
@@ -1736,8 +1736,8 @@
     <example service.version="6">Servlet/3.0; JBossAS-6</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss AS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_wildfly_application_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_wildfly_application_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^JBoss-EAP\/(\d+)$">
     <description>JBoss EAP</description>
@@ -1745,8 +1745,8 @@
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.family" value="JBoss"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Apache Tomcat/(\d\.[\d.]+)(?:-LE-jdk14)? \(HTTP/1.1 Connector\)$">
     <description>HTTP connector for Apache Tomcat to run as a standalone
@@ -1757,8 +1757,8 @@
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="0" name="service.product" value="Tomcat"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="0" name="service.component.vendor" value="Apache"/>
     <param pos="0" name="service.component.family" value="Apache Tomcat HTTP Connector"/>
     <param pos="0" name="service.component.product" value="Apache Tomcat HTTP Connector"/>
@@ -1772,9 +1772,9 @@
     <example>Tomcat Web Server/3.3.1 Final ( JSP 1.1; Servlet 2.2 )</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="2" name="tomcat.info"/>
   </fingerprint>
   <fingerprint pattern="^Tomcat/(\S+)$">
@@ -1782,9 +1782,9 @@
     <example>Tomcat/2.1</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^PHP/(\S+)$">
     <description>PHP</description>
@@ -1820,9 +1820,9 @@
     <example>Oracle Application Server/10g (10.1.2) Apache/1.3.34 (Unix) mod_perl/1.29 mod_jk/1.2.14 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=119642322340,0)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="3" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
     <param pos="1" name="apache.variant.version"/>
@@ -1838,8 +1838,8 @@
     <example>Oracle-Application-Server-10g/9.0.4.1.0 Oracle-HTTP-Server</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="service.family" value="Apache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
     <param pos="1" name="apache.variant.version"/>
@@ -1850,8 +1850,8 @@
     <example>Oracle9iAS/9.0.3.1 Oracle HTTP Server Oracle9iAS-Web-Cache/9.0.3.1.0 (N)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="service.family" value="Apache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
     <param pos="1" name="apache.variant.version"/>
@@ -1863,9 +1863,9 @@
     <example>Oracle HTTP Server Powered by Apache/1.3.19 (Win32) mod_ssl/2.8.1 OpenSSL/0.9.5a mod_fastcgi/2.2.10 mod_oprocmgr/1.0 mod_perl/1.25</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
   </fingerprint>
@@ -1874,8 +1874,8 @@
     <example>Oracle HTTP Server Powered by Apache</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="service.family" value="Apache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="apache.variant" value="Oracle"/>
   </fingerprint>
   <fingerprint pattern="^HP Apache-based Web Server/([012][\d.]*)\s*\(Unix\)\s*(.*)$">
@@ -1884,16 +1884,16 @@
     <example>HP Apache-based Web Server/1.3.26 (Unix)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
     <param pos="0" name="apache.variant" value="HP-UX"/>
     <param pos="0" name="os.vendor" value="HP"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:hp:hp-ux:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="HP-UX"/>
     <param pos="0" name="os.product" value="HP-UX"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:hp-ux:-"/>
   </fingerprint>
   <fingerprint pattern="^CompaqHTTPServer/([0-9.]*)(?: HP System Management Homepage(?:/.*)?)?$">
     <description>HP/Compaq HTTP Server</description>
@@ -2098,10 +2098,10 @@
     <description>RealMedia Helix Server</description>
     <example>Helix Server Version 9.0.4.960 (win32) (RealServer compatible)</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="service.vendor" value="RealMedia"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="Helix Server"/>
@@ -2121,10 +2121,10 @@
     <description>Windows Media Services (older versions)</description>
     <example>Cougar/9.01.01.3841</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="Windows Media Services"/>
@@ -2134,10 +2134,10 @@
     <description>Windows Media Services (newer versions)</description>
     <example>WMServer/9.1.1.3841</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="Windows Media Services"/>
@@ -2147,20 +2147,20 @@
     <description>Generic Microsoft HTTP service</description>
     <example>Microsoft-HTTPAPI/2.0</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^ASP.NET$">
     <description>Something written in ASP.NET</description>
     <example>ASP.NET</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="os.certainty" value="0.6"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^[Xx]itami$">
     <description>Xitami web server</description>
@@ -2200,8 +2200,8 @@
     <example>IBM HTTP Server/V5R3M0</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="HTTP Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:http_server:-"/>
     <param pos="0" name="service.family" value="HTTP Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:http_server:-"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.device" value="General"/>
@@ -2223,9 +2223,9 @@
     <example>IBM_HTTP_Server/6.1 Apache/2.0.47 (Win32) PHP/5.1.1</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="3" name="apache.info"/>
     <param pos="0" name="apache.variant" value="IBM"/>
     <param pos="1" name="apache.variant.version"/>
@@ -2236,8 +2236,8 @@
     <example>IBM_HTTP_Server/7.0.0.9 (Unix)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="service.family" value="Apache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="apache.variant" value="IBM"/>
     <param pos="1" name="apache.variant.version"/>
   </fingerprint>
@@ -2247,8 +2247,8 @@
     <example>IBM_HTTP_Server</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="service.family" value="Apache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
     <param pos="0" name="apache.variant" value="IBM"/>
   </fingerprint>
   <!--
@@ -2261,8 +2261,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Application Server"/>
     <param pos="0" name="service.product" value="Java System Application Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_application_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_application_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Sun[ -]Java[ -]System[ /]Application[ -]Server Platform Edition( \d\.[\d_]+)?$">
     <description>Sun Java System Application Server (formerly iPlanet Application Server,
@@ -2299,8 +2299,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Server"/>
     <param pos="0" name="service.product" value="Java System Web Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^(?:Sun-Java-System-Web-Server|Sun-ONE-Web-Server)/(?:\d\.[\d_]+)$">
     <description>Sun Java System Web Server (formerly Netscape Enterprise Server, iPlanet Web
@@ -2333,8 +2333,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Sun-ONE-Web-Proxy-Server/(.*)$">
     <description>Sun ONE WebProxy Server (formerly iPlanet WebProxy Server,
@@ -2343,8 +2343,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/([^.]+\.[^.]+\.[^.]+)$">
     <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server,
@@ -2353,8 +2353,8 @@
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/(?:4\.\d+)$">
     <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server,
@@ -2384,8 +2384,8 @@
     <example>HP-iLO-Server/1.30</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="iLO"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:hp:integrated_lights_out:-"/>
     <param pos="0" name="service.family" value="iLO"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:hp:integrated_lights_out:-"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
@@ -2405,9 +2405,9 @@
     <example>Jetty/5.1.10 (Linux/2.6.12 i386 java/1.5.0_05)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="2" name="jetty.info"/>
   </fingerprint>
   <!-- Catch-all for Jetty versions using the Jetty/version format. -->
@@ -2416,18 +2416,18 @@
     <example>Jetty/4.2.x (VxWorks/WIND version 2.9 ppc java/1.1-rr-std-b12)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Jetty\((\S+)\)$">
     <description>Mort Bay Jetty</description>
     <example>Jetty(6.1.7)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^[Ss]quid/(\d+\.[\w.]+)$">
     <description>Squid Web </description>
@@ -2471,9 +2471,9 @@
     <description>nginx without version info</description>
     <example>nginx</example>
     <param pos="0" name="service.product" value="nginx"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
   </fingerprint>
   <fingerprint pattern="^nginx\/?(:?[\d.]+)?">
     <description>nginx with version info and/or mods</description>
@@ -2482,10 +2482,10 @@
     <example>nginx + Phusion Passenger 5.1.11</example>
     <example>nginx + Phusion Passenger</example>
     <param pos="0" name="service.product" value="nginx"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:{service.version}"/>
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Lotus(?:-Domino)?(?:/|/0|/Release)?$">
     <description>IBM Lotus Notes/Domino with no useful version info</description>
@@ -2495,8 +2495,8 @@
     <example>Lotus-Domino/Release</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:-"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:-"/>
   </fingerprint>
   <fingerprint pattern="^Lotus(?:-Domino)?/(?:Release-?)?([4-7][\d.]+)\s*(?:.*)$">
     <description>IBM Lotus Notes/Domino with version info</description>
@@ -2504,9 +2504,9 @@
     <example>Lotus-Domino/Release-4.6.7(Intl)</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:{service.version}"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^WebLogic (?:WebLogic )?Server (\d+\.\d+(?:\s+SP\d+)?)\s+.*$">
     <description>BEA WebLogic</description>
@@ -2515,9 +2515,9 @@
     <example>WebLogic WebLogic Server 6.1 SP4  11/08/2002 21:50:43 #221641</example>
     <param pos="0" name="service.vendor" value="BEA"/>
     <param pos="0" name="service.product" value="WebLogic"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:bea:weblogic_server:{service.version}"/>
     <param pos="0" name="service.family" value="WebLogic"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:bea:weblogic_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^WebSphere Application Server/(\d+\.\d+)$">
     <description>IBM WebSphere</description>
@@ -2535,9 +2535,9 @@
     <example>Resin/2.1.s030827</example>
     <param pos="0" name="service.vendor" value="Caucho"/>
     <param pos="0" name="service.product" value="Resin"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:caucho:resin:{service.version}"/>
     <param pos="0" name="service.family" value="Resin"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:caucho:resin:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Ipswitch-IMail/(\d\.\d+)$">
     <description>Ipswitch IMail Server</description>
@@ -2546,14 +2546,14 @@
     <example>Ipswitch-IMail/8.05</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="0" name="service.product" value="IMail Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:ipswitch:imail_server:{service.version}"/>
     <param pos="0" name="service.family" value="IMail Server"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ipswitch:imail_server:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Abyss/(\d\.[\d.]+)-X1-Win32 AbyssLib/(?:\d\.[\d.]+)$">
     <description>Aprelium Technologies Abyss Web Server X1
@@ -2565,10 +2565,10 @@
     <param pos="0" name="service.family" value="Abyss Web Server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Abyss/(\d\.[\d.]+)-X2-Win32 AbyssLib/(?:\d\.[\d.]+)$">
     <description>Aprelium Technologies Abyss Web Server X2
@@ -2578,10 +2578,10 @@
     <param pos="0" name="service.family" value="Abyss Web Server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft (Commerce Server\s*(?:2002|2007)?, (?:Enterprise|Standard|Evaluation|Developer) Edition)$">
     <description>Microsoft Commerce Server</description>
@@ -2589,25 +2589,25 @@
     <param pos="1" name="service.product"/>
     <param pos="0" name="service.family" value="Commerce Server"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^NetWare-Enterprise-Web-Server/(\d+\.\d+)$">
     <description>NetWare Enterprise Web Server (runs on NetWare 5.1)</description>
     <param pos="0" name="service.vendor" value="Novell"/>
     <param pos="0" name="service.product" value="NetWare Enterprise Web Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:novell:netware_enterprise_web_server:{service.version}"/>
     <param pos="0" name="service.family" value="NetWare Enterprise Web Server"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:novell:netware_enterprise_web_server:{service.version}"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="Novell"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:{os.version}"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^NetWare HTTP Stack$">
     <description>NetWare HTTP stack (runs on 6.0 and 6.5)</description>
@@ -2615,10 +2615,10 @@
     <param pos="0" name="service.product" value="NetWare HTTP Stack"/>
     <param pos="0" name="service.family" value="NetWare HTTP Stack"/>
     <param pos="0" name="os.vendor" value="Novell"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:-"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:-"/>
   </fingerprint>
   <fingerprint pattern="^Novell-HTTP-Server/3.1R1$">
     <description>NetWare HTTP Server (runs on NetWare 4.11)</description>
@@ -2631,8 +2631,8 @@
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:4.11"/>
     <param pos="0" name="os.version" value="4.11"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:4.11"/>
   </fingerprint>
   <fingerprint pattern="^Novell-HTTP-Server/2.51R1$">
     <description>NetWare HTTP Server (runs on NetWare 4.1)</description>
@@ -2645,24 +2645,24 @@
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.family" value="NetWare"/>
     <param pos="0" name="os.product" value="NetWare"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:4.1"/>
     <param pos="0" name="os.version" value="4.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:novell:netware:4.1"/>
   </fingerprint>
   <fingerprint pattern="^Netscape-FastTrack/(\d+\.[\w\s.]+)$">
     <description>Netscape FastTrack Server</description>
     <param pos="0" name="service.vendor" value="Netscape"/>
     <param pos="0" name="service.product" value="FastTrack Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:fasttrack_server:{service.version}"/>
     <param pos="0" name="service.family" value="FastTrack Server"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:fasttrack_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Netscape-Commerce/(\d+\.[\w\s.]+)$">
     <description>Netscape Commerce Server</description>
     <param pos="0" name="service.vendor" value="Netscape"/>
     <param pos="0" name="service.product" value="Commerce Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:commerce_server:{service.version}"/>
     <param pos="0" name="service.family" value="Commerce Server"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:netscape:commerce_server:{service.version}"/>
   </fingerprint>
   <!--
       TODO
@@ -2723,9 +2723,9 @@
     <param pos="0" name="os.vendor" value="NetApp"/>
     <param pos="0" name="os.family" value="Data ONTAP"/>
     <param pos="0" name="os.product" value="Data ONTAP"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:netapp:data_ontap:{os.version}"/>
     <param pos="0" name="os.device" value="File server"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:netapp:data_ontap:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^BlueCoat-Security-Appliance$">
     <description>Blue Coat security appliance</description>
@@ -2739,8 +2739,8 @@
     <description>F5 BIG-IP</description>
     <param pos="0" name="service.vendor" value="F5"/>
     <param pos="0" name="service.product" value="BIG-IP LTM"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:f5:big-ip_local_traffic_manager:-"/>
     <param pos="0" name="service.family" value="BIG-IP"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:f5:big-ip_local_traffic_manager:-"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
@@ -2850,10 +2850,10 @@
     <param pos="0" name="service.product" value="IOS"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:-"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
     <param pos="0" name="os.certainty" value="0.8"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
   </fingerprint>
   <fingerprint pattern="^cisco-IOS/([^\s]+) HTTP-server/.*$">
@@ -2864,10 +2864,10 @@
     <param pos="0" name="service.product" value="IOS"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:{os.version}"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:{os.version}"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
   </fingerprint>
   <fingerprint pattern="^Cisco AWARE (.*)$">
@@ -2892,16 +2892,16 @@
     <param pos="0" name="service.product" value="Desktop Authority"/>
     <param pos="0" name="service.family" value="Desktop Authority"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Agent-ListenServer-HttpSvr/.*$">
     <description>McAfee ePolicy Orchestrator</description>
     <param pos="0" name="service.vendor" value="McAfee"/>
     <param pos="0" name="service.product" value="ePolicy Orchestrator"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mcafee:epolicy_orchestrator:-"/>
     <param pos="0" name="service.family" value="ePolicy Orchestrator"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mcafee:epolicy_orchestrator:-"/>
   </fingerprint>
   <fingerprint pattern="^EWS-NIC\d/(\S+)$">
     <description>Xerox Embedded Web Server (EWS)</description>
@@ -2925,9 +2925,9 @@
     <param pos="0" name="service.product" value="ASM"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^JRun Web Server$">
     <description>Macromedia (formerly Allaire) JRun</description>
@@ -2959,17 +2959,17 @@
     <description>Rumpus FTP Server, Web File Manager interface</description>
     <example>Rumpus</example>
     <param pos="0" name="os.vendor" value="Apple"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
   </fingerprint>
   <fingerprint pattern="^servermgrd$">
     <description>Mac OS X Server administrative daemon</description>
     <example>servermgrd</example>
     <param pos="0" name="os.vendor" value="Apple"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
   </fingerprint>
   <fingerprint pattern="^(RMC Webserver|RAC_ONE_HTTP) (\d\.\d)$">
     <description>Dell Remote Access Controller</description>
@@ -3018,9 +3018,9 @@
     <param pos="0" name="service.product" value="TUX web server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linux"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:-"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:-"/>
   </fingerprint>
   <fingerprint pattern="^RealVNC/(?:\S+)$">
     <description>RealVNC built-in webserver</description>
@@ -3142,9 +3142,9 @@
     <example>CherryPy/3</example>
     <param pos="0" name="service.vendor" value="CherryPy"/>
     <param pos="0" name="service.product" value="CherryPy"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cherrypy:cherrypy:{service.version}"/>
     <param pos="0" name="service.family" value="CherryPy"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cherrypy:cherrypy:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^TornadoServer/((?:\d+\.)*\d+)$" flags="REG_ICASE">
     <description>Tornado Python web framework and asynchronous networking library.</description>
@@ -3171,10 +3171,10 @@
     <example>HP Web Jetadmin/2 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="apache.variant" value="HP Web Jetadmin"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:{service.version}"/>
     <param pos="2" name="apache.info"/>
   </fingerprint>
   <fingerprint pattern="^HP Web Jetadmin ([\d\.]+)(?: \([^\)]+\))?$">
@@ -3183,8 +3183,8 @@
     <example service.version="10.3.91358">HP Web Jetadmin 10.3.91358 (10.3 SR5)</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="Web Jetadmin"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:hp:web_jetadmin:{service.version}"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:hp:web_jetadmin:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Citrix Web PN Server$">
     <description>Citrix Web PN (Program Neighborhood) Server is an HTTP server used by Citrix products</description>
@@ -3282,9 +3282,9 @@
     <example>CUPS/1.1</example>
     <param pos="0" name="service.vendor" value="Apple"/>
     <param pos="0" name="service.product" value="CUPS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:apple:cups:{service.version}"/>
     <param pos="0" name="service.family" value="CUPS"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apple:cups:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^TwistedWeb/([\d.rc]+)$">
     <description>Twisted Matrix Labs - TwistedWeb</description>
@@ -3319,9 +3319,9 @@
     <example>Avocent DSView 3/3</example>
     <param pos="0" name="service.vendor" value="Avocent"/>
     <param pos="0" name="service.product" value="DSView"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:avocent:dsview:{service.version}"/>
     <param pos="0" name="service.family" value="DSView"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:avocent:dsview:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Mongrel ((?:\d+\.)*\d+)$">
     <description>Ruby-based web server and HTTP library.</description>
@@ -3393,9 +3393,9 @@
     <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="service.product" value="PA Firewall"/>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
     <param pos="0" name="os.product" value="PA Firewall"/>
     <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
   </fingerprint>
   <fingerprint pattern="^Ews/((?:\d+\.)*\d+)$">
     <description>IBM Network Printer Manager.</description>
@@ -3553,11 +3553,11 @@
     <example service.version="5.0">QTSS/5.0 (Build/452; Platform/MacOSX; Release/Panther; )</example>
     <example service.version="5.0.3.3">QTSS/5.0.3.3 (Build/452.22.4; Platform/MacOSX; Release/Panther; Update/Security; )</example>
     <param pos="0" name="os.vendor" value="Apple"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.3"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.device" value="General"/>
     <param pos="0" name="os.version" value="10.3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.3"/>
     <param pos="0" name="service.product" value="QTSS"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -3565,10 +3565,10 @@
     <description>QTSS OS X</description>
     <example service.version="6.1.0">QTSS/6.1.0 (Build/532; Platform/MacOSX; Release/Mac OS X Server; )</example>
     <param pos="0" name="os.vendor" value="Apple"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
     <param pos="0" name="service.product" value="QTSS"/>
     <param pos="1" name="service.version"/>
   </fingerprint>


### PR DESCRIPTION
This PR is a banner update of the `http_servers.xml` file using data from a Project Sonar survey of HTTP on port 80 that occurred on 2018.08.13.

There are additional tweaks to support CPE generation as well as add `hw.device` and similar fields where possible.

*Note:* I am unsure as to why the CPE ordering changed.