### PR TITLE
Refactor interpolation

### DIFF
--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -81,7 +81,7 @@ class Fingerprint
       if pos == 0
         # A match offset of 0 means this param has a hardcoded value
         result[k] = v[1]
-        # if this value uses interpolation, not it for handling later
+        # if this value uses interpolation, note it for handling later
         v[1].scan(/\{([^\s{}]+)\}/).flatten.each do |replacement|
           replacements[k] ||= Set[]
           replacements[k] << replacement
@@ -103,6 +103,7 @@ class Fingerprint
 
     result['fingerprint_db'] = @match_key if @match_key
 
+    # for everything identified as using interpolation, do so
     replacements.each_pair do |replacement_k, replacement_vs|
       replacement_vs.each do |replacement|
         if result[replacement]

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -3,6 +3,8 @@ module Recog
 # A fingerprint that can be {#match matched} against a particular kind of
 # fingerprintable data, e.g. an HTTP `Server` header
 class Fingerprint
+  require 'set'
+
   require 'recog/fingerprint/regexp_factory'
   require 'recog/fingerprint/test'
 
@@ -73,11 +75,17 @@ class Fingerprint
     return if match_data.nil?
 
     result = { 'matched' => @name }
+    replacements = {}
     @params.each_pair do |k,v|
       pos = v[0]
       if pos == 0
         # A match offset of 0 means this param has a hardcoded value
         result[k] = v[1]
+        # if this value uses interpolation, not it for handling later
+        v[1].scan(/\{([^\s{}]+)\}/).flatten.each do |replacement|
+          replacements[k] ||= Set[]
+          replacements[k] << replacement
+        end
       else
         # A match offset other than 0 means the value should come from
         # the corresponding match result index
@@ -95,17 +103,10 @@ class Fingerprint
 
     result['fingerprint_db'] = @match_key if @match_key
 
-    result.each_pair do |k,v|
-      # skip any nil result values, which is allowed but woud jam up the match below
-      next if v.nil?
-      # if this key's value uses interpolation of the form "foo{some.thing}",
-      # if some.thing was "bar" then this keys value would be set to "foobar".
-      if /\{(?<replace>[^\s{}]+)\}/ =~ v
-        if result[replace]
-          if /\{(?<bad_replace>[^\s{}]+)\}/ =~ result[replace]
-            raise "Invalid recursive use of #{bad_replace} in #{replace}"
-          end
-          result[k] = v.gsub(/\{#{replace}\}/, result[replace])
+    replacements.each_pair do |replacement_k, replacement_vs|
+      replacement_vs.each do |replacement|
+        if result[replacement]
+          result[replacement_k] = result[replacement_k].gsub(/\{#{replacement}\}/, result[replacement])
         else
           # if the value uses an interpolated value that does not exist, in general this could be
           # very bad, but over time we have allowed the use of regexes with
@@ -116,10 +117,10 @@ class Fingerprint
           # standard of '-' for the version, otherwise raise and exception as
           # this code currently does not handle interpolation of undefined
           # values in other cases.
-          if k =~ /\.cpe23$/ and replace =~ /\.version$/
-            result[k] = v.gsub(/\{#{replace}\}/, '-')
+          if replacement_k =~ /\.cpe23$/ and replacement =~ /\.version$/
+            result[replacement_k] = result[replacement_k].gsub(/\{#{replacement}\}/, '-')
           else
-            raise "Invalid use of nil interpolated value #{replace} in non-cpe23 fingerprint param #{k}"
+            raise "Invalid use of nil interpolated non-version value #{replacement} in non-cpe23 fingerprint param #{replacement_k}"
           end
         end
       end

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -60,6 +60,14 @@ describe Recog::DB do
                 param_names << param_name
               end
             end
+
+            it "uses interpolation correctly" do
+              if pos == 0 && /\{(?<interpolated>[^\s{}]+)\}/ =~ value
+                unless fp.params.key?(interpolated)
+                  fail "'#{fp.name}' uses interpolated value '#{interpolated}' that does not exist"
+                end
+              end
+            end
           end
         end
 


### PR DESCRIPTION
Two big things are changing here:

* Rather than checking for and, if necessary, attempting interpolation on every emitted fingerprint value, determine which need it in advance, and what values each interpolates.  Among other things, it prevents this:
```
$  echo "X1 NT-ESMTP Server {FOO} (IMail 6.06 EVAL 11347-1)" | ./bin/recog_match xml/smtp_banners.xml
/Users/jhart/rapid7/recog/lib/recog/fingerprint.rb:122:in `block in match': Invalid use of nil interpolated value FOO in non-cpe23 fingerprint param host.name (RuntimeError)
	from /Users/jhart/rapid7/recog/lib/recog/fingerprint.rb:98:in `each_pair'
	from /Users/jhart/rapid7/recog/lib/recog/fingerprint.rb:98:in `match'
	from /Users/jhart/rapid7/recog/lib/recog/matcher.rb:34:in `block (3 levels) in match_banners'
	from /Users/jhart/rapid7/recog/lib/recog/matcher.rb:33:in `each'
	from /Users/jhart/rapid7/recog/lib/recog/matcher.rb:33:in `block (2 levels) in match_banners'
	from /Users/jhart/rapid7/recog/lib/recog/matcher.rb:26:in `each_line'
	from /Users/jhart/rapid7/recog/lib/recog/matcher.rb:26:in `block in match_banners'
	from /Users/jhart/rapid7/recog/lib/recog/match_reporter.rb:14:in `report'
	from /Users/jhart/rapid7/recog/lib/recog/matcher.rb:16:in `match_banners'
	from ./bin/recog_match:55:in `<main>'
```
* Multiple-recursion is supported now.  "{service.version}{host.name}" will work if service.version and host.name are parts of the final fingerprint