### PR TITLE
OCTO-1870 MDNS device-info improvement

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -3,6 +3,9 @@ mappings:
     vendor: apache
     products:
       httpd: http_server
+  apple:
+    products:
+      ios: iphone_os
   alt-n:
     vendor: altn
   bea:

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <fingerprints matches="mdns.device-info.txt" protocol="mdns" database_type="util.os">
   <!--
     Fingerprint definitions that are matched against the string values in the
@@ -12,110 +12,462 @@
      The number specified after osxvers= is equivalent to the major
      version of OS X plus 4. E.g. osxvers=13 means OS X 10.9
    -->
+  <fingerprint pattern="^osxvers=17">
+    <description>OS X 10.13 (High Sierra)</description>
+    <example>osxvers=17</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.13"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.version" value="10.13"/>
+  </fingerprint>
+  <fingerprint pattern="^osxvers=16">
+    <description>OS X 10.12 (Sierra)</description>
+    <example>osxvers=16</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.12"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.version" value="10.12"/>
+  </fingerprint>
+  <fingerprint pattern="^osxvers=15">
+    <description>OS X 10.11 (El Capitan)</description>
+    <example>osxvers=15</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.11"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.version" value="10.11"/>
+  </fingerprint>
   <fingerprint pattern="^osxvers=14">
     <description>OS X 10.10 (Yosemite)</description>
     <example>osxvers=14</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.10"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.10"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=13">
     <description>OS X 10.9 (Mavericks)</description>
     <example>osxvers=13</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.9"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.9"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.9"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=12">
     <description>OS X 10.8 (Mountain Lion)</description>
     <example>osxvers=12</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.8"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.8"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.8"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=11">
     <description>Mac OS X 10.7 (Lion)</description>
     <example>osxvers=11</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.7"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.7"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.7"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=10">
     <description>Mac OS X 10.6 (Snow Leopard)</description>
     <example>osxvers=10</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.6"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.6"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.6"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=9">
     <description>Mac OS X 10.5 (Leopard)</description>
     <example>osxvers=9</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.5"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.5"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.5"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=8">
     <description>Mac OS X 10.4 (Tiger)</description>
     <example>osxvers=8</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.4"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.4"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.4"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=7">
     <description>Mac OS X 10.3 (Panther)</description>
     <example>osxvers=7</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.3"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.3"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.3"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=6">
     <description>Mac OS X 10.2 (Jaguar)</description>
     <example>osxvers=6</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.2"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.2"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.2"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=5">
     <description>Mac OS X 10.1 (Puma)</description>
     <example>osxvers=5</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.1"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.1"/>
   </fingerprint>
   <fingerprint pattern="^osxvers=4">
     <description>Mac OS X 10.0 (Cheetah)</description>
     <example>osxvers=4</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.0"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="os.version" value="10.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.0"/>
   </fingerprint>
+  <!-- The entry below is very likely an AirPort Extreme but I can't find a reference. -->
   <fingerprint pattern="^model=AirPort.*$">
     <description>AirPort</description>
     <example>model=AirPort5,114</example>
     <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:airport_base_station_firmware:-"/>
     <param pos="0" name="os.family" value="AirPort"/>
-    <param pos="0" name="os.product" value="AirPort"/>
+    <param pos="0" name="os.product" value="AirPort Base Station Firmware"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="AirPort"/>
+    <param pos="0" name="hw.product" value="AirPort"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+  </fingerprint>
+  <!-- MacBookPro - Reference for the following: https://support.apple.com/en-us/HT201300 -->
+  <fingerprint pattern="^model=MacBookPro15,2$">
+    <description>MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)</description>
+    <example>model=MacBookPro15,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro15,1$">
+    <description>MacBook Pro (15-inch, 2018)</description>
+    <example>model=MacBookPro15,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, 2018)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro14,3$">
+    <description>MacBook Pro (15-inch, 2017)</description>
+    <example>model=MacBookPro14,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, 2017)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro14,2$">
+    <description>MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)</description>
+    <example>model=MacBookPro14,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro14,1$">
+    <description>MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)</description>
+    <example>model=MacBookPro14,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro13,3$">
+    <description>MacBook Pro (15-inch, 2016)</description>
+    <example>model=MacBookPro13,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, 2016)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro13,2$">
+    <description>MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)</description>
+    <example>model=MacBookPro13,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2016, Four Thunderbolt 3 ports)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro13,1$">
+    <description>MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)</description>
+    <example>model=MacBookPro13,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro11,4$">
+    <description>MacBook Pro (Retina, 15-inch, Mid 2015)</description>
+    <example>model=MacBookPro11,4</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (Retina, 15-inch, Mid 2015)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro11,3$">
+    <description>MacBook Pro (Retina, 15-inch, Late 2013) - rev 2</description>
+    <example>model=MacBookPro11,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (Retina, 15-inch, Late 2013)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro11,2$">
+    <description>MacBook Pro (Retina, 15-inch, Late 2013)</description>
+    <example>model=MacBookPro11,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (Retina, 15-inch, Late 2013)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro11,1$">
+    <description>MacBook Pro (Retina, 13-inch, Late 2013)</description>
+    <example>model=MacBookPro11,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (Retina, 13-inch, Late 2013)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro10,2$">
+    <description>MacBook Pro (Retina, 13-inch, Early 2013)</description>
+    <example>model=MacBookPro10,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (Retina, 13-inch, Early 2013)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro10,1$">
+    <description>MacBook Pro (Retina, 15-inch, Early 2013)</description>
+    <example>model=MacBookPro10,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (Retina, 15-inch, Early 2013)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <!-- MacBook - Reference for the following: https://support.apple.com/en-us/HT201608 -->
+  <fingerprint pattern="^model=MacBook10,1$">
+    <description>MacBook (Retina, 12-inch, 2017)</description>
+    <example>model=MacBook10,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook (Retina, 12-inch, 2017)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBook9,1$">
+    <description>MacBook (Retina, 12-inch, Early 2016)</description>
+    <example>model=MacBook9,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook (Retina, 12-inch, Early 2016)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBook8,1$">
+    <description>MacBook (Retina, 12-inch, Early 2015)</description>
+    <example>model=MacBook8,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook (Retina, 12-inch, Early 2015)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBook7,1$">
+    <description>MacBook (13-inch, Mid 2010)</description>
+    <example>model=MacBook7,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook (Retina, 12-inch, Early 2015)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <!-- MacMini - Reference for the following: https://support.apple.com/en-us/HT201894 -->
+  <fingerprint pattern="^model=Macmini7,1$">
+    <description>Mac mini (Late 2014)</description>
+    <example>model=Macmini7,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Late 2014)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=Macmini6,2$">
+    <description>Mac mini (Late 2012) - rev 2</description>
+    <example>model=Macmini6,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Late 2012)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=Macmini6,1$">
+    <description>Mac mini (Late 2012)</description>
+    <example>model=Macmini6,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Late 2012)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <!-- iPad Pro - Reference for the following: https://www.theiphonewiki.com/ -->
+  <fingerprint pattern="^model=J20[78]AP$">
+    <description>iPad Pro (10.5-inch)</description>
+    <example>model=J207AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Pro"/>
+    <param pos="0" name="hw.product" value="iPad Pro (10.5-inch)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <fingerprint pattern="^model=J12[78]AP$">
+    <description>iPad Pro (9.7-inch))</description>
+    <example>model=J127AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Pro"/>
+    <param pos="0" name="hw.product" value="iPad Pro (9.7-inch)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <!-- iPad -->
+  <fingerprint pattern="^model=J71[ts]AP$">
+    <description>iPad (5th generation)</description>
+    <example>model=J71tAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad"/>
+    <param pos="0" name="hw.product" value="iPad (5th generation)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <!-- iPad Air -->
+  <fingerprint pattern="^model=J7[123]AP$">
+    <description>iPad Air</description>
+    <example>model=J72AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Air"/>
+    <param pos="0" name="hw.product" value="iPad Air"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <!-- iPad mini -->
+  <fingerprint pattern="^model=J8[567]AP$">
+    <description>iPad mini 2</description>
+    <example>model=J85AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad mini"/>
+    <param pos="0" name="hw.product" value="iPad mini 2"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
 </fingerprints>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -12,6 +12,15 @@
      The number specified after osxvers= is equivalent to the major
      version of OS X plus 4. E.g. osxvers=13 means OS X 10.9
    -->
+   <fingerprint pattern="^osxvers=18">
+    <description>OS X 10.14 (Mojave)</description>
+    <example>osxvers=18</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.14"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.version" value="10.14"/>
+  </fingerprint>
   <fingerprint pattern="^osxvers=17">
     <description>OS X 10.13 (High Sierra)</description>
     <example>osxvers=17</example>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -366,7 +366,7 @@
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="MacBook"/>
-    <param pos="0" name="hw.product" value="MacBook (Retina, 12-inch, Early 2015)"/>
+    <param pos="0" name="hw.product" value="MacBook (13-inch, Mid 2010)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
   <!-- MacMini - Reference for the following: https://support.apple.com/en-us/HT201894 -->

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <fingerprints matches="mdns.device-info.txt" protocol="mdns" database_type="util.os">
   <!--
     Fingerprint definitions that are matched against the string values in the


### PR DESCRIPTION
## Description
This PR adds fingerprints for `osxvers=` and `model=` strings.  This new coverage, while not comprehensive, add significant coverage for Apple devices.  The information was pulled from network captures from multiple locations.

I also added a value to `cpe-remap.yaml` which converts the value for Apple iOS to the standard CPE value of `iphone_os`.

Note:  The CPE fields are reordered in the original macOS fingerprints.  I don't know why, I used the same command as before.
```
./update_cpes.py mdns_device-info_txt.xml official-cpe-dictionary_v2.3.xml cpe-remap.yaml  && \
xmllint --format --noblanks official-cpe-dictionary_v2.3.xml > official-cpe-dictionary_v2.3.xml.bak && \
mv official-cpe-dictionary_v2.3.xml.bak official-cpe-dictionary_v2.3.xml 
```

## Testing
Testing was performed via `rspec` locally + Jenkins reruns of the same.