### PR TITLE
RCG-22: Replace Recog flags w/ inline flags

### DIFF
--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -12,7 +12,7 @@
    LaserJet and Designjet are registered trademarks of HP. Therefore matching for the keywords
    is sufficient for asserting all relevant information
    -->
-  <fingerprint pattern="laserjet (.*)(?: series)?" flags="REG_ICASE">
+  <fingerprint pattern="(?i)laserjet (.*)(?: series)?">
     <description>HP JetDirect Printer</description>
     <example>HP LaserJet 4100 Series</example>
     <example>HP LaserJet 2200</example>
@@ -27,7 +27,7 @@
     <param pos="0" name="os.family" value="LaserJet"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="(designjet \S+)" flags="REG_ICASE">
+  <fingerprint pattern="(?i)(designjet \S+)">
     <description>HP Designjet printer</description>
     <example>hp designjet 110plus</example>
     <example>DESIGNJET 1050C</example>
@@ -156,7 +156,7 @@
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^Oce (fx[^\s:]+):.*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Oce (fx[^\s:]+):.*$">
     <description>Oce FX series multifunction device</description>
     <example os.product="fx3000">Oce fx3000:8C5-B29:Ver.D:U0707161719:B0601271355</example>
     <param pos="0" name="os.vendor" value="Oce"/>
@@ -164,7 +164,7 @@
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^Oce (VL\S+):.*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Oce (VL\S+):.*$">
     <description>Oce VarioLink multifunction device</description>
     <example>Oce VL3200:8C5-D92:Ver.B</example>
     <param pos="0" name="os.vendor" value="Oce"/>
@@ -174,7 +174,7 @@
   </fingerprint>
   <!-- IGI is Imagistics International, which was acquired by Oce.
         I can't find MX-MBX3 or any variant online. -->
-  <fingerprint pattern="^OceIGI MX-\S+" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^OceIGI MX-\S+">
     <description>Oce-acquired IGI printer</description>
     <example>OceIGI MX-NBX3 02-Jul-07 14:47</example>
     <param pos="0" name="os.vendor" value="Oce"/>
@@ -182,7 +182,7 @@
   </fingerprint>
   <!-- im3510/4510 is actually a range of model numbers, but asserting a range
         of models as a product is preferableto asserting nothing. -->
-  <fingerprint pattern="^Imagistics (im\S+) (.+)" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Imagistics (im\S+) (.+)">
     <description>Oce IM series multifunction device</description>
     <example>Imagistics im3510/4510 02-Aug-04 10:56</example>
     <param pos="0" name="os.vendor" value="Oce"/>
@@ -209,7 +209,7 @@
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^RICOH ((?:Aficio|MP|SP) .*)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^RICOH ((?:Aficio|MP|SP) .*)$">
     <description>Ricoh Aficio Printer</description>
     <example>RICOH Aficio 2075</example>
     <example>RICOH Aficio AP610N</example>
@@ -222,7 +222,7 @@
   </fingerprint>
   <!-- NRG was acquired by Ricoh; classify NRG printers as such.
          Be consistent with snmp_sysdescr.xml. -->
-  <fingerprint pattern="^NRG ([MS]P \S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^NRG ([MS]P \S+)$">
     <description>Ricoh NRG printer</description>
     <example>NRG MP 171</example>
     <example>NRG MP 3350</example>
@@ -238,28 +238,28 @@
   </fingerprint>
   <!-- Gestetner == NRG, and was acquired by Ricoh.
          Assert the range of products as os.product. -->
-  <fingerprint pattern="^Gestetner (MP\S+/DSc\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Gestetner (MP\S+/DSc\S+)$">
     <description>Ricoh Gestetner multifunction device</description>
     <example>Gestetner MPC2500/DSc525</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^HYDRA$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^HYDRA$">
     <description>RSI Hydra printer</description>
     <example>HYDRA</example>
     <param pos="0" name="os.vendor" value="RSI"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.product" value="Hydra"/>
   </fingerprint>
-  <fingerprint pattern="^Savin (\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Savin (\S+)$">
     <description>Savin Printer</description>
     <example>SAVIN 4075</example>
     <param pos="0" name="os.vendor" value="Savin"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^Samsung ((?:SCX|CLX)-\S+) Series$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Samsung ((?:SCX|CLX)-\S+) Series$">
     <description>Samsung multifunction device</description>
     <example>Samsung SCX-5835_5935 Series</example>
     <example>Samsung CLX-4195 Series</example>
@@ -267,7 +267,7 @@
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^Samsung ((?:ML|CLP)-\S+) Series$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Samsung ((?:ML|CLP)-\S+) Series$">
     <description>Samsung printer</description>
     <example>Samsung CLP-680 Series</example>
     <example>Samsung ML-5012_5512 Series</example>
@@ -275,7 +275,7 @@
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^SHARP (\S+-\S+) .*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^SHARP (\S+-\S+) .*$">
     <description>Sharp Printer</description>
     <example>Sharp MX-NBX3 18-Mar-08 10:22</example>
     <example>Sharp AR-P17 24-Mar-04 19:55</example>
@@ -283,7 +283,7 @@
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^Source Technologies (\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Source Technologies (\S+)$">
     <description>Source Technologies Printer</description>
     <example>Source Technologies ST-9620</example>
     <param pos="0" name="os.vendor" value="Source Technologies"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -397,20 +397,20 @@
         a similar cookie name, you must ensure that it is located prior to
         these and this is enforced by rspec.
     -->
-  <fingerprint pattern="^JSESSIONID(?:\.[^=]+)?=[^;]+;.*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^JSESSIONID(?:\.[^=]+)?=[^;]+;.*$">
     <description>Ignore simple JSESSIONID and related cookies</description>
     <example>JSESSIONID=6ooov35i4l3n36qtaf8csvg0;Path=/</example>
     <example>jsessionid=6nkp66iogcdc92720%2Dc6e4%2D4989%2Db7b2%2D5021624cfdff;Path=/;secure</example>
     <example>JSESSIONID.c00a9623=v216643eijh19p9duve5srgf;Path=/;HttpOnly</example>
   </fingerprint>
-  <fingerprint pattern="^_?SESSION_?ID\s*=\s*[^;]+;.*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^_?SESSION_?ID\s*=\s*[^;]+;.*$">
     <description>Ignore simple SESSIONID and related cookies</description>
     <example>sessionId=7dba3249cfcd4b59854055311099a294; path=/;</example>
     <example>_session_id=7fe933db0fea13e9c872103ba2d142db; path=/; HttpOnly</example>
     <example>sessionId =0VrS6Ro6uC5QPXKgNdqGvyUgUFtUOVwv6OWAEWcWQ3jLRtAk2TVAgAApN9yTWVz;postId=; path=/;</example>
     <example>_session_id=18b3e173aa11db0533fd01752e81f583; path=/; HttpOnly</example>
   </fingerprint>
-  <fingerprint pattern="^sid=[^;]+;.*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^sid=[^;]+;.*$">
     <description>Ignore simple SID and related cookies</description>
     <example>sid=sfd10bf73-654458f687aa3c68b3874915f651e0ca;path=/;"</example>
   </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -22,7 +22,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:redhat:linux:-"/>
   </fingerprint>
-  <fingerprint pattern="^Apache/\d$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Apache/\d$">
     <description>Apache returning only its major version number</description>
     <example>Apache/1</example>
     <example>Apache/2</example>
@@ -31,7 +31,7 @@
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
   </fingerprint>
-  <fingerprint pattern="^Apache$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Apache$">
     <description>Apache returning no version information</description>
     <example>Apache</example>
     <example>apache</example>
@@ -40,7 +40,7 @@
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
   </fingerprint>
-  <fingerprint pattern="^Apache(?:-AdvancedExtranetServer)?(?:/([012][\d.]*)\s*(.*))?$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Apache(?:-AdvancedExtranetServer)?(?:/([012][\d.]*)\s*(.*))?$">
     <description>Apache</description>
     <example>Apache-AdvancedExtranetServer/2.0.44 (Mandrake Linux/11mdk) mod_perl/1.99_08 Perl/v5.8.0 mod_ssl/2.0.44 OpenSSL/0.9.7a PHP/4.3.1 mod_jk2/2.0.0</example>
     <example>Apache-AdvancedExtranetServer/2.0.47 (Mandrake Linux/6.12.92mdk) mod_perl/1.99_09 Perl/v5.8.1 mod_ssl/2.0.47 OpenSSL/0.9.7b PHP/4.3.2</example>
@@ -517,7 +517,7 @@
     <param pos="0" name="service.family" value="SMH"/>
     <param pos="0" name="service.product" value="SMH"/>
   </fingerprint>
-  <fingerprint pattern="^eHTTP[/ ]v?(\d+\.\d+)" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^eHTTP[/ ]v?(\d+\.\d+)">
     <description>HTTP Server present on seemingly only HP ProCurve network devices</description>
     <example service.version="1.1">EHTTP/1.1</example>
     <example service.version="2.0">eHTTP v2.0</example>
@@ -832,7 +832,7 @@
     <param pos="0" name="apache.variant" value="IBM"/>
     <param pos="1" name="apache.variant.version"/>
   </fingerprint>
-  <fingerprint pattern="^(?:IBM_HTTP_SERVER|IBM-HTTP-SERVER)/(\S+)(?: \(\S+\))?$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^(?:IBM_HTTP_SERVER|IBM-HTTP-SERVER)/(\S+)(?: \(\S+\))?$">
     <description>IBM HTTP Server with hardly useful version info</description>
     <example>IBM-HTTP-Server/1.0</example>
     <example>IBM_HTTP_Server/7.0.0.9 (Unix)</example>
@@ -843,7 +843,7 @@
     <param pos="0" name="apache.variant" value="IBM"/>
     <param pos="1" name="apache.variant.version"/>
   </fingerprint>
-  <fingerprint pattern="^(?:IBM_HTTP_SERVER|IBM-HTTP-SERVER)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^(?:IBM_HTTP_SERVER|IBM-HTTP-SERVER)$">
     <description>IBM HTTP Server with no version info</description>
     <example>IBM_HTTP_SERVER</example>
     <example>IBM_HTTP_Server</example>
@@ -1748,7 +1748,7 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:cherrypy:cherrypy:{service.version}"/>
   </fingerprint>
-  <fingerprint pattern="^TornadoServer/((?:\d+\.)*\d+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^TornadoServer/((?:\d+\.)*\d+)$">
     <description>Tornado Python web framework and asynchronous networking library.</description>
     <example>TornadoServer/4.0.2</example>
     <param pos="0" name="service.vendor" value="TornadoWeb"/>
@@ -1757,7 +1757,7 @@
     <param pos="0" name="service.family" value="Tornado"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^SimpleHTTP/((?:\d+\.)*\d+)\s*Python/((?:\d+\.)*\d+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^SimpleHTTP/((?:\d+\.)*\d+)\s*Python/((?:\d+\.)*\d+)$">
     <description>SimpleHTTPRequestHandler Python class is a simple HTTP request handler.</description>
     <example>SimpleHTTP/0.6 Python/2.7.6</example>
     <example>SimpleHTTP/0.6 Python/3.4.0</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -171,7 +171,7 @@
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;Broadcom Management Service&quot;.*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^(?:Basic|Digest) .*realm=&quot;Broadcom Management Service&quot;.*$">
     <description>Supposedly part of Broadcom Advanced Control Suite 3 (BACS3) or something similar</description>
     <example>Digest qop="auth", realm="Broadcom Management Service", nonce="AAAAAAAAAAAAAP//DwHpMwYy1zc=", algorithm="MD5"</example>
     <param pos="0" name="service.vendor" value="Broadcom"/>
@@ -207,7 +207,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:f5:big-ip_local_traffic_manager:-"/>
   </fingerprint>
   <!-- HP ProCurve -->
-  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(?:HP|ProCurve) (J[3]\d{3}A)&quot;$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^(?:Basic|Digest) realm=&quot;(?:HP|ProCurve) (J[3]\d{3}A)&quot;$">
     <description>HP ProCurve Hubs</description>
     <example os.product="J3295A">Basic realm="HP J3295A"</example>
     <param pos="0" name="os.vendor" value="HP"/>
@@ -215,7 +215,7 @@
     <param pos="0" name="os.device" value="Hub"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(?:HP|ProCurve) (J[489]\d{3}A)&quot;$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^(?:Basic|Digest) realm=&quot;(?:HP|ProCurve) (J[489]\d{3}A)&quot;$">
     <description>HP ProCurve Switches</description>
     <example os.product="J4110A">Basic realm="HP J4110A"</example>
     <example os.product="J8164A">Basic realm="ProCurve J8164A"</example>
@@ -234,7 +234,7 @@
     <param pos="0" name="service.family" value="Oracle"/>
   </fingerprint>
   <!-- a variety of headers we currently just ignore -->
-  <fingerprint pattern="^NTLM$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^NTLM$">
     <description>Ignore NTLM-only</description>
     <example>NTLM</example>
     <example>Ntlm</example>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -67,7 +67,7 @@
     <param pos="2" name="service.component.version"/>
     <param pos="3" name="host.domain"/>
   </fingerprint>
-  <fingerprint pattern="^Qpop(?:per)? \(version ([\d\.]+)\) at (.+)(?: starting\.)?.*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Qpop(?:per)? \(version ([\d\.]+)\) at (.+)(?: starting\.)?.*$">
     <description>Qpopper missing version info</description>
     <example>Qpopper (version 4.0.16) at foo.example.com</example>
     <example>QPOP (version 2.53) at domain starting.  &lt;xxx@domain&gt;</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -63,7 +63,7 @@
     <param pos="0" name="os.product" value="ADSL Modem"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^3Com (Link(?:Switch|Builder) [^,]+), SW version:(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^3Com (Link(?:Switch|Builder) [^,]+), SW version:(\S+)$">
     <description>3COM LinkBuilder/LinkSwitch</description>
     <example>3Com LinkBuilder FMS, SW version:3.11</example>
     <example>3Com LinkSwitch 1000, SW Version:1.04</example>
@@ -73,7 +73,7 @@
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^3Com MCNS external (\S+(?: \S+)?) Cable Modem,.*SW_VER:\s*(.*)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^3Com MCNS external (\S+(?: \S+)?) Cable Modem,.*SW_VER:\s*(.*)$">
     <description>3COM Cable Modem</description>
     <example>3Com MCNS external 2-way Cable Modem, HW_REV: 2.00 ,SW_VER: 01.03</example>
     <example>3Com MCNS external 2-way Cable Modem, HW_REV: A01.3 ,SW_VER: 12.30</example>
@@ -207,7 +207,7 @@
     <param pos="0" name="os.device" value="General"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^3Com Baseline Switch (\S+ Plus).* Software Version (\d+\.\S+ release \S+).*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^3Com Baseline Switch (\S+ Plus).* Software Version (\d+\.\S+ release \S+).*$">
     <description>3COM Switch</description>
     <example>3Com Baseline Switch 2920-SFP Plus Software Version 5.20 RELEASE 1101 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
     <example>3Com Baseline Switch 2920-SFP Plus Software Version 5.20 Release 1101P02 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
@@ -420,7 +420,7 @@
   <!--======================================================================
                               ADTRAN
    =======================================================================-->
-  <fingerprint pattern="^ADTRAN (MX\d+(?: \S+)?(?: \S+)?)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^ADTRAN (MX\d+(?: \S+)?(?: \S+)?)$">
     <description>ADTRAN Multiplexer</description>
     <example>ADTRAN MX2820 Multiplexer</example>
     <example>ADTRAN MX2800 DS3 Multiplexer</example>
@@ -431,7 +431,7 @@
     <param pos="0" name="os.family" value="MX"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^ADTRAN (NetVanta\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^ADTRAN (NetVanta\S+)$">
     <description>ADTRAN Netvanta Router</description>
     <example>ADTRAN NetVanta8044</example>
     <example>ADTRAN NetVanta8044M</example>
@@ -449,7 +449,7 @@
     <param pos="0" name="os.family" value="NetVanta"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^ADTRAN (TA\S+(?: \S+)?(?: \S+)?)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^ADTRAN (TA\S+(?: \S+)?(?: \S+)?)$">
     <description>ADTRAN TotalAccess</description>
     <example os.product="TA1448S-CE">ADTRAN TA1448S-CE</example>
     <example os.product="TA1124">Adtran TA1124</example>
@@ -505,7 +505,7 @@
     <param pos="0" name="os.family" value="Total Access"/>
     <param pos="0" name="os.product" value="DSLAM Shelf"/>
   </fingerprint>
-  <fingerprint pattern="^ADTRAN (T3SU-\S+).*$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^ADTRAN (T3SU-\S+).*$">
     <description>ADTRAN DSU/CSU</description>
     <example>ADTRAN T3SU-300 (1200.217L1)</example>
     <param pos="0" name="os.device" value="DSU/CSU"/>
@@ -876,7 +876,7 @@
   <!--======================================================================
                               AXIS
    =======================================================================-->
-  <fingerprint pattern="^AXIS (.*server).*(?:v|Version:\s*)([\d\.]+)" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^AXIS (.*server).*(?:v|Version:\s*)([\d\.]+)">
     <description>AXIS Network Print Server</description>
     <example os.product="5470e Network Print Server" os.version="6.21">AXIS 5470e Network Print Server V6.21 Dec  5 2000</example>
     <example os.product="70U Network Document Server" os.version="1.08">AXIS 70U Network Document Server,Version: 1.08</example>
@@ -1169,7 +1169,7 @@
     <param pos="1" name="os.product"/>
   </fingerprint>
   <!-- This is a catch-all for other Canon models that are less common -->
-  <fingerprint pattern="^Canon(?: Inc\.)? (?:Color )?(?:Large Format )?(?:LASER CLASS )?(?:LASER SHOT )?(\S+(?: [A-Z0-9]\S+)?)(?: Series)?(?: \([^\)]+\))?(?: /P)?(?: EEPROM \S+)?$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Canon(?: Inc\.)? (?:Color )?(?:Large Format )?(?:LASER CLASS )?(?:LASER SHOT )?(\S+(?: [A-Z0-9]\S+)?)(?: Series)?(?: \([^\)]+\))?(?: /P)?(?: EEPROM \S+)?$">
     <description>Canon printer</description>
     <example>Canon MF8170 /P</example>
     <example>Canon MF5900 Series /P</example>
@@ -1394,7 +1394,7 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:vpn_3000_concentrator:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-[^\)]+\), Version ([^, ]+)[,\s]?.*$" flags="REG_DOT_NEWLINE">
+  <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-[^\)]+\), Version ([^, ]+)[,\s]?">
     <description>Cisco Catalyst Network Analysis Module</description>
     <example>Network Analysis Module (WS-SVC-NAM-1), Version 3.1(1)
 Copyright (c) 1999-2003 by cisco Systems, Inc.</example>
@@ -1420,11 +1420,31 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     <param pos="0" name="os.device" value="General"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^Cisco (?:Internetwork Operating System|IOS) Software.*Version\s+([^,]+),?.*" flags="REG_DOT_NEWLINE">
+  <fingerprint pattern="^Cisco (?:Internetwork Operating System|IOS) Software,? (?:\r|\n|.)+Version\s+([^,]+),">
     <description>Cisco IOS</description>
-    <example>Cisco Internetwork Operating System Software ..IOS (tm) C1700 Software (C1700-Y-M), Version 12.2(4)YB, EARLY DEPLOYMENT RELEASE SOFTWARE (fc1)..Synched to technology version 12.2(6.8)T2..TAC Support: http://www.cisco.com/tac..Copyright (c) 1986-2002 by ci</example>
-    <example>Cisco Internetwork Operating System Software ..IOS (tm) C2600 Software (C2600-I-M), Version 12.0(3)T3,  RELEASE SOFTWARE (fc1)..Copyright (c) 1986-1999 by cisco Systems, Inc...Compiled Thu 15-Apr-99 15:41 by kpma</example>
-    <example>Cisco IOS Software, C1700 Software (C1700-ADVSECURITYK9-M), Version 12.3(11)YZ2, RELEASE SOFTWARE (fc2)..Technical Support: http://www.cisco.com/techsupport..Copyright (c) 1986-2007 by Cisco Systems, Inc...Compiled Wed 08-Aug-07 19:22 by dchih</example>
+    <!-- Cisco Internetwork Operating System Software \r\nIOS (tm) C1700 Software (C1700-Y-M), Version 12.2(4)YB, EARLY DEPLOYMENT RELEASE SOFTWARE (fc1)\r\nSynched to technology version 12.2(6.8)T2\r\nTAC Support: http://www.cisco.com/tac\r\nCopyright (c) 1986-2002 by ci -->
+    <example _encoding="base64">
+      Q2lzY28gSW50ZXJuZXR3b3JrIE9wZXJhdGluZyBTeXN0ZW0gU29mdHdhcmUgDQpJT1MgKHRtK
+      SBDMTcwMCBTb2Z0d2FyZSAoQzE3MDAtWS1NKSwgVmVyc2lvbiAxMi4yKDQpWUIsIEVBUkxZIE
+      RFUExPWU1FTlQgUkVMRUFTRSBTT0ZUV0FSRSAoZmMxKQ0KU3luY2hlZCB0byB0ZWNobm9sb2d
+      5IHZlcnNpb24gMTIuMig2LjgpVDINClRBQyBTdXBwb3J0OiBodHRwOi8vd3d3LmNpc2NvLmNv
+      bS90YWMNCkNvcHlyaWdodCAoYykgMTk4Ni0yMDAyIGJ5IGNpCg==
+    </example>
+    <!-- Cisco Internetwork Operating System Software \r\nIOS (tm) C2600 Software (C2600-I-M), Version 12.0(3)T3,  RELEASE SOFTWARE (fc1)\r\nCopyright (c) 1986-1999 by cisco Systems, Inc\r\n\nCompiled Thu 15-Apr-99 15:41 by kpma -->
+    <example _encoding="base64">
+      Q2lzY28gSW50ZXJuZXR3b3JrIE9wZXJhdGluZyBTeXN0ZW0gU29mdHdhcmUgDQpJT1MgKHRtK
+      SBDMjYwMCBTb2Z0d2FyZSAoQzI2MDAtSS1NKSwgVmVyc2lvbiAxMi4wKDMpVDMsICBSRUxFQV
+      NFIFNPRlRXQVJFIChmYzEpDQpDb3B5cmlnaHQgKGMpIDE5ODYtMTk5OSBieSBjaXNjbyBTeXN
+      0ZW1zLCBJbmMNCgpDb21waWxlZCBUaHUgMTUtQXByLTk5IDE1OjQxIGJ5IGtwbWEK
+    </example>
+    <!-- Cisco IOS Software, C1700 Software (C1700-ADVSECURITYK9-M), Version 12.3(11)YZ2, RELEASE SOFTWARE (fc2)\r\nTechnical Support: http://www.cisco.com/techsupport\r\nCopyright (c) 1986-2007 by Cisco Systems, Inc\r\nCompiled Wed 08-Aug-07 19:22 by dchih -->
+    <example _encoding="base64">
+      Q2lzY28gSU9TIFNvZnR3YXJlLCBDMTcwMCBTb2Z0d2FyZSAoQzE3MDAtQURWU0VDVVJJVFlLO
+      S1NKSwgVmVyc2lvbiAxMi4zKDExKVlaMiwgUkVMRUFTRSBTT0ZUV0FSRSAoZmMyKQ0KVGVjaG
+      5pY2FsIFN1cHBvcnQ6IGh0dHA6Ly93d3cuY2lzY28uY29tL3RlY2hzdXBwb3J0DQpDb3B5cml
+      naHQgKGMpIDE5ODYtMjAwNyBieSBDaXNjbyBTeXN0ZW1zLCBJbmMNCkNvbXBpbGVkIFdlZCAw
+      OC1BdWctMDcgMTk6MjIgYnkgZGNoaWgK
+    </example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="IOS"/>
@@ -1433,7 +1453,7 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Cisco Systems, Inc\. \S+.Cisco Catalyst Operating System Software, Version (\S+).Copyright \(c\).*$" flags="REG_DOT_NEWLINE">
+  <fingerprint pattern="^Cisco Systems, Inc\. \S+[\r\n]+Cisco Catalyst Operating System Software, Version (\S+)[\r\n]+Copyright \(c\)">
     <description>Cisco Catalyst</description>
     <example>Cisco Systems, Inc. WS-C2948
 Cisco Catalyst Operating System Software, Version 6.3(5)
@@ -1463,7 +1483,7 @@ Copyright (c) 1995-2002 by Cisco Systems, Inc.
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:catos:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Cisco Systems \S+.Cisco Catalyst Operating System Software, Version (\S+).Copyright \(c\).*$" flags="REG_DOT_NEWLINE">
+  <fingerprint pattern="^Cisco Systems \S+[\r\n]+Cisco Catalyst Operating System Software, Version (\S+)[\r\n]+Copyright \(c\)">
     <description>Cisco Catalyst</description>
     <example>Cisco Systems WS-C6009
 Cisco Catalyst Operating System Software, Version 8.3(7)
@@ -2249,18 +2269,21 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="3" name="hw.product"/>
     <param pos="2" name="os.version.version"/>
   </fingerprint>
-  <fingerprint pattern="^H3C Comware Platform Software, Software Version ([\d\.]+) Release \d+.*H3C (\S+).*Copyright.*$" flags="REG_DOT_NEWLINE">
+  <fingerprint pattern="^H3C Comware Platform Software, Software Version ([\d\.]+) Release \d+[\r\n]+H3C (\S+)[\r\n]+Copyright">
     <description>H3C Comware, generic, pre-HP acquisition</description>
-    <example os.version="5.20" hw.product="S5500-28C-EI">H3C Comware Platform Software, Software Version 5.20 Release 2208
-       H3C S5500-28C-EI
-       Copyright (c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved.</example>
+    <!-- H3C Comware Platform Software, Software Version 5.20 Release 2208\r\nH3C S5500-28C-EI\r\nCopyright (c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved. -->
+    <example _encoding="base64">
+      SDNDIENvbXdhcmUgUGxhdGZvcm0gU29mdHdhcmUsIFNvZnR3YXJlIFZlcnNpb24gNS4yMCBSZ
+      WxlYXNlIDIyMDgNCkgzQyBTNTUwMC0yOEMtRUkNCkNvcHlyaWdodCAoYykgMjAwNC0yMDEwIE
+      hhbmd6aG91IEgzQyBUZWNoLiBDby4sIEx0ZC4gQWxsIHJpZ2h0cyByZXNlcnZlZC4K
+    </example>
     <param pos="0" name="os.vendor" value="H3C"/>
     <param pos="0" name="os.family" value="Comware"/>
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.product" value="Comware"/>
     <param pos="2" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^H3C Switch (\S+) Software Version ([\d\.]+), Release .*" flags="REG_DOT_NEWLINE">
+  <fingerprint pattern="^H3C Switch (\S+) Software Version ([\d\.]+), Release">
     <description>H3C Comware, switch, pre-HP acquisition</description>
     <example os.version="5.20" hw.product="S5120-28P-SI">H3C Switch S5120-28P-SI Software Version 5.20, Release 1101P10
        Copyright(c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved.
@@ -5439,7 +5462,7 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               IBM Printers
    =======================================================================-->
-  <fingerprint pattern="^(?:IBM )?InfoPrint(?: Color)? (\S+)(?: MFP)? Version (\S+)" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^(?:IBM )?InfoPrint(?: Color)? (\S+)(?: MFP)? Version (\S+)">
     <description>IBM Infoprint Printer</description>
     <example>IBM Infoprint 1332 version 55.00.39 kernel 2.4.0-test6 All-N-1</example>
     <example>IBM Infoprint 1372 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
@@ -5511,7 +5534,7 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                                     SAVIN
    =======================================================================-->
-  <fingerprint pattern="^SAVIN (\S+)(?: / .*)?$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^SAVIN (\S+)(?: / .*)?$">
     <description>Savin Printer</description>
     <example>SAVIN 2400WD</example>
     <example>Savin 9965DP</example>
@@ -6462,7 +6485,7 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                                     Xyplex
    =======================================================================-->
-  <fingerprint pattern="^.*Xyplex hardware (\S+) .*Xyplex software Terminal Server V(\S+)\s*$" flags="REG_DOT_NEWLINE">
+  <fingerprint pattern="^.*Xyplex hardware (\S+) .*Xyplex software Terminal Server V(\S+)\s*$">
     <description>Xyplex Terminal Server</description>
     <example>- Netlink-Xyplex Xyplex hardware MX-1600 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0S91 </example>
     <example>- WTF? Xyplex hardware CSERV-20 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0.3 </example>

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fingerprints matches="ssdp_header.server" protocol="ssdp" database_type="service" preference="0.70">
   <!-- UPnP Server headers are matched against these patterns to fingerprint UPnP servers. -->
-  <fingerprint pattern="^Linux/(\S+) UPnP/[\d\.]+ miniupnpd/([\d\.]+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Linux/(\S+) UPnP/[\d\.]+ miniupnpd/([\d\.]+)$">
     <description>Linux MiniUPnPd UPnP Server</description>
     <example>Linux/Cross_compiled UPnP/1.0 miniupnpd/1.0</example>
     <example>Linux/2.6.29.6-217.2.3.fc11.i686.PAE UPnP/1.0 miniupnpd/1.0</example>
@@ -20,7 +20,7 @@
     <param pos="0" name="service.product" value="MiniUPnP"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="^(RT-\w+) UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^(RT-\w+) UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>Asus WAP UPnP Server</description>
     <example>RT-G32 UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -29,7 +29,7 @@
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
-  <fingerprint pattern="^DrayTek/Vigor(\S+) UPnP/\S+ miniupnpd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^DrayTek/Vigor(\S+) UPnP/\S+ miniupnpd/(\S+)$">
     <description>DrayTek Vigor router UPnP Server</description>
     <example>DrayTek/Vigor2130 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -39,7 +39,7 @@
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>
-  <fingerprint pattern="^OpenWRT/kamikaze UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^OpenWRT/kamikaze UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>OpenWRT Kamikaze WAP UPnP Server</description>
     <example>OpenWRT/kamikaze UPnP/1.0 MiniUPnPd/1.5</example>
     <example>OpenWRT/kamikaze UPnP/1.0 MiniUPnPd/1.2</example>
@@ -51,7 +51,7 @@
     <param pos="0" name="os.product" value="Kamikaze"/>
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
-  <fingerprint pattern="^Netgear/\S+ UPnP/\S+ miniupnpd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Netgear/\S+ UPnP/\S+ miniupnpd/(\S+)$">
     <description>Netgear DG834G or WNDR3300 WAP UPnP Server</description>
     <example>Netgear/1.0 UPnP/1.0 miniupnpd/1.0</example>
     <example>Netgear/1.0 UPnP/1.0 miniupnpd/1.0</example>
@@ -74,7 +74,7 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Debian\/(\S+) UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Debian\/(\S+) UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on a Debian variant</description>
     <example os.version="wheezy/sid" service.version="1.8">Debian/wheezy/sid UPnP/1.1 MiniUPnPd/1.8</example>
     <example os.version="4.0" service.version="1.0">Debian/4.0 UPnP/1.0 miniupnpd/1.0</example>
@@ -86,7 +86,7 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Fedora(?:Core)?\/(\S+) UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Fedora(?:Core)?\/(\S+) UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on a Fedora variant</description>
     <example os.version="10" service.version="1.4">Fedora/10 UPnP/1.0 MiniUPnPd/1.4</example>
     <example os.version="8" service.version="1.0">Fedora/8 UPnP/1.0 miniupnpd/1.0</example>
@@ -99,7 +99,7 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/([\d\.]+) UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/([\d\.]+) UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu variant</description>
     <example os.version="10.04" service.version="1.0">Ubuntu/10.04 UPnP/1.0 miniupnpd/1.0</example>
     <example os.version="10.10" service.version="1.0">Ubuntu/10.10 UPnP/1.0 miniupnpd/1.0</example>
@@ -112,7 +112,7 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/bionic UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/bionic UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu bionic/18.04</description>
     <example os.version="18.04" service.version="1.4">Ubuntu/bionic UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -122,7 +122,7 @@
     <param pos="0" name="os.version" value="18.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:18.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/yakkety UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/yakkety UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu yakkety/16.10</description>
     <example os.version="16.10" service.version="1.4">Ubuntu/yakkety UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -132,7 +132,7 @@
     <param pos="0" name="os.version" value="16.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.10"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/xenial UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/xenial UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu xenial/16.04</description>
     <example os.version="16.04" service.version="1.4">Ubuntu/xenial UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -142,7 +142,7 @@
     <param pos="0" name="os.version" value="16.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/utopic UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/utopic UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu utopic/14.10</description>
     <example os.version="14.10" service.version="1.4">Ubuntu/utopic UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -152,7 +152,7 @@
     <param pos="0" name="os.version" value="14.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.10"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/trusty UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/trusty UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu trusty/14.04</description>
     <example os.version="14.04" service.version="1.4">Ubuntu/trusty UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -162,7 +162,7 @@
     <param pos="0" name="os.version" value="14.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/saucy UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/saucy UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu saucy/13.10</description>
     <example os.version="13.10" service.version="1.4">Ubuntu/saucy UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -172,7 +172,7 @@
     <param pos="0" name="os.version" value="13.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:13.10"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/raring UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/raring UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu raring/13.04</description>
     <example os.version="13.04" service.version="1.4">Ubuntu/raring UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -182,7 +182,7 @@
     <param pos="0" name="os.version" value="13.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:13.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/quantal UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/quantal UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu quantal/12.10</description>
     <example os.version="12.10" service.version="1.4">Ubuntu/quantal UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -192,7 +192,7 @@
     <param pos="0" name="os.version" value="12.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:12.10"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/precise UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/precise UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu precise/12.04</description>
     <example os.version="12.04" service.version="1.4">Ubuntu/precise UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -202,7 +202,7 @@
     <param pos="0" name="os.version" value="12.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:12.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/oneiric UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/oneiric UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu oneiric/11.10</description>
     <example os.version="11.10" service.version="1.4">Ubuntu/oneiric UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -212,7 +212,7 @@
     <param pos="0" name="os.version" value="11.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:11.10"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/natty UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/natty UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu natty/11.04</description>
     <example os.version="11.04" service.version="1.4">Ubuntu/natty UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -222,7 +222,7 @@
     <param pos="0" name="os.version" value="11.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:11.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/maverick UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/maverick UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu maverick/10.10</description>
     <example os.version="10.10" service.version="1.4">Ubuntu/maverick UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -232,7 +232,7 @@
     <param pos="0" name="os.version" value="10.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:10.10"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/lucid UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/lucid UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu lucid/10.04</description>
     <example os.version="10.04" service.version="1.4">Ubuntu/lucid UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -242,7 +242,7 @@
     <param pos="0" name="os.version" value="10.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:10.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/karmic UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/karmic UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu karmic/9.10</description>
     <example os.version="9.10" service.version="1.4">Ubuntu/karmic UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -252,7 +252,7 @@
     <param pos="0" name="os.version" value="9.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:9.10"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/jaunty UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/jaunty UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu jaunty/9.04</description>
     <example os.version="9.04" service.version="1.4">Ubuntu/jaunty UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -262,7 +262,7 @@
     <param pos="0" name="os.version" value="9.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:9.04"/>
   </fingerprint>
-  <fingerprint pattern="^Ubuntu\/hardy UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Ubuntu\/hardy UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>miniupnpd on an Ubuntu hardy/8.04</description>
     <example os.version="8.04" service.version="1.4">Ubuntu/hardy UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -272,7 +272,7 @@
     <param pos="0" name="os.version" value="8.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:8.04"/>
   </fingerprint>
-  <fingerprint pattern="^Linux Mips (\S+) UPnP/\S+ MiniUPnPd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^Linux Mips (\S+) UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>Linux MIPS UPnP Server</description>
     <example>Linux Mips 2.4.20 UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
@@ -282,7 +282,7 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^SmoothWall Express/\S+ UPnP/\S+ miniupnpd/(\S+)$" flags="REG_ICASE">
+  <fingerprint pattern="(?i)^SmoothWall Express/\S+ UPnP/\S+ miniupnpd/(\S+)$">
     <description>Smoothwall Express UPnP Server</description>
     <example>SmoothWall Express/3.0 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="Smoothwall"/>


### PR DESCRIPTION
## Description
This PR is the first pass at replacing the use of `flags=`in fingerprints with inline flags. The changes here should make the fingerprints more portable across languages.

This PR covers most fingerprint databases but there are a couple that were deferred since nearly every fingerprint in those files have one or more flags and so would be easier to review if handled individually. 

Note: I've tried to avoid replacing `flags="REG_DOT_NEWLINE"` with `(?m)` as the behavior of `(?m)` is different across languages.  See https://www.regular-expressions.info/modifiers.html

## Testing
Local testing via `rspec` and Jenkins testing of the same.