### PR TITLE
Support interpolation of fingerprint values

### DIFF
--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -100,10 +100,10 @@ class Fingerprint
       next if v.nil?
       # if this key's value uses interpolation of the form "foo{some.thing}",
       # if some.thing was "bar" then this keys value would be set to "foobar".
-      if matches = v.match(/\{(?<replace>\S+)\}/)
+      if matches = v.match(/\{(?<replace>[^\s{}]+)\}/)
         replace = matches[:replace]
         if result[replace]
-          if recursive_match = result[replace].match(/\{(?<bad_replace>\S+)\}/)
+          if recursive_match = result[replace].match(/\{(?<bad_replace>[^\s{}]+)\}/)
             raise "Invalid recursive use of #{recursive_match[:bad_replace]} in #{replace}"
           end
           v.gsub!(/\{#{replace}\}/, result[replace])

--- a/spec/lib/recog/fingerprint_spec.rb
+++ b/spec/lib/recog/fingerprint_spec.rb
@@ -2,16 +2,22 @@ require 'nokogiri'
 require 'recog/fingerprint'
 
 describe Recog::Fingerprint do
-  let(:xml) do
-    path = File.expand_path(File.join('spec', 'data', 'whitespaced_fingerprint.xml'))
-    doc = Nokogiri::XML(IO.read(path))
-    doc.xpath("//fingerprint").first
-  end
-  subject { Recog::Fingerprint.new(xml) }
-
-  describe "#name" do
-    it "properly squashes whitespace" do
-      expect(subject.name).to eq('I love whitespace!')
+  context "whitespace" do
+    let(:xml) do
+      path = File.expand_path(File.join('spec', 'data', 'whitespaced_fingerprint.xml'))
+      doc = Nokogiri::XML(IO.read(path))
+      doc.xpath("//fingerprint").first
     end
+    subject { Recog::Fingerprint.new(xml) }
+
+    describe "#name" do
+      it "properly squashes whitespace" do
+        expect(subject.name).to eq('I love whitespace!')
+      end
+    end
+  end
+
+  skip  "value interpolation" do
+    # TODO
   end
 end

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3,11 +3,8 @@
   <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
-    <example>Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
-    <example>Stronghold/3.0 Apache/1.3.22 RedHat/3017c (Unix) PHP/4.1.2 mod_ssl/2.8.7 OpenSSL/0.9.6</example>
-    <example>Stronghold/3.0 Apache/1.3.22 RedHat/3017c (Unix) PHP/4.3.3 mod_ssl/2.8.7 OpenSSL/0.9.6 mod_perl/1.25</example>
-    <example>Stronghold/4.0 Apache/1.3.22</example>
-    <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
+    <example service.version="1.3.19" service.cpe23="cp3:/a:apache:http-server:1.3.19">Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
+    <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22" apache.info="(Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -7,7 +7,7 @@
     <example>Stronghold/3.0 Apache/1.3.22 RedHat/3017c (Unix) PHP/4.1.2 mod_ssl/2.8.7 OpenSSL/0.9.6</example>
     <example>Stronghold/3.0 Apache/1.3.22 RedHat/3017c (Unix) PHP/4.3.3 mod_ssl/2.8.7 OpenSSL/0.9.6 mod_perl/1.25</example>
     <example>Stronghold/4.0 Apache/1.3.22</example>
-    <example>Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
+    <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3,8 +3,8 @@
   <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
-    <example service.version="1.3.19" service.cpe23="cp3:/a:apache:http_server:1.3.19">Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
-    <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22" apache.info="(Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
+    <example service.version="1.3.19" service.cpe23="cpe:/a:apache:http_server:1.3.19" service.component.cpe23="cpe:/a:redhat:stronghold:3.0">Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
+    <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22" service.component.cpe23="cpe:/a:redhat:stronghold:4.0" apache.info="(Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3,7 +3,7 @@
   <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
-    <example service.version="1.3.19" service.cpe23="cp3:/a:apache:http-server:1.3.19">Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
+    <example service.version="1.3.19" service.cpe23="cp3:/a:apache:http_server:1.3.19">Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
     <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22" apache.info="(Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>


### PR DESCRIPTION
When we added the CPE functionality to recog xml/product, we also introduced the concept of value interpolation such that if you had a `fingerprint` with a `params` like:

```
    ...
    <param pos="1" name="service.component.version"/>
    <param pos="0" name="service.component.cpe23" value="cpe:/a:redhat:stronghold:{service.component.version}"/>
   ...
```

The idea is that the value of `service.component.cpe23` would be composed of `cpe:/a:redhat:stronghold:` and the value of `service.component.version` which is extracted at fingerprint match time.

This PR adds the necessary functionality to recog "product" to enable this.  I updated one simple `param` as an example of this.  I added a check/test for this in `Fingerprint` itself, but part of me feels like it should be in the self test spec instead.  

@tsellers-r7 looking for your feedback here.  I believe we had discussed possibly allowing this interpolation to happen recursively and perhaps even supporting it in the `param` `name` themselves.  