### PR TITLE
Add new issue template for fingerprint requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/fingerprint_request.md
+++ b/.github/ISSUE_TEMPLATE/fingerprint_request.md
@@ -1,0 +1,27 @@
+---
+name: Fingerprint request
+about: Request new fingerprint coverage
+
+---
+
+**Request for new fingerprint(s) for a product**  
+Briefly describe the product to be fingerprinted, including vendor and version information.  
+<!-- Include links to relevant public documentation from the vendor or other sources, if available -->
+
+**Provide details about the product**  
+What protocol(s) can be used to retrieve identifiable information about the product?  
+<!-- Examples: Telnet, SSH, SNMP, SMTP, HTTP(S), Vendor Proprietary Protocol -->
+
+What information can be collected on each protocol?  
+<!-- Example: HTTP Server banner: nginx/0.8.53 -->
+
+What request, command, and/or payload can be used to retrieve information on each protocol?  
+<!-- Use code fences like the below example to preserve formatting -->
+```
+HTTP HEAD /
+
+HTTP GET /info.php
+```
+
+**Example banner(s) with specific version info**  
+<!-- Paste raw text here, using code fences to preserve formatting if needed-->


### PR DESCRIPTION
## Description
This adds a new issue template specifically for requesting fingerprint coverage.

## Motivation and Context
After adding the other issue templates I realized that they might be overwhelming for someone who just wants some new fingerprint added. Ultimately I want this repo to be as accessible as possible in order to encourage more community participation.

## Preview

![fingerprint_template](https://user-images.githubusercontent.com/4418817/48514111-5f41c000-e812-11e8-9329-dcf29b570161.gif)
