### PR TITLE
Improve telnet fingerprinting

### DIFF
--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -993,7 +993,7 @@
   <fingerprint pattern=".*Nortel.*Passport ([^ ]*) .*Software Release ([^ ]*).*">
     <description>Nortel Passport</description>
     <!-- *********************************************\n\n\n* Copyright (c) 2003 Nortel Networks, Inc.  *\n\n\n* All Rights Reserved                       *\n\n\n* Passport 8010                             *\n\n\n* Software Release 3.5.0.0                  *\n\n\n*********************************************\n\n\n\n\nLogin: -->
-    <example _encoding="base64" hw.product="8010" os.version="3.5.0.0">
+    <example _encoding="base64" os.product="8010" os.version="3.5.0.0">
       KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmlnaHQgKG
       MpIDIwMDMgTm9ydGVsIE5ldHdvcmtzLCBJbmMuICAqXG5cblxuKiBBbGwgUmlnaHRzIFJlc2VydmVkICAgICAg
       ICAgICAgICAgICAgICAgICAqXG5cblxuKiBQYXNzcG9ydCA4MDEwICAgICAgICAgICAgICAgICAgICAgICAgIC

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -834,7 +834,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
     <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
@@ -846,7 +846,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
     <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="RedHat Enterprise AS"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
@@ -860,7 +860,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
     <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="RedHat Enterprise WS"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
@@ -874,6 +874,7 @@
     <param pos="0" name="hw.vendor" value="Redhat"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="hw.product" value="Fedora"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
@@ -885,11 +886,14 @@
     </example>
     <param pos="0" name="hw.vendor" value="SUSE"/>
     <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
     <param pos="3" name="linux.kernel.version"/>
   </fingerprint>
   <fingerprint pattern="^Turbolinux ApplianceServer (\d+\.\d+).*">
+    <description>Turbolinux ApplianceServer</description>
     <example _encoding="base64" os.version="4.0">
      VHVyYm9saW51eCBBcHBsaWFuY2VTZXJ2ZXIgNC4wIChBdGxhczIpIExpbnV4IDIuNi4zMi00MzEuMjMuMy5lbDYueDg
      2XzY0IG9uIGEgeDg2XzY0IChzZW55bzE5MXg4OS5kaWdpdGFsaW5rLm5lLmpwKSBUVFk6IDEyOjE1IG9uIFR1ZXNkYX
@@ -897,6 +901,8 @@
     </example>
     <param pos="0" name="hw.vendor" value="Turbolinux"/>
     <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^UnixWare ([^ ]+).*$">
@@ -907,6 +913,7 @@
     <param pos="0" name="hw.vendor" value="SCO"/>
     <param pos="0" name="hw.family" value="UnixWare"/>
     <param pos="0" name="hw.device" value="UnixWare"/>
+    <param pos="0" name="hw.product" value="UnixWare"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Telnet Server Build (5.*)">
@@ -917,13 +924,15 @@
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
+    <param pos="0" name="hw.product" value="Windows 2000"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Welcome. Type return, enter password at # prompt">
+    <description>Brother Printer</description>
     <example _encoding="base64">
      V2VsY29tZS4gVHlwZSByZXR1cm4sIGVudGVyIHBhc3N3b3JkIGF0ICMgcHJvbXB0Cg== 
     </example>
-    <description>Brother Printer</description>
     <param pos="0" name="hw.vendor" value="Brother"/>
     <param pos="0" name="hw.device" value="Printer" />
     <param pos="0" name="hw.product" value="Brother Printer"/>
@@ -935,6 +944,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Arescom"/>
     <param pos="0" name="hw.device" value="WAP" />
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
     <param pos="1" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="Welcome to ViewStation">
@@ -943,25 +953,9 @@
     V2VsY29tZSB0byBWaWV3U3RhdGlvbgoKUGFzc3dvcmQ6
     </example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
-    <param pos="0" name="hw.product" value="ViewStation"/>
-  </fingerprint>
-  <fingerprint pattern="Here is what I know about myself:">
-    <description>Polycom ViewStation Video Conference System</description>
-    <example _encoding="base64">
-     SGksIG15IG5hbWUgaXMgOiAgICAgUklER0VMQU5EIENBTVBVUwpIZXJlIGlzIHdoYXQgSSBrbm93IGFib3V0IG15c2VsZjo
-     KTW9kZWw6ICAgICAgICAgICAgICAgVlNYIDgwMDAKU2VyaWFsIE51bWJlcjogICAgICAgODIwODA4MDkzNTMyTjIKU29mdH
-     dhcmUgVmVyc2lvbjogICAgUmVsZWFzZSA5LjAuNi4yLTEwMyAtIDA0U2VwMjAxMSAyMToyNwpCdWlsZCBJbmZvcm1hdGlvb
-     jogICBlY29tbWFuZGVyIG9uIGVuZ2ludDAwLmF1c3Rpbi5wb2x5Y29tLmNvbQpGUEdBIFJldmlzaW9uOiAgICAgICA0LjQu
-     MgpNYWluIFByb2Nlc3NvcjogICAgICBCU1AxNSAgIHYwLjAgfiBDb3JlL01lbSBDbGtzIDQwNS8xMzUgIFszOjQgMDozXQp
-     UaW1lIEluIExhc3QgQ2FsbDogICAxOjU4OjAxClRvdGFsIFRpbWUgSW4gQ2FsbHM6IDE1NzowNDo1NQpUb3RhbCBDYWxscz
-     ogICAgICAgICAyMDYKU05UUCBUaW1lIFNlcnZpY2U6ICAgYXV0byBpbnN5bmMgMC5wb29sLm50cC5vcmcKTG9jYWwgVGltZ
-     SBpczogICAgICAgIFdlZCwgIDMgT2N0IDIwMTggMjE6MDg6MTcgLTExMDAKTmV0d29yayBJbnRlcmZhY2U6ICAgTk9ORQpJ
-     UCBWaWRlbyBOdW1iZXI6ICAgICAxNzIuMjAuMTkyLjI0OApJU0ROIFZpZGVvIE51bWJlcjogICAxLgpNUCBFbmFibGVkOiA
-     gICAgICAgICBLRUEwLTc5REEtNTZFMC0wMDAwLTAwODEKSDMyMyBFbmFibGVkOiAgICAgICAgVHJ1ZQpGVFAgRW5hYmxlZD
-     ogICAgICAgICBUcnVlCkhUVFAgRW5hYmxlZDogICAgICAgIFRydWUKU05NUCBFbmFibGVkOiAgICAgICAgRmFsc2U=
-    </example>
-    <param pos="0" name="hw.vendor" value="Polycom"/>
-    <param pos="0" name="hw.product" value="ViewStation"/>
+    <param pos="0" name="hw.device" value="ViewStation"/>
+    <param pos="0" name="hw.product" value="UNKNOWN"/>
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="FlowPoint\/(.*) SDSL \[ATM\] Router .*v(.*) Ready">
     <description>iFlowPoint 2200 DSL router</description>
@@ -971,6 +965,7 @@
     <param pos="0" name="hw.vendor" value="Flowpoint"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
     <param pos="0" name="hw.product" value="DSL router"/>
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
     <param pos="1" name="hw.model"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -982,12 +977,17 @@
     </example>
     <param pos="0" name="hw.vendor" value="Conexant"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
+    <param pos="0" name="hw.product" value="UNKNOWN"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="VxWorks login:">
     <description>VxWorks embedded device</description>
     <example>VxWorks login: </example>
-    <param pos="0" name="hw.device" value="VxWorks"/>
+    <param pos="0" name="hw.family" value="VxWorks"/>
+    <param pos="0" name="hw.product" value="UNKNOWN"/>
+    <param pos="0" name="hw.vendor" value="UNKNOWN"/>
+    <param pos="0" name="hw.device" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern=".*Nortel.*Passport ([^ ]*) .*Software Release ([^ ]*).*">
     <description>Nortel Passport</description>
@@ -1000,6 +1000,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Nortel"/>
     <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1012,6 +1013,7 @@
     <param pos="0" name="hw.vendor" value="Check Point"/>
     <param pos="0" name="hw.family" value="Check Point"/>
     <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.product" value="IPSO"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="Tasman Networks Inc.*Telnet Login">
@@ -1025,6 +1027,7 @@
     <param pos="0" name="hw.vendor" value="Tasman Networks"/>
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="0" name="hw.product" value="Tasman Networks router"/>
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="Pragma Systems">
     <description>MS Windows running Pragma TelnetD server</description>
@@ -1034,6 +1037,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Application Required. No Installation Default">
@@ -1044,6 +1048,8 @@
     </example>
     <param pos="0" name="hw.vendor" value="IBM"/>
     <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="UNKNOWN"/>
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="This copy of the Ataman TCP Remote Logon Services">
     <description>Windows NT/2k/2k3 running Ataman telnet server</description>
@@ -1053,6 +1059,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Cobalt Linux release (.*)$">
@@ -1062,7 +1069,8 @@
     </example>
     <param pos="0" name="hw.vendor" value="Cobalt"/>
     <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.product" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="Check Point FireWall-1 authenticated Telnet server running on (.*)">
@@ -1118,20 +1126,21 @@
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Digital Unix"/>
   </fingerprint>
-  <fingerprint pattern="Compaq Tru64 UNIX V(.*) \(Rev. (.*)\).*" flags="REG_MULTILINE">
+  <fingerprint pattern="Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*" flags="REG_MULTILINE">
     <description>System is Compaq Tru64 UNIX V</description>
-    <example _encoding="base64" os.version="5.1B">
+    <example _encoding="base64" os.version="5.1B" os.rev="2650">
      Q29tcGFxIFRydTY0IFVOSVggVjUuMUIgKFJldi4gMjY1MCkgKGRvY2FscGhhKSAocHRzLzExKQoKCgoKCmxvZ2luOg== 
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="Digital Unix"/>
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="TRU64"/>
-    <param pos="1" name ="os.version"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.rev"/>
   </fingerprint>
   <fingerprint pattern="HP-UX ([^ ]+) [A-Z]\.([^ ]+) ([^ ]+) ([^ ]+)\s([^ ]+\)).*$">
     <description>System HP-UX</description>
-    <example _encoding="base64" host.name="ctout" os.version="11.11">
+    <example _encoding="base64" host.name="ctout" os.version="11.11" hw.series="9000/800" hw.model="(tc)">
       SFAtVVggY3RvdXQgQi4xMS4xMSBVIDkwMDAvODAwICh0YykKCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
@@ -1140,6 +1149,9 @@
     <param pos="0" name="hw.product" value="HP-UX"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
+    <param pos="3" name="hw.version"/>
+    <param pos="4" name="hw.series"/>
+    <param pos="5" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="Data ONTAP">
     <description>System is a NetApp apliance</description>
@@ -1173,10 +1185,11 @@
   <fingerprint pattern="% Username:  timeout expired!">
     <description>System is some kind of Cisco device</description>
     <example _encoding="base64">
-      VXNlciBBY2Nlc3MgVmVyaWZpY2F0aW9uCgpVc2VybmFtZTogCiUgVXNlcm5hbWU6ICB0aW1lb3V0IGV4cGlyZWQh
+      JSBVc2VybmFtZTogIHRpbWVvdXQgZXhwaXJlZCE=
     </example>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="IOS"/>
+    <param pos="0" name="hw.device" value="UNKNOWN"/>
     <param pos="0" name="hw.product" value="IOS"/>
   </fingerprint>
   <fingerprint pattern="Welcome to MKS Telnet Server Version">
@@ -1194,6 +1207,8 @@
     <example>Sorry, this system is engaged.</example>
     <param pos="0" name="hw.vendor" value="Epson"/>
     <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.product" value="UNKNOWN"/>
+    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="TELNET session now in ESTABLISHED state">
     <description>System is an Allied Telesyn router</description>
@@ -1251,16 +1266,6 @@
     <param pos="1" name="os.arch"/>
     <param pos="2" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="FreeBSD">
-    <description>System is FreeBSD</description>
-    <example _encoding="base64">
-      RnJlZUJTRC9pMzg2IChTUlZWUE5TbW9sZW4tMikgKHB0cy8wKQoKCgpsb2dpbjog
-    </example>
-    <param pos="0" name="hw.vendor" value="FreeBSD"/>
-    <param pos="0" name="hw.family" value="FreeBSD"/>
-    <param pos="0" name="hw.device" value="General"/>
-    <param pos="0" name="hw.product" value="FreeBSD"/>
-  </fingerprint>
   <fingerprint pattern="NetBSD">
     <description>System is NetBSD</description>
     <example _encoding="base64">
@@ -1281,21 +1286,9 @@
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="IRIX"/>
   </fingerprint>
-  <fingerprint pattern="Tasman Networks Inc.">
-    <description>System is Tasman Networks router</description>
-    <example _encoding="base64">
-      Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
-      S0tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS
-      0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2h
-      hcmFjdGVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
-    </example>
-    <param pos="0" name="hw.vendor" value="Tasman Networks"/>
-    <param pos="0" name="hw.family" value="TiOS"/>
-    <param pos="0" name="hw.device" value="Router"/>
-  </fingerprint>
   <fingerprint pattern="^(RS [^\s]+) System Software, Version ([^\s]+).*" flags="REG_MULTILINE">
     <description>System is RiverStone router</description>
-    <example _encoding="base64" hw.device="RS 8000">
+    <example _encoding="base64" hw.product="RS 8000" os.version="9.3.0.5">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d2
       9ya3MsIEluYy4sIENvcHlyaWdodCAoYykgMjAwMC0yMDA0LiBBbGwgcmlnaHRzIHJlc2VydmVkLgpTeXN0ZW0
@@ -1304,11 +1297,13 @@
     </example>
     <param pos="0" name="hw.vendor" value="Riverstone"/>
     <param pos="0" name="hw.family" value="Riverstone"/>
-    <param pos="1" name="hw.device"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="(ES [^\s]+) System Software, Version ([^\s]+)">
-    <description>System is a Tasman Networks Ethernet router`</description>
-    <example _encoding="base64" hw.device="ES 10170" os.version="9.3.0.4">
+    <description>System is a Riverstone router`</description>
+    <example _encoding="base64" hw.product="ES 10170" os.version="9.3.0.4">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
       dvcmtzLCBJbmMuLCBDb3B5cmlnaHQgKGMpIDIwMDAtMjAwMy4gQWxsIHJpZ2h0cyByZXNlcnZlZC4KU3lzdGV
@@ -1317,20 +1312,29 @@
     </example>
     <param pos="0" name="hw.vendor" value="Riverstone"/>
     <param pos="0" name="hw.family" value="ES"/>
-    <param pos="1" name="hw.device"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="HP.*ProCurve Switch">
     <description>System is HP ProCurve Switch</description>
     <example _encoding="base64">
-      SFAgSjQxMjFBIFByb0N1cnZlIFN3aXRjaCA0MDAwTQpGaXJtd2FyZSByZXZpc2lvbiBDLjA5LjIyCgpDb3B
-      5cmlnaHQgKEMpIDE5OTEtMjAwMiBIZXdsZXR0LVBhY2thcmQgQ28uICBBbGwgUmlnaHRzIFJlc2VydmVkLg
-      oKICAgICAgICAgICAgICAgICAgICAgICAgICAgUkVTVFJJQ1RFRCBSSUdIVFMgTEVHRU5ECgogVXNlLCBkd
-      XBsaWNhdGlvbiwgb3IgZGlzY2xvc3VyZSBieSB0aGUgR292ZXJubWVudCBpcyBzdWJqZWN0IHRvIHJlc3Ry
-      aWN0aW9ucwogYXMgc2V0IGZvcnRoIGluIHN1YmRpdmlzaW9uIChiKSAoMykgKGlpKSBvZiB0aGUgUmlnaHR
-      zIGluIFRlY2huaWNhbCBEYXRhIGFuZAogQ29tcHV0ZXIgU29mdHdhcmUgY2xhdXNlIGF0IDUyLjIyNy03MD
-      EzLgoKICAgICAgICAgSEVXTEVUVC1QQUNLQVJEIENPTVBBTlksIDMwMDAgSGFub3ZlciBTdC4sIFBhbG8gQ
-      Wx0bywgQ0EgOTQzMDMKCgpVc2VyIEFjY2VzcyBWZXJpZmljYXRpb24KClVzZXJuYW1lOiA=
+      PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09P
+      T09PT09PT09PT09PT09PT09PT09PT09CkhQIEo0MTIxQSBQcm9DdXJ2ZSBTd2l0Y2ggNDAwME
+      0KRmlybXdhcmUgcmV2aXNpb24gdjIuMi4zCgpDb3B5cmlnaHQgKEMpIDE5OTEtMjAwNCBIZXd
+      sZXR0LVBhY2thcmQgQ28uIEFsbCBSaWdodHMgUmVzZXJ2ZWQuCgogICAgICAgICAgICAgICAg
+      ICAgICAgICBSRVNUUklDVEVEIFJJR0hUUyBMRUdFTkQKCiBVc2UsIGR1cGxpY2F0aW9uLCBvc
+      iBkaXNjbG9zdXJlIGJ5IHRoZSBHb3Zlcm5tZW50IGlzIHN1YmplY3QgdG8gcmVzdHJpY3Rpb2
+      5zCiAKIGFzIHNldCBmb3J0aCBpbiBzdWJkaXZpc2lvbiAoYikgKDMpIChpaSkgb2YgdGhlIFJ
+      pZ2h0cyBpbiBUZWNobmljYWwgRGF0YSBhbmQKIAogQ29tcHV0ZXIgU29mdHdhcmUgY2xhdXNl
+      IGF0IDUyLjIyNy03MDEzLgoKICAgICAgSEVXTEVUVC1QQUNLQVJEIENPTVBBTlksIDMwMDAgS
+      GFub3ZlciBTdC4sIFBhbG8gQWx0bywgQ0EgOTQzMDMKCiAgICAgICAgICAgICAgICAgICAgIC
+      AgIApXZSdkIGxpa2UgdG8ga2VlcCB5b3UgdXAgdG8gZGF0ZSBhYm91dDoKICogU29mdHdhcmU
+      gZmVhdHVyZSB1cGRhdGVzCiAqIE5ldyBwcm9kdWN0IGFubm91bmNlbWVudHMKICogU3BlY2lh
+      bCBldmVudHMKCiAgICAgICAgICAgICAgICAgICAgICAgIApQbGVhc2UgcmVnaXN0ZXIgeW91c
+      iBwcm9kdWN0cyBub3cgYXQ6IHd3dy5Qcm9DdXJ2ZS5jb20KPT09PT09PT09PT09PT09PT09PT
+      09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0
+      9PT09CgoKVXNlcm5hbWU6IA==
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="ProCurve"/>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -818,6 +818,7 @@
   </fingerprint>
   <fingerprint pattern="^Red Hat Linux release ([^\\s]+)\\s*.*$">
     <description>RedHat general purpose linux</description>
+    <!-- Red Hat Linux release 9 (Shrike)\nKernel 2.4.20-8 on an i686\nlogin: -->
     <example _encoding="base64" os.version="9 (Shrike)">
       UmVkIEhhdCBMaW51eCByZWxlYXNlIDkgKFNocmlrZSlcbktlcm5lbCAyLjQuMjAtOCBvbiBhbiBpNjg2XG5sb2dpbjo=
    </example>
@@ -826,8 +827,9 @@
     <param pos="0" name="hw.device" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)">
     <description>RedHat Enterprise Linux ES</description>
+    <!-- Red Hat Enterprise Linux ES release 3 (Taroon Update 9\nKernel 2.4.21-47.EL on an x86_64\nlogin: -->
     <example _encoding="base64" os.version="3" linux.kernel.version="2.4.21-47.EL" os.arch="x86_64">
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEVTIHJlbGVhc2UgMyAoVGFyb29uIFVwZGF0ZSA5KQpLZXJuZWwgMi40LjIxLTQ3Lk
       VMIG9uIGFuIHg4Nl82NApsb2dpbjo=
@@ -839,61 +841,63 @@
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^Red Hat Enterprise Linux AS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)Red Hat Enterprise Linux AS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)">
     <description>RedHat Enterprise Linux AS</description>
+    <!-- Red Hat Enterprise Linux AS release 5.8 (Tikanga)\nKernel 2.6.18-308.11.1.el5 on an x86_64\nlogin: -->
     <example _encoding="base64" os.version="5.8" linux.kernel.version="2.6.18-308.11.1.el5" os.arch="x86_64">
-      UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEFTIHJlbGVhc2UgNS44IChUaWthbmdhKQpLZXJuZWwgMi42LjE4LTMwOC4xMS4xLmVsNSBvbiBhbiB4ODZfNjQKbG9naW46
+      UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEFTIHJlbGVhc2UgNS44IChUaWthbmdhKQpLZXJuZWwgM
+      i42LjE4LTMwOC4xMS4xLmVsNSBvbiBhbiB4ODZfNjQKbG9naW46
     </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
     <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="RedHat Enterprise AS"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^Red Hat Enterprise Linux WS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)Red Hat Enterprise Linux WS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)">
     <description>RedHat Enterprise Linux WS</description>
+    <!--Red Hat Enterprise Linux WS release 2.1 (Tampa) \nKernel 2.4.9-e.40smp on an i686 \nlogin:  -->
     <example _encoding="base64" os.version="2.1" linux.kernel.version="2.4.9-e.40smp" os.arch="i686">
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IFdTIHJlbGVhc2UgMi4xIChUYW1wY
       SkgCktlcm5lbCAyLjQuOS1lLjQwc21wIG9uIGFuIGk2ODYgCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
     <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="RedHat Enterprise WS"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^Fedora Core.release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d).*$" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)Fedora Core.release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d).*$">
     <description>Fedora Core Release</description>
+    <!-- Fedora Core release 1 (Yarrow)\nKernel 2.4.20-13.9ensim-3.5.0-13 on an i686\nlogin:-->
     <example _encoding="base64" os.version="1" linux.kernel.version="2.4.20-13.9ensim-3.5.0-13" os.arch="i686">
      RmVkb3JhIENvcmUgcmVsZWFzZSAxIChZYXJyb3cpCktlcm5lbCAyLjQuMjAtMTMuOWVuc2ltLTMuNS4wLTEzIG9uIGFuIGk2ODYKbG9naW46
     </example>
     <param pos="0" name="hw.vendor" value="Redhat"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="hw.product" value="Fedora"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^Welcome to SuSE Linux (.*) \(([^\)]+)\) - Kernel (.*) .*" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)Welcome to SuSE Linux (.*) \(([^\)]+)\) - Kernel (.*) .*">
     <description>SuSE Linux</description>
+    <!-- Welcome to SuSE Linux 7.0 (i386) - Kernel 2.2.16-RAID (0). 2VG029037\n\nlogin: -->
     <example _encoding="base64" os.version="7.0" os.arch="i386" linux.kernel.version="2.2.16-RAID (0). 2VG029037">
       V2VsY29tZSB0byBTdVNFIExpbnV4IDcuMCAoaTM4NikgLSBLZXJuZWwgMi4yLjE2LVJBSUQgKDApLiAyVkcwMjkwMzcgCgpsb2dpbjo=
     </example>
     <param pos="0" name="hw.vendor" value="SUSE"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
     <param pos="3" name="linux.kernel.version"/>
   </fingerprint>
   <fingerprint pattern="^Turbolinux ApplianceServer (\d+\.\d+).*">
     <description>Turbolinux ApplianceServer</description>
+    <!--Turbolinux ApplianceServer 4.0 (Atlas2) Linux 2.6.32-431.23.3.el6.x86_64 on a x86_64\n(senyo191x89.digitalink.ne.jp) TTY: 12:15 on Tuesday, 02 October 2018 login:  -->
     <example _encoding="base64" os.version="4.0">
      VHVyYm9saW51eCBBcHBsaWFuY2VTZXJ2ZXIgNC4wIChBdGxhczIpIExpbnV4IDIuNi4zMi00MzEuMjMuMy5lbDYueDg
      2XzY0IG9uIGEgeDg2XzY0IChzZW55bzE5MXg4OS5kaWdpdGFsaW5rLm5lLmpwKSBUVFk6IDEyOjE1IG9uIFR1ZXNkYX
@@ -902,11 +906,11 @@
     <param pos="0" name="hw.vendor" value="Turbolinux"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^UnixWare ([^ ]+).*$">
     <description>UnixWare</description>
+    <!-- UnixWare 2.1.3 (profil) (pts/3)\n\n\nlogin:  -->
     <example _encoding="base64" os.version="2.1.3">
      VW5peFdhcmUgMi4xLjMgKHByb2ZpbCkgKHB0cy8zKQoKCgpsb2dpbjog
     </example>
@@ -918,6 +922,7 @@
   </fingerprint>
   <fingerprint pattern="^Telnet Server Build (5.*)">
     <description>Windows 2000</description>
+    <!--Microsoft (R) Windows NT (TM) Version 4.00 (Build 1381)\nWelcome to Microsoft Telnet Service \nTelnet Server Build 5.00.99034.1\nlogin:  -->
     <example _encoding="base64" os.version="5.00.99034.1">
       TWljcm9zb2Z0IChSKSBXaW5kb3dzIE5UIChUTSkgVmVyc2lvbiA0LjAwIChCdWlsZCAxMzgxKQpXZWxj
       b21lIHRvIE1pY3Jvc29mdCBUZWxuZXQgU2VydmljZSAKVGVsbmV0IFNlcnZlciBCdWlsZCA1LjAwLjk5MDM0LjEKCmxvZ2luOiA=
@@ -925,11 +930,11 @@
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
     <param pos="0" name="hw.product" value="Windows 2000"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Welcome. Type return, enter password at # prompt">
     <description>Brother Printer</description>
+    <!-- Welcome. Type return, enter password at # prompt -->
     <example _encoding="base64">
       V2VsY29tZS4gVHlwZSByZXR1cm4sIGVudGVyIHBhc3N3b3JkIGF0ICMgcHJvbXB0Cg== 
     </example>
@@ -940,25 +945,25 @@
   </fingerprint>
   <fingerprint pattern="^(.*) Copyright by ARESCOM">
     <description>Arescom System</description>
+    <!--NDS1260HE-TLI Copyright by ARESCOM 2002\n\n\nPassword: -->
     <example _encoding="base64" hw.model="NDS1260HE-TLI">
       TkRTMTI2MEhFLVRMSSBDb3B5cmlnaHQgYnkgQVJFU0NPTSAyMDAyCgoKClBhc3N3b3JkOgo=
     </example>
     <param pos="0" name="hw.vendor" value="Arescom"/>
     <param pos="0" name="hw.device" value="WAP"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
     <param pos="1" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="Welcome to ViewStation">
     <description>Polycom ViewStation Video Vonference System</description>
+    <!-- Welcome to ViewStation\nPassword: -->
     <example _encoding="base64">
       V2VsY29tZSB0byBWaWV3U3RhdGlvbgoKUGFzc3dvcmQ6
     </example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="ViewStation"/>
-    <param pos="0" name="hw.product" value="UNKNOWN"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="FlowPoint\/(.*) SDSL \[ATM\] Router .*v(.*) Ready">
+    <!--FlowPoint/2200 SDSL [ATM] Router fp2200-12 v3.0.2 Ready\nLogin:  -->
     <description>iFlowPoint 2200 DSL router</description>
     <example _encoding="base64" hw.model="2200" os.version="3.0.2">
     Rmxvd1BvaW50LzIyMDAgU0RTTCBbQVRNXSBSb3V0ZXIgZnAyMjAwLTEyIHYzLjAuMiBSZWFkeQpMb2dpbjog
@@ -966,32 +971,28 @@
     <param pos="0" name="hw.vendor" value="Flowpoint"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
     <param pos="0" name="hw.product" value="DSL router"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
     <param pos="1" name="hw.model"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="GlobespanVirata Inc\., Software Release (.*)">
     <description>GlobespanVirata broadband router</description>
+    <!--GlobespanVirata Inc., Software Release 2.1.040407a3_u_e_A\nCopyright (c) 2001-2003 by GlobespanVirata, Inc.\n\nlogin:  -->
     <example _encoding="base64" os.version="2.1.040407a3_u_e_A">
       R2xvYmVzcGFuVmlyYXRhIEluYy4sIFNvZnR3YXJlIFJlbGVhc2UgMi4xLjA0MDQwN2EzX3VfZV9BCgpDb3B5cmlnaHQgKG
       MpIDIwMDEtMjAwMyBieSBHbG9iZXNwYW5WaXJhdGEsIEluYy4KCgpsb2dpbjog
     </example>
     <param pos="0" name="hw.vendor" value="Conexant"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
-    <param pos="0" name="hw.product" value="UNKNOWN"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="VxWorks login:">
     <description>VxWorks embedded device</description>
     <example>VxWorks login: </example>
     <param pos="0" name="hw.family" value="VxWorks"/>
-    <param pos="0" name="hw.product" value="UNKNOWN"/>
-    <param pos="0" name="hw.vendor" value="UNKNOWN"/>
-    <param pos="0" name="hw.device" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern=".*Nortel.*Passport ([^ ]*) .*Software Release ([^ ]*).*">
     <description>Nortel Passport</description>
+    <!-- *********************************************\n\n\n* Copyright (c) 2003 Nortel Networks, Inc.  *\n\n\n* All Rights Reserved                       *\n\n\n* Passport 8010                             *\n\n\n* Software Release 3.5.0.0                  *\n\n\n*********************************************\n\n\n\n\nLogin: -->
     <example _encoding="base64" hw.product="8010" os.version="3.5.0.0">
       KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmlnaHQgKG
       MpIDIwMDMgTm9ydGVsIE5ldHdvcmtzLCBJbmMuICAqXG5cblxuKiBBbGwgUmlnaHRzIFJlc2VydmVkICAgICAg
@@ -1001,12 +1002,12 @@
     </example>
     <param pos="0" name="hw.vendor" value="Nortel"/>
     <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="IPSO.* \((.*)\) \(tty.*\)">
     <description>Checkpoint Firewall-1 running on a Nokia IPSO appliance</description>
+    <!-- IPSO/i386 (BJ-IDC-FW2) (ttyp7)\n\n\nThis system is for authorized use only.\n\n\n\n\n\n\nlogin: -->
     <example _encoding="base64" host.name="BJ-IDC-FW2">
      SVBTTy9pMzg2IChCSi1JREMtRlcyKSAodHR5cDcpCgoKClRoaXMgc3lzdGVtIGlzIGZvciBhdXRob3Jpem
      VkIHVzZSBvbmx5LgoKCgoKCgoKbG9naW46IA==
@@ -1019,6 +1020,7 @@
   </fingerprint>
   <fingerprint pattern="Tasman Networks Inc.*Telnet Login">
     <description>Tasman Networks Login</description>
+    <!-- Welcome to Gemadept Logistics RF Server\n(C) Copyright 1994-2012 Pragma Systems, Inc.\nlogin name: -->
     <example _encoding="base64" hw.vendor="Tasman Networks">
       Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0
       tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS
@@ -1028,54 +1030,52 @@
     <param pos="0" name="hw.vendor" value="Tasman Networks"/>
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="0" name="hw.product" value="Tasman Networks router"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="Pragma Systems">
     <description>MS Windows running Pragma TelnetD server</description>
+    <!-- Welcome to Gemadept Logistics RF Server\n(C) Copyright 1994-2012 Pragma Systems, Inc.\nlogin name: -->
     <example _encoding="base64">
       V2VsY29tZSB0byBHZW1hZGVwdCBMb2dpc3RpY3MgUkYgU2VydmVyCihDKSBDb3B5cmlnaHQgMTk5NC0yMDEyIFB
       yYWdtYSBTeXN0ZW1zLCBJbmMuCgpsb2dpbiBuYW1lOiA=
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Application Required. No Installation Default">
     <description>probably IBM AS/400 running TN3270 or 5250 emulation server</description>
+    <!-- Application Required. No Installation Default\nEnter Application Name: -->
     <example _encoding="base64">
      QXBwbGljYXRpb24gUmVxdWlyZWQuIE5vIEluc3RhbGxhdGlvbiBEZWZhdWx0ICAgICAgICA
      gICAgICAgICAgICAgICAgICAgICAgICAgIApFbnRlciBBcHBsaWNhdGlvbiBOYW1lOg==
     </example>
     <param pos="0" name="hw.vendor" value="IBM"/>
-    <param pos="0" name="hw.device" value="General"/>
-    <param pos="0" name="hw.product" value="UNKNOWN"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="This copy of the Ataman TCP Remote Logon Services">
     <description>Windows NT/2k/2k3 running Ataman telnet server</description>
+    <!-- This copy of the Ataman TCP Remote Logon Services is registered as licensed to:\nECI2/DDMS\nAccount Name: -->
     <example _encoding="base64">
       VGhpcyBjb3B5IG9mIHRoZSBBdGFtYW4gVENQIFJlbW90ZSBMb2dvbiBTZXJ2aWNlcyBpcyByZWdpc3RlcmVkIG
       FzIGxpY2Vuc2VkIHRvOgoJRUNJMi9ERE1TCgpBY2NvdW50IE5hbWU6IA==
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
-  <fingerprint pattern="Cobalt Linux release (.*)$">
+  <fingerprint pattern="Cobalt Linux release\W(.*)\W\(.*">
     <description>Cobalt Linux</description>
-    <example _encoding="base64" os.version="6.0 (Shinkansen)">
+    <!-- Cobalt Linux release 6.0 (Shinkansen)\nKernel 2.2.16C37_III on an i586\nlogin:  -->
+    <example _encoding="base64" os.version="6.0">
       Q29iYWx0IExpbnV4IHJlbGVhc2UgNi4wIChTaGlua2Fuc2VuKQpLZXJuZWwgMi4yLjE2QzM3X0lJSSBvbiBhbiBpNTg2CmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="Cobalt"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="Check Point FireWall-1 authenticated Telnet server running on (.*)">
     <description>Check Point Firewall-1</description>
+    <!-- Check Point FireWall-1 authenticated Telnet server running on gaatdrf2\nUser: -->
     <example _encoding="base64" host.name="gaatdrf2">
       Q2hlY2sgUG9pbnQgRmlyZVdhbGwtMSBhdXRoZW50aWNhdGVkIFRlbG5ldCBzZXJ2ZXIgcnVubmluZyBvbiBnYWF0ZHJmMgoKVXNlcjog
     </example>
@@ -1087,6 +1087,7 @@
   </fingerprint>
   <fingerprint pattern="Raptor Firewall">
     <description>Raptor Firewall</description>
+    <!-- Raptor Firewall Secure Gateway.\nHostname: -->
     <example _encoding="base64">
       UmFwdG9yIEZpcmV3YWxsIFNlY3VyZSBHYXRld2F5LgoKSG9zdG5hbWU6IA==
     </example>
@@ -1095,58 +1096,59 @@
     <param pos="0" name="hw.device" value="Firewall"/>
     <param pos="0" name="hw.product" value="Raptor"/>
   </fingerprint>
-  <fingerprint pattern="UNIX\(r\) System V Release 4.0">
-    <description>SunOS 5.x (Solaris)</description>
-    <example _encoding="base64">
+  <fingerprint pattern="UNIX\(r\) System V Release (\d*.\d*)">
+    <description>SunOS (Solaris)</description>
+    <!-- Raptor Firewall Secure Gateway.\nHostname: -->
+    <example _encoding="base64" os.version="4.0">
       VU5JWChyKSBTeXN0ZW0gViBSZWxlYXNlIDQuMCAoVGhlLVNlcnZlcikKCgoKbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="Sun"/>
     <param pos="0" name="hw.family" value="Solaris"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Solaris"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="Solaris (.*)">
     <description>Solaris</description>
+    <!-- Seattle Community Network Sun Solaris 1.1.1.B\nPlease login as 'visitor' if you are a visitorn\n\nSunOS UNIX (scn)\n\n\nlogin:-->
     <example _encoding="base64" os.version="1.1.1.B">
       U2VhdHRsZSBDb21tdW5pdHkgTmV0d29yayBTdW4gU29sYXJpcyAxLjEuMS5CClBsZWFzZSBsb2dpbiBhcyAndml
       zaXRvcicgaWYgeW91IGFyZSBhIHZpc2l0b3IKCgpTdW5PUyBVTklYIChzY24pCgoKCmxvZ2luOg==
     </example>
     <param pos="0" name="hw.vendor" value="Sun"/>
     <param pos="0" name="hw.family" value="Solaris"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="Digital UNIX">
     <description>Digital Unix</description>
+    <!-- Digital UNIX (journal) (ttyp2)\n\n\nlogin: -->
     <example _encoding="base64">
       RGlnaXRhbCBVTklYIChqb3VybmFsKSAodHR5cDIpCgoKCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="Digital Unix"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Digital Unix"/>
   </fingerprint>
-  <fingerprint pattern="Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*">
     <description>Compaq Tru64 UNIX V</description>
+    <!-- Compaq Tru64 UNIX V5.1B (Rev. 2650) (docalpha) (pts/11)\n\n\n\n\nlogin: -->
     <example _encoding="base64" os.version="5.1B" os.rev="2650">
      Q29tcGFxIFRydTY0IFVOSVggVjUuMUIgKFJldi4gMjY1MCkgKGRvY2FscGhhKSAocHRzLzExKQoKCgoKCmxvZ2luOg== 
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="Digital Unix"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="TRU64"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.rev"/>
   </fingerprint>
   <fingerprint pattern="HP-UX ([^ ]+) [A-Z]\.([^ ]+) ([^ ]+) ([^ ]+)\s([^ ]+\)).*$">
     <description>System HP-UX</description>
+    <!-- HP-UX ctout B.11.11 U 9000/800 (tc)\nlogin: -->
     <example _encoding="base64" host.name="ctout" os.version="11.11" hw.series="9000/800" hw.model="(tc)">
       SFAtVVggY3RvdXQgQi4xMS4xMSBVIDkwMDAvODAwICh0YykKCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="HP-UX"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="HP-UX"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
@@ -1156,41 +1158,44 @@
   </fingerprint>
   <fingerprint pattern="Data ONTAP">
     <description>A NetApp apliance</description>
+    <!-- Data ONTAP (s500.)\nlogin: -->
     <example _encoding="base64">RGF0YSBPTlRBUCAoczUwMC4pCmxvZ2luOiA=</example>
     <param pos="0" name="hw.vendor" value="NetApp"/>
     <param pos="0" name="hw.family" value="Data ONTAP"/>
     <param pos="0" name="hw.device" value="Storage"/>
     <param pos="0" name="hw.product" value="Data ONTAP"/>
   </fingerprint>
-  <fingerprint pattern="OpenVMS">
+  <fingerprint pattern="OpenVMS.*Version\sV(\d*.\d*).*">
     <description>OpenVMS</description>
-    <example _encoding="base64">
-      V2VsY29tZSB0byBPcGVuVk1TIChUTSkgQWxwaGEgT3BlcmF0aW5nIFN5c3RlbSwgVmVyc2lvbiBWNy4zLTIgIAoKClVzZXJuYW1lOiA=
+    <!--  Welcome to OpenVMS (TM) Alpha Operating System, Version V8.4     - NOT70\n\nUsername: -->
+    <example _encoding="base64" os.version="8.4">
+      IFdlbGNvbWUgdG8gT3BlblZNUyAoVE0pIEFscGhhIE9wZXJhdGluZyBTeXN0Z
+      W0sIFZlcnNpb24gVjguNCAgICAgLSBOT1Q3MAoKClVzZXJuYW1lOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="OpenVMS"/>
-    <param pos="0" name="hw.device" value="General"/>
+          <param pos="0" name="hw.family" value="OpenVMS"/>CCESS RUNNER ADSL CONSOLE PORT
     <param pos="0" name="hw.product" value="VMS"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="SCO OpenServer\(TM\) Release ([^ ]+).*$" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)SCO OpenServer\(TM\) Release ([^ ]+).*$">
     <description>SCO OpenServer</description>
+    <!-- SCO OpenServer(TM) Release 5 (bomdia.co.za) (ttyp6)\nlogin: -->
     <example _encoding="base64" os.version="5">
       U0NPIE9wZW5TZXJ2ZXIoVE0pIFJlbGVhc2UgNSAoYm9tZGlhLmNvLnphKSAodHR5cDYpCgpsb2dpbjo=
     </example>
     <param pos="0" name="hw.vendor" value="SCO"/>
     <param pos="0" name="hw.family" value="OpenServer"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="OpenServer"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="% Username:  timeout expired!">
     <description>Some kind of Cisco device</description>
+    <!-- % Username:  timeout expired!-->
     <example _encoding="base64">
       JSBVc2VybmFtZTogIHRpbWVvdXQgZXhwaXJlZCE=
     </example>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="IOS"/>
-    <param pos="0" name="hw.device" value="UNKNOWN"/>
     <param pos="0" name="hw.product" value="IOS"/>
   </fingerprint>
   <fingerprint pattern="Welcome to MKS Telnet Server Version">
@@ -1200,7 +1205,6 @@
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Sorry, this system is engaged\.">
@@ -1208,11 +1212,10 @@
     <example>Sorry, this system is engaged.</example>
     <param pos="0" name="hw.vendor" value="Epson"/>
     <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="0" name="hw.product" value="UNKNOWN"/>
-    <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="TELNET session now in ESTABLISHED state">
     <description>an Allied Telesyn router</description>
+    <!-- TELNET session now in ESTABLISHED state\n\nGEO-003 login: -->
     <example _encoding="base64">
       VEVMTkVUIHNlc3Npb24gbm93IGluIEVTVEFCTElTSEVEIHN0YXRlCgpHRU8tMDAzIGxvZ2luOiA=
     </example>
@@ -1233,6 +1236,7 @@
   </fingerprint>
   <fingerprint pattern="System administrator is connecting from">
     <description>a DrayTek Vigor SOHO Router</description>
+    <!-- System administrator is connecting from 54.39.173.86\n\nReject the connection request !!! -->
     <example _encoding="base64">
       U3lzdGVtIGFkbWluaXN0cmF0b3IgaXMgY29ubmVjdGluZyBmcm9tIDU0LjM5LjE3My44NgoKUmVqZWN0IH
       RoZSBjb25uZWN0aW9uIHJlcXVlc3QgISEh
@@ -1241,54 +1245,52 @@
     <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="0" name="hw.product" value="Vigor"/>
   </fingerprint>
-  <fingerprint pattern="OpenBSD">
+  <fingerprint pattern=".*Version\s(\d*.\d*)\/OpenBSD.*">
     <description>OpenBSD</description>
-    <example _encoding="base64">
-      V2VsY29tZSB0byB0aGUgT3BlbkJTRCBpbnN0YWxsYXRpb24gYW5kIHVwZGF0ZSBkZW1vcwoKVGhlcmUgYXJ
-      lIHNldmVyYWwgc2hvd3MgYXZhaWxhYmxlIHRoYXQgd2lsbCBiZSByb3RhdGVkIGV2ZXJ5IDYwIHNlY29uZH
-      MuCkN1cnJlbnRseSBzZWxlY3RlZCBpcyBzaG93IG51bWJlciAwMy4gSWYgeW91IHdhbnQgdG8gc2VlIGFub
-      3RoZXIgb25lLApkaXNjb25uZWN0IG5vdyBhbmQgcmVjb25uZWN0IGxhdGVyLgoKU2hvdyAwMSAoRHVyYXRp
-      b246IDAwOjA3OjU3KToKICAgICAgICBQZXJmZWN0bHkgbm9ybWFsIGFuZCBib3JpLi4u
+    <!-- 220 killer09 FTP server (Version 6.4/OpenBSD/Linux-ftpd-0.17) ready. -->
+    <example _encoding="base64" os.version="6.4">
+      MjIwIGtpbGxlcjA5IEZUUCBzZXJ2ZXIgKFZlcnNpb24gNi40L09wZW5CU0QvTGludXgtZnRwZC0wLjE3KSByZWFkeS4K
     </example>
     <param pos="0" name="hw.vendor" value="OpenBSD"/>
     <param pos="0" name="hw.family" value="OpenBSD"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="OpenBSD"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="FreeBSD\/([^\\s]+)\s+\(([^\s]+)\)">
     <description>a FreeBSD</description>
+    <!-- FreeBSD/amd64 (ms.gymspgs.cz) (pts/0)\n\n\n\nlogin: -->
     <example _encoding="base64" os.arch="amd64" host.name="ms.gymspgs.cz">
       RnJlZUJTRC9hbWQ2NCAobXMuZ3ltc3Bncy5jeikgKHB0cy8wKQoKCgpsb2dpbjo=
     </example>
     <param pos="0" name="hw.vendor" value="FreeBSD"/>
     <param pos="0" name="hw.family" value="FreeBSD"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="FreeBSD"/>
     <param pos="1" name="os.arch"/>
     <param pos="2" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="NetBSD">
     <description>NetBSD</description>
+    <!-- NetBSD/messimips () (ttyp3)\n\nlogin:  -->
     <example _encoding="base64">
       TmV0QlNEL21lc3NpbWlwcyAoKSAodHR5cDMpCgpsb2dpbjog
     </example>
     <param pos="0" name="hw.vendor" value="NetBSD"/>
     <param pos="0" name="hw.family" value="NetBSD"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="NetBSD"/>
   </fingerprint>
   <fingerprint pattern="IRIX">
     <description>SGI IRIX</description>
+    <!-- IRIX (artemis.biol.uoa.gr)\n\n\n\nlogin: -->
     <example _encoding="base64">
       SVJJWCAoYXJ0ZW1pcy5iaW9sLnVvYS5ncikKCgoKbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="SGI"/>
     <param pos="0" name="hw.family" value="IRIX"/>
-    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="IRIX"/>
   </fingerprint>
-  <fingerprint pattern="^(RS [^\s]+) System Software, Version ([^\s]+).*" flags="REG_MULTILINE">
+  <fingerprint pattern="^(?m)(RS [^\s]+) System Software, Version ([^\s]+).*">
     <description>RiverStone router</description>
+    <!-- ++++++++++++++++++++++++++++++++++++++++\nRS 8000 System Software, Version 9.3.0.5\nRiverstone Networks, Inc., Copyright (c) 2000-2004. All rights reserved.\nSystem started on 2018-10-11 22:02:03\n++++++++++++++++++++++++++++++++++++++++ -->
     <example _encoding="base64" hw.product="RS 8000" os.version="9.3.0.5">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d2
@@ -1304,6 +1306,7 @@
   </fingerprint>
   <fingerprint pattern="(ES [^\s]+) System Software, Version ([^\s]+)">
     <description>a Riverstone router`</description>
+    <!-- +++++++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\nRiverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n+++++++++++++++++++++++++++++++++++++++ -->
     <example _encoding="base64" hw.product="ES 10170" os.version="9.3.0.4">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
@@ -1319,6 +1322,7 @@
   </fingerprint>
   <fingerprint pattern="HP.*ProCurve Switch">
     <description>HP ProCurve Switch</description>
+    <!-- ==============================================================================\nHP J4121A ProCurve Switch 4000M\nFirmware revision v2.2.3\n\nCopyright (C) 1991-2004 Hewlett-Packard Co. All Rights Reserved.\n\n RESTRICTED RIGHTS LEGEND\n\n Use, duplication, or disclosure by the Government is subject to restrictions\n\nas set forth in subdivision (b) (3) (ii) of the Rights in Technical Data and\n\nComputer Software clause at 52.227-7013.\n\nHEWLETT-PACKARD COMPANY, 3000 Hanover St., Palo Alto, CA 94303\n\n\nWe'd like to keep you up to date about:\n* Software feature updates\n* New product announcements\n* Special events\n\n\nPlease register your products now at: www.ProCurve.com\n==============================================================================\n\n\nUsername:  -->
     <example _encoding="base64">
       PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09P
       T09PT09PT09PT09PT09PT09PT09PT09CkhQIEo0MTIxQSBQcm9DdXJ2ZSBTd2l0Y2ggNDAwME
@@ -1344,7 +1348,8 @@
   </fingerprint>
   <fingerprint pattern="ConnectUPS">
     <description>PowerWare ConnectUPS</description>
-    <example _encoding="base64"  >
+    <!-- +============================================================================+\n|            [ ConnectUPS Web/SNMP Card Configuration Utility ]              |\n+============================================================================+\n\nEnter Password: -->
+    <example _encoding="base64">
       Kz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0
       9PT09PT09PT09PT09PT0rCnwgICAgICAgICAgICBbIENvbm5lY3RVUFMgV2ViL1NOTVAgQ2FyZCBDb25maW
       d1cmF0aW9uIFV0aWxpdHkgXSAgICAgICAgICAgICAgfAorPT09PT09PT09PT09PT09PT09PT09PT09PT09P
@@ -1358,6 +1363,7 @@
   </fingerprint>
   <fingerprint pattern="Imagistics.*im">
     <description>an Imagistics device</description>
+    <!-- Imagistics im3511/im4511 Ver 01.00.20 TELNET server.\nCopyright(c) 2001-2005, silex technology, Inc.\nlogin: -->
     <example _encoding="base64">
       SW1hZ2lzdGljcyBpbTM1MTEvaW00NTExIFZlciAwMS4wMC4yMCBURUxORVQgc2VydmVyLgpDb3B5cmlnaH
       QoYykgMjAwMS0yMDA1LCBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
@@ -1369,6 +1375,7 @@
   </fingerprint>
   <fingerprint pattern="NRG Maintenance Shell">
     <description>a Ricoh NRG device</description>
+    <!-- NRG Maintenance Shell.   \nUser access verification.\nlogin: -->
     <example _encoding="base64"  >
       TlJHIE1haW50ZW5hbmNlIFNoZWxsLiAgIAoKVXNlciBhY2Nlc3MgdmVyaWZpY2F0aW9uLgoKbG9naW46
     </example>
@@ -1378,6 +1385,7 @@
   </fingerprint>
   <fingerprint pattern="^SHARP (AR-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>SHARP AR Series multifunction device</description>
+    <!-- SHARP AR-M351U Ver 01.00.18 TELNET server.\nCopyright(c) 2001-2005, silex technology, Inc.\nlogin: -->
     <example _encoding="base64" hw.product="AR-M351U" os.version="01.00.18">
       U0hBUlAgQVItTTM1MVUgVmVyIDAxLjAwLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChjKSAyMDAx
       LTIwMDUsIHNpbGV4IHRlY2hub2xvZ3ksIEluYy4KbG9naW46IA==
@@ -1390,6 +1398,7 @@
   </fingerprint>
   <fingerprint pattern="^SHARP (MX-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>SHARP MX Series multifunction device</description>
+    <!-- SHARP MX-3610N Ver 01.05.00.0o.18 TELNET server.\nCopyright(C) 2005-     SHARP CORPORATION\nCopyright(C) 2005-     silex technology, Inc.\nlogin:  -->
     <example _encoding="base64" hw.product="MX-3610N" os.version="01.05.00.0o.18">
       U0hBUlAgTVgtMzYxME4gVmVyIDAxLjA1LjAwLjBvLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodC
       hDKSAyMDA1LSAgICAgU0hBUlAgQ09SUE9SQVRJT04KQ29weXJpZ2h0KEMpIDIwMDUtICAgICBzaWxl

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1293,7 +1293,8 @@
   </fingerprint>
   <fingerprint pattern="(?m)(ES|RS)\s([^\s]+) System Software, Version ([^\s]+).*Riverstone Networks">
     <description>a Riverstone router</description>
-    <!-- +++++++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\n
+    <!-- Using '+' instead of '-' due to xml issue -->
+    <!-- ++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\n
     Riverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n
     +++++++++++++++++++++++++++++++++++++++ -->
     <example _encoding="base64" os.product="10170" os.version="9.3.0.4" os.family="ES">

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1042,7 +1042,7 @@
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Application Required. No Installation Default">
-    <description>System is probably IBM AS/400 running TN3270 or 5250 emulation server</description>
+    <description>probably IBM AS/400 running TN3270 or 5250 emulation server</description>
     <example _encoding="base64">
      QXBwbGljYXRpb24gUmVxdWlyZWQuIE5vIEluc3RhbGxhdGlvbiBEZWZhdWx0ICAgICAgICA
      gICAgICAgICAgICAgICAgICAgICAgICAgIApFbnRlciBBcHBsaWNhdGlvbiBOYW1lOg==
@@ -1096,7 +1096,7 @@
     <param pos="0" name="hw.product" value="Raptor"/>
   </fingerprint>
   <fingerprint pattern="UNIX\(r\) System V Release 4.0">
-    <description>System is SunOS 5.x (Solaris)</description>
+    <description>SunOS 5.x (Solaris)</description>
     <example _encoding="base64">
       VU5JWChyKSBTeXN0ZW0gViBSZWxlYXNlIDQuMCAoVGhlLVNlcnZlcikKCgoKbG9naW46IA==
     </example>
@@ -1106,7 +1106,7 @@
     <param pos="0" name="hw.product" value="Solaris"/>
   </fingerprint>
   <fingerprint pattern="Solaris (.*)">
-    <description>System is Solaris</description>
+    <description>Solaris</description>
     <example _encoding="base64" os.version="1.1.1.B">
       U2VhdHRsZSBDb21tdW5pdHkgTmV0d29yayBTdW4gU29sYXJpcyAxLjEuMS5CClBsZWFzZSBsb2dpbiBhcyAndml
       zaXRvcicgaWYgeW91IGFyZSBhIHZpc2l0b3IKCgpTdW5PUyBVTklYIChzY24pCgoKCmxvZ2luOg==
@@ -1118,7 +1118,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="Digital UNIX">
-    <description>System is Digital Unix</description>
+    <description>Digital Unix</description>
     <example _encoding="base64">
       RGlnaXRhbCBVTklYIChqb3VybmFsKSAodHR5cDIpCgoKCmxvZ2luOiA=
     </example>
@@ -1128,7 +1128,7 @@
     <param pos="0" name="hw.product" value="Digital Unix"/>
   </fingerprint>
   <fingerprint pattern="Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*" flags="REG_MULTILINE">
-    <description>System is Compaq Tru64 UNIX V</description>
+    <description>Compaq Tru64 UNIX V</description>
     <example _encoding="base64" os.version="5.1B" os.rev="2650">
      Q29tcGFxIFRydTY0IFVOSVggVjUuMUIgKFJldi4gMjY1MCkgKGRvY2FscGhhKSAocHRzLzExKQoKCgoKCmxvZ2luOg== 
     </example>
@@ -1155,7 +1155,7 @@
     <param pos="5" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="Data ONTAP">
-    <description>System is a NetApp apliance</description>
+    <description>A NetApp apliance</description>
     <example _encoding="base64">RGF0YSBPTlRBUCAoczUwMC4pCmxvZ2luOiA=</example>
     <param pos="0" name="hw.vendor" value="NetApp"/>
     <param pos="0" name="hw.family" value="Data ONTAP"/>
@@ -1163,7 +1163,7 @@
     <param pos="0" name="hw.product" value="Data ONTAP"/>
   </fingerprint>
   <fingerprint pattern="OpenVMS">
-    <description>System is OpenVMS</description>
+    <description>OpenVMS</description>
     <example _encoding="base64">
       V2VsY29tZSB0byBPcGVuVk1TIChUTSkgQWxwaGEgT3BlcmF0aW5nIFN5c3RlbSwgVmVyc2lvbiBWNy4zLTIgIAoKClVzZXJuYW1lOiA=
     </example>
@@ -1173,7 +1173,7 @@
     <param pos="0" name="hw.product" value="VMS"/>
   </fingerprint>
   <fingerprint pattern="SCO OpenServer\(TM\) Release ([^ ]+).*$" flags="REG_MULTILINE">
-    <description>System is SCO OpenServer</description>
+    <description>SCO OpenServer</description>
     <example _encoding="base64" os.version="5">
       U0NPIE9wZW5TZXJ2ZXIoVE0pIFJlbGVhc2UgNSAoYm9tZGlhLmNvLnphKSAodHR5cDYpCgpsb2dpbjo=
     </example>
@@ -1184,7 +1184,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="% Username:  timeout expired!">
-    <description>System is some kind of Cisco device</description>
+    <description>Some kind of Cisco device</description>
     <example _encoding="base64">
       JSBVc2VybmFtZTogIHRpbWVvdXQgZXhwaXJlZCE=
     </example>
@@ -1194,7 +1194,7 @@
     <param pos="0" name="hw.product" value="IOS"/>
   </fingerprint>
   <fingerprint pattern="Welcome to MKS Telnet Server Version">
-    <description>System is Windows running MKS Telnet Server</description>
+    <description>Windows running MKS Telnet Server</description>
     <example _encoding="base64">
       V2VsY29tZSB0byBNS1MgVGVsbmV0IFNlcnZlciBWZXJzaW9uIDQuNzAuMDAwMC4KbG9naW46IA==
     </example>
@@ -1204,7 +1204,7 @@
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Sorry, this system is engaged\.">
-    <description>System is an embedded print server</description>
+    <description>an embedded print server</description>
     <example>Sorry, this system is engaged.</example>
     <param pos="0" name="hw.vendor" value="Epson"/>
     <param pos="0" name="hw.device" value="Printer"/>
@@ -1212,7 +1212,7 @@
     <param pos="0" name="hw.family" value="UNKNOWN"/>
   </fingerprint>
   <fingerprint pattern="TELNET session now in ESTABLISHED state">
-    <description>System is an Allied Telesyn router</description>
+    <description>an Allied Telesyn router</description>
     <example _encoding="base64">
       VEVMTkVUIHNlc3Npb24gbm93IGluIEVTVEFCTElTSEVEIHN0YXRlCgpHRU8tMDAzIGxvZ2luOiA=
     </example>
@@ -1221,7 +1221,7 @@
     <param pos="0" name="hw.product" value="Allied Telesyn router"/>
   </fingerprint>
   <fingerprint pattern="CONEXANT SYSTEMS.*ACCESS RUNNER ADSL">
-    <description>System is a Conexant ADSL router</description>
+    <description>a Conexant ADSL router</description>
     <example _encoding="base64">
       G1swbRtbMkobWzAxOzI4SENPTkVYQU5UIFNZU1RFTVMsIElOQy4bWzAyOzE5SCBBQ0NFU1MgUlVOTkVSIEF
       EU0wgQ09OU09MRSBQT1JUG1syNDswMUg+Pj4bWzI0OzAxSExPR09OIFBBU1NXT1JEPhtbMDI7NTNIMy4yNx
@@ -1232,7 +1232,7 @@
     <param pos="0" name="hw.product" value="AccessRunner ADSL router"/>
   </fingerprint>
   <fingerprint pattern="System administrator is connecting from">
-    <description>System is a DrayTek Vigor SOHO Router</description>
+    <description>a DrayTek Vigor SOHO Router</description>
     <example _encoding="base64">
       U3lzdGVtIGFkbWluaXN0cmF0b3IgaXMgY29ubmVjdGluZyBmcm9tIDU0LjM5LjE3My44NgoKUmVqZWN0IH
       RoZSBjb25uZWN0aW9uIHJlcXVlc3QgISEh
@@ -1242,7 +1242,7 @@
     <param pos="0" name="hw.product" value="Vigor"/>
   </fingerprint>
   <fingerprint pattern="OpenBSD">
-    <description>System is OpenBSD</description>
+    <description>OpenBSD</description>
     <example _encoding="base64">
       V2VsY29tZSB0byB0aGUgT3BlbkJTRCBpbnN0YWxsYXRpb24gYW5kIHVwZGF0ZSBkZW1vcwoKVGhlcmUgYXJ
       lIHNldmVyYWwgc2hvd3MgYXZhaWxhYmxlIHRoYXQgd2lsbCBiZSByb3RhdGVkIGV2ZXJ5IDYwIHNlY29uZH
@@ -1256,7 +1256,7 @@
     <param pos="0" name="hw.product" value="OpenBSD"/>
   </fingerprint>
   <fingerprint pattern="FreeBSD\/([^\\s]+)\s+\(([^\s]+)\)">
-    <description>System is a FreeBSD</description>
+    <description>a FreeBSD</description>
     <example _encoding="base64" os.arch="amd64" host.name="ms.gymspgs.cz">
       RnJlZUJTRC9hbWQ2NCAobXMuZ3ltc3Bncy5jeikgKHB0cy8wKQoKCgpsb2dpbjo=
     </example>
@@ -1268,7 +1268,7 @@
     <param pos="2" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="NetBSD">
-    <description>System is NetBSD</description>
+    <description>NetBSD</description>
     <example _encoding="base64">
       TmV0QlNEL21lc3NpbWlwcyAoKSAodHR5cDMpCgpsb2dpbjog
     </example>
@@ -1278,7 +1278,7 @@
     <param pos="0" name="hw.product" value="NetBSD"/>
   </fingerprint>
   <fingerprint pattern="IRIX">
-    <description>System is SGI IRIX</description>
+    <description>SGI IRIX</description>
     <example _encoding="base64">
       SVJJWCAoYXJ0ZW1pcy5iaW9sLnVvYS5ncikKCgoKbG9naW46IA==
     </example>
@@ -1288,7 +1288,7 @@
     <param pos="0" name="hw.product" value="IRIX"/>
   </fingerprint>
   <fingerprint pattern="^(RS [^\s]+) System Software, Version ([^\s]+).*" flags="REG_MULTILINE">
-    <description>System is RiverStone router</description>
+    <description>RiverStone router</description>
     <example _encoding="base64" hw.product="RS 8000" os.version="9.3.0.5">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d2
@@ -1303,7 +1303,7 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="(ES [^\s]+) System Software, Version ([^\s]+)">
-    <description>System is a Riverstone router`</description>
+    <description>a Riverstone router`</description>
     <example _encoding="base64" hw.product="ES 10170" os.version="9.3.0.4">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
@@ -1318,7 +1318,7 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="HP.*ProCurve Switch">
-    <description>System is HP ProCurve Switch</description>
+    <description>HP ProCurve Switch</description>
     <example _encoding="base64">
       PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09P
       T09PT09PT09PT09PT09PT09PT09PT09CkhQIEo0MTIxQSBQcm9DdXJ2ZSBTd2l0Y2ggNDAwME
@@ -1343,7 +1343,7 @@
     <param pos="0" name="hw.product" value="ProCurve"/>
   </fingerprint>
   <fingerprint pattern="ConnectUPS">
-    <description>System is PowerWare ConnectUPS</description>
+    <description>PowerWare ConnectUPS</description>
     <example _encoding="base64"  >
       Kz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0
       9PT09PT09PT09PT09PT0rCnwgICAgICAgICAgICBbIENvbm5lY3RVUFMgV2ViL1NOTVAgQ2FyZCBDb25maW
@@ -1357,7 +1357,7 @@
     <param pos="0" name="hw.product" value="ConnectUPS"/>
   </fingerprint>
   <fingerprint pattern="Imagistics.*im">
-    <description>System is an Imagistics device</description>
+    <description>an Imagistics device</description>
     <example _encoding="base64">
       SW1hZ2lzdGljcyBpbTM1MTEvaW00NTExIFZlciAwMS4wMC4yMCBURUxORVQgc2VydmVyLgpDb3B5cmlnaH
       QoYykgMjAwMS0yMDA1LCBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
@@ -1368,7 +1368,7 @@
     <param pos="0" name="hw.product" value="im"/>
   </fingerprint>
   <fingerprint pattern="NRG Maintenance Shell">
-    <description>System is a Ricoh NRG device</description>
+    <description>a Ricoh NRG device</description>
     <example _encoding="base64"  >
       TlJHIE1haW50ZW5hbmNlIFNoZWxsLiAgIAoKVXNlciBhY2Nlc3MgdmVyaWZpY2F0aW9uLgoKbG9naW46
     </example>
@@ -1377,7 +1377,7 @@
     <param pos="0" name="hw.product" value="NRG Printer"/>
   </fingerprint>
   <fingerprint pattern="^SHARP (AR-[^\\s]+) Ver ([^\\s]+) TELNET server">
-    <description>System is SHARP AR Series multifunction device</description>
+    <description>SHARP AR Series multifunction device</description>
     <example _encoding="base64" hw.product="AR-M351U" os.version="01.00.18">
       U0hBUlAgQVItTTM1MVUgVmVyIDAxLjAwLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChjKSAyMDAx
       LTIwMDUsIHNpbGV4IHRlY2hub2xvZ3ksIEluYy4KbG9naW46IA==
@@ -1389,7 +1389,7 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^SHARP (MX-[^\\s]+) Ver ([^\\s]+) TELNET server">
-    <description>System is SHARP MX Series multifunction device</description>
+    <description>SHARP MX Series multifunction device</description>
     <example _encoding="base64" hw.product="MX-3610N" os.version="01.05.00.0o.18">
       U0hBUlAgTVgtMzYxME4gVmVyIDAxLjA1LjAwLjBvLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodC
       hDKSAyMDA1LSAgICAgU0hBUlAgQ09SUE9SQVRJT04KQ29weXJpZ2h0KEMpIDIwMDUtICAgICBzaWxl

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1000,9 +1000,9 @@
       AgICAqXG5cblxuKiBTb2Z0d2FyZSBSZWxlYXNlIDMuNS4wLjAgICAgICAgICAgICAgICAgICAqXG5cblxuKioq
       KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuXG5cbkxvZ2luOg==
     </example>
-    <param pos="0" name="hw.vendor" value="Nortel"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Nortel"/>
+    <param pos="0" name="os.device" value="Switch"/>
+    <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="IPSO.* \((.*)\) \(tty.*\)">
@@ -1227,6 +1227,7 @@
   </fingerprint>
   <fingerprint pattern="CONEXANT SYSTEMS.*ACCESS RUNNER ADSL">
     <description>a Conexant ADSL router</description>
+    <!-- CONEXANT SYSTEMS, INC. ACCESS RUNNER ADSL CONSOLE PORT>>>LOGON PASSWORD>3.27****** -->
     <example _encoding="base64">
       G1swbRtbMkobWzAxOzI4SENPTkVYQU5UIFNZU1RFTVMsIElOQy4bWzAyOzE5SCBBQ0NFU1MgUlVOTkVSIEF
       EU0wgQ09OU09MRSBQT1JUG1syNDswMUg+Pj4bWzI0OzAxSExPR09OIFBBU1NXT1JEPhtbMDI7NTNIMy4yNx

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1473,7 +1473,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^(?m)HP ProLiant.*v(\d+.\d+)">
-    <description>Sytem is HP ProLiant switch</description>
+    <description>Sytem is HP ProLiant server</description>
     <example _encoding="base64" os.version="2.00">
       SFAgUHJvTGlhbnQgQkwgZS1DbGFzcyBJbnRlZ3JhdGVkIEFkbWluaXN0cmF0b3IgdjIuMDAKICAgICAgI
       CAgQ29weXJpZ2h0IDIwMDUgSGV3bGV0dC1QYWNrYXJkIERldmVsb3BtZW50IEdyb3VwLCBMLlAuCgogIC
@@ -1488,7 +1488,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="ProLiant"/>
-    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.device" value="Server"/>
     <param pos="0" name="hw.product" value="ProLiant"/>
     <param pos="1" name="os.version"/>
   </fingerprint>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1020,7 +1020,8 @@
   </fingerprint>
   <fingerprint pattern="Tasman Networks Inc.*Telnet Login">
     <description>Tasman Networks Login</description>
-    <!-- Welcome to Gemadept Logistics RF Server\n(C) Copyright 1994-2012 Pragma Systems, Inc.\nlogin name: -->
+    <!-- #\n# Tasman Networks Inc. Telnet Login\n#Escape character is '^]'\n\n\n\nlogin: -->
+    <!-- Dashes removed from example banner due to xml issue -->
     <example _encoding="base64" hw.vendor="Tasman Networks">
       Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0
       tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1319,7 +1319,7 @@
     <param pos="2" name="os.product"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="HP.*ProCurve Switch">
+  <fingerprint pattern="HP ([^\s]+) ProCurve Switch">
     <description>HP ProCurve Switch</description>
     <!-- ==============================================================================\nHP J4121A ProCurve Switch 4000M\n
     Firmware revision v2.2.3\n\nCopyright (C) 1991-2004 Hewlett-Packard Co. All Rights Reserved.\n\n
@@ -1329,7 +1329,7 @@
     Software feature updates\n* New product announcements\n* Special events\n\n\nPlease register your
     products now at: www.ProCurve.com\n==============================================================================\n
     \n\nUsername:  -->
-    <example _encoding="base64">
+    <example _encoding="base64" os.product="J4121A">
       PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09P
       T09PT09PT09PT09PT09PT09PT09PT09CkhQIEo0MTIxQSBQcm9DdXJ2ZSBTd2l0Y2ggNDAwME
       0KRmlybXdhcmUgcmV2aXNpb24gdjIuMi4zCgpDb3B5cmlnaHQgKEMpIDE5OTEtMjAwNCBIZXd
@@ -1350,7 +1350,7 @@
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
-    <param pos="0" name="os.product" value="ProCurve"/>
+    <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="ConnectUPS">
     <description>PowerWare ConnectUPS</description>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -268,7 +268,9 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
+    <param pos="2" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^CentOS release ([\d.]+) \(Final\)(?:\r|\n)+Kernel ([\w.-]+) on an (\w+)(?:\r|\n)+(?:([\w.-]+) )?login:\s*$">
     <description>CentOS</description>
@@ -816,27 +818,30 @@
   </fingerprint>
   <fingerprint pattern="^Red Hat Linux release ([^\\s]+)\\s*.*$">
     <description>RedHat general purpose linux</description>
-    <example _encoding="base64">
+    <example _encoding="base64" os.version="9 (Shrike)">
       UmVkIEhhdCBMaW51eCByZWxlYXNlIDkgKFNocmlrZSlcbktlcm5lbCAyLjQuMjAtOCBvbiBhbiBpNjg2XG5sb2dpbjo=
    </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
-    <param pos="0" name="he.family" value="Linux" />
-    <param pos="0" name="hw.device" value="Linux" />
+    <param pos="0" name="he.family" value="Linux"/>
+    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
+  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
     <description>RedHat Enterprise Linux ES</description>
-    <example _encoding="base64" os.version="3">
+    <example _encoding="base64" os.version="3" linux.kernel.version="2.4.21-47.EL" os.arch="x86_64">
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEVTIHJlbGVhc2UgMyAoVGFyb29uIFVwZGF0ZSA5KQpLZXJuZWwgMi40LjIxLTQ3Lk
       VMIG9uIGFuIHg4Nl82NApsb2dpbjo=
     </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="hw.device" value="Linux"/>
-    <param pos="1" name ="os.version"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="linux.kernel.version"/>
+    <param pos="3" name="os.arch"/>
   </fingerprint>
-  <fingerprint pattern="^Red Hat Enterprise Linux AS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
+  <fingerprint pattern="^Red Hat Enterprise Linux AS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
     <description>RedHat Enterprise Linux AS</description>
-    <example _encoding="base64" os.version="5.8" >
+    <example _encoding="base64" os.version="5.8" linux.kernel.version="2.6.18-308.11.1.el5" os.arch="x86_64">
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEFTIHJlbGVhc2UgNS44IChUaWthbmdhKQpLZXJuZWwgMi42LjE4LTMwOC4xMS4xLmVsNSBvbiBhbiB4ODZfNjQKbG9naW46
     </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
@@ -844,10 +849,12 @@
     <param pos="0" name="hw.device" value="Linux"/>
     <param pos="0" name="hw.product" value="RedHat Enterprise AS"/>
     <param pos="1" name="os.version"/>
+    <param pos="2" name="linux.kernel.version"/>
+    <param pos="3" name="os.arch"/>
   </fingerprint>
   <fingerprint pattern="^Red Hat Enterprise Linux WS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
     <description>RedHat Enterprise Linux WS</description>
-    <example _encoding="base64" os.version="2.1" >
+    <example _encoding="base64" os.version="2.1" linux.kernel.version="2.4.9-e.40smp" os.arch="i686">
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IFdTIHJlbGVhc2UgMi4xIChUYW1wY
       SkgCktlcm5lbCAyLjQuOS1lLjQwc21wIG9uIGFuIGk2ODYgCmxvZ2luOiA=
     </example>
@@ -856,76 +863,61 @@
     <param pos="0" name="hw.device" value="Linux"/>
     <param pos="0" name="hw.product" value="RedHat Enterprise WS"/>
     <param pos="1" name="os.version"/>
+    <param pos="2" name="linux.kernel.version"/>
+    <param pos="3" name="os.arch"/>
   </fingerprint>
   <fingerprint pattern="^Fedora Core.release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d).*$" flags="REG_MULTILINE">
     <description>Fedora Core Release</description>
-    <example _encoding="base64" linux.kernel.version="2.4.20-13.9ensim-3.5.0-13" os.arch="i686" >
+    <example _encoding="base64" os.version="1" linux.kernel.version="2.4.20-13.9ensim-3.5.0-13" os.arch="i686">
      RmVkb3JhIENvcmUgcmVsZWFzZSAxIChZYXJyb3cpCktlcm5lbCAyLjQuMjAtMTMuOWVuc2ltLTMuNS4wLTEzIG9uIGFuIGk2ODYKbG9naW46
     </example>
     <param pos="0" name="hw.vendor" value="Redhat"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="hw.product" value="Fedora"/>
+    <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
   </fingerprint>
   <fingerprint pattern="^Welcome to SuSE Linux (.*) \(([^\)]+)\) - Kernel (.*) .*" flags="REG_MULTILINE">
     <description>SuSE Linux</description>
-    <example _encoding="base64" os.version="7.0" os.arch="i386">
+    <example _encoding="base64" os.version="7.0" os.arch="i386" linux.kernel.version="2.2.16-RAID (0). 2VG029037">
       V2VsY29tZSB0byBTdVNFIExpbnV4IDcuMCAoaTM4NikgLSBLZXJuZWwgMi4yLjE2LVJBSUQgKDApLiAyVkcwMjkwMzcgCgpsb2dpbjo=
     </example>
     <param pos="0" name="hw.vendor" value="SUSE"/>
     <param pos="0" name="hw.family" value="Linux"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
+    <param pos="3" name="linux.kernel.version"/>
   </fingerprint>
-  <fingerprint pattern="^Turbolinux ApplianceServer (.*)$">
-    <example _encoding="base64">
+  <fingerprint pattern="^Turbolinux ApplianceServer (\d+\.\d+).*">
+    <example _encoding="base64" os.version="4.0">
      VHVyYm9saW51eCBBcHBsaWFuY2VTZXJ2ZXIgNC4wIChBdGxhczIpIExpbnV4IDIuNi4zMi00MzEuMjMuMy5lbDYueDg
      2XzY0IG9uIGEgeDg2XzY0IChzZW55bzE5MXg4OS5kaWdpdGFsaW5rLm5lLmpwKSBUVFk6IDEyOjE1IG9uIFR1ZXNkYX
      ksIDAyIE9jdG9iZXIgMjAxOCBsb2dpbjog
     </example>
     <param pos="0" name="hw.vendor" value="Turbolinux"/>
     <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^UnixWare ([^ ]+).*$">
     <description>UnixWare</description>
-    <example _encoding="base64">
+    <example _encoding="base64" os.version="2.1.3">
      VW5peFdhcmUgMi4xLjMgKHByb2ZpbCkgKHB0cy8zKQoKCgpsb2dpbjog
     </example>
     <param pos="0" name="hw.vendor" value="SCO"/>
     <param pos="0" name="hw.family" value="UnixWare"/>
     <param pos="0" name="hw.device" value="UnixWare"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Telnet Server Build (5.*)">
     <description>Windows 2000</description>
-    <example _encoding="base64" >
+    <example _encoding="base64" os.version="5.00.99034.1">
       TWljcm9zb2Z0IChSKSBXaW5kb3dzIE5UIChUTSkgVmVyc2lvbiA0LjAwIChCdWlsZCAxMzgxKQpXZWxj
       b21lIHRvIE1pY3Jvc29mdCBUZWxuZXQgU2VydmljZSAKVGVsbmV0IFNlcnZlciBCdWlsZCA1LjAwLjk5MDM0LjEKCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
-  </fingerprint>
-  <fingerprint pattern="^Welcome to MELCO Print Server.*Server Name *: *([^ ]*).*Server Model *: *([^ ]*).*F/W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. ..).*$">
-    <description>System is a Buffalo/MELCO Embedded Print Server</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Buffalo"/>
-    <param pos="0" name="hw.family" value="PrintServer" />
-    <param pos="0" name="hw.device" value="Printer"/>
-  </fingerprint>
-  <fingerprint pattern="^JetDirect Telnet Configuration">
-    <description>JetDirect Telnet</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="JetDirect"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="0" name="hw.product" value="Brother Printer"/>
-  </fingerprint>
-  <fingerprint pattern="^Welcome to MELCO Print  Server.*Server Name *: *([^ ]*).*Server Model *: *([^ ]*).*F/W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. ..).*$">
-    <description>MELCO Embedded Print Server</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Buffalo"/>
-    <param pos="0" name="hw.family" value="PrintServer" />
-    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Welcome. Type return, enter password at # prompt">
     <example _encoding="base64"  >
@@ -938,32 +930,16 @@
   </fingerprint>
   <fingerprint pattern="^(.*) Copyright by ARESCOM">
     <description>Arescom System</description>
-    <example _encoding="base64">
+    <example _encoding="base64" hw.model="NDS1260HE-TLI">
      TkRTMTI2MEhFLVRMSSBDb3B5cmlnaHQgYnkgQVJFU0NPTSAyMDAyCgoKClBhc3N3b3JkOgo=
     </example>
     <param pos="0" name="hw.vendor" value="Arescom"/>
     <param pos="0" name="hw.device" value="WAP" />
-  </fingerprint>
-  <fingerprint pattern="Access not permitted\. Closing connection\.\.\.">
-    <description>System IOS switch</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="service.vendor" value="Cisco"/>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="0" name="hw.family" value="IOS"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="0" name="hw.product" value="IOS"/>
-  </fingerprint>
-  <fingerprint pattern="PIX passwd">
-    <description></description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="0" name="hw.family" value="PIX"/>
-    <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.product" value="PIX"/>
+    <param pos="1" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="Welcome to ViewStation">
     <description>Polycom ViewStation Video Vonference System</description>
-    <example _encoding="base64" >
+    <example _encoding="base64">
     V2VsY29tZSB0byBWaWV3U3RhdGlvbgoKUGFzc3dvcmQ6
     </example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
@@ -971,7 +947,7 @@
   </fingerprint>
   <fingerprint pattern="Here is what I know about myself:">
     <description>Polycom ViewStation Video Conference System</description>
-    <example _encoding="base64"  >
+    <example _encoding="base64">
      SGksIG15IG5hbWUgaXMgOiAgICAgUklER0VMQU5EIENBTVBVUwpIZXJlIGlzIHdoYXQgSSBrbm93IGFib3V0IG15c2VsZjo
      KTW9kZWw6ICAgICAgICAgICAgICAgVlNYIDgwMDAKU2VyaWFsIE51bWJlcjogICAgICAgODIwODA4MDkzNTMyTjIKU29mdH
      dhcmUgVmVyc2lvbjogICAgUmVsZWFzZSA5LjAuNi4yLTEwMyAtIDA0U2VwMjAxMSAyMToyNwpCdWlsZCBJbmZvcm1hdGlvb
@@ -989,7 +965,7 @@
   </fingerprint>
   <fingerprint pattern="FlowPoint\/(.*) SDSL \[ATM\] Router .*v(.*) Ready">
     <description>iFlowPoint 2200 DSL router</description>
-    <example _encoding="base64" hw.model="2200" os.version="3.0.2" >
+    <example _encoding="base64" hw.model="2200" os.version="3.0.2">
     Rmxvd1BvaW50LzIyMDAgU0RTTCBbQVRNXSBSb3V0ZXIgZnAyMjAwLTEyIHYzLjAuMiBSZWFkeQpMb2dpbjog
     </example>
     <param pos="0" name="hw.vendor" value="Flowpoint"/>
@@ -1000,7 +976,7 @@
   </fingerprint>
   <fingerprint pattern="GlobespanVirata Inc\., Software Release (.*)">
     <description>GlobespanVirata broadband router</description>
-    <example _encoding="base64" os.version="2.1.040407a3_u_e_A" >
+    <example _encoding="base64" os.version="2.1.040407a3_u_e_A">
       R2xvYmVzcGFuVmlyYXRhIEluYy4sIFNvZnR3YXJlIFJlbGVhc2UgMi4xLjA0MDQwN2EzX3VfZV9BCgpDb3B5cmlnaHQgKG
       MpIDIwMDEtMjAwMyBieSBHbG9iZXNwYW5WaXJhdGEsIEluYy4KCgpsb2dpbjog
     </example>
@@ -1011,11 +987,11 @@
   <fingerprint pattern="VxWorks login:">
     <description>VxWorks embedded device</description>
     <example>VxWorks login: </example>
-    <param pos="0" name="hw.device" value="VxWorks" />
+    <param pos="0" name="hw.device" value="VxWorks"/>
   </fingerprint>
   <fingerprint pattern=".*Nortel.*Passport ([^ ]*) .*Software Release ([^ ]*).*">
     <description>Nortel Passport</description>
-    <example _encoding="base64" hw.product="8010" os.version="3.5.0.0" >
+    <example _encoding="base64" hw.product="8010" os.version="3.5.0.0">
 KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmlnaHQgKGMpIDIwMDMgTm9ydGVsIE5ldHdvcmtzLCBJbmMuICAqXG5cblxuKiBBbGwgUmlnaHRzIFJlc2VydmVkICAgICAgICAgICAgICAgICAgICAgICAqXG5cblxuKiBQYXNzcG9ydCA4MDEwICAgICAgICAgICAgICAgICAgICAgICAgICAgICAqXG5cblxuKiBTb2Z0d2FyZSBSZWxlYXNlIDMuNS4wLjAgICAgICAgICAgICAgICAgICAqXG5cblxuKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuXG5cbkxvZ2luOg==
     </example>
     <param pos="0" name="hw.vendor" value="Nortel"/>
@@ -1025,31 +1001,18 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="IPSO.* \((.*)\) \(tty.*\)">
     <description>Checkpoint Firewall-1 running on a Nokia IPSO appliance</description>
-    <example _encoding="base64" hw.product="BJ-IDC-FW2" >
+    <example _encoding="base64" host.name="BJ-IDC-FW2">
      SVBTTy9pMzg2IChCSi1JREMtRlcyKSAodHR5cDcpCgoKClRoaXMgc3lzdGVtIGlzIGZvciBhdXRob3Jpem
      VkIHVzZSBvbmx5LgoKCgoKCgoKbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="Check Point"/>
     <param pos="0" name="hw.family" value="Check Point"/>
     <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="1" name="hw.product"/>
-  </fingerprint>
-  <fingerprint pattern="Meridian.*Integrated.*RAN.*Version ([^ ]*) \\((.*)\\)">
-    <description>Nortel Meridian</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Nortel"/>
-    <param pos="0" name="hw.device" value="PBX"/>
-  </fingerprint>
-  <fingerprint pattern="BayStack ([^ ]*).*BoSS ([^ ]*)">
-    <description>System is a Nortel/BayStack</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Nortel"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="0" name="hw.product" value="Nortel Baystack Boss"/>
+    <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="Tasman Networks Inc.*Telnet Login">
     <description>Tasman Networks Login</description>
-    <example _encoding="base64" hw.vendor="Tasman Networks" >
+    <example _encoding="base64" hw.vendor="Tasman Networks">
      Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2hhcmFjdGVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="Tasman Networks"/>
@@ -1065,13 +1028,6 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     <param pos="0" name="hw.family" value="Windows"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
-  <fingerprint pattern="OpenNt Telnet Server on Windows NT">
-    <description>Windows NT running OpenNT telnet server</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Microsoft"/>
-    <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.product" value="Windows"/>
-</fingerprint>
   <fingerprint pattern="Application Required. No Installation Default">
     <description>System is probably IBM AS/400 running TN3270 or 5250 emulation server</description>
     <example _encoding="base64">
@@ -1089,13 +1045,6 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     <param pos="0" name="hw.family" value="Windows"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
-  <fingerprint pattern="Administration on this server address is not allowed">
-    <description>Novell Netware</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Novell"/>
-    <param pos="0" name="hw.family" value="Netware"/>
-    <param pos="0" name="hw.product" value="Netware"/>
-  </fingerprint>
   <fingerprint pattern="Cobalt Linux release (.*)$">
     <description>Cobalt Linux</description>
     <example _encoding="base64" os.version="6.0 (Shinkansen)">
@@ -1108,7 +1057,7 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="Check Point FireWall-1 authenticated Telnet server running on (.*)">
     <description>Check Point Firewall-1</description>
-    <example _encoding="base64" host.name="gaatdrf2" >
+    <example _encoding="base64" host.name="gaatdrf2">
       Q2hlY2sgUG9pbnQgRmlyZVdhbGwtMSBhdXRoZW50aWNhdGVkIFRlbG5ldCBzZXJ2ZXIgcnVubmluZyBvbiBnYWF0ZHJmMgoKVXNlcjog
     </example>
     <param pos="0" name="hw.vendor" value="Checkpoint"/>
@@ -1126,13 +1075,6 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     <param pos="0" name="hw.family" value="Raptor"/>
     <param pos="0" name="hw.device" value="Firewall"/>
     <param pos="0" name="hw.product" value="Raptor"/>
-  </fingerprint>
-  <fingerprint pattern="Eagle Secure Gateway">
-    <description>Tekelec Eagle Secure Gateway</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Tekelec"/>
-    <param pos="0" name="hw.family" value="Eagle Secure Gateway"/>
-    <param pos="0" name="hw.product" value="Eagle Secure Gateway"/>
   </fingerprint>
   <fingerprint pattern="UNIX\(r\) System V Release 4.0">
     <description>System is SunOS 5.x (Solaris)</description>
@@ -1176,14 +1118,6 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     <param pos="0" name="hw.product" value="TRU64"/>
     <param pos="1" name ="os.version"/>
   </fingerprint>
-  <fingerprint pattern="AIX (?:Version)? *(.*)$">
-    <description>System is IBM AIX v</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="IBM"/>
-    <param pos="0" name="hw.family" value="AIX"/>
-    <param pos="0" name="hw.device" value="General"/>
-    <param pos="0" name="hw.product" value="AIX"/>
-  </fingerprint>
   <fingerprint pattern="HP-UX ([^ ]+) [A-Z]\.([^ ]+) ([^ ]+) ([^ ]+)\s([^ ]+\)).*$">
     <description>System HP-UX</description>
     <example _encoding="base64" host.name="ctout" os.version="11.11">
@@ -1216,7 +1150,7 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="SCO OpenServer\(TM\) Release ([^ ]+).*$" flags="REG_MULTILINE">
     <description>System is SCO OpenServer</description>
-    <example _encoding="base64" os.version="5" >
+    <example _encoding="base64" os.version="5">
       U0NPIE9wZW5TZXJ2ZXIoVE0pIFJlbGVhc2UgNSAoYm9tZGlhLmNvLnphKSAodHR5cDYpCgpsb2dpbjo=
     </example>
     <param pos="0" name="hw.vendor" value="SCO"/>
@@ -1227,29 +1161,16 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="% Username:  timeout expired!">
     <description>System is some kind of Cisco device</description>
-    <example _encoding="base64"  >
+    <example _encoding="base64">
       VXNlciBBY2Nlc3MgVmVyaWZpY2F0aW9uCgpVc2VybmFtZTogCiUgVXNlcm5hbWU6ICB0aW1lb3V0IGV4cGlyZWQh
     </example>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="IOS"/>
     <param pos="0" name="hw.product" value="IOS"/>
   </fingerprint>
-  <fingerprint pattern="Access not permitted. Closing connection\.\.\.">
-    <description>System is some kind of Cisco device</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="0" name="hw.family" value="IOS"/>
-    <param pos="0" name="hw.product" value="IOS" />
-  </fingerprint>
-  <fingerprint pattern="MSA Fabric Switch ([^ ]*)">
-    <description>System is an HP/Compaq MSA Fabric Switch</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-  </fingerprint>
   <fingerprint pattern="Welcome to MKS Telnet Server Version">
     <description>System is Windows running MKS Telnet Server</description>
-    <example _encoding="base64"  >
+    <example _encoding="base64">
       V2VsY29tZSB0byBNS1MgVGVsbmV0IFNlcnZlciBWZXJzaW9uIDQuNzAuMDAwMC4KbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
@@ -1257,41 +1178,11 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Windows"/>
   </fingerprint>
-  <fingerprint pattern="Extended DX">
-    <description>System is an ExtendNet DX print server</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="ExtendNet"/>
-    <param pos="0" name="hw.family" value="Print Server"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="0" name="hw.product" value="DX Print Server"/>
-  </fingerprint>
-  <fingerprint pattern="Extended SX">
-    <description>System is an ExtendNet SX print server</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="ExtendNet"/>
-    <param pos="0" name="hw.family" value="Print Server"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="0" name="hw.product" value="SX Print Server"/>
-  </fingerprint>
-  <fingerprint pattern="2H252-25R">
-    <description>System is a Cabletron 2H252-25R-2FR switch</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Cabletron"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-  </fingerprint>
   <fingerprint pattern="Sorry, this system is engaged\.">
     <description>System is an embedded print server</description>
     <example>Sorry, this system is engaged.</example>
     <param pos="0" name="hw.vendor" value="Epson"/>
     <param pos="0" name="hw.device" value="Printer"/>
-  </fingerprint>
-  <fingerprint pattern="(?:ScreenOS\\s+(\\d+\\.\\d\\S*)\\s.*?)?Remote Management Console">
-    <description>System is a NetScreen firewall</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Juniper"/>
-    <param pos="0" name="hw.family" value="ScreenOS"/>
-    <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.product" value="ScreenOS"/>
   </fingerprint>
   <fingerprint pattern="TELNET session now in ESTABLISHED state">
     <description>System is an Allied Telesyn router</description>
@@ -1321,28 +1212,6 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="0" name="hw.product" value="Vigor"/>
   </fingerprint>
-  <fingerprint pattern="SonicWALL SSL-RX SSL Accelerator">
-    <description>System is a SonicWALL SSL-RX SSL Accelerator</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="SonicWALL"/>
-    <param pos="0" name="hw.device" value="Encryption accelerator"/>
-    <param pos="0" name="hw.product" value="SonicOS"/>
-  </fingerprint>
-  <fingerprint pattern="Welcome to WiseWan system">
-    <description>System is a NetReality WiseWan traffic shaper</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="NetReality"/>
-    <param pos="0" name="hw.family" value="WiseWan"/>
-    <param pos="0" name="hw.product" value="WiseWan"/>
-  </fingerprint>
-  <fingerprint pattern="User Name :">
-    <description>System is APC UPS</description>
-    <example>User Name : </example>
-    <param pos="0" name="hw.vendor" value="APC"/>
-    <param pos="0" name="hw.family" value="APC"/>
-    <param pos="0" name="hw.device" value="Power Device"/>
-    <param pos="0" name="hw.product" value="UPS"/>
-  </fingerprint>
   <fingerprint pattern="OpenBSD">
     <description>System is OpenBSD</description>
     <example _encoding="base64">
@@ -1353,25 +1222,23 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="OpenBSD"/>
   </fingerprint>
-  <fingerprint pattern="FreeBSD/([^\\s]+)\\s+\\(([^\\s]+)\\)">
+  <fingerprint pattern="FreeBSD\/([^\\s]+)\s+\(([^\s]+)\)">
     <description>System is a FreeBSD</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64" os.arch="amd64" host.name="ms.gymspgs.cz">
+      RnJlZUJTRC9hbWQ2NCAobXMuZ3ltc3Bncy5jeikgKHB0cy8wKQoKCgpsb2dpbjo=
+    </example>
     <param pos="0" name="hw.vendor" value="FreeBSD"/>
     <param pos="0" name="hw.family" value="FreeBSD"/>
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="FreeBSD"/>
-  </fingerprint>
-  <fingerprint pattern="FreeBSD\\s+([^\\s]+)[^/]*/([^\\s]+)\\s+\\(([^\\s]+)\\)">
-    <description>System is FreeBSD</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="FreeBSD"/>
-    <param pos="0" name="hw.family" value="FreeBSD"/>
-    <param pos="0" name="hw.device" value="General"/>
-    <param pos="0" name="hw.product" value="FreeBSD"/>
+    <param pos="1" name="os.arch"/>
+    <param pos="2" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="FreeBSD">
     <description>System is FreeBSD</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64">
+      RnJlZUJTRC9pMzg2IChTUlZWUE5TbW9sZW4tMikgKHB0cy8wKQoKCgpsb2dpbjog
+    </example>
     <param pos="0" name="hw.vendor" value="FreeBSD"/>
     <param pos="0" name="hw.family" value="FreeBSD"/>
     <param pos="0" name="hw.device" value="General"/>
@@ -1379,7 +1246,9 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="NetBSD">
     <description>System is NetBSD</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64">
+      TmV0QlNEL21lc3NpbWlwcyAoKSAodHR5cDMpCgpsb2dpbjog
+    </example>
     <param pos="0" name="hw.vendor" value="NetBSD"/>
     <param pos="0" name="hw.family" value="NetBSD"/>
     <param pos="0" name="hw.device" value="General"/>
@@ -1387,7 +1256,9 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="IRIX">
     <description>System is SGI IRIX</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64">
+      SVJJWCAoYXJ0ZW1pcy5iaW9sLnVvYS5ncikKCgoKbG9naW46IA==
+    </example>
     <param pos="0" name="hw.vendor" value="SGI"/>
     <param pos="0" name="hw.family" value="IRIX"/>
     <param pos="0" name="hw.device" value="General"/>
@@ -1395,109 +1266,91 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="Tasman Networks Inc.">
     <description>System is Tasman Networks router</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64">
+      Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2hhcmFjdGVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
+    </example>
     <param pos="0" name="hw.vendor" value="Tasman Networks"/>
     <param pos="0" name="hw.family" value="TiOS"/>
     <param pos="0" name="hw.device" value="Router"/>
-    <param pos="0" name="hw.product" vlaue="TiOS"/>
   </fingerprint>
-  <fingerprint pattern="(RS [^\\s]+) System Software, Version ([^\\s]+)">
-    <description>System is Tasman Networks router</description>
-    <example _encoding="base64"  ></example>
+  <fingerprint pattern="^(RS [^\s]+) System Software, Version ([^\s]+).*" flags="REG_MULTILINE">
+    <description>System is RiverStone router</description>
+    <example _encoding="base64" hw.device="RS 8000">
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d29ya3MsIEluYy4sIENvcHlyaWdodCAoYykgMjAwMC0yMDA0LiBBbGwgcmlnaHRzIHJlc2VydmVkLgpTeXN0ZW0gc3RhcnRlZCBvbiAyMDE4LTEwLTExIDIyOjAyOjAzCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
+    </example>
     <param pos="0" name="hw.vendor" value="Riverstone"/>
     <param pos="0" name="hw.family" value="Riverstone"/>
-    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="1" name="hw.device"/>
   </fingerprint>
-  <fingerprint pattern="(ES [^\\s]+) System Software, Version ([^\\s]+)">
+  <fingerprint pattern="(ES [^\s]+) System Software, Version ([^\s]+)">
     <description>System is a Tasman Networks Ethernet router`</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64" hw.device="ES 10170" os.version="9.3.0.4">
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldHdvcmtzLCBJbmMuLCBDb3B5cmlnaHQgKGMpIDIwMDAtMjAwMy4gQWxsIHJpZ2h0cyByZXNlcnZlZC4KU3lzdGVtIHN0YXJ0ZWQgb24gMjAxOC0wOS0wNiAxNTo1ODozMAotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
+    </example>
     <param pos="0" name="hw.vendor" value="Riverstone"/>
     <param pos="0" name="hw.family" value="ES"/>
-    <param pos="0" name="hw.device" value="ES"/>
+    <param pos="1" name="hw.device"/>
+    <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="HP.*ProCurve Switch">
     <description>System is HP ProCurve Switch</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64">
+            SFAgSjQxMjFBIFByb0N1cnZlIFN3aXRjaCA0MDAwTQpGaXJtd2FyZSByZXZpc2lvbiBDLjA5LjIyCgpDb3B5cmlnaHQgKEMpIDE5OTEtMjAwMiBIZXdsZXR0LVBhY2thcmQgQ28uICBBbGwgUmlnaHRzIFJlc2VydmVkLgoKICAgICAgICAgICAgICAgICAgICAgICAgICAgUkVTVFJJQ1RFRCBSSUdIVFMgTEVHRU5ECgogVXNlLCBkdXBsaWNhdGlvbiwgb3IgZGlzY2xvc3VyZSBieSB0aGUgR292ZXJubWVudCBpcyBzdWJqZWN0IHRvIHJlc3RyaWN0aW9ucwogYXMgc2V0IGZvcnRoIGluIHN1YmRpdmlzaW9uIChiKSAoMykgKGlpKSBvZiB0aGUgUmlnaHRzIGluIFRlY2huaWNhbCBEYXRhIGFuZAogQ29tcHV0ZXIgU29mdHdhcmUgY2xhdXNlIGF0IDUyLjIyNy03MDEzLgoKICAgICAgICAgSEVXTEVUVC1QQUNLQVJEIENPTVBBTlksIDMwMDAgSGFub3ZlciBTdC4sIFBhbG8gQWx0bywgQ0EgOTQzMDMKCgpVc2VyIEFjY2VzcyBWZXJpZmljYXRpb24KClVzZXJuYW1lOiA=
+    </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="ProCurve"/>
     <param pos="0" name="hw.device" value="Switch"/>
     <param pos="0" name="hw.product" value="ProCurve"/>
-  </fingerprint>
-  <fingerprint pattern="Sorry, the maximum number of telnet sessions are active\.\\s*Try again later\.">
-    <description>System is a HP ProCurve Switch</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="ProCurve"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="0" name="hw.product" value="ProCurve"/>
-  </fingerprint>
-  <fingerprint pattern="Madge CrossFire">
-    <description>System is a Madge CrossFire</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Madge"/>
-    <param pos="0" name="hw.family" value="Madge CrossFire"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="0" name="hw.product" value="Madge CrossFire"/>
-  </fingerprint>
-  <fingerprint pattern="HP ProLiant.*Switch">
-    <description>Sytem is HP ProLiant switch</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="ProLiant"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="0" name="hw.product" value="ProLiant"/>
   </fingerprint>
   <fingerprint pattern="ConnectUPS">
     <description>System is PowerWare ConnectUPS</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64"  >
+      Kz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0rCnwgICAgICAgICAgICBbIENvbm5lY3RVUFMgV2ViL1NOTVAgQ2FyZCBDb25maWd1cmF0aW9uIFV0aWxpdHkgXSAgICAgICAgICAgICAgfAorPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PSsKCkVudGVyIFBhc3N3b3JkOiA=
+    </example>
     <param pos="0" name="hw.vendor" value="PowerWare"/>
     <param pos="0" name="hw.family" value="ConnectUPS"/>
     <param pos="0" name="hw.device" value="UPS"/>
-    <param pos="0" name="hw.product" vaule="ConnectUPS"/>
+    <param pos="0" name="hw.product" value="ConnectUPS"/>
   </fingerprint>
   <fingerprint pattern="Imagistics.*im">
     <description>System is an Imagistics device</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64">
+      SW1hZ2lzdGljcyBpbTM1MTEvaW00NTExIFZlciAwMS4wMC4yMCBURUxORVQgc2VydmVyLgpDb3B5cmlnaHQoYykgMjAwMS0yMDA1LCBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
+    </example>
     <param pos="0" name="hw.vendor" value="Imagistics"/>
     <param pos="0" name="hw.family" value="Imagistics"/>
     <param pos="0" name="hw.device" value="Malfunction Device"/>
     <param pos="0" name="hw.product" value="im"/>
   </fingerprint>
-  <fingerprint pattern="Imagistics.*cs">
-    <description>System is an Imagistics device</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Imagistics"/>
-    <param pos="0" name="hw.family" value="Imagistics"/>
-    <param pos="0" name="hw.device" value="Malfunction Device"/>
-    <param pos="0" name="hw.product" value="cs"/>
-  </fingerprint>
   <fingerprint pattern="NRG Maintenance Shell">
     <description>System is a Ricoh NRG device</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64"  >
+      TlJHIE1haW50ZW5hbmNlIFNoZWxsLiAgIAoKVXNlciBhY2Nlc3MgdmVyaWZpY2F0aW9uLgoKbG9naW46
+    </example>
     <param pos="0" name="hw.vendor" value="Ricoh"/>
     <param pos="0" name="hw.device" value="Printer" />
     <param pos="0" name="hw.product" value="NRG Printer"/>
   </fingerprint>
   <fingerprint pattern="^SHARP (AR-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>System is SHARP AR Series multifunction device</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64" hw.product="AR-M351U" os.version="01.00.18">
+      U0hBUlAgQVItTTM1MVUgVmVyIDAxLjAwLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChjKSAyMDAxLTIwMDUsIHNpbGV4IHRlY2hub2xvZ3ksIEluYy4KbG9naW46IA==
+    </example>
     <param pos="0" name="hw.vendor" value="Sharp"/>
     <param pos="0" name="hw.family" value="Sharp AR Series"/>
     <param pos="0" name="hw.device" value="Multifunction Device"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^SHARP (MX-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>System is SHARP MX Series multifunction device</description>
-    <example _encoding="base64"  ></example>
+    <example _encoding="base64" hw.product="MX-3610N" os.version="01.05.00.0o.18">
+      U0hBUlAgTVgtMzYxME4gVmVyIDAxLjA1LjAwLjBvLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChDKSAyMDA1LSAgICAgU0hBUlAgQ09SUE9SQVRJT04KQ29weXJpZ2h0KEMpIDIwMDUtICAgICBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
+    </example>
     <param pos="0" name="hw.vendor" value="Sharp"/>
     <param pos="0" name="hw.family" value="Sharp MX Series"/>
     <param pos="0" name="hw.device" value="Multifunction Device"/>
-  </fingerprint>
-  <fingerprint pattern="^CIMC Debug Firmware Utility Shell">
-    <description>System is Cisco UCS Device</description>
-    <example _encoding="base64"  ></example>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="0" name="hw.family" value="UCS"/>
-    <param pos="0" name="hw.device" value="General"/>
-    <param pos="0" name="hw.product" value="UCS Device"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="os.version"/>
   </fingerprint>
 </fingerprints>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1292,7 +1292,9 @@
   </fingerprint>
   <fingerprint pattern="^(?m)(RS [^\s]+) System Software, Version ([^\s]+).*">
     <description>RiverStone router</description>
-    <!-- ++++++++++++++++++++++++++++++++++++++++\nRS 8000 System Software, Version 9.3.0.5\nRiverstone Networks, Inc., Copyright (c) 2000-2004. All rights reserved.\nSystem started on 2018-10-11 22:02:03\n++++++++++++++++++++++++++++++++++++++++ -->
+    <!-- ++++++++++++++++++++++++++++++++++++++++\nRS 8000 System Software, Version 9.3.0.5\n
+    Riverstone Networks, Inc., Copyright (c) 2000-2004. All rights reserved.\nSystem started on 2018-10-11 22:02:03
+    \n++++++++++++++++++++++++++++++++++++++++ -->
     <example _encoding="base64" hw.product="RS 8000" os.version="9.3.0.5">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d2
@@ -1308,7 +1310,9 @@
   </fingerprint>
   <fingerprint pattern="(ES [^\s]+) System Software, Version ([^\s]+)">
     <description>a Riverstone router`</description>
-    <!-- +++++++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\nRiverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n+++++++++++++++++++++++++++++++++++++++ -->
+    <!-- +++++++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\n
+    Riverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n
+    +++++++++++++++++++++++++++++++++++++++ -->
     <example _encoding="base64" hw.product="ES 10170" os.version="9.3.0.4">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
@@ -1324,7 +1328,14 @@
   </fingerprint>
   <fingerprint pattern="HP.*ProCurve Switch">
     <description>HP ProCurve Switch</description>
-    <!-- ==============================================================================\nHP J4121A ProCurve Switch 4000M\nFirmware revision v2.2.3\n\nCopyright (C) 1991-2004 Hewlett-Packard Co. All Rights Reserved.\n\n RESTRICTED RIGHTS LEGEND\n\n Use, duplication, or disclosure by the Government is subject to restrictions\n\nas set forth in subdivision (b) (3) (ii) of the Rights in Technical Data and\n\nComputer Software clause at 52.227-7013.\n\nHEWLETT-PACKARD COMPANY, 3000 Hanover St., Palo Alto, CA 94303\n\n\nWe'd like to keep you up to date about:\n* Software feature updates\n* New product announcements\n* Special events\n\n\nPlease register your products now at: www.ProCurve.com\n==============================================================================\n\n\nUsername:  -->
+    <!-- ==============================================================================\nHP J4121A ProCurve Switch 4000M\n
+    Firmware revision v2.2.3\n\nCopyright (C) 1991-2004 Hewlett-Packard Co. All Rights Reserved.\n\n
+    RESTRICTED RIGHTS LEGEND\n\n Use, duplication, or disclosure by the Government is subject to restrictions\n\n
+    as set forth in subdivision (b) (3) (ii) of the Rights in Technical Data and\n\nComputer Software clause at 52.227-7013.\n\n
+    HEWLETT-PACKARD COMPANY, 3000 Hanover St., Palo Alto, CA 94303\n\n\nWe'd like to keep you up to date about:\n*
+    Software feature updates\n* New product announcements\n* Special events\n\n\nPlease register your
+    products now at: www.ProCurve.com\n==============================================================================\n
+    \n\nUsername:  -->
     <example _encoding="base64">
       PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09P
       T09PT09PT09PT09PT09PT09PT09PT09CkhQIEo0MTIxQSBQcm9DdXJ2ZSBTd2l0Y2ggNDAwME
@@ -1350,7 +1361,9 @@
   </fingerprint>
   <fingerprint pattern="ConnectUPS">
     <description>PowerWare ConnectUPS</description>
-    <!-- +============================================================================+\n|            [ ConnectUPS Web/SNMP Card Configuration Utility ]              |\n+============================================================================+\n\nEnter Password: -->
+    <!-- +============================================================================+\n|            [ ConnectUPS Web/SNMP
+     Card Configuration Utility ]              |\n+============================================================================+\n
+     \nEnter Password: -->
     <example _encoding="base64">
       Kz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0
       9PT09PT09PT09PT09PT0rCnwgICAgICAgICAgICBbIENvbm5lY3RVUFMgV2ViL1NOTVAgQ2FyZCBDb25maW
@@ -1400,7 +1413,8 @@
   </fingerprint>
   <fingerprint pattern="^SHARP (MX-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>SHARP MX Series multifunction device</description>
-    <!-- SHARP MX-3610N Ver 01.05.00.0o.18 TELNET server.\nCopyright(C) 2005-     SHARP CORPORATION\nCopyright(C) 2005-     silex technology, Inc.\nlogin:  -->
+    <!-- SHARP MX-3610N Ver 01.05.00.0o.18 TELNET server.\nCopyright(C) 2005-     SHARP CORPORATION\nCopyright(C) 2005-
+    silex technology, Inc.\nlogin:  -->
     <example _encoding="base64" hw.product="MX-3610N" os.version="01.05.00.0o.18">
       U0hBUlAgTVgtMzYxME4gVmVyIDAxLjA1LjAwLjBvLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodC
       hDKSAyMDA1LSAgICAgU0hBUlAgQ09SUE9SQVRJT04KQ29weXJpZ2h0KEMpIDIwMDUtICAgICBzaWxl
@@ -1414,7 +1428,9 @@
   </fingerprint>
     <fingerprint pattern="^(?m).*Welcome to MELCO Print Server.*Server Name *: *([^ ]*)\W.*Server Model *: *([^ ]*).*F \/ W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. .. ..).*$">
     <description>System is a Buffalo/MELCO Embedded Print Server</description>
-    <!-- ***********************************\n* Welcome to MELCO Print Server *\n* Telnet Console *\n***********************************\n \nServer Name: PS-B04E8E\nServer Model: LPV 2 - TX 1\nF / W Version: 2.00 J \nMAC Address: AE 32 EA 21 BB E3\nUptime: 0 days, 00: 00: 12\n \nPlease Enter Password:"--> 
+    <!-- ***********************************\n* Welcome to MELCO Print Server *\n* Telnet Console *\n***********************************
+    \n \nServer Name: PS-B04E8E\nServer Model: LPV 2 - TX 1\nF / W Version: 2.00 J \nMAC Address: AE 32 EA 21 BB E3\n
+    Uptime: 0 days, 00: 00: 12\n \nPlease Enter Password:"-->
     <example _encoding="base64" os.version="2.00" host.id="PS-B04E8E" hw.model="LPV" hw.address="AE 32 EA 21 BB E3">
       KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiogV2VsY29tZSB0byBNRUxDTyBQc
       mludCBTZXJ2ZXIgKlxuKiBUZWxuZXQgQ29uc29sZSAqXG4qKioqKioqKioqKioqKioqKioqKioqKi

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1119,15 +1119,16 @@
     <param pos="0" name="hw.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="Digital UNIX">
+  <fingerprint pattern="Digital UNIX \(([^)]+).*">
     <description>Digital Unix</description>
     <!-- Digital UNIX (journal) (ttyp2)\n\n\nlogin: -->
-    <example _encoding="base64">
+    <example _encoding="base64" host.name="journal">
       RGlnaXRhbCBVTklYIChqb3VybmFsKSAodHR5cDIpCgoKCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="Digital Unix"/>
     <param pos="0" name="hw.product" value="Digital Unix"/>
+    <param pos="1" name="host.name"/>`
   </fingerprint>
   <fingerprint pattern="^(?m)Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*">
     <description>Compaq Tru64 UNIX V</description>
@@ -1428,5 +1429,49 @@
     <param pos="2" name="hw.model"/>
     <param pos="3" name="os.version"/>
     <param pos="4" name="hw.address"/>
+  </fingerprint>
+  <fingerprint pattern="^(?m)AIX Version\W(\d).*">
+    <description>System is IBM AIX v</description>
+    <!-- AIX Version 6\nCopyright IBM Corporation, 1982, 2007.\nlogin: -->
+    <example _encoding="base64" os.version="6">
+      QUlYIFZlcnNpb24gNgpDb3B5cmlnaHQgSUJNIENvcnBvcmF0aW9uLCAxOTgyLCAyMDA3Lgpsb2dpbjogCg==
+    </example>
+    <param pos="0" name="hw.vendor" value="IBM"/>
+    <param pos="0" name="hw.family" value="AIX"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="AIX"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^(?m)CIMC Debug Firmware Utility Shell\W([^\s]+).*">
+    <description>System is Cisco UCS Device</description>
+    <!-- CIMC Debug Firmware Utility Shell\nfake-ucs-device-3-1-p login: -->
+    <example _encoding="base64" host.name="fake-ucs-device-3-1-p">
+      Q0lNQyBEZWJ1ZyBGaXJtd2FyZSBVdGlsaXR5IFNoZWxsCmZha2UtdWNzLWRldmljZS0zLTEtcCBsb2dpbjogCg==
+    </example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="UCS"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="UCS Device"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+  <fingerprint pattern="^(?m)HP ProLiant.*v(\d+.\d+)">
+    <description>Sytem is HP ProLiant switch</description>
+    <example _encoding="base64" os.version="2.00">
+      SFAgUHJvTGlhbnQgQkwgZS1DbGFzcyBJbnRlZ3JhdGVkIEFkbWluaXN0cmF0b3IgdjIuMDAKICAgICAgI
+      CAgQ29weXJpZ2h0IDIwMDUgSGV3bGV0dC1QYWNrYXJkIERldmVsb3BtZW50IEdyb3VwLCBMLlAuCgogIC
+      AgICAgICAtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0
+      tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQogICAgICAgICBXQVJOSU5HOiBUaGlzIGlzIGEgcHJpdmF0ZSBz
+      eXN0ZW0uICBEbyBub3QgYXR0ZW1wdCB0byBsb2dpbiB1bmxlc3MgeW91IGFyZSBhbgogICAgICAgICBhd
+      XRob3JpemVkIHVzZXIuICBBbnkgYXV0aG9yaXplZCBvciB1bmF1dGhvcml6ZWQgYWNjZXNzIGFuZCB1c2
+      UgbWF5IGJlIG1vbmktCiAgICAgICAgIHRvcmVkIGFuZCBjYW4gcmVzdWx0IGluIGNyaW1pbmFsIG9yIGN
+      pdmlsIHByb3NlY3V0aW9uIHVuZGVyIGFwcGxpY2FibGUgbGF3LgogICAgICAgICAtLS0tLS0tLS0tLS0t
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
+      S0tLQoKCiAgICAgICAgIElBLTAwNTA4QkVCQUE1OSBsb2dpbjo=
+    </example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="ProLiant"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="ProLiant"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
 </fingerprints>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -826,7 +826,7 @@
     <param pos="0" name="hw.device" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
+  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)">
     <description>RedHat Enterprise Linux ES</description>
     <example _encoding="base64" os.version="3" linux.kernel.version="2.4.21-47.EL" os.arch="x86_64">
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEVTIHJlbGVhc2UgMyAoVGFyb29uIFVwZGF0ZSA5KQpLZXJuZWwgMi40LjIxLTQ3Lk
@@ -931,26 +931,27 @@
   <fingerprint pattern="^Welcome. Type return, enter password at # prompt">
     <description>Brother Printer</description>
     <example _encoding="base64">
-     V2VsY29tZS4gVHlwZSByZXR1cm4sIGVudGVyIHBhc3N3b3JkIGF0ICMgcHJvbXB0Cg== 
+      V2VsY29tZS4gVHlwZSByZXR1cm4sIGVudGVyIHBhc3N3b3JkIGF0ICMgcHJvbXB0Cg== 
     </example>
     <param pos="0" name="hw.vendor" value="Brother"/>
-    <param pos="0" name="hw.device" value="Printer" />
+    <param pos="0" name="hw.family" value="Brother"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="0" name="hw.product" value="Brother Printer"/>
   </fingerprint>
   <fingerprint pattern="^(.*) Copyright by ARESCOM">
     <description>Arescom System</description>
     <example _encoding="base64" hw.model="NDS1260HE-TLI">
-     TkRTMTI2MEhFLVRMSSBDb3B5cmlnaHQgYnkgQVJFU0NPTSAyMDAyCgoKClBhc3N3b3JkOgo=
+      TkRTMTI2MEhFLVRMSSBDb3B5cmlnaHQgYnkgQVJFU0NPTSAyMDAyCgoKClBhc3N3b3JkOgo=
     </example>
     <param pos="0" name="hw.vendor" value="Arescom"/>
-    <param pos="0" name="hw.device" value="WAP" />
+    <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.family" value="UNKNOWN"/>
     <param pos="1" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="Welcome to ViewStation">
     <description>Polycom ViewStation Video Vonference System</description>
     <example _encoding="base64">
-    V2VsY29tZSB0byBWaWV3U3RhdGlvbgoKUGFzc3dvcmQ6
+      V2VsY29tZSB0byBWaWV3U3RhdGlvbgoKUGFzc3dvcmQ6
     </example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="ViewStation"/>
@@ -1118,7 +1119,7 @@
   </fingerprint>
   <fingerprint pattern="Digital UNIX">
     <description>System is Digital Unix</description>
-    <example _encoding="base64"  >
+    <example _encoding="base64">
       RGlnaXRhbCBVTklYIChqb3VybmFsKSAodHR5cDIpCgoKCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -968,7 +968,7 @@
     <example _encoding="base64" hw.model="2200" os.version="3.0.2">
       Rmxvd1BvaW50LzIyMDAgU0RTTCBbQVRNXSBSb3V0ZXIgZnAyMjAwLTEyIHYzLjAuMiBSZWFkeQpMb2dpbjog
     </example>
-    <param pos="0" name="hw.vendor" value="Flowpoint"/>
+    <param pos="0" name="os.vendor" value="Flowpoint"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
     <param pos="0" name="hw.product" value="DSL router"/>
     <param pos="1" name="hw.model"/>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -826,7 +826,7 @@
     <param pos="0" name="hw.device" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)">
+  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
     <description>RedHat Enterprise Linux ES</description>
     <example _encoding="base64" os.version="3" linux.kernel.version="2.4.21-47.EL" os.arch="x86_64">
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEVTIHJlbGVhc2UgMyAoVGFyb29uIFVwZGF0ZSA5KQpLZXJuZWwgMi40LjIxLTQ3Lk

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1410,4 +1410,23 @@
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
+    <fingerprint pattern="^(?m).*Welcome to MELCO Print Server.*Server Name *: *([^ ]*)\W.*Server Model *: *([^ ]*).*F \/ W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. .. ..).*$">
+    <description>System is a Buffalo/MELCO Embedded Print Server</description>
+    <!-- ***********************************\n* Welcome to MELCO Print Server *\n* Telnet Console *\n***********************************\n \nServer Name: PS-B04E8E\nServer Model: LPV 2 - TX 1\nF / W Version: 2.00 J \nMAC Address: AE 32 EA 21 BB E3\nUptime: 0 days, 00: 00: 12\n \nPlease Enter Password:"--> 
+    <example _encoding="base64" os.version="2.00" host.id="PS-B04E8E" hw.model="LPV" hw.address="AE 32 EA 21 BB E3">
+      KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiogV2VsY29tZSB0byBNRUxDTyBQc
+      mludCBTZXJ2ZXIgKlxuKiBUZWxuZXQgQ29uc29sZSAqXG4qKioqKioqKioqKioqKioqKioqKioqKi
+      oqKioqKioqKioqKlxuIFxuU2VydmVyIE5hbWU6IFBTLUIwNEU4RVxuU2VydmVyIE1vZGVsOiBMUFY
+      gMiAtIFRYIDFcbkYgLyBXIFZlcnNpb246IDIuMDAgSiBcbk1BQyBBZGRyZXNzOiBBRSAzMiBFQSAy
+      MSBCQiBFM1xuVXB0aW1lOiAwIGRheXMsIDAwOiAwMDogMTJcbiBcblBsZWFzZSBFbnRlciBQYXNzd
+      29yZDoi
+    </example>
+    <param pos="0" name="hw.vendor" value="Buffalo"/>
+    <param pos="0" name="hw.family" value="PrintServer" />
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="host.id"/>
+    <param pos="2" name="hw.model"/>
+    <param pos="3" name="os.version"/>
+    <param pos="4" name="hw.address"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1466,6 +1466,12 @@
   </fingerprint>
   <fingerprint pattern="^(?m)HP ProLiant.*v(\d+.\d+)">
     <description>Sytem is HP ProLiant server</description>
+    <!-- HP ProLiant BL e-Class Integrated Administrator v2.00
+         Copyright 2005 Hewlett-Packard Development Group, L.P.
+         WARNING: This is a private system.  Do not attempt to login unless you are an
+         authorized user.  Any authorized or unauthorized access and use may be moni-
+         tored and can result in criminal or civil prosecution under applicable law.
+         IA-00508BEBAA59 login: -->
     <example _encoding="base64" os.version="2.00">
       SFAgUHJvTGlhbnQgQkwgZS1DbGFzcyBJbnRlZ3JhdGVkIEFkbWluaXN0cmF0b3IgdjIuMDAKICAgICAgI
       CAgQ29weXJpZ2h0IDIwMDUgSGV3bGV0dC1QYWNrYXJkIERldmVsb3BtZW50IEdyb3VwLCBMLlAuCgogIC

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -268,9 +268,7 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
-    <param pos="2" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^CentOS release ([\d.]+) \(Final\)(?:\r|\n)+Kernel ([\w.-]+) on an (\w+)(?:\r|\n)+(?:([\w.-]+) )?login:\s*$">
     <description>CentOS</description>
@@ -815,5 +813,691 @@
     <param pos="3" name="host.id"/>
     <param pos="4" name="os.version"/>
     <param pos="5" name="os.version.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Red Hat Linux release ([^\\s]+)\\s*.*$">
+    <description>RedHat general purpose linux</description>
+    <example _encoding="base64">
+      UmVkIEhhdCBMaW51eCByZWxlYXNlIDkgKFNocmlrZSlcbktlcm5lbCAyLjQuMjAtOCBvbiBhbiBpNjg2XG5sb2dpbjo=
+   </example>
+    <param pos="0" name="hw.vendor" value="RedHat"/>
+    <param pos="0" name="he.family" value="Linux" />
+    <param pos="0" name="hw.device" value="Linux" />
+  </fingerprint>
+  <fingerprint pattern="Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
+    <description>RedHat Enterprise Linux ES</description>
+    <example _encoding="base64" os.version="3">
+      UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEVTIHJlbGVhc2UgMyAoVGFyb29uIFVwZGF0ZSA5KQpLZXJuZWwgMi40LjIxLTQ3Lk
+      VMIG9uIGFuIHg4Nl82NApsb2dpbjo=
+    </example>
+    <param pos="0" name="hw.vendor" value="RedHat"/>
+    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="1" name ="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Red Hat Enterprise Linux AS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
+    <description>RedHat Enterprise Linux AS</description>
+    <example _encoding="base64" os.version="5.8" >
+      UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEFTIHJlbGVhc2UgNS44IChUaWthbmdhKQpLZXJuZWwgMi42LjE4LTMwOC4xMS4xLmVsNSBvbiBhbiB4ODZfNjQKbG9naW46
+    </example>
+    <param pos="0" name="hw.vendor" value="RedHat"/>
+    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="0" name="hw.product" value="RedHat Enterprise AS"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Red Hat Enterprise Linux WS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
+    <description>RedHat Enterprise Linux WS</description>
+    <example _encoding="base64" os.version="2.1" >
+      UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IFdTIHJlbGVhc2UgMi4xIChUYW1wY
+      SkgCktlcm5lbCAyLjQuOS1lLjQwc21wIG9uIGFuIGk2ODYgCmxvZ2luOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="RedHat"/>
+    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="0" name="hw.product" value="RedHat Enterprise WS"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Fedora Core.release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d).*$" flags="REG_MULTILINE">
+    <description>Fedora Core Release</description>
+    <example _encoding="base64" linux.kernel.version="2.4.20-13.9ensim-3.5.0-13" os.arch="i686" >
+     RmVkb3JhIENvcmUgcmVsZWFzZSAxIChZYXJyb3cpCktlcm5lbCAyLjQuMjAtMTMuOWVuc2ltLTMuNS4wLTEzIG9uIGFuIGk2ODYKbG9naW46
+    </example>
+    <param pos="0" name="hw.vendor" value="Redhat"/>
+    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="hw.product" value="Fedora"/>
+    <param pos="2" name="linux.kernel.version"/>
+    <param pos="3" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to SuSE Linux (.*) \(([^\)]+)\) - Kernel (.*) .*" flags="REG_MULTILINE">
+    <description>SuSE Linux</description>
+    <example _encoding="base64" os.version="7.0" os.arch="i386">
+      V2VsY29tZSB0byBTdVNFIExpbnV4IDcuMCAoaTM4NikgLSBLZXJuZWwgMi4yLjE2LVJBSUQgKDApLiAyVkcwMjkwMzcgCgpsb2dpbjo=
+    </example>
+    <param pos="0" name="hw.vendor" value="SUSE"/>
+    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.arch"/>
+  </fingerprint>
+  <fingerprint pattern="^Turbolinux ApplianceServer (.*)$">
+    <example _encoding="base64">
+     VHVyYm9saW51eCBBcHBsaWFuY2VTZXJ2ZXIgNC4wIChBdGxhczIpIExpbnV4IDIuNi4zMi00MzEuMjMuMy5lbDYueDg
+     2XzY0IG9uIGEgeDg2XzY0IChzZW55bzE5MXg4OS5kaWdpdGFsaW5rLm5lLmpwKSBUVFk6IDEyOjE1IG9uIFR1ZXNkYX
+     ksIDAyIE9jdG9iZXIgMjAxOCBsb2dpbjog
+    </example>
+    <param pos="0" name="hw.vendor" value="Turbolinux"/>
+    <param pos="0" name="hw.family" value="Linux"/>
+  </fingerprint>
+  <fingerprint pattern="^UnixWare ([^ ]+).*$">
+    <description>UnixWare</description>
+    <example _encoding="base64">
+     VW5peFdhcmUgMi4xLjMgKHByb2ZpbCkgKHB0cy8zKQoKCgpsb2dpbjog
+    </example>
+    <param pos="0" name="hw.vendor" value="SCO"/>
+    <param pos="0" name="hw.family" value="UnixWare"/>
+    <param pos="0" name="hw.device" value="UnixWare"/>
+  </fingerprint>
+  <fingerprint pattern="^Telnet Server Build (5.*)">
+    <description>Windows 2000</description>
+    <example _encoding="base64" >
+      TWljcm9zb2Z0IChSKSBXaW5kb3dzIE5UIChUTSkgVmVyc2lvbiA0LjAwIChCdWlsZCAxMzgxKQpXZWxj
+      b21lIHRvIE1pY3Jvc29mdCBUZWxuZXQgU2VydmljZSAKVGVsbmV0IFNlcnZlciBCdWlsZCA1LjAwLjk5MDM0LjEKCmxvZ2luOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="Microsoft"/>
+    <param pos="0" name="hw.family" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to MELCO Print Server.*Server Name *: *([^ ]*).*Server Model *: *([^ ]*).*F/W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. ..).*$">
+    <description>System is a Buffalo/MELCO Embedded Print Server</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Buffalo"/>
+    <param pos="0" name="hw.family" value="PrintServer" />
+    <param pos="0" name="hw.device" value="Printer"/>
+  </fingerprint>
+  <fingerprint pattern="^JetDirect Telnet Configuration">
+    <description>JetDirect Telnet</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="JetDirect"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.product" value="Brother Printer"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome to MELCO Print  Server.*Server Name *: *([^ ]*).*Server Model *: *([^ ]*).*F/W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. ..).*$">
+    <description>MELCO Embedded Print Server</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Buffalo"/>
+    <param pos="0" name="hw.family" value="PrintServer" />
+    <param pos="0" name="hw.device" value="Printer"/>
+  </fingerprint>
+  <fingerprint pattern="^Welcome. Type return, enter password at # prompt">
+    <example _encoding="base64"  >
+     V2VsY29tZS4gVHlwZSByZXR1cm4sIGVudGVyIHBhc3N3b3JkIGF0ICMgcHJvbXB0Cg== 
+    </example>
+    <description>Brother Printer</description>
+    <param pos="0" name="hw.vendor" value="Brother"/>
+    <param pos="0" name="hw.device" value="Printer" />
+    <param pos="0" name="hw.product" value="Brother Printer"/>
+  </fingerprint>
+  <fingerprint pattern="^(.*) Copyright by ARESCOM">
+    <description>Arescom System</description>
+    <example _encoding="base64">
+     TkRTMTI2MEhFLVRMSSBDb3B5cmlnaHQgYnkgQVJFU0NPTSAyMDAyCgoKClBhc3N3b3JkOgo=
+    </example>
+    <param pos="0" name="hw.vendor" value="Arescom"/>
+    <param pos="0" name="hw.device" value="WAP" />
+  </fingerprint>
+  <fingerprint pattern="Access not permitted\. Closing connection\.\.\.">
+    <description>System IOS switch</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="service.vendor" value="Cisco"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="IOS"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="IOS"/>
+  </fingerprint>
+  <fingerprint pattern="PIX passwd">
+    <description></description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="PIX"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.product" value="PIX"/>
+  </fingerprint>
+  <fingerprint pattern="Welcome to ViewStation">
+    <description>Polycom ViewStation Video Vonference System</description>
+    <example _encoding="base64" >
+    V2VsY29tZSB0byBWaWV3U3RhdGlvbgoKUGFzc3dvcmQ6
+    </example>
+    <param pos="0" name="hw.vendor" value="Polycom"/>
+    <param pos="0" name="hw.product" value="ViewStation"/>
+  </fingerprint>
+  <fingerprint pattern="Here is what I know about myself:">
+    <description>Polycom ViewStation Video Conference System</description>
+    <example _encoding="base64"  >
+     SGksIG15IG5hbWUgaXMgOiAgICAgUklER0VMQU5EIENBTVBVUwpIZXJlIGlzIHdoYXQgSSBrbm93IGFib3V0IG15c2VsZjo
+     KTW9kZWw6ICAgICAgICAgICAgICAgVlNYIDgwMDAKU2VyaWFsIE51bWJlcjogICAgICAgODIwODA4MDkzNTMyTjIKU29mdH
+     dhcmUgVmVyc2lvbjogICAgUmVsZWFzZSA5LjAuNi4yLTEwMyAtIDA0U2VwMjAxMSAyMToyNwpCdWlsZCBJbmZvcm1hdGlvb
+     jogICBlY29tbWFuZGVyIG9uIGVuZ2ludDAwLmF1c3Rpbi5wb2x5Y29tLmNvbQpGUEdBIFJldmlzaW9uOiAgICAgICA0LjQu
+     MgpNYWluIFByb2Nlc3NvcjogICAgICBCU1AxNSAgIHYwLjAgfiBDb3JlL01lbSBDbGtzIDQwNS8xMzUgIFszOjQgMDozXQp
+     UaW1lIEluIExhc3QgQ2FsbDogICAxOjU4OjAxClRvdGFsIFRpbWUgSW4gQ2FsbHM6IDE1NzowNDo1NQpUb3RhbCBDYWxscz
+     ogICAgICAgICAyMDYKU05UUCBUaW1lIFNlcnZpY2U6ICAgYXV0byBpbnN5bmMgMC5wb29sLm50cC5vcmcKTG9jYWwgVGltZ
+     SBpczogICAgICAgIFdlZCwgIDMgT2N0IDIwMTggMjE6MDg6MTcgLTExMDAKTmV0d29yayBJbnRlcmZhY2U6ICAgTk9ORQpJ
+     UCBWaWRlbyBOdW1iZXI6ICAgICAxNzIuMjAuMTkyLjI0OApJU0ROIFZpZGVvIE51bWJlcjogICAxLgpNUCBFbmFibGVkOiA
+     gICAgICAgICBLRUEwLTc5REEtNTZFMC0wMDAwLTAwODEKSDMyMyBFbmFibGVkOiAgICAgICAgVHJ1ZQpGVFAgRW5hYmxlZD
+     ogICAgICAgICBUcnVlCkhUVFAgRW5hYmxlZDogICAgICAgIFRydWUKU05NUCBFbmFibGVkOiAgICAgICAgRmFsc2U=
+    </example>
+    <param pos="0" name="hw.vendor" value="Polycom"/>
+    <param pos="0" name="hw.product" value="ViewStation"/>
+  </fingerprint>
+  <fingerprint pattern="FlowPoint\/(.*) SDSL \[ATM\] Router .*v(.*) Ready">
+    <description>iFlowPoint 2200 DSL router</description>
+    <example _encoding="base64" hw.model="2200" os.version="3.0.2" >
+    Rmxvd1BvaW50LzIyMDAgU0RTTCBbQVRNXSBSb3V0ZXIgZnAyMjAwLTEyIHYzLjAuMiBSZWFkeQpMb2dpbjog
+    </example>
+    <param pos="0" name="hw.vendor" value="Flowpoint"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.product" value="DSL router"/>
+    <param pos="1" name="hw.model"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="GlobespanVirata Inc\., Software Release (.*)">
+    <description>GlobespanVirata broadband router</description>
+    <example _encoding="base64" os.version="2.1.040407a3_u_e_A" >
+      R2xvYmVzcGFuVmlyYXRhIEluYy4sIFNvZnR3YXJlIFJlbGVhc2UgMi4xLjA0MDQwN2EzX3VfZV9BCgpDb3B5cmlnaHQgKG
+      MpIDIwMDEtMjAwMyBieSBHbG9iZXNwYW5WaXJhdGEsIEluYy4KCgpsb2dpbjog
+    </example>
+    <param pos="0" name="hw.vendor" value="Conexant"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="VxWorks login:">
+    <description>VxWorks embedded device</description>
+    <example>VxWorks login: </example>
+    <param pos="0" name="hw.device" value="VxWorks" />
+  </fingerprint>
+  <fingerprint pattern=".*Nortel.*Passport ([^ ]*) .*Software Release ([^ ]*).*">
+    <description>Nortel Passport</description>
+    <example _encoding="base64" hw.product="8010" os.version="3.5.0.0" >
+KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmlnaHQgKGMpIDIwMDMgTm9ydGVsIE5ldHdvcmtzLCBJbmMuICAqXG5cblxuKiBBbGwgUmlnaHRzIFJlc2VydmVkICAgICAgICAgICAgICAgICAgICAgICAqXG5cblxuKiBQYXNzcG9ydCA4MDEwICAgICAgICAgICAgICAgICAgICAgICAgICAgICAqXG5cblxuKiBTb2Z0d2FyZSBSZWxlYXNlIDMuNS4wLjAgICAgICAgICAgICAgICAgICAqXG5cblxuKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuXG5cbkxvZ2luOg==
+    </example>
+    <param pos="0" name="hw.vendor" value="Nortel"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="IPSO.* \((.*)\) \(tty.*\)">
+    <description>Checkpoint Firewall-1 running on a Nokia IPSO appliance</description>
+    <example _encoding="base64" hw.product="BJ-IDC-FW2" >
+     SVBTTy9pMzg2IChCSi1JREMtRlcyKSAodHR5cDcpCgoKClRoaXMgc3lzdGVtIGlzIGZvciBhdXRob3Jpem
+     VkIHVzZSBvbmx5LgoKCgoKCgoKbG9naW46IA==
+    </example>
+    <param pos="0" name="hw.vendor" value="Check Point"/>
+    <param pos="0" name="hw.family" value="Check Point"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+  <fingerprint pattern="Meridian.*Integrated.*RAN.*Version ([^ ]*) \\((.*)\\)">
+    <description>Nortel Meridian</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Nortel"/>
+    <param pos="0" name="hw.device" value="PBX"/>
+  </fingerprint>
+  <fingerprint pattern="BayStack ([^ ]*).*BoSS ([^ ]*)">
+    <description>System is a Nortel/BayStack</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Nortel"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="Nortel Baystack Boss"/>
+  </fingerprint>
+  <fingerprint pattern="Tasman Networks Inc.*Telnet Login">
+    <description>Tasman Networks Login</description>
+    <example _encoding="base64" hw.vendor="Tasman Networks" >
+     Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2hhcmFjdGVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
+    </example>
+    <param pos="0" name="hw.vendor" value="Tasman Networks"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.product" value="Tasman Networks router"/>
+  </fingerprint>
+  <fingerprint pattern="Pragma Systems">
+    <description>MS Windows running Pragma TelnetD server</description>
+    <example _encoding="base64"  >
+      V2VsY29tZSB0byBHZW1hZGVwdCBMb2dpc3RpY3MgUkYgU2VydmVyCihDKSBDb3B5cmlnaHQgMTk5NC0yMDEyIFByYWdtYSBTeXN0ZW1zLCBJbmMuCgpsb2dpbiBuYW1lOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="Microsoft"/>
+    <param pos="0" name="hw.family" value="Windows"/>
+    <param pos="0" name="hw.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="OpenNt Telnet Server on Windows NT">
+    <description>Windows NT running OpenNT telnet server</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Microsoft"/>
+    <param pos="0" name="hw.family" value="Windows"/>
+    <param pos="0" name="hw.product" value="Windows"/>
+</fingerprint>
+  <fingerprint pattern="Application Required. No Installation Default">
+    <description>System is probably IBM AS/400 running TN3270 or 5250 emulation server</description>
+    <example _encoding="base64">
+     QXBwbGljYXRpb24gUmVxdWlyZWQuIE5vIEluc3RhbGxhdGlvbiBEZWZhdWx0ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIApFbnRlciBBcHBsaWNhdGlvbiBOYW1lOg==
+    </example>
+    <param pos="0" name="hw.vendor" value="IBM"/>
+    <param pos="0" name="hw.device" value="General"/>
+  </fingerprint>
+  <fingerprint pattern="This copy of the Ataman TCP Remote Logon Services">
+    <description>Windows NT/2k/2k3 running Ataman telnet server</description>
+    <example _encoding="base64">
+      VGhpcyBjb3B5IG9mIHRoZSBBdGFtYW4gVENQIFJlbW90ZSBMb2dvbiBTZXJ2aWNlcyBpcyByZWdpc3RlcmVkIGFzIGxpY2Vuc2VkIHRvOgoJRUNJMi9ERE1TCgpBY2NvdW50IE5hbWU6IA==
+    </example>
+    <param pos="0" name="hw.vendor" value="Microsoft"/>
+    <param pos="0" name="hw.family" value="Windows"/>
+    <param pos="0" name="hw.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="Administration on this server address is not allowed">
+    <description>Novell Netware</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Novell"/>
+    <param pos="0" name="hw.family" value="Netware"/>
+    <param pos="0" name="hw.product" value="Netware"/>
+  </fingerprint>
+  <fingerprint pattern="Cobalt Linux release (.*)$">
+    <description>Cobalt Linux</description>
+    <example _encoding="base64" os.version="6.0 (Shinkansen)">
+      Q29iYWx0IExpbnV4IHJlbGVhc2UgNi4wIChTaGlua2Fuc2VuKQpLZXJuZWwgMi4yLjE2QzM3X0lJSSBvbiBhbiBpNTg2CmxvZ2luOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="Cobalt"/>
+    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="hw.product" value="Linux"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="Check Point FireWall-1 authenticated Telnet server running on (.*)">
+    <description>Check Point Firewall-1</description>
+    <example _encoding="base64" host.name="gaatdrf2" >
+      Q2hlY2sgUG9pbnQgRmlyZVdhbGwtMSBhdXRoZW50aWNhdGVkIFRlbG5ldCBzZXJ2ZXIgcnVubmluZyBvbiBnYWF0ZHJmMgoKVXNlcjog
+    </example>
+    <param pos="0" name="hw.vendor" value="Checkpoint"/>
+    <param pos="0" name="hw.family" value="Checkpoint"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.product" value="Checkpoint FW1"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+  <fingerprint pattern="Raptor Firewall">
+    <description>Raptor Firewall</description>
+    <example _encoding="base64">
+      UmFwdG9yIEZpcmV3YWxsIFNlY3VyZSBHYXRld2F5LgoKSG9zdG5hbWU6IA==
+    </example>
+    <param pos="0" name="hw.vendor" value="Symantec"/>
+    <param pos="0" name="hw.family" value="Raptor"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.product" value="Raptor"/>
+  </fingerprint>
+  <fingerprint pattern="Eagle Secure Gateway">
+    <description>Tekelec Eagle Secure Gateway</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Tekelec"/>
+    <param pos="0" name="hw.family" value="Eagle Secure Gateway"/>
+    <param pos="0" name="hw.product" value="Eagle Secure Gateway"/>
+  </fingerprint>
+  <fingerprint pattern="UNIX\(r\) System V Release 4.0">
+    <description>System is SunOS 5.x (Solaris)</description>
+    <example _encoding="base64">
+      VU5JWChyKSBTeXN0ZW0gViBSZWxlYXNlIDQuMCAoVGhlLVNlcnZlcikKCgoKbG9naW46IA==
+    </example>
+    <param pos="0" name="hw.vendor" value="Sun"/>
+    <param pos="0" name="hw.family" value="Solaris"/>
+    <param pos="0" name="hw.device" value="General" />
+    <param pos="0" name="hw.product" value="Solaris"/>
+  </fingerprint>
+  <fingerprint pattern="Solaris (.*)">
+    <description>System is Solaris</description>
+    <example _encoding="base64" os.version="1.1.1.B">
+      U2VhdHRsZSBDb21tdW5pdHkgTmV0d29yayBTdW4gU29sYXJpcyAxLjEuMS5CClBsZWFzZSBsb2dpbiBhcyAndmlzaXRvcicgaWYgeW91IGFyZSBhIHZpc2l0b3IKCgpTdW5PUyBVTklYIChzY24pCgoKCmxvZ2luOg==
+    </example>
+    <param pos="0" name="hw.vendor" value="Sun"/>
+    <param pos="0" name="hw.family" value="Solaris"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="Solaris"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="Digital UNIX">
+    <description>System is Digital Unix</description>
+    <example _encoding="base64"  >
+      RGlnaXRhbCBVTklYIChqb3VybmFsKSAodHR5cDIpCgoKCmxvZ2luOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="Digital Unix"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="Digital Unix"/>
+  </fingerprint>
+  <fingerprint pattern="Compaq Tru64 UNIX V(.*) \(Rev. (.*)\).*" flags="REG_MULTILINE">
+    <description>System is Compaq Tru64 UNIX V</description>
+    <example _encoding="base64" os.version="5.1B">
+     Q29tcGFxIFRydTY0IFVOSVggVjUuMUIgKFJldi4gMjY1MCkgKGRvY2FscGhhKSAocHRzLzExKQoKCgoKCmxvZ2luOg== 
+    </example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="Digital Unix"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="TRU64"/>
+    <param pos="1" name ="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="AIX (?:Version)? *(.*)$">
+    <description>System is IBM AIX v</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="IBM"/>
+    <param pos="0" name="hw.family" value="AIX"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="AIX"/>
+  </fingerprint>
+  <fingerprint pattern="HP-UX ([^ ]+) [A-Z]\.([^ ]+) ([^ ]+) ([^ ]+)\s([^ ]+\)).*$">
+    <description>System HP-UX</description>
+    <example _encoding="base64" host.name="ctout" os.version="11.11">
+      SFAtVVggY3RvdXQgQi4xMS4xMSBVIDkwMDAvODAwICh0YykKCmxvZ2luOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="HP-UX"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="HP-UX"/>
+    <param pos="1" name="host.name"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="Data ONTAP">
+    <description>System is a NetApp apliance</description>
+    <example _encoding="base64">RGF0YSBPTlRBUCAoczUwMC4pCmxvZ2luOiA=</example>
+    <param pos="0" name="hw.vendor" value="NetApp"/>
+    <param pos="0" name="hw.family" value="Data ONTAP"/>
+    <param pos="0" name="hw.device" value="Storage"/>
+    <param pos="0" name="hw.product" value="Data ONTAP"/>
+  </fingerprint>
+  <fingerprint pattern="OpenVMS">
+    <description>System is OpenVMS</description>
+    <example _encoding="base64"  >
+      V2VsY29tZSB0byBPcGVuVk1TIChUTSkgQWxwaGEgT3BlcmF0aW5nIFN5c3RlbSwgVmVyc2lvbiBWNy4zLTIgIAoKClVzZXJuYW1lOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="OpenVMS" />
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="VMS"/>
+  </fingerprint>
+  <fingerprint pattern="SCO OpenServer\(TM\) Release ([^ ]+).*$" flags="REG_MULTILINE">
+    <description>System is SCO OpenServer</description>
+    <example _encoding="base64" os.version="5" >
+      U0NPIE9wZW5TZXJ2ZXIoVE0pIFJlbGVhc2UgNSAoYm9tZGlhLmNvLnphKSAodHR5cDYpCgpsb2dpbjo=
+    </example>
+    <param pos="0" name="hw.vendor" value="SCO"/>
+    <param pos="0" name="hw.family" value="OpenServer"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="OpenServer"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="% Username:  timeout expired!">
+    <description>System is some kind of Cisco device</description>
+    <example _encoding="base64"  >
+      VXNlciBBY2Nlc3MgVmVyaWZpY2F0aW9uCgpVc2VybmFtZTogCiUgVXNlcm5hbWU6ICB0aW1lb3V0IGV4cGlyZWQh
+    </example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="IOS"/>
+    <param pos="0" name="hw.product" value="IOS"/>
+  </fingerprint>
+  <fingerprint pattern="Access not permitted. Closing connection\.\.\.">
+    <description>System is some kind of Cisco device</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="IOS"/>
+    <param pos="0" name="hw.product" value="IOS" />
+  </fingerprint>
+  <fingerprint pattern="MSA Fabric Switch ([^ ]*)">
+    <description>System is an HP/Compaq MSA Fabric Switch</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+  </fingerprint>
+  <fingerprint pattern="Welcome to MKS Telnet Server Version">
+    <description>System is Windows running MKS Telnet Server</description>
+    <example _encoding="base64"  >
+      V2VsY29tZSB0byBNS1MgVGVsbmV0IFNlcnZlciBWZXJzaW9uIDQuNzAuMDAwMC4KbG9naW46IA==
+    </example>
+    <param pos="0" name="hw.vendor" value="Microsoft"/>
+    <param pos="0" name="hw.family" value="Windows"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="Extended DX">
+    <description>System is an ExtendNet DX print server</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="ExtendNet"/>
+    <param pos="0" name="hw.family" value="Print Server"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.product" value="DX Print Server"/>
+  </fingerprint>
+  <fingerprint pattern="Extended SX">
+    <description>System is an ExtendNet SX print server</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="ExtendNet"/>
+    <param pos="0" name="hw.family" value="Print Server"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.product" value="SX Print Server"/>
+  </fingerprint>
+  <fingerprint pattern="2H252-25R">
+    <description>System is a Cabletron 2H252-25R-2FR switch</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Cabletron"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+  </fingerprint>
+  <fingerprint pattern="Sorry, this system is engaged\.">
+    <description>System is an embedded print server</description>
+    <example>Sorry, this system is engaged.</example>
+    <param pos="0" name="hw.vendor" value="Epson"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+  </fingerprint>
+  <fingerprint pattern="(?:ScreenOS\\s+(\\d+\\.\\d\\S*)\\s.*?)?Remote Management Console">
+    <description>System is a NetScreen firewall</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Juniper"/>
+    <param pos="0" name="hw.family" value="ScreenOS"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.product" value="ScreenOS"/>
+  </fingerprint>
+  <fingerprint pattern="TELNET session now in ESTABLISHED state">
+    <description>System is an Allied Telesyn router</description>
+    <example _encoding="base64">
+      VEVMTkVUIHNlc3Npb24gbm93IGluIEVTVEFCTElTSEVEIHN0YXRlCgpHRU8tMDAzIGxvZ2luOiA=
+    </example>
+    <param pos="0" name="hw.vendor" value="Allied Telesyn"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.product" value="Allied Telesyn router"/>
+  </fingerprint>
+  <fingerprint pattern="CONEXANT SYSTEMS.*ACCESS RUNNER ADSL">
+    <description>System is a Conexant ADSL router</description>
+    <example _encoding="base64">
+      G1swbRtbMkobWzAxOzI4SENPTkVYQU5UIFNZU1RFTVMsIElOQy4bWzAyOzE5SCBBQ0NFU1MgUlVOTkVSIEFEU0wgQ09OU09MRSBQT1JUG1syNDswMUg+Pj4bWzI0OzAxSExPR09OIFBBU1NXT1JEPhtbMDI7NTNIMy4yNxtbMjQ7MTdIG1syNDsxN0g=
+    </example>
+    <param pos="0" name="hw.vendor" value="Conexant"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+    <param pos="0" name="hw.product" value="AccessRunner ADSL router"/>
+  </fingerprint>
+  <fingerprint pattern="System administrator is connecting from">
+    <description>System is a DrayTek Vigor SOHO Router</description>
+    <example _encoding="base64">
+      U3lzdGVtIGFkbWluaXN0cmF0b3IgaXMgY29ubmVjdGluZyBmcm9tIDU0LjM5LjE3My44NgoKUmVqZWN0IH
+      RoZSBjb25uZWN0aW9uIHJlcXVlc3QgISEh
+    </example>
+    <param pos="0" name="hw.vendor" value="Draytek"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+    <param pos="0" name="hw.product" value="Vigor"/>
+  </fingerprint>
+  <fingerprint pattern="SonicWALL SSL-RX SSL Accelerator">
+    <description>System is a SonicWALL SSL-RX SSL Accelerator</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="SonicWALL"/>
+    <param pos="0" name="hw.device" value="Encryption accelerator"/>
+    <param pos="0" name="hw.product" value="SonicOS"/>
+  </fingerprint>
+  <fingerprint pattern="Welcome to WiseWan system">
+    <description>System is a NetReality WiseWan traffic shaper</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="NetReality"/>
+    <param pos="0" name="hw.family" value="WiseWan"/>
+    <param pos="0" name="hw.product" value="WiseWan"/>
+  </fingerprint>
+  <fingerprint pattern="User Name :">
+    <description>System is APC UPS</description>
+    <example>User Name : </example>
+    <param pos="0" name="hw.vendor" value="APC"/>
+    <param pos="0" name="hw.family" value="APC"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="hw.product" value="UPS"/>
+  </fingerprint>
+  <fingerprint pattern="OpenBSD">
+    <description>System is OpenBSD</description>
+    <example _encoding="base64">
+      V2VsY29tZSB0byB0aGUgT3BlbkJTRCBpbnN0YWxsYXRpb24gYW5kIHVwZGF0ZSBkZW1vcwoKVGhlcmUgYXJlIHNldmVyYWwgc2hvd3MgYXZhaWxhYmxlIHRoYXQgd2lsbCBiZSByb3RhdGVkIGV2ZXJ5IDYwIHNlY29uZHMuCkN1cnJlbnRseSBzZWxlY3RlZCBpcyBzaG93IG51bWJlciAwMy4gSWYgeW91IHdhbnQgdG8gc2VlIGFub3RoZXIgb25lLApkaXNjb25uZWN0IG5vdyBhbmQgcmVjb25uZWN0IGxhdGVyLgoKU2hvdyAwMSAoRHVyYXRpb246IDAwOjA3OjU3KToKICAgICAgICBQZXJmZWN0bHkgbm9ybWFsIGFuZCBib3JpLi4u
+    </example>
+    <param pos="0" name="hw.vendor" value="OpenBSD"/>
+    <param pos="0" name="hw.family" value="OpenBSD"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="OpenBSD"/>
+  </fingerprint>
+  <fingerprint pattern="FreeBSD/([^\\s]+)\\s+\\(([^\\s]+)\\)">
+    <description>System is a FreeBSD</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="FreeBSD"/>
+    <param pos="0" name="hw.family" value="FreeBSD"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="FreeBSD"/>
+  </fingerprint>
+  <fingerprint pattern="FreeBSD\\s+([^\\s]+)[^/]*/([^\\s]+)\\s+\\(([^\\s]+)\\)">
+    <description>System is FreeBSD</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="FreeBSD"/>
+    <param pos="0" name="hw.family" value="FreeBSD"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="FreeBSD"/>
+  </fingerprint>
+  <fingerprint pattern="FreeBSD">
+    <description>System is FreeBSD</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="FreeBSD"/>
+    <param pos="0" name="hw.family" value="FreeBSD"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="FreeBSD"/>
+  </fingerprint>
+  <fingerprint pattern="NetBSD">
+    <description>System is NetBSD</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="NetBSD"/>
+    <param pos="0" name="hw.family" value="NetBSD"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="NetBSD"/>
+  </fingerprint>
+  <fingerprint pattern="IRIX">
+    <description>System is SGI IRIX</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="SGI"/>
+    <param pos="0" name="hw.family" value="IRIX"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="IRIX"/>
+  </fingerprint>
+  <fingerprint pattern="Tasman Networks Inc.">
+    <description>System is Tasman Networks router</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Tasman Networks"/>
+    <param pos="0" name="hw.family" value="TiOS"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.product" vlaue="TiOS"/>
+  </fingerprint>
+  <fingerprint pattern="(RS [^\\s]+) System Software, Version ([^\\s]+)">
+    <description>System is Tasman Networks router</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Riverstone"/>
+    <param pos="0" name="hw.family" value="Riverstone"/>
+    <param pos="0" name="hw.device" value="Router"/>
+  </fingerprint>
+  <fingerprint pattern="(ES [^\\s]+) System Software, Version ([^\\s]+)">
+    <description>System is a Tasman Networks Ethernet router`</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Riverstone"/>
+    <param pos="0" name="hw.family" value="ES"/>
+    <param pos="0" name="hw.device" value="ES"/>
+  </fingerprint>
+  <fingerprint pattern="HP.*ProCurve Switch">
+    <description>System is HP ProCurve Switch</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="ProCurve"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="ProCurve"/>
+  </fingerprint>
+  <fingerprint pattern="Sorry, the maximum number of telnet sessions are active\.\\s*Try again later\.">
+    <description>System is a HP ProCurve Switch</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="ProCurve"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="ProCurve"/>
+  </fingerprint>
+  <fingerprint pattern="Madge CrossFire">
+    <description>System is a Madge CrossFire</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Madge"/>
+    <param pos="0" name="hw.family" value="Madge CrossFire"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="Madge CrossFire"/>
+  </fingerprint>
+  <fingerprint pattern="HP ProLiant.*Switch">
+    <description>Sytem is HP ProLiant switch</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.family" value="ProLiant"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="ProLiant"/>
+  </fingerprint>
+  <fingerprint pattern="ConnectUPS">
+    <description>System is PowerWare ConnectUPS</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="PowerWare"/>
+    <param pos="0" name="hw.family" value="ConnectUPS"/>
+    <param pos="0" name="hw.device" value="UPS"/>
+    <param pos="0" name="hw.product" vaule="ConnectUPS"/>
+  </fingerprint>
+  <fingerprint pattern="Imagistics.*im">
+    <description>System is an Imagistics device</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Imagistics"/>
+    <param pos="0" name="hw.family" value="Imagistics"/>
+    <param pos="0" name="hw.device" value="Malfunction Device"/>
+    <param pos="0" name="hw.product" value="im"/>
+  </fingerprint>
+  <fingerprint pattern="Imagistics.*cs">
+    <description>System is an Imagistics device</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Imagistics"/>
+    <param pos="0" name="hw.family" value="Imagistics"/>
+    <param pos="0" name="hw.device" value="Malfunction Device"/>
+    <param pos="0" name="hw.product" value="cs"/>
+  </fingerprint>
+  <fingerprint pattern="NRG Maintenance Shell">
+    <description>System is a Ricoh NRG device</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Ricoh"/>
+    <param pos="0" name="hw.device" value="Printer" />
+    <param pos="0" name="hw.product" value="NRG Printer"/>
+  </fingerprint>
+  <fingerprint pattern="^SHARP (AR-[^\\s]+) Ver ([^\\s]+) TELNET server">
+    <description>System is SHARP AR Series multifunction device</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Sharp"/>
+    <param pos="0" name="hw.family" value="Sharp AR Series"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+  </fingerprint>
+  <fingerprint pattern="^SHARP (MX-[^\\s]+) Ver ([^\\s]+) TELNET server">
+    <description>System is SHARP MX Series multifunction device</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Sharp"/>
+    <param pos="0" name="hw.family" value="Sharp MX Series"/>
+    <param pos="0" name="hw.device" value="Multifunction Device"/>
+  </fingerprint>
+  <fingerprint pattern="^CIMC Debug Firmware Utility Shell">
+    <description>System is Cisco UCS Device</description>
+    <example _encoding="base64"  ></example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="UCS"/>
+    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.product" value="UCS Device"/>
   </fingerprint>
 </fingerprints>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1167,7 +1167,7 @@
     <param pos="0" name="os.device" value="Server"/>
     <param pos="0" name="os.product" value="Data ONTAP"/>
   </fingerprint>
-  <fingerprint pattern="OpenVMS.*Version\sV(\d*.\d*).*">
+  <fingerprint pattern="OpenVMS.*Version\sV([^\s]+).*">
     <description>OpenVMS</description>
     <!--  Welcome to OpenVMS (TM) Alpha Operating System, Version V8.4     - NOT70\n\nUsername: -->
     <example _encoding="base64" os.version="8.4">

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -953,7 +953,7 @@
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.model"/>
   </fingerprint>
-  <fingerprint pattern="Welcome to ViewStation">
+  <fingerprint pattern="^Welcome to ViewStation">
     <description>Polycom ViewStation Video Vonference System</description>
     <!-- Welcome to ViewStation\nPassword: -->
     <example _encoding="base64">
@@ -962,11 +962,11 @@
     <param pos="0" name="os.vendor" value="Polycom"/>
     <param pos="0" name="os.device" value="ViewStation"/>
   </fingerprint>
-  <fingerprint pattern="FlowPoint\/(.*) SDSL \[ATM\] Router .*v(.*) Ready">
+  <fingerprint pattern="^FlowPoint\/(.*) SDSL \[ATM\] Router .*v(.*) Ready">
     <!--FlowPoint/2200 SDSL [ATM] Router fp2200-12 v3.0.2 Ready\nLogin:  -->
-    <description>iFlowPoint 2200 DSL router</description>
+    <description>FlowPoint 2200 DSL router</description>
     <example _encoding="base64" hw.model="2200" os.version="3.0.2">
-    Rmxvd1BvaW50LzIyMDAgU0RTTCBbQVRNXSBSb3V0ZXIgZnAyMjAwLTEyIHYzLjAuMiBSZWFkeQpMb2dpbjog
+      Rmxvd1BvaW50LzIyMDAgU0RTTCBbQVRNXSBSb3V0ZXIgZnAyMjAwLTEyIHYzLjAuMiBSZWFkeQpMb2dpbjog
     </example>
     <param pos="0" name="hw.vendor" value="Flowpoint"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
@@ -974,7 +974,7 @@
     <param pos="1" name="hw.model"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="GlobespanVirata Inc\., Software Release (.*)">
+  <fingerprint pattern="^GlobespanVirata Inc\., Software Release (.*)">
     <description>GlobespanVirata broadband router</description>
     <!--GlobespanVirata Inc., Software Release 2.1.040407a3_u_e_A\nCopyright (c) 2001-2003 by GlobespanVirata, Inc.\n\nlogin:  -->
     <example _encoding="base64" os.version="2.1.040407a3_u_e_A">
@@ -985,7 +985,7 @@
     <param pos="0" name="hw.device" value="Broadband Router"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="VxWorks login:">
+  <fingerprint pattern="^VxWorks login:">
     <description>VxWorks embedded device</description>
     <example>VxWorks login: </example>
     <param pos="0" name="os.family" value="VxWorks"/>
@@ -1005,7 +1005,7 @@
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="IPSO.* \((.*)\) \(tty.*\)">
+  <fingerprint pattern="^IPSO.* \((.*)\) \(tty.*\)">
     <description>Checkpoint Firewall-1 running on a Nokia IPSO appliance</description>
     <!-- IPSO/i386 (BJ-IDC-FW2) (ttyp7)\n\n\nThis system is for authorized use only.\n\n\n\n\n\n\nlogin: -->
     <example _encoding="base64" host.name="BJ-IDC-FW2">
@@ -1043,7 +1043,7 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
-  <fingerprint pattern="Application Required. No Installation Default">
+  <fingerprint pattern="^Application Required. No Installation Default">
     <description>probably IBM AS/400 running TN3270 or 5250 emulation server</description>
     <!-- Application Required. No Installation Default\nEnter Application Name: -->
     <example _encoding="base64">
@@ -1052,7 +1052,7 @@
     </example>
     <param pos="0" name="os.vendor" value="IBM"/>
   </fingerprint>
-  <fingerprint pattern="This copy of the Ataman TCP Remote Logon Services">
+  <fingerprint pattern="^This copy of the Ataman TCP Remote Logon Services">
     <description>Windows NT/2k/2k3 running Ataman telnet server</description>
     <!-- This copy of the Ataman TCP Remote Logon Services is registered as licensed to:\nECI2/DDMS\nAccount Name: -->
     <example _encoding="base64">
@@ -1074,7 +1074,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="Check Point FireWall-1 authenticated Telnet server running on (.*)">
+  <fingerprint pattern="^Check Point FireWall-1 authenticated Telnet server running on (.*)">
     <description>Check Point Firewall-1</description>
     <!-- Check Point FireWall-1 authenticated Telnet server running on gaatdrf2\nUser: -->
     <example _encoding="base64" host.name="gaatdrf2">
@@ -1086,7 +1086,7 @@
     <param pos="0" name="os.product" value="Checkpoint FW1"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="Raptor Firewall">
+  <fingerprint pattern="^Raptor Firewall">
     <description>Raptor Firewall</description>
     <!-- Raptor Firewall Secure Gateway.\nHostname: -->
     <example _encoding="base64">
@@ -1120,7 +1120,7 @@
     <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="Digital UNIX \(([^)]+).*">
+  <fingerprint pattern="^Digital UNIX \(([^)]+).*">
     <description>Digital Unix</description>
     <!-- Digital UNIX (journal) (ttyp2)\n\n\nlogin: -->
     <example _encoding="base64" host.name="journal">
@@ -1158,7 +1158,7 @@
     <param pos="4" name="hw.series"/>
     <param pos="5" name="hw.model"/>
   </fingerprint>
-  <fingerprint pattern="Data ONTAP">
+  <fingerprint pattern="^Data ONTAP">
     <description>A NetApp apliance</description>
     <!-- Data ONTAP (s500.)\nlogin: -->
     <example _encoding="base64">RGF0YSBPTlRBUCAoczUwMC4pCmxvZ2luOiA=</example>
@@ -1190,7 +1190,7 @@
     <param pos="0" name="os.product" value="OpenServer"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="% Username:  timeout expired!">
+  <fingerprint pattern="^% Username:  timeout expired!">
     <description>Some kind of Cisco device</description>
     <!-- % Username:  timeout expired!-->
     <example _encoding="base64">
@@ -1200,7 +1200,7 @@
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
   </fingerprint>
-  <fingerprint pattern="Welcome to MKS Telnet Server Version">
+  <fingerprint pattern="^Welcome to MKS Telnet Server Version">
     <description>Windows running MKS Telnet Server</description>
     <example _encoding="base64">
       V2VsY29tZSB0byBNS1MgVGVsbmV0IFNlcnZlciBWZXJzaW9uIDQuNzAuMDAwMC4KbG9naW46IA==
@@ -1209,13 +1209,13 @@
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
-  <fingerprint pattern="Sorry, this system is engaged\.">
+  <fingerprint pattern="^Sorry, this system is engaged\.">
     <description>an embedded print server</description>
     <example>Sorry, this system is engaged.</example>
     <param pos="0" name="os.vendor" value="Epson"/>
     <param pos="0" name="os.device" value="Printer"/>
   </fingerprint>
-  <fingerprint pattern="TELNET session now in ESTABLISHED state">
+  <fingerprint pattern="^TELNET session now in ESTABLISHED state">
     <description>an Allied Telesyn router</description>
     <!-- TELNET session now in ESTABLISHED state\n\nGEO-003 login: -->
     <example _encoding="base64">
@@ -1225,19 +1225,18 @@
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.product" value="Allied Telesyn router"/>
   </fingerprint>
-  <fingerprint pattern="CONEXANT SYSTEMS.*ACCESS RUNNER ADSL">
+  <fingerprint pattern="^CONEXANT SYSTEMS.*ACCESS RUNNER ADSL">
     <description>a Conexant ADSL router</description>
     <!-- CONEXANT SYSTEMS, INC. ACCESS RUNNER ADSL CONSOLE PORT>>>LOGON PASSWORD>3.27****** -->
     <example _encoding="base64">
-      G1swbRtbMkobWzAxOzI4SENPTkVYQU5UIFNZU1RFTVMsIElOQy4bWzAyOzE5SCBBQ0NFU1MgUlVOTkVSIEF
-      EU0wgQ09OU09MRSBQT1JUG1syNDswMUg+Pj4bWzI0OzAxSExPR09OIFBBU1NXT1JEPhtbMDI7NTNIMy4yNx
-      tbMjQ7MTdIG1syNDsxN0g=
+      Q09ORVhBTlQgU1lTVEVNUywgSU5DLiBBQ0NFU1MgUlVOTkVSIEFEU0wgQ09OU09MRSBQ
+      T1JUPj4+TE9HT04gUEFTU1dPUkQ+My4yNyoqKioqKg==
     </example>
     <param pos="0" name="os.vendor" value="Conexant"/>
     <param pos="0" name="os.device" value="Broadband router"/>
     <param pos="0" name="os.product" value="AccessRunner ADSL router"/>
   </fingerprint>
-  <fingerprint pattern="System administrator is connecting from">
+  <fingerprint pattern="^System administrator is connecting from">
     <description>a DrayTek Vigor SOHO Router</description>
     <!-- System administrator is connecting from 54.39.173.86\n\nReject the connection request !!! -->
     <example _encoding="base64">
@@ -1259,7 +1258,7 @@
     <param pos="0" name="os.product" value="OpenBSD"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="FreeBSD\/([^\\s]+)\s+\(([^\s]+)\)">
+  <fingerprint pattern="^FreeBSD\/([^\\s]+)\s+\(([^\s]+)\)">
     <description>a FreeBSD</description>
     <!-- FreeBSD/amd64 (ms.gymspgs.cz) (pts/0)\n\n\n\nlogin: -->
     <example _encoding="base64" os.arch="amd64" host.name="ms.gymspgs.cz">
@@ -1271,7 +1270,7 @@
     <param pos="1" name="os.arch"/>
     <param pos="2" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="NetBSD">
+  <fingerprint pattern="^NetBSD">
     <description>NetBSD</description>
     <!-- NetBSD/evbsh3 (Fukuyama.Host_AKS_0555_WL-v2.60d) (ttyp1)  -->
     <example _encoding="base64">
@@ -1281,7 +1280,7 @@
     <param pos="0" name="os.family" value="NetBSD"/>
     <param pos="0" name="os.product" value="NetBSD"/>
   </fingerprint>
-  <fingerprint pattern="IRIX\W\((.*)\)">
+  <fingerprint pattern="^IRIX\W\((.*)\)">
     <description>SGI IRIX</description>
     <!-- IRIX (artemis.biol.uoa.gr)\n\n\n\nlogin: -->
     <example _encoding="base64" host.name="artemis.biol.uoa.gr">
@@ -1320,7 +1319,7 @@
     <param pos="2" name="os.product"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="HP ([^\s]+) ProCurve Switch">
+  <fingerprint pattern="^HP ([^\s]+) ProCurve Switch">
     <description>HP ProCurve Switch</description>
     <!-- ==============================================================================\nHP J4121A ProCurve Switch 4000M\n
     Firmware revision v2.2.3\n\nCopyright (C) 1991-2004 Hewlett-Packard Co. All Rights Reserved.\n\n
@@ -1353,7 +1352,7 @@
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="ConnectUPS">
+  <fingerprint pattern="^(?m).*ConnectUPS">
     <description>PowerWare ConnectUPS</description>
     <!-- +============================================================================+\n|            [ ConnectUPS Web/SNMP
      Card Configuration Utility ]              |\n+============================================================================+\n
@@ -1370,7 +1369,7 @@
     <param pos="0" name="os.device" value="UPS"/>
     <param pos="0" name="os.product" value="ConnectUPS"/>
   </fingerprint>
-  <fingerprint pattern="Imagistics.*im">
+  <fingerprint pattern="^Imagistics.*im">
     <description>an Imagistics device</description>
     <!-- Imagistics im3511/im4511 Ver 01.00.20 TELNET server.\nCopyright(c) 2001-2005, silex technology, Inc.\nlogin: -->
     <example _encoding="base64">
@@ -1382,7 +1381,7 @@
     <param pos="0" name="os.device" value="Malfunction Device"/>
     <param pos="0" name="os.product" value="im"/>
   </fingerprint>
-  <fingerprint pattern="NRG Maintenance Shell">
+  <fingerprint pattern="^NRG Maintenance Shell">
     <description>a Ricoh NRG device</description>
     <!-- NRG Maintenance Shell.   \nUser access verification.\nlogin: -->
     <example _encoding="base64"  >

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -822,9 +822,9 @@
     <example _encoding="base64" os.version="9 (Shrike)">
       UmVkIEhhdCBMaW51eCByZWxlYXNlIDkgKFNocmlrZSlcbktlcm5lbCAyLjQuMjAtOCBvbiBhbiBpNjg2XG5sb2dpbjo=
    </example>
-    <param pos="0" name="hw.vendor" value="RedHat"/>
-    <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.device" value="Linux"/>
+    <param pos="0" name="os.vendor" value="RedHat"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.device" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^(?m)Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)">
@@ -834,8 +834,8 @@
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEVTIHJlbGVhc2UgMyAoVGFyb29uIFVwZGF0ZSA5KQpLZXJuZWwgMi40LjIxLTQ3Lk
       VMIG9uIGFuIHg4Nl82NApsb2dpbjo=
     </example>
-    <param pos="0" name="hw.vendor" value="RedHat"/>
-    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="os.vendor" value="RedHat"/>
+    <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
@@ -848,9 +848,9 @@
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IEFTIHJlbGVhc2UgNS44IChUaWthbmdhKQpLZXJuZWwgM
       i42LjE4LTMwOC4xMS4xLmVsNSBvbiBhbiB4ODZfNjQKbG9naW46
     </example>
-    <param pos="0" name="hw.vendor" value="RedHat"/>
-    <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.product" value="RedHat Enterprise AS"/>
+    <param pos="0" name="os.vendor" value="RedHat"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="RedHat Enterprise AS"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
@@ -862,9 +862,9 @@
       UmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IFdTIHJlbGVhc2UgMi4xIChUYW1wY
       SkgCktlcm5lbCAyLjQuOS1lLjQwc21wIG9uIGFuIGk2ODYgCmxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="RedHat"/>
-    <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.product" value="RedHat Enterprise WS"/>
+    <param pos="0" name="os.vendor" value="RedHat"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="RedHat Enterprise WS"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
@@ -875,9 +875,9 @@
     <example _encoding="base64" os.version="1" linux.kernel.version="2.4.20-13.9ensim-3.5.0-13" os.arch="i686">
      RmVkb3JhIENvcmUgcmVsZWFzZSAxIChZYXJyb3cpCktlcm5lbCAyLjQuMjAtMTMuOWVuc2ltLTMuNS4wLTEzIG9uIGFuIGk2ODYKbG9naW46
     </example>
-    <param pos="0" name="hw.vendor" value="Redhat"/>
-    <param pos="0" name="hw.family" value="Linux"/>
-    <param pos="0" name="hw.product" value="Fedora"/>
+    <param pos="0" name="os.vendor" value="Redhat"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Fedora"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
@@ -888,8 +888,8 @@
     <example _encoding="base64" os.version="7.0" os.arch="i386" linux.kernel.version="2.2.16-RAID (0). 2VG029037">
       V2VsY29tZSB0byBTdVNFIExpbnV4IDcuMCAoaTM4NikgLSBLZXJuZWwgMi4yLjE2LVJBSUQgKDApLiAyVkcwMjkwMzcgCgpsb2dpbjo=
     </example>
-    <param pos="0" name="hw.vendor" value="SUSE"/>
-    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="os.vendor" value="SUSE"/>
+    <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.arch"/>
@@ -903,8 +903,8 @@
      2XzY0IG9uIGEgeDg2XzY0IChzZW55bzE5MXg4OS5kaWdpdGFsaW5rLm5lLmpwKSBUVFk6IDEyOjE1IG9uIFR1ZXNkYX
      ksIDAyIE9jdG9iZXIgMjAxOCBsb2dpbjog
     </example>
-    <param pos="0" name="hw.vendor" value="Turbolinux"/>
-    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="os.vendor" value="Turbolinux"/>
+    <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
@@ -914,10 +914,10 @@
     <example _encoding="base64" os.version="2.1.3">
      VW5peFdhcmUgMi4xLjMgKHByb2ZpbCkgKHB0cy8zKQoKCgpsb2dpbjog
     </example>
-    <param pos="0" name="hw.vendor" value="SCO"/>
-    <param pos="0" name="hw.family" value="UnixWare"/>
-    <param pos="0" name="hw.device" value="UnixWare"/>
-    <param pos="0" name="hw.product" value="UnixWare"/>
+    <param pos="0" name="os.vendor" value="SCO"/>
+    <param pos="0" name="os.family" value="UnixWare"/>
+    <param pos="0" name="os.device" value="UnixWare"/>
+    <param pos="0" name="os.product" value="UnixWare"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Telnet Server Build (5.*)">
@@ -927,9 +927,9 @@
       TWljcm9zb2Z0IChSKSBXaW5kb3dzIE5UIChUTSkgVmVyc2lvbiA0LjAwIChCdWlsZCAxMzgxKQpXZWxj
       b21lIHRvIE1pY3Jvc29mdCBUZWxuZXQgU2VydmljZSAKVGVsbmV0IFNlcnZlciBCdWlsZCA1LjAwLjk5MDM0LjEKCmxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="Microsoft"/>
-    <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.product" value="Windows 2000"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows 2000"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Welcome. Type return, enter password at # prompt">
@@ -938,20 +938,20 @@
     <example _encoding="base64">
       V2VsY29tZS4gVHlwZSByZXR1cm4sIGVudGVyIHBhc3N3b3JkIGF0ICMgcHJvbXB0Cg== 
     </example>
-    <param pos="0" name="hw.vendor" value="Brother"/>
-    <param pos="0" name="hw.family" value="Brother"/>
-    <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="0" name="hw.product" value="Brother Printer"/>
+    <param pos="0" name="os.vendor" value="Brother"/>
+    <param pos="0" name="os.family" value="Brother"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="os.product" value="Brother Printer"/>
   </fingerprint>
   <fingerprint pattern="^(.*) Copyright by ARESCOM">
     <description>Arescom System</description>
     <!--NDS1260HE-TLI Copyright by ARESCOM 2002\n\n\nPassword: -->
-    <example _encoding="base64" hw.model="NDS1260HE-TLI">
+    <example _encoding="base64" os.model="NDS1260HE-TLI">
       TkRTMTI2MEhFLVRMSSBDb3B5cmlnaHQgYnkgQVJFU0NPTSAyMDAyCgoKClBhc3N3b3JkOgo=
     </example>
-    <param pos="0" name="hw.vendor" value="Arescom"/>
-    <param pos="0" name="hw.device" value="WAP"/>
-    <param pos="1" name="hw.model"/>
+    <param pos="0" name="os.vendor" value="Arescom"/>
+    <param pos="0" name="os.device" value="WAP"/>
+    <param pos="1" name="os.model"/>
   </fingerprint>
   <fingerprint pattern="Welcome to ViewStation">
     <description>Polycom ViewStation Video Vonference System</description>
@@ -959,8 +959,8 @@
     <example _encoding="base64">
       V2VsY29tZSB0byBWaWV3U3RhdGlvbgoKUGFzc3dvcmQ6
     </example>
-    <param pos="0" name="hw.vendor" value="Polycom"/>
-    <param pos="0" name="hw.device" value="ViewStation"/>
+    <param pos="0" name="os.vendor" value="Polycom"/>
+    <param pos="0" name="os.device" value="ViewStation"/>
   </fingerprint>
   <fingerprint pattern="FlowPoint\/(.*) SDSL \[ATM\] Router .*v(.*) Ready">
     <!--FlowPoint/2200 SDSL [ATM] Router fp2200-12 v3.0.2 Ready\nLogin:  -->
@@ -981,14 +981,14 @@
       R2xvYmVzcGFuVmlyYXRhIEluYy4sIFNvZnR3YXJlIFJlbGVhc2UgMi4xLjA0MDQwN2EzX3VfZV9BCgpDb3B5cmlnaHQgKG
       MpIDIwMDEtMjAwMyBieSBHbG9iZXNwYW5WaXJhdGEsIEluYy4KCgpsb2dpbjog
     </example>
-    <param pos="0" name="hw.vendor" value="Conexant"/>
+    <param pos="0" name="os.vendor" value="Conexant"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="VxWorks login:">
     <description>VxWorks embedded device</description>
     <example>VxWorks login: </example>
-    <param pos="0" name="hw.family" value="VxWorks"/>
+    <param pos="0" name="os.family" value="VxWorks"/>
   </fingerprint>
   <fingerprint pattern=".*Nortel.*Passport ([^ ]*) .*Software Release ([^ ]*).*">
     <description>Nortel Passport</description>
@@ -1012,25 +1012,25 @@
      SVBTTy9pMzg2IChCSi1JREMtRlcyKSAodHR5cDcpCgoKClRoaXMgc3lzdGVtIGlzIGZvciBhdXRob3Jpem
      VkIHVzZSBvbmx5LgoKCgoKCgoKbG9naW46IA==
     </example>
-    <param pos="0" name="hw.vendor" value="Check Point"/>
-    <param pos="0" name="hw.family" value="Check Point"/>
-    <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.product" value="IPSO"/>
+    <param pos="0" name="os.vendor" value="Check Point"/>
+    <param pos="0" name="os.family" value="Check Point"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.product" value="IPSO"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="Tasman Networks Inc.*Telnet Login">
     <description>Tasman Networks Login</description>
     <!-- #\n# Tasman Networks Inc. Telnet Login\n#Escape character is '^]'\n\n\n\nlogin: -->
     <!-- Dashes removed from example banner due to xml issue -->
-    <example _encoding="base64" hw.vendor="Tasman Networks">
+    <example _encoding="base64" os.vendor="Tasman Networks">
       Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0
       tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS
       0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2hhcmFjd
       GVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
     </example>
-    <param pos="0" name="hw.vendor" value="Tasman Networks"/>
-    <param pos="0" name="hw.device" value="Router"/>
-    <param pos="0" name="hw.product" value="Tasman Networks router"/>
+    <param pos="0" name="os.vendor" value="Tasman Networks"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.product" value="Tasman Networks router"/>
   </fingerprint>
   <fingerprint pattern="Pragma Systems">
     <description>MS Windows running Pragma TelnetD server</description>
@@ -1039,9 +1039,9 @@
       V2VsY29tZSB0byBHZW1hZGVwdCBMb2dpc3RpY3MgUkYgU2VydmVyCihDKSBDb3B5cmlnaHQgMTk5NC0yMDEyIFB
       yYWdtYSBTeXN0ZW1zLCBJbmMuCgpsb2dpbiBuYW1lOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="Microsoft"/>
-    <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.product" value="Windows"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Application Required. No Installation Default">
     <description>probably IBM AS/400 running TN3270 or 5250 emulation server</description>
@@ -1050,7 +1050,7 @@
      QXBwbGljYXRpb24gUmVxdWlyZWQuIE5vIEluc3RhbGxhdGlvbiBEZWZhdWx0ICAgICAgICA
      gICAgICAgICAgICAgICAgICAgICAgICAgIApFbnRlciBBcHBsaWNhdGlvbiBOYW1lOg==
     </example>
-    <param pos="0" name="hw.vendor" value="IBM"/>
+    <param pos="0" name="os.vendor" value="IBM"/>
   </fingerprint>
   <fingerprint pattern="This copy of the Ataman TCP Remote Logon Services">
     <description>Windows NT/2k/2k3 running Ataman telnet server</description>
@@ -1059,9 +1059,9 @@
       VGhpcyBjb3B5IG9mIHRoZSBBdGFtYW4gVENQIFJlbW90ZSBMb2dvbiBTZXJ2aWNlcyBpcyByZWdpc3RlcmVkIG
       FzIGxpY2Vuc2VkIHRvOgoJRUNJMi9ERE1TCgpBY2NvdW50IE5hbWU6IA==
     </example>
-    <param pos="0" name="hw.vendor" value="Microsoft"/>
-    <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.product" value="Windows"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Cobalt Linux release\W(.*)\W\(.*">
     <description>Cobalt Linux</description>
@@ -1069,8 +1069,8 @@
     <example _encoding="base64" os.version="6.0">
       Q29iYWx0IExpbnV4IHJlbGVhc2UgNi4wIChTaGlua2Fuc2VuKQpLZXJuZWwgMi4yLjE2QzM3X0lJSSBvbiBhbiBpNTg2CmxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="Cobalt"/>
-    <param pos="0" name="hw.family" value="Linux"/>
+    <param pos="0" name="os.vendor" value="Cobalt"/>
+    <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
@@ -1080,10 +1080,10 @@
     <example _encoding="base64" host.name="gaatdrf2">
       Q2hlY2sgUG9pbnQgRmlyZVdhbGwtMSBhdXRoZW50aWNhdGVkIFRlbG5ldCBzZXJ2ZXIgcnVubmluZyBvbiBnYWF0ZHJmMgoKVXNlcjog
     </example>
-    <param pos="0" name="hw.vendor" value="Checkpoint"/>
-    <param pos="0" name="hw.family" value="Checkpoint"/>
-    <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.product" value="Checkpoint FW1"/>
+    <param pos="0" name="os.vendor" value="Checkpoint"/>
+    <param pos="0" name="os.family" value="Checkpoint"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.product" value="Checkpoint FW1"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="Raptor Firewall">
@@ -1092,10 +1092,10 @@
     <example _encoding="base64">
       UmFwdG9yIEZpcmV3YWxsIFNlY3VyZSBHYXRld2F5LgoKSG9zdG5hbWU6IA==
     </example>
-    <param pos="0" name="hw.vendor" value="Symantec"/>
-    <param pos="0" name="hw.family" value="Raptor"/>
-    <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.product" value="Raptor"/>
+    <param pos="0" name="os.vendor" value="Symantec"/>
+    <param pos="0" name="os.family" value="Raptor"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.product" value="Raptor"/>
   </fingerprint>
   <fingerprint pattern="UNIX\(r\) System V Release (\d*.\d*)">
     <description>SunOS (Solaris)</description>
@@ -1103,9 +1103,9 @@
     <example _encoding="base64" os.version="4.0">
       VU5JWChyKSBTeXN0ZW0gViBSZWxlYXNlIDQuMCAoVGhlLVNlcnZlcikKCgoKbG9naW46IA==
     </example>
-    <param pos="0" name="hw.vendor" value="Sun"/>
-    <param pos="0" name="hw.family" value="Solaris"/>
-    <param pos="0" name="hw.product" value="Solaris"/>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="Solaris (.*)">
@@ -1115,9 +1115,9 @@
       U2VhdHRsZSBDb21tdW5pdHkgTmV0d29yayBTdW4gU29sYXJpcyAxLjEuMS5CClBsZWFzZSBsb2dpbiBhcyAndml
       zaXRvcicgaWYgeW91IGFyZSBhIHZpc2l0b3IKCgpTdW5PUyBVTklYIChzY24pCgoKCmxvZ2luOg==
     </example>
-    <param pos="0" name="hw.vendor" value="Sun"/>
-    <param pos="0" name="hw.family" value="Solaris"/>
-    <param pos="0" name="hw.product" value="Solaris"/>
+    <param pos="0" name="os.vendor" value="Sun"/>
+    <param pos="0" name="os.family" value="Solaris"/>
+    <param pos="0" name="os.product" value="Solaris"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="Digital UNIX \(([^)]+).*">
@@ -1126,9 +1126,9 @@
     <example _encoding="base64" host.name="journal">
       RGlnaXRhbCBVTklYIChqb3VybmFsKSAodHR5cDIpCgoKCmxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="Digital Unix"/>
-    <param pos="0" name="hw.product" value="Digital Unix"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.family" value="Digital Unix"/>
+    <param pos="0" name="os.product" value="Digital Unix"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^(?m)Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*">
@@ -1137,9 +1137,9 @@
     <example _encoding="base64" os.version="5.1B" os.rev="2650">
      Q29tcGFxIFRydTY0IFVOSVggVjUuMUIgKFJldi4gMjY1MCkgKGRvY2FscGhhKSAocHRzLzExKQoKCgoKCmxvZ2luOg== 
     </example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="Digital Unix"/>
-    <param pos="0" name="hw.product" value="TRU64"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.family" value="Digital Unix"/>
+    <param pos="0" name="os.product" value="TRU64"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.rev"/>
   </fingerprint>
@@ -1149,9 +1149,9 @@
     <example _encoding="base64" host.name="ctout" os.version="11.11" hw.series="9000/800" hw.model="(tc)">
       SFAtVVggY3RvdXQgQi4xMS4xMSBVIDkwMDAvODAwICh0YykKCmxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="HP-UX"/>
-    <param pos="0" name="hw.product" value="HP-UX"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.family" value="HP-UX"/>
+    <param pos="0" name="os.product" value="HP-UX"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="os.version"/>
     <param pos="3" name="hw.version"/>
@@ -1162,10 +1162,10 @@
     <description>A NetApp apliance</description>
     <!-- Data ONTAP (s500.)\nlogin: -->
     <example _encoding="base64">RGF0YSBPTlRBUCAoczUwMC4pCmxvZ2luOiA=</example>
-    <param pos="0" name="hw.vendor" value="NetApp"/>
-    <param pos="0" name="hw.family" value="Data ONTAP"/>
-    <param pos="0" name="hw.device" value="Server"/>
-    <param pos="0" name="hw.product" value="Data ONTAP"/>
+    <param pos="0" name="os.vendor" value="NetApp"/>
+    <param pos="0" name="os.family" value="Data ONTAP"/>
+    <param pos="0" name="os.device" value="Server"/>
+    <param pos="0" name="os.product" value="Data ONTAP"/>
   </fingerprint>
   <fingerprint pattern="OpenVMS.*Version\sV(\d*.\d*).*">
     <description>OpenVMS</description>
@@ -1174,9 +1174,9 @@
       IFdlbGNvbWUgdG8gT3BlblZNUyAoVE0pIEFscGhhIE9wZXJhdGluZyBTeXN0Z
       W0sIFZlcnNpb24gVjguNCAgICAgLSBOT1Q3MAoKClVzZXJuYW1lOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-          <param pos="0" name="hw.family" value="OpenVMS"/>CCESS RUNNER ADSL CONSOLE PORT
-    <param pos="0" name="hw.product" value="VMS"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.family" value="OpenVMS"/>
+    <param pos="0" name="os.product" value="VMS"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^(?m)SCO OpenServer\(TM\) Release ([^ ]+).*$">
@@ -1185,9 +1185,9 @@
     <example _encoding="base64" os.version="5">
       U0NPIE9wZW5TZXJ2ZXIoVE0pIFJlbGVhc2UgNSAoYm9tZGlhLmNvLnphKSAodHR5cDYpCgpsb2dpbjo=
     </example>
-    <param pos="0" name="hw.vendor" value="SCO"/>
-    <param pos="0" name="hw.family" value="OpenServer"/>
-    <param pos="0" name="hw.product" value="OpenServer"/>
+    <param pos="0" name="os.vendor" value="SCO"/>
+    <param pos="0" name="os.family" value="OpenServer"/>
+    <param pos="0" name="os.product" value="OpenServer"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="% Username:  timeout expired!">
@@ -1196,24 +1196,24 @@
     <example _encoding="base64">
       JSBVc2VybmFtZTogIHRpbWVvdXQgZXhwaXJlZCE=
     </example>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="0" name="hw.family" value="IOS"/>
-    <param pos="0" name="hw.product" value="IOS"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="IOS"/>
+    <param pos="0" name="os.product" value="IOS"/>
   </fingerprint>
   <fingerprint pattern="Welcome to MKS Telnet Server Version">
     <description>Windows running MKS Telnet Server</description>
     <example _encoding="base64">
       V2VsY29tZSB0byBNS1MgVGVsbmV0IFNlcnZlciBWZXJzaW9uIDQuNzAuMDAwMC4KbG9naW46IA==
     </example>
-    <param pos="0" name="hw.vendor" value="Microsoft"/>
-    <param pos="0" name="hw.family" value="Windows"/>
-    <param pos="0" name="hw.product" value="Windows"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="Sorry, this system is engaged\.">
     <description>an embedded print server</description>
     <example>Sorry, this system is engaged.</example>
-    <param pos="0" name="hw.vendor" value="Epson"/>
-    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="os.vendor" value="Epson"/>
+    <param pos="0" name="os.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="TELNET session now in ESTABLISHED state">
     <description>an Allied Telesyn router</description>
@@ -1221,9 +1221,9 @@
     <example _encoding="base64">
       VEVMTkVUIHNlc3Npb24gbm93IGluIEVTVEFCTElTSEVEIHN0YXRlCgpHRU8tMDAzIGxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="Allied Telesyn"/>
-    <param pos="0" name="hw.device" value="Router"/>
-    <param pos="0" name="hw.product" value="Allied Telesyn router"/>
+    <param pos="0" name="os.vendor" value="Allied Telesyn"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.product" value="Allied Telesyn router"/>
   </fingerprint>
   <fingerprint pattern="CONEXANT SYSTEMS.*ACCESS RUNNER ADSL">
     <description>a Conexant ADSL router</description>
@@ -1232,9 +1232,9 @@
       EU0wgQ09OU09MRSBQT1JUG1syNDswMUg+Pj4bWzI0OzAxSExPR09OIFBBU1NXT1JEPhtbMDI7NTNIMy4yNx
       tbMjQ7MTdIG1syNDsxN0g=
     </example>
-    <param pos="0" name="hw.vendor" value="Conexant"/>
-    <param pos="0" name="hw.device" value="Broadband router"/>
-    <param pos="0" name="hw.product" value="AccessRunner ADSL router"/>
+    <param pos="0" name="os.vendor" value="Conexant"/>
+    <param pos="0" name="os.device" value="Broadband router"/>
+    <param pos="0" name="os.product" value="AccessRunner ADSL router"/>
   </fingerprint>
   <fingerprint pattern="System administrator is connecting from">
     <description>a DrayTek Vigor SOHO Router</description>
@@ -1243,9 +1243,9 @@
       U3lzdGVtIGFkbWluaXN0cmF0b3IgaXMgY29ubmVjdGluZyBmcm9tIDU0LjM5LjE3My44NgoKUmVqZWN0IH
       RoZSBjb25uZWN0aW9uIHJlcXVlc3QgISEh
     </example>
-    <param pos="0" name="hw.vendor" value="Draytek"/>
-    <param pos="0" name="hw.device" value="Broadband router"/>
-    <param pos="0" name="hw.product" value="Vigor"/>
+    <param pos="0" name="os.vendor" value="Draytek"/>
+    <param pos="0" name="os.device" value="Broadband router"/>
+    <param pos="0" name="os.product" value="Vigor"/>
   </fingerprint>
   <fingerprint pattern=".*Version\s(\d*.\d*)\/OpenBSD.*">
     <description>OpenBSD</description>
@@ -1253,9 +1253,9 @@
     <example _encoding="base64" os.version="6.4">
       MjIwIGtpbGxlcjA5IEZUUCBzZXJ2ZXIgKFZlcnNpb24gNi40L09wZW5CU0QvTGludXgtZnRwZC0wLjE3KSByZWFkeS4K
     </example>
-    <param pos="0" name="hw.vendor" value="OpenBSD"/>
-    <param pos="0" name="hw.family" value="OpenBSD"/>
-    <param pos="0" name="hw.product" value="OpenBSD"/>
+    <param pos="0" name="os.vendor" value="OpenBSD"/>
+    <param pos="0" name="os.family" value="OpenBSD"/>
+    <param pos="0" name="os.product" value="OpenBSD"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="FreeBSD\/([^\\s]+)\s+\(([^\s]+)\)">
@@ -1264,9 +1264,9 @@
     <example _encoding="base64" os.arch="amd64" host.name="ms.gymspgs.cz">
       RnJlZUJTRC9hbWQ2NCAobXMuZ3ltc3Bncy5jeikgKHB0cy8wKQoKCgpsb2dpbjo=
     </example>
-    <param pos="0" name="hw.vendor" value="FreeBSD"/>
-    <param pos="0" name="hw.family" value="FreeBSD"/>
-    <param pos="0" name="hw.product" value="FreeBSD"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="1" name="os.arch"/>
     <param pos="2" name="host.name"/>
   </fingerprint>
@@ -1276,9 +1276,9 @@
     <example _encoding="base64">
       TmV0QlNEL21lc3NpbWlwcyAoKSAodHR5cDMpCgpsb2dpbjog
     </example>
-    <param pos="0" name="hw.vendor" value="NetBSD"/>
-    <param pos="0" name="hw.family" value="NetBSD"/>
-    <param pos="0" name="hw.product" value="NetBSD"/>
+    <param pos="0" name="os.vendor" value="NetBSD"/>
+    <param pos="0" name="os.family" value="NetBSD"/>
+    <param pos="0" name="os.product" value="NetBSD"/>
   </fingerprint>
   <fingerprint pattern="IRIX\W\((.*)\)">
     <description>SGI IRIX</description>
@@ -1286,9 +1286,9 @@
     <example _encoding="base64" host.name="artemis.biol.uoa.gr">
       SVJJWCAoYXJ0ZW1pcy5iaW9sLnVvYS5ncikKCgoKbG9naW46IA==
     </example>
-    <param pos="0" name="hw.vendor" value="SGI"/>
-    <param pos="0" name="hw.family" value="IRIX"/>
-    <param pos="0" name="hw.product" value="IRIX"/>
+    <param pos="0" name="os.vendor" value="SGI"/>
+    <param pos="0" name="os.family" value="IRIX"/>
+    <param pos="0" name="os.product" value="IRIX"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="(?m)(ES|RS)\s([^\s]+) System Software, Version ([^\s]+).*Riverstone Networks">
@@ -1296,7 +1296,7 @@
     <!-- +++++++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\n
     Riverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n
     +++++++++++++++++++++++++++++++++++++++ -->
-    <example _encoding="base64" hw.product="10170" os.version="9.3.0.4" os.family="ES">
+    <example _encoding="base64" os.product="10170" os.version="9.3.0.4" os.family="ES">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
       dvcmtzLCBJbmMuLCBDb3B5cmlnaHQgKGMpIDIwMDAtMjAwMy4gQWxsIHJpZ2h0cyByZXNlcnZlZC4KU3lzdGV
@@ -1306,17 +1306,17 @@
         <!-- +++++++++++++++++++++++++++++++++++++++\nRS 10170 System Software, Version 9.3.0.5\n
     Riverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n
     +++++++++++++++++++++++++++++++++++++++ -->
-    <example _encoding="base64" hw.product="8000" os.version="9.3.0.5" os.family="RS">
+    <example _encoding="base64" os.product="8000" os.version="9.3.0.5" os.family="RS">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d2
       9ya3MsIEluYy4sIENvcHlyaWdodCAoYykgMjAwMC0yMDA0LiBBbGwgcmlnaHRzIHJlc2VydmVkLgpTeXN0ZW0
       gc3RhcnRlZCBvbiAyMDE4LTEwLTExIDIyOjAyOjAzCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
     </example>
-    <param pos="0" name="hw.vendor" value="Riverstone"/>
-    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="os.vendor" value="Riverstone"/>
+    <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.family"/>
-    <param pos="2" name="hw.product"/>
+    <param pos="2" name="os.product"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="HP.*ProCurve Switch">
@@ -1347,10 +1347,10 @@
       09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0
       9PT09CgoKVXNlcm5hbWU6IA==
     </example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="ProCurve"/>
-    <param pos="0" name="hw.device" value="Switch"/>
-    <param pos="0" name="hw.product" value="ProCurve"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.family" value="ProCurve"/>
+    <param pos="0" name="os.device" value="Switch"/>
+    <param pos="0" name="os.product" value="ProCurve"/>
   </fingerprint>
   <fingerprint pattern="ConnectUPS">
     <description>PowerWare ConnectUPS</description>
@@ -1364,10 +1364,10 @@
       T09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PSsKCkVudGVyIFBhc3N3
       b3JkOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="PowerWare"/>
-    <param pos="0" name="hw.family" value="ConnectUPS"/>
-    <param pos="0" name="hw.device" value="UPS"/>
-    <param pos="0" name="hw.product" value="ConnectUPS"/>
+    <param pos="0" name="os.vendor" value="PowerWare"/>
+    <param pos="0" name="os.family" value="ConnectUPS"/>
+    <param pos="0" name="os.device" value="UPS"/>
+    <param pos="0" name="os.product" value="ConnectUPS"/>
   </fingerprint>
   <fingerprint pattern="Imagistics.*im">
     <description>an Imagistics device</description>
@@ -1376,10 +1376,10 @@
       SW1hZ2lzdGljcyBpbTM1MTEvaW00NTExIFZlciAwMS4wMC4yMCBURUxORVQgc2VydmVyLgpDb3B5cmlnaH
       QoYykgMjAwMS0yMDA1LCBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="Imagistics"/>
-    <param pos="0" name="hw.family" value="Imagistics"/>
-    <param pos="0" name="hw.device" value="Malfunction Device"/>
-    <param pos="0" name="hw.product" value="im"/>
+    <param pos="0" name="os.vendor" value="Imagistics"/>
+    <param pos="0" name="os.family" value="Imagistics"/>
+    <param pos="0" name="os.device" value="Malfunction Device"/>
+    <param pos="0" name="os.product" value="im"/>
   </fingerprint>
   <fingerprint pattern="NRG Maintenance Shell">
     <description>a Ricoh NRG device</description>
@@ -1387,36 +1387,36 @@
     <example _encoding="base64"  >
       TlJHIE1haW50ZW5hbmNlIFNoZWxsLiAgIAoKVXNlciBhY2Nlc3MgdmVyaWZpY2F0aW9uLgoKbG9naW46
     </example>
-    <param pos="0" name="hw.vendor" value="Ricoh"/>
-    <param pos="0" name="hw.device" value="Printer" />
-    <param pos="0" name="hw.product" value="NRG Printer"/>
+    <param pos="0" name="os.vendor" value="Ricoh"/>
+    <param pos="0" name="os.device" value="Printer" />
+    <param pos="0" name="os.product" value="NRG Printer"/>
   </fingerprint>
   <fingerprint pattern="^SHARP (AR-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>SHARP AR Series multifunction device</description>
     <!-- SHARP AR-M351U Ver 01.00.18 TELNET server.\nCopyright(c) 2001-2005, silex technology, Inc.\nlogin: -->
-    <example _encoding="base64" hw.product="AR-M351U" os.version="01.00.18">
+    <example _encoding="base64" os.product="AR-M351U" os.version="01.00.18">
       U0hBUlAgQVItTTM1MVUgVmVyIDAxLjAwLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChjKSAyMDAx
       LTIwMDUsIHNpbGV4IHRlY2hub2xvZ3ksIEluYy4KbG9naW46IA==
     </example>
-    <param pos="0" name="hw.vendor" value="Sharp"/>
-    <param pos="0" name="hw.family" value="Sharp AR Series"/>
-    <param pos="0" name="hw.device" value="Multifunction Device"/>
-    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Sharp"/>
+    <param pos="0" name="os.family" value="Sharp AR Series"/>
+    <param pos="0" name="os.device" value="Multifunction Device"/>
+    <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^SHARP (MX-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>SHARP MX Series multifunction device</description>
     <!-- SHARP MX-3610N Ver 01.05.00.0o.18 TELNET server.\nCopyright(C) 2005-     SHARP CORPORATION\nCopyright(C) 2005-
     silex technology, Inc.\nlogin:  -->
-    <example _encoding="base64" hw.product="MX-3610N" os.version="01.05.00.0o.18">
+    <example _encoding="base64" os.product="MX-3610N" os.version="01.05.00.0o.18">
       U0hBUlAgTVgtMzYxME4gVmVyIDAxLjA1LjAwLjBvLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodC
       hDKSAyMDA1LSAgICAgU0hBUlAgQ09SUE9SQVRJT04KQ29weXJpZ2h0KEMpIDIwMDUtICAgICBzaWxl
       eCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
     </example>
-    <param pos="0" name="hw.vendor" value="Sharp"/>
-    <param pos="0" name="hw.family" value="Sharp MX Series"/>
-    <param pos="0" name="hw.device" value="Multifunction Device"/>
-    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Sharp"/>
+    <param pos="0" name="os.family" value="Sharp MX Series"/>
+    <param pos="0" name="os.device" value="Multifunction Device"/>
+    <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
     <fingerprint pattern="^(?m).*Welcome to MELCO Print Server.*Server Name *: *([^ ]*)\W.*Server Model *: *([^ ]*).*F \/ W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. .. ..).*$">
@@ -1424,7 +1424,7 @@
     <!-- ***********************************\n* Welcome to MELCO Print Server *\n* Telnet Console *\n***********************************
     \n \nServer Name: PS-B04E8E\nServer Model: LPV 2 - TX 1\nF / W Version: 2.00 J \nMAC Address: AE 32 EA 21 BB E3\n
     Uptime: 0 days, 00: 00: 12\n \nPlease Enter Password:"-->
-    <example _encoding="base64" os.version="2.00" host.id="PS-B04E8E" hw.model="LPV" hw.address="AE 32 EA 21 BB E3">
+    <example _encoding="base64" os.version="2.00" host.id="PS-B04E8E" os.model="LPV" os.address="AE 32 EA 21 BB E3">
       KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiogV2VsY29tZSB0byBNRUxDTyBQc
       mludCBTZXJ2ZXIgKlxuKiBUZWxuZXQgQ29uc29sZSAqXG4qKioqKioqKioqKioqKioqKioqKioqKi
       oqKioqKioqKioqKlxuIFxuU2VydmVyIE5hbWU6IFBTLUIwNEU4RVxuU2VydmVyIE1vZGVsOiBMUFY
@@ -1432,13 +1432,13 @@
       MSBCQiBFM1xuVXB0aW1lOiAwIGRheXMsIDAwOiAwMDogMTJcbiBcblBsZWFzZSBFbnRlciBQYXNzd
       29yZDoi
     </example>
-    <param pos="0" name="hw.vendor" value="Buffalo"/>
-    <param pos="0" name="hw.family" value="PrintServer" />
-    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="os.vendor" value="Buffalo"/>
+    <param pos="0" name="os.family" value="PrintServer" />
+    <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="host.id"/>
-    <param pos="2" name="hw.model"/>
+    <param pos="2" name="os.model"/>
     <param pos="3" name="os.version"/>
-    <param pos="4" name="hw.address"/>
+    <param pos="4" name="os.address"/>
   </fingerprint>
   <fingerprint pattern="^(?m)AIX Version\W(\d).*">
     <description>System is IBM AIX v</description>
@@ -1446,10 +1446,10 @@
     <example _encoding="base64" os.version="6">
       QUlYIFZlcnNpb24gNgpDb3B5cmlnaHQgSUJNIENvcnBvcmF0aW9uLCAxOTgyLCAyMDA3Lgpsb2dpbjogCg==
     </example>
-    <param pos="0" name="hw.vendor" value="IBM"/>
-    <param pos="0" name="hw.family" value="AIX"/>
-    <param pos="0" name="hw.device" value="General"/>
-    <param pos="0" name="hw.product" value="AIX"/>
+    <param pos="0" name="os.vendor" value="IBM"/>
+    <param pos="0" name="os.family" value="AIX"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.product" value="AIX"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^(?m)CIMC Debug Firmware Utility Shell\W([^\s]+).*">
@@ -1458,10 +1458,10 @@
     <example _encoding="base64" host.name="fake-ucs-device-3-1-p">
       Q0lNQyBEZWJ1ZyBGaXJtd2FyZSBVdGlsaXR5IFNoZWxsCmZha2UtdWNzLWRldmljZS0zLTEtcCBsb2dpbjogCg==
     </example>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="0" name="hw.family" value="UCS"/>
-    <param pos="0" name="hw.device" value="General"/>
-    <param pos="0" name="hw.product" value="UCS Device"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="UCS"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.product" value="UCS Device"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^(?m)HP ProLiant.*v(\d+.\d+)">
@@ -1478,10 +1478,10 @@
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLQoKCiAgICAgICAgIElBLTAwNTA4QkVCQUE1OSBsb2dpbjo=
     </example>
-    <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="ProLiant"/>
-    <param pos="0" name="hw.device" value="Server"/>
-    <param pos="0" name="hw.product" value="ProLiant"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.family" value="ProLiant"/>
+    <param pos="0" name="os.device" value="Server"/>
+    <param pos="0" name="os.product" value="ProLiant"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
 </fingerprints>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -823,7 +823,7 @@
       UmVkIEhhdCBMaW51eCByZWxlYXNlIDkgKFNocmlrZSlcbktlcm5lbCAyLjQuMjAtOCBvbiBhbiBpNjg2XG5sb2dpbjo=
    </example>
     <param pos="0" name="hw.vendor" value="RedHat"/>
-    <param pos="0" name="he.family" value="Linux"/>
+    <param pos="0" name="hw.family" value="Linux"/>
     <param pos="0" name="hw.device" value="Linux"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
@@ -1129,7 +1129,7 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="Digital Unix"/>
     <param pos="0" name="hw.product" value="Digital Unix"/>
-    <param pos="1" name="host.name"/>`
+    <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^(?m)Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*">
     <description>Compaq Tru64 UNIX V</description>
@@ -1164,7 +1164,7 @@
     <example _encoding="base64">RGF0YSBPTlRBUCAoczUwMC4pCmxvZ2luOiA=</example>
     <param pos="0" name="hw.vendor" value="NetApp"/>
     <param pos="0" name="hw.family" value="Data ONTAP"/>
-    <param pos="0" name="hw.device" value="Storage"/>
+    <param pos="0" name="hw.device" value="Server"/>
     <param pos="0" name="hw.product" value="Data ONTAP"/>
   </fingerprint>
   <fingerprint pattern="OpenVMS.*Version\sV(\d*.\d*).*">
@@ -1291,12 +1291,22 @@
     <param pos="0" name="hw.product" value="IRIX"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="^(?m)(RS [^\s]+) System Software, Version ([^\s]+).*">
-    <description>RiverStone router</description>
-    <!-- ++++++++++++++++++++++++++++++++++++++++\nRS 8000 System Software, Version 9.3.0.5\n
-    Riverstone Networks, Inc., Copyright (c) 2000-2004. All rights reserved.\nSystem started on 2018-10-11 22:02:03
-    \n++++++++++++++++++++++++++++++++++++++++ -->
-    <example _encoding="base64" hw.product="RS 8000" os.version="9.3.0.5">
+  <fingerprint pattern="(?m)(ES|RS)\s([^\s]+) System Software, Version ([^\s]+).*Riverstone Networks">
+    <description>a Riverstone router</description>
+    <!-- +++++++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\n
+    Riverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n
+    +++++++++++++++++++++++++++++++++++++++ -->
+    <example _encoding="base64" hw.product="10170" os.version="9.3.0.4" os.family="ES">
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
+      S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
+      dvcmtzLCBJbmMuLCBDb3B5cmlnaHQgKGMpIDIwMDAtMjAwMy4gQWxsIHJpZ2h0cyByZXNlcnZlZC4KU3lzdGV
+      tIHN0YXJ0ZWQgb24gMjAxOC0wOS0wNiAxNTo1ODozMAotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
+    </example>
+        <!-- +++++++++++++++++++++++++++++++++++++++\nRS 10170 System Software, Version 9.3.0.5\n
+    Riverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n
+    +++++++++++++++++++++++++++++++++++++++ -->
+    <example _encoding="base64" hw.product="8000" os.version="9.3.0.5" os.family="RS">
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
       S0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d2
       9ya3MsIEluYy4sIENvcHlyaWdodCAoYykgMjAwMC0yMDA0LiBBbGwgcmlnaHRzIHJlc2VydmVkLgpTeXN0ZW0
@@ -1304,28 +1314,10 @@
       LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
     </example>
     <param pos="0" name="hw.vendor" value="Riverstone"/>
-    <param pos="0" name="hw.family" value="Riverstone"/>
     <param pos="0" name="hw.device" value="Router"/>
-    <param pos="1" name="hw.product"/>
-    <param pos="2" name="os.version"/>
-  </fingerprint>
-  <fingerprint pattern="(ES [^\s]+) System Software, Version ([^\s]+)">
-    <description>a Riverstone router`</description>
-    <!-- +++++++++++++++++++++++++++++++++++++++\nES 10170 System Software, Version 9.3.0.4\n
-    Riverstone Networks, Inc., Copyright (c) 2000-2003. All rights reserved.\nSystem started on 2018-09-06 15:58:\n
-    +++++++++++++++++++++++++++++++++++++++ -->
-    <example _encoding="base64" hw.product="ES 10170" os.version="9.3.0.4">
-      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
-      S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
-      dvcmtzLCBJbmMuLCBDb3B5cmlnaHQgKGMpIDIwMDAtMjAwMy4gQWxsIHJpZ2h0cyByZXNlcnZlZC4KU3lzdGV
-      tIHN0YXJ0ZWQgb24gMjAxOC0wOS0wNiAxNTo1ODozMAotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t
-      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
-    </example>
-    <param pos="0" name="hw.vendor" value="Riverstone"/>
-    <param pos="0" name="hw.family" value="ES"/>
-    <param pos="0" name="hw.device" value="Router"/>
-    <param pos="1" name="hw.product"/>
-    <param pos="2" name="os.version"/>
+    <param pos="1" name="os.family"/>
+    <param pos="2" name="hw.product"/>
+    <param pos="3" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="HP.*ProCurve Switch">
     <description>HP ProCurve Switch</description>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1271,7 +1271,7 @@
   </fingerprint>
   <fingerprint pattern="NetBSD">
     <description>NetBSD</description>
-    <!-- NetBSD/messimips () (ttyp3)\n\nlogin:  -->
+    <!-- NetBSD/evbsh3 (Fukuyama.Host_AKS_0555_WL-v2.60d) (ttyp1)  -->
     <example _encoding="base64">
       TmV0QlNEL21lc3NpbWlwcyAoKSAodHR5cDMpCgpsb2dpbjog
     </example>
@@ -1279,15 +1279,16 @@
     <param pos="0" name="hw.family" value="NetBSD"/>
     <param pos="0" name="hw.product" value="NetBSD"/>
   </fingerprint>
-  <fingerprint pattern="IRIX">
+  <fingerprint pattern="IRIX\W\((.*)\)">
     <description>SGI IRIX</description>
     <!-- IRIX (artemis.biol.uoa.gr)\n\n\n\nlogin: -->
-    <example _encoding="base64">
+    <example _encoding="base64" host.name="artemis.biol.uoa.gr">
       SVJJWCAoYXJ0ZW1pcy5iaW9sLnVvYS5ncikKCgoKbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="SGI"/>
     <param pos="0" name="hw.family" value="IRIX"/>
     <param pos="0" name="hw.product" value="IRIX"/>
+    <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^(?m)(RS [^\s]+) System Software, Version ([^\s]+).*">
     <description>RiverStone router</description>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -920,7 +920,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Welcome. Type return, enter password at # prompt">
-    <example _encoding="base64"  >
+    <example _encoding="base64">
      V2VsY29tZS4gVHlwZSByZXR1cm4sIGVudGVyIHBhc3N3b3JkIGF0ICMgcHJvbXB0Cg== 
     </example>
     <description>Brother Printer</description>
@@ -992,7 +992,11 @@
   <fingerprint pattern=".*Nortel.*Passport ([^ ]*) .*Software Release ([^ ]*).*">
     <description>Nortel Passport</description>
     <example _encoding="base64" hw.product="8010" os.version="3.5.0.0">
-KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmlnaHQgKGMpIDIwMDMgTm9ydGVsIE5ldHdvcmtzLCBJbmMuICAqXG5cblxuKiBBbGwgUmlnaHRzIFJlc2VydmVkICAgICAgICAgICAgICAgICAgICAgICAqXG5cblxuKiBQYXNzcG9ydCA4MDEwICAgICAgICAgICAgICAgICAgICAgICAgICAgICAqXG5cblxuKiBTb2Z0d2FyZSBSZWxlYXNlIDMuNS4wLjAgICAgICAgICAgICAgICAgICAqXG5cblxuKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuXG5cbkxvZ2luOg==
+      KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmlnaHQgKG
+      MpIDIwMDMgTm9ydGVsIE5ldHdvcmtzLCBJbmMuICAqXG5cblxuKiBBbGwgUmlnaHRzIFJlc2VydmVkICAgICAg
+      ICAgICAgICAgICAgICAgICAqXG5cblxuKiBQYXNzcG9ydCA4MDEwICAgICAgICAgICAgICAgICAgICAgICAgIC
+      AgICAqXG5cblxuKiBTb2Z0d2FyZSBSZWxlYXNlIDMuNS4wLjAgICAgICAgICAgICAgICAgICAqXG5cblxuKioq
+      KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuXG5cbkxvZ2luOg==
     </example>
     <param pos="0" name="hw.vendor" value="Nortel"/>
     <param pos="0" name="hw.device" value="Switch"/>
@@ -1013,7 +1017,10 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="Tasman Networks Inc.*Telnet Login">
     <description>Tasman Networks Login</description>
     <example _encoding="base64" hw.vendor="Tasman Networks">
-     Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2hhcmFjdGVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
+      Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0
+      tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS
+      0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2hhcmFjd
+      GVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="Tasman Networks"/>
     <param pos="0" name="hw.device" value="Router"/>
@@ -1021,8 +1028,9 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="Pragma Systems">
     <description>MS Windows running Pragma TelnetD server</description>
-    <example _encoding="base64"  >
-      V2VsY29tZSB0byBHZW1hZGVwdCBMb2dpc3RpY3MgUkYgU2VydmVyCihDKSBDb3B5cmlnaHQgMTk5NC0yMDEyIFByYWdtYSBTeXN0ZW1zLCBJbmMuCgpsb2dpbiBuYW1lOiA=
+    <example _encoding="base64">
+      V2VsY29tZSB0byBHZW1hZGVwdCBMb2dpc3RpY3MgUkYgU2VydmVyCihDKSBDb3B5cmlnaHQgMTk5NC0yMDEyIFB
+      yYWdtYSBTeXN0ZW1zLCBJbmMuCgpsb2dpbiBuYW1lOiA=
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
@@ -1031,7 +1039,8 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="Application Required. No Installation Default">
     <description>System is probably IBM AS/400 running TN3270 or 5250 emulation server</description>
     <example _encoding="base64">
-     QXBwbGljYXRpb24gUmVxdWlyZWQuIE5vIEluc3RhbGxhdGlvbiBEZWZhdWx0ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIApFbnRlciBBcHBsaWNhdGlvbiBOYW1lOg==
+     QXBwbGljYXRpb24gUmVxdWlyZWQuIE5vIEluc3RhbGxhdGlvbiBEZWZhdWx0ICAgICAgICA
+     gICAgICAgICAgICAgICAgICAgICAgICAgIApFbnRlciBBcHBsaWNhdGlvbiBOYW1lOg==
     </example>
     <param pos="0" name="hw.vendor" value="IBM"/>
     <param pos="0" name="hw.device" value="General"/>
@@ -1039,7 +1048,8 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="This copy of the Ataman TCP Remote Logon Services">
     <description>Windows NT/2k/2k3 running Ataman telnet server</description>
     <example _encoding="base64">
-      VGhpcyBjb3B5IG9mIHRoZSBBdGFtYW4gVENQIFJlbW90ZSBMb2dvbiBTZXJ2aWNlcyBpcyByZWdpc3RlcmVkIGFzIGxpY2Vuc2VkIHRvOgoJRUNJMi9ERE1TCgpBY2NvdW50IE5hbWU6IA==
+      VGhpcyBjb3B5IG9mIHRoZSBBdGFtYW4gVENQIFJlbW90ZSBMb2dvbiBTZXJ2aWNlcyBpcyByZWdpc3RlcmVkIG
+      FzIGxpY2Vuc2VkIHRvOgoJRUNJMi9ERE1TCgpBY2NvdW50IE5hbWU6IA==
     </example>
     <param pos="0" name="hw.vendor" value="Microsoft"/>
     <param pos="0" name="hw.family" value="Windows"/>
@@ -1083,13 +1093,14 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
     </example>
     <param pos="0" name="hw.vendor" value="Sun"/>
     <param pos="0" name="hw.family" value="Solaris"/>
-    <param pos="0" name="hw.device" value="General" />
+    <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="Solaris"/>
   </fingerprint>
   <fingerprint pattern="Solaris (.*)">
     <description>System is Solaris</description>
     <example _encoding="base64" os.version="1.1.1.B">
-      U2VhdHRsZSBDb21tdW5pdHkgTmV0d29yayBTdW4gU29sYXJpcyAxLjEuMS5CClBsZWFzZSBsb2dpbiBhcyAndmlzaXRvcicgaWYgeW91IGFyZSBhIHZpc2l0b3IKCgpTdW5PUyBVTklYIChzY24pCgoKCmxvZ2luOg==
+      U2VhdHRsZSBDb21tdW5pdHkgTmV0d29yayBTdW4gU29sYXJpcyAxLjEuMS5CClBsZWFzZSBsb2dpbiBhcyAndml
+      zaXRvcicgaWYgeW91IGFyZSBhIHZpc2l0b3IKCgpTdW5PUyBVTklYIChzY24pCgoKCmxvZ2luOg==
     </example>
     <param pos="0" name="hw.vendor" value="Sun"/>
     <param pos="0" name="hw.family" value="Solaris"/>
@@ -1140,11 +1151,11 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   </fingerprint>
   <fingerprint pattern="OpenVMS">
     <description>System is OpenVMS</description>
-    <example _encoding="base64"  >
+    <example _encoding="base64">
       V2VsY29tZSB0byBPcGVuVk1TIChUTSkgQWxwaGEgT3BlcmF0aW5nIFN5c3RlbSwgVmVyc2lvbiBWNy4zLTIgIAoKClVzZXJuYW1lOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="0" name="hw.family" value="OpenVMS" />
+    <param pos="0" name="hw.family" value="OpenVMS"/>
     <param pos="0" name="hw.device" value="General"/>
     <param pos="0" name="hw.product" value="VMS"/>
   </fingerprint>
@@ -1196,7 +1207,9 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="CONEXANT SYSTEMS.*ACCESS RUNNER ADSL">
     <description>System is a Conexant ADSL router</description>
     <example _encoding="base64">
-      G1swbRtbMkobWzAxOzI4SENPTkVYQU5UIFNZU1RFTVMsIElOQy4bWzAyOzE5SCBBQ0NFU1MgUlVOTkVSIEFEU0wgQ09OU09MRSBQT1JUG1syNDswMUg+Pj4bWzI0OzAxSExPR09OIFBBU1NXT1JEPhtbMDI7NTNIMy4yNxtbMjQ7MTdIG1syNDsxN0g=
+      G1swbRtbMkobWzAxOzI4SENPTkVYQU5UIFNZU1RFTVMsIElOQy4bWzAyOzE5SCBBQ0NFU1MgUlVOTkVSIEF
+      EU0wgQ09OU09MRSBQT1JUG1syNDswMUg+Pj4bWzI0OzAxSExPR09OIFBBU1NXT1JEPhtbMDI7NTNIMy4yNx
+      tbMjQ7MTdIG1syNDsxN0g=
     </example>
     <param pos="0" name="hw.vendor" value="Conexant"/>
     <param pos="0" name="hw.device" value="Broadband router"/>
@@ -1215,7 +1228,11 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="OpenBSD">
     <description>System is OpenBSD</description>
     <example _encoding="base64">
-      V2VsY29tZSB0byB0aGUgT3BlbkJTRCBpbnN0YWxsYXRpb24gYW5kIHVwZGF0ZSBkZW1vcwoKVGhlcmUgYXJlIHNldmVyYWwgc2hvd3MgYXZhaWxhYmxlIHRoYXQgd2lsbCBiZSByb3RhdGVkIGV2ZXJ5IDYwIHNlY29uZHMuCkN1cnJlbnRseSBzZWxlY3RlZCBpcyBzaG93IG51bWJlciAwMy4gSWYgeW91IHdhbnQgdG8gc2VlIGFub3RoZXIgb25lLApkaXNjb25uZWN0IG5vdyBhbmQgcmVjb25uZWN0IGxhdGVyLgoKU2hvdyAwMSAoRHVyYXRpb246IDAwOjA3OjU3KToKICAgICAgICBQZXJmZWN0bHkgbm9ybWFsIGFuZCBib3JpLi4u
+      V2VsY29tZSB0byB0aGUgT3BlbkJTRCBpbnN0YWxsYXRpb24gYW5kIHVwZGF0ZSBkZW1vcwoKVGhlcmUgYXJ
+      lIHNldmVyYWwgc2hvd3MgYXZhaWxhYmxlIHRoYXQgd2lsbCBiZSByb3RhdGVkIGV2ZXJ5IDYwIHNlY29uZH
+      MuCkN1cnJlbnRseSBzZWxlY3RlZCBpcyBzaG93IG51bWJlciAwMy4gSWYgeW91IHdhbnQgdG8gc2VlIGFub
+      3RoZXIgb25lLApkaXNjb25uZWN0IG5vdyBhbmQgcmVjb25uZWN0IGxhdGVyLgoKU2hvdyAwMSAoRHVyYXRp
+      b246IDAwOjA3OjU3KToKICAgICAgICBQZXJmZWN0bHkgbm9ybWFsIGFuZCBib3JpLi4u
     </example>
     <param pos="0" name="hw.vendor" value="OpenBSD"/>
     <param pos="0" name="hw.family" value="OpenBSD"/>
@@ -1267,7 +1284,10 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="Tasman Networks Inc.">
     <description>System is Tasman Networks router</description>
     <example _encoding="base64">
-      Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2hhcmFjdGVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
+      Iy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
+      S0tLS0tLS0tCiMgVGFzbWFuIE5ldHdvcmtzIEluYy4gVGVsbmV0IExvZ2luCiMtLS0tLS0tLS0tLS0tLS0tLS
+      0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFc2NhcGUgY2h
+      hcmFjdGVyIGlzICdeXScuCgoKICAgICAgICAKbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="Tasman Networks"/>
     <param pos="0" name="hw.family" value="TiOS"/>
@@ -1276,7 +1296,11 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="^(RS [^\s]+) System Software, Version ([^\s]+).*" flags="REG_MULTILINE">
     <description>System is RiverStone router</description>
     <example _encoding="base64" hw.device="RS 8000">
-      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d29ya3MsIEluYy4sIENvcHlyaWdodCAoYykgMjAwMC0yMDA0LiBBbGwgcmlnaHRzIHJlc2VydmVkLgpTeXN0ZW0gc3RhcnRlZCBvbiAyMDE4LTEwLTExIDIyOjAyOjAzCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
+      S0tLS0tLQpSUyA4MDAwIFN5c3RlbSBTb2Z0d2FyZSwgVmVyc2lvbiA5LjMuMC41ClJpdmVyc3RvbmUgTmV0d2
+      9ya3MsIEluYy4sIENvcHlyaWdodCAoYykgMjAwMC0yMDA0LiBBbGwgcmlnaHRzIHJlc2VydmVkLgpTeXN0ZW0
+      gc3RhcnRlZCBvbiAyMDE4LTEwLTExIDIyOjAyOjAzCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
     </example>
     <param pos="0" name="hw.vendor" value="Riverstone"/>
     <param pos="0" name="hw.family" value="Riverstone"/>
@@ -1285,7 +1309,11 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="(ES [^\s]+) System Software, Version ([^\s]+)">
     <description>System is a Tasman Networks Ethernet router`</description>
     <example _encoding="base64" hw.device="ES 10170" os.version="9.3.0.4">
-      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldHdvcmtzLCBJbmMuLCBDb3B5cmlnaHQgKGMpIDIwMDAtMjAwMy4gQWxsIHJpZ2h0cyByZXNlcnZlZC4KU3lzdGVtIHN0YXJ0ZWQgb24gMjAxOC0wOS0wNiAxNTo1ODozMAotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tL
+      S0tLS0tLQpFUyAxMDE3MCBTeXN0ZW0gU29mdHdhcmUsIFZlcnNpb24gOS4zLjAuNApSaXZlcnN0b25lIE5ldH
+      dvcmtzLCBJbmMuLCBDb3B5cmlnaHQgKGMpIDIwMDAtMjAwMy4gQWxsIHJpZ2h0cyByZXNlcnZlZC4KU3lzdGV
+      tIHN0YXJ0ZWQgb24gMjAxOC0wOS0wNiAxNTo1ODozMAotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t
+      LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS4uLg==
     </example>
     <param pos="0" name="hw.vendor" value="Riverstone"/>
     <param pos="0" name="hw.family" value="ES"/>
@@ -1295,7 +1323,14 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="HP.*ProCurve Switch">
     <description>System is HP ProCurve Switch</description>
     <example _encoding="base64">
-            SFAgSjQxMjFBIFByb0N1cnZlIFN3aXRjaCA0MDAwTQpGaXJtd2FyZSByZXZpc2lvbiBDLjA5LjIyCgpDb3B5cmlnaHQgKEMpIDE5OTEtMjAwMiBIZXdsZXR0LVBhY2thcmQgQ28uICBBbGwgUmlnaHRzIFJlc2VydmVkLgoKICAgICAgICAgICAgICAgICAgICAgICAgICAgUkVTVFJJQ1RFRCBSSUdIVFMgTEVHRU5ECgogVXNlLCBkdXBsaWNhdGlvbiwgb3IgZGlzY2xvc3VyZSBieSB0aGUgR292ZXJubWVudCBpcyBzdWJqZWN0IHRvIHJlc3RyaWN0aW9ucwogYXMgc2V0IGZvcnRoIGluIHN1YmRpdmlzaW9uIChiKSAoMykgKGlpKSBvZiB0aGUgUmlnaHRzIGluIFRlY2huaWNhbCBEYXRhIGFuZAogQ29tcHV0ZXIgU29mdHdhcmUgY2xhdXNlIGF0IDUyLjIyNy03MDEzLgoKICAgICAgICAgSEVXTEVUVC1QQUNLQVJEIENPTVBBTlksIDMwMDAgSGFub3ZlciBTdC4sIFBhbG8gQWx0bywgQ0EgOTQzMDMKCgpVc2VyIEFjY2VzcyBWZXJpZmljYXRpb24KClVzZXJuYW1lOiA=
+      SFAgSjQxMjFBIFByb0N1cnZlIFN3aXRjaCA0MDAwTQpGaXJtd2FyZSByZXZpc2lvbiBDLjA5LjIyCgpDb3B
+      5cmlnaHQgKEMpIDE5OTEtMjAwMiBIZXdsZXR0LVBhY2thcmQgQ28uICBBbGwgUmlnaHRzIFJlc2VydmVkLg
+      oKICAgICAgICAgICAgICAgICAgICAgICAgICAgUkVTVFJJQ1RFRCBSSUdIVFMgTEVHRU5ECgogVXNlLCBkd
+      XBsaWNhdGlvbiwgb3IgZGlzY2xvc3VyZSBieSB0aGUgR292ZXJubWVudCBpcyBzdWJqZWN0IHRvIHJlc3Ry
+      aWN0aW9ucwogYXMgc2V0IGZvcnRoIGluIHN1YmRpdmlzaW9uIChiKSAoMykgKGlpKSBvZiB0aGUgUmlnaHR
+      zIGluIFRlY2huaWNhbCBEYXRhIGFuZAogQ29tcHV0ZXIgU29mdHdhcmUgY2xhdXNlIGF0IDUyLjIyNy03MD
+      EzLgoKICAgICAgICAgSEVXTEVUVC1QQUNLQVJEIENPTVBBTlksIDMwMDAgSGFub3ZlciBTdC4sIFBhbG8gQ
+      Wx0bywgQ0EgOTQzMDMKCgpVc2VyIEFjY2VzcyBWZXJpZmljYXRpb24KClVzZXJuYW1lOiA=
     </example>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="ProCurve"/>
@@ -1305,7 +1340,11 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="ConnectUPS">
     <description>System is PowerWare ConnectUPS</description>
     <example _encoding="base64"  >
-      Kz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0rCnwgICAgICAgICAgICBbIENvbm5lY3RVUFMgV2ViL1NOTVAgQ2FyZCBDb25maWd1cmF0aW9uIFV0aWxpdHkgXSAgICAgICAgICAgICAgfAorPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PSsKCkVudGVyIFBhc3N3b3JkOiA=
+      Kz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0
+      9PT09PT09PT09PT09PT0rCnwgICAgICAgICAgICBbIENvbm5lY3RVUFMgV2ViL1NOTVAgQ2FyZCBDb25maW
+      d1cmF0aW9uIFV0aWxpdHkgXSAgICAgICAgICAgICAgfAorPT09PT09PT09PT09PT09PT09PT09PT09PT09P
+      T09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PSsKCkVudGVyIFBhc3N3
+      b3JkOiA=
     </example>
     <param pos="0" name="hw.vendor" value="PowerWare"/>
     <param pos="0" name="hw.family" value="ConnectUPS"/>
@@ -1315,7 +1354,8 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="Imagistics.*im">
     <description>System is an Imagistics device</description>
     <example _encoding="base64">
-      SW1hZ2lzdGljcyBpbTM1MTEvaW00NTExIFZlciAwMS4wMC4yMCBURUxORVQgc2VydmVyLgpDb3B5cmlnaHQoYykgMjAwMS0yMDA1LCBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
+      SW1hZ2lzdGljcyBpbTM1MTEvaW00NTExIFZlciAwMS4wMC4yMCBURUxORVQgc2VydmVyLgpDb3B5cmlnaH
+      QoYykgMjAwMS0yMDA1LCBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="Imagistics"/>
     <param pos="0" name="hw.family" value="Imagistics"/>
@@ -1334,7 +1374,8 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="^SHARP (AR-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>System is SHARP AR Series multifunction device</description>
     <example _encoding="base64" hw.product="AR-M351U" os.version="01.00.18">
-      U0hBUlAgQVItTTM1MVUgVmVyIDAxLjAwLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChjKSAyMDAxLTIwMDUsIHNpbGV4IHRlY2hub2xvZ3ksIEluYy4KbG9naW46IA==
+      U0hBUlAgQVItTTM1MVUgVmVyIDAxLjAwLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChjKSAyMDAx
+      LTIwMDUsIHNpbGV4IHRlY2hub2xvZ3ksIEluYy4KbG9naW46IA==
     </example>
     <param pos="0" name="hw.vendor" value="Sharp"/>
     <param pos="0" name="hw.family" value="Sharp AR Series"/>
@@ -1345,7 +1386,9 @@ KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG5cblxuKiBDb3B5cmln
   <fingerprint pattern="^SHARP (MX-[^\\s]+) Ver ([^\\s]+) TELNET server">
     <description>System is SHARP MX Series multifunction device</description>
     <example _encoding="base64" hw.product="MX-3610N" os.version="01.05.00.0o.18">
-      U0hBUlAgTVgtMzYxME4gVmVyIDAxLjA1LjAwLjBvLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodChDKSAyMDA1LSAgICAgU0hBUlAgQ09SUE9SQVRJT04KQ29weXJpZ2h0KEMpIDIwMDUtICAgICBzaWxleCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
+      U0hBUlAgTVgtMzYxME4gVmVyIDAxLjA1LjAwLjBvLjE4IFRFTE5FVCBzZXJ2ZXIuCkNvcHlyaWdodC
+      hDKSAyMDA1LSAgICAgU0hBUlAgQ09SUE9SQVRJT04KQ29weXJpZ2h0KEMpIDIwMDUtICAgICBzaWxl
+      eCB0ZWNobm9sb2d5LCBJbmMuCmxvZ2luOiA=
     </example>
     <param pos="0" name="hw.vendor" value="Sharp"/>
     <param pos="0" name="hw.family" value="Sharp MX Series"/>


### PR DESCRIPTION
We have improved recog's telnet coverage by adding various fingerprints that were previously missing. Most notably the addition of Red Hat, Fedora, AIX and SuSE telnet coverage, as well as adding to the already Cisco coverage that was previously being used.