### PR TITLE
Improve Squid fingerprinting

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -103,6 +103,8 @@ mappings:
       jboss_eap: jboss_enterprise_application_platform
       jbossweb: jboss_web_framework_kit
       red_hat_directory_server: directory_server
+  squid_cache:
+    vendor: squid-cache
   sun:
     vendor: sun
     products:

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1038,6 +1038,7 @@
     <example>squid/2.6.STABLE13</example>
     <param pos="0" name="service.vendor" value="Squid Cache"/>
     <param pos="0" name="service.product" value="Squid"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:squid-cache:squid:{service.version}"/>
     <param pos="0" name="service.family" value="Squid"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -1047,6 +1048,7 @@
     <example>squid</example>
     <param pos="0" name="service.vendor" value="Squid Cache"/>
     <param pos="0" name="service.product" value="Squid"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:squid-cache:squid:-"/>
     <param pos="0" name="service.family" value="Squid"/>
   </fingerprint>
   <fingerprint pattern="^thttpd/(\d\.[\w.]+)-MX\s*.*$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1031,14 +1031,23 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
   </fingerprint>
-  <fingerprint pattern="^[Ss]quid/(\d+\.[\w.]+)$">
-    <description>Squid Web </description>
+  <fingerprint pattern="^(?i)squid/(\d+\.[\w.]+)$">
+    <description>Squid Web Proxy with a version</description>
     <example>Squid/2.3.STABLE1</example>
     <example>squid/2.5.12.cc1.29</example>
     <example>squid/2.6.STABLE13</example>
+    <param pos="0" name="service.vendor" value="Squid Cache"/>
     <param pos="0" name="service.product" value="Squid"/>
     <param pos="0" name="service.family" value="Squid"/>
     <param pos="1" name="service.version"/>
+  </fingerprint>
+  <fingerprint pattern="^(?i)squid$">
+    <description>Squid Web Proxy without a version</description>
+    <example>Squid</example>
+    <example>squid</example>
+    <param pos="0" name="service.vendor" value="Squid Cache"/>
+    <param pos="0" name="service.product" value="Squid"/>
+    <param pos="0" name="service.family" value="Squid"/>
   </fingerprint>
   <fingerprint pattern="^thttpd/(\d\.[\w.]+)-MX\s*.*$">
     <description>thttpd with SSL support</description>


### PR DESCRIPTION
## Description

This improves the fingerprinting of Squid by:
 * Making the existing regex more case-insensitive
 * Adding a fingerprint for when Squid presents no version
 * Add a vendor to all Squid fingerprints
 * Add Squid CPE support

## Motivation and Context

Squid is a popular web cache/proxy with millions of endpoints exposed on the public Internet.

## How Has This Been Tested?

The existing examples are tested automatically.

## Types of changes

- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
