### PR TITLE
Add matches to all recog fingerprints

### DIFF
--- a/xml/h323_callresp.xml
+++ b/xml/h323_callresp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="h.323" database_type="service" preference="0.80">
+<fingerprints matches="h323.setup_response" protocol="h.323" database_type="service" preference="0.80">
   <!--
   Responses to H.323 call SETUP messages are matched against these patterns
   to fingerprint H.323 servers.

--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints matches"pjl.info_id" protocol="pjl" database_type="service" preference="0.10">
+<fingerprints matches="pjl.info_id" protocol="pjl" database_type="service" preference="0.10">
   <!--
   For printers running the PJL protocol (usually on 9100/tcp), their type can be requested
   by the INFO ID command. The printer types (strings surrounded by double quotes) are

--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="pjl" database_type="service" preference="0.10">
+<fingerprints matches"pjl.info_id" protocol="pjl" database_type="service" preference="0.10">
   <!--
   For printers running the PJL protocol (usually on 9100/tcp), their type can be requested
   by the INFO ID command. The printer types (strings surrounded by double quotes) are

--- a/xml/rsh_resp.xml
+++ b/xml/rsh_resp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="rsh" database_type="service">
+<fingerprints matches="rsh.response" protocol="rsh" database_type="service">
   <!--
   Rservices responses to requests are matched against these patterns to fingerprint the OSes of servers.
   -->

--- a/xml/smtp_debug.xml
+++ b/xml/smtp_debug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.14">
+<fingerprints matches="smtp.debug" protocol="smtp" database_type="service" preference="0.14">
   <!--
   SMTP response lines to the DEBUG command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_ehlo.xml
+++ b/xml/smtp_ehlo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.19">
+<fingerprints matches="smtp.ehlo" protocol="smtp" database_type="service" preference="0.19">
   <!--
   SMTP response lines to the EHLO command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_expn.xml
+++ b/xml/smtp_expn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.16">
+<fingerprints matches="smtp.expn" protocol="smtp" database_type="service" preference="0.16">
   <!--
   SMTP response lines to the EXPN command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.18">
+<fingerprints matches="smtp.help" protocol="smtp" database_type="service" preference="0.18">
   <!--
   SMTP response lines to the HELP command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_mailfrom.xml
+++ b/xml/smtp_mailfrom.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service">
-  <!--
-  This file is currently unused.
-  -->
+<fingerprints matches="smtp.mailfrom" protocol="smtp" database_type="service">
   <fingerprint pattern="250 .* is syntactically correct *">
     <description>exim</description>
     <example>250 &lt;nosuchuser@rapid7.com&gt; is syntactically correct</example>

--- a/xml/smtp_noop.xml
+++ b/xml/smtp_noop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.17">
+<fingerprints matches="smtp.noop" protocol="smtp" database_type="service" preference="0.17">
   <!--
   SMTP response lines to the NOOP command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_quit.xml
+++ b/xml/smtp_quit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.11">
+<fingerprints matches="smtp.quit" protocol="smtp" database_type="service" preference="0.11">
   <!--
   SMTP response lines to the QUIT command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_rcptto.xml
+++ b/xml/smtp_rcptto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service">
+<fingerprints matches="smtp.rcptto" protocol="smtp" database_type="service">
   <!--
    <fingerprint pattern="501[ -]Invalid domain *">
       <description>

--- a/xml/smtp_rset.xml
+++ b/xml/smtp_rset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.12">
+<fingerprints matches="smtp.rset" protocol="smtp" database_type="service" preference="0.12">
   <!--
   SMTP response lines to the RSET command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_turn.xml
+++ b/xml/smtp_turn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.13">
+<fingerprints matches="smtp.turn" protocol="smtp" database_type="service" preference="0.13">
   <!--
   SMTP response lines to the TURN command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/smtp_vrfy.xml
+++ b/xml/smtp_vrfy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="smtp" database_type="service" preference="0.15">
+<fingerprints matches="smtp.vrfy" protocol="smtp" database_type="service" preference="0.15">
   <!--
   SMTP response lines to the VRFY command are matched against these patterns
   (1 line at a time) to fingerprint SMTP servers.

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="telnet" database_type="service" preference=".80">
+<fingerprints matches="telnet.banner" protocol="telnet" database_type="service" preference=".80">
   <!--
   TELNET banners with CR/LF/whitespace trimmed from either end.
   Examples with CR, LF, etc must be base64 encoded in order to past tests.


### PR DESCRIPTION
The current functionality is that this value will default to the `basename` of the fingerprint file in which it was found minus the .xml extension.  The problem with this is that you can't then easily have multiple files for the same protocol response, which might be useful for very large or complicated protocols like HTTP where we might want to keep fingerprints grouped in separate files for some reason.  Furthermore, I think it opens us up to more bugs with products that only integrate recog content which rely on specific recog XML file names but there are no corresponding tests in recog land to ensure that those XML files always exist.   Using the `matches` field is a more reliable and useful way of doing this.  Debating also making it required.  