### PR TITLE
Add HTTP fingerprints for some Amazon products

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2147,6 +2147,12 @@
     <param pos="0" name="service.product" value="CloudFront Load Balancer"/>
     <param pos="0" name="service.family" value="CloudFront"/>
   </fingerprint>
+  <fingerprint pattern="^Amazon-Cloud-Drive$">
+    <description>Amazon Cloud Drive / Drive</description>
+    <example>Amazon-Cloud-Drive</example>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.product" value="Drive"/>
+  </fingerprint>
   <fingerprint pattern="^AmazonS3$">
     <description>Amazon S3 (Simple Cloud Storage Service)</description>
     <example>AmazonS3</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2147,6 +2147,12 @@
     <param pos="0" name="service.product" value="CloudFront Load Balancer"/>
     <param pos="0" name="service.family" value="CloudFront"/>
   </fingerprint>
+  <fingerprint pattern="^AmazonS3$">
+    <description>Amazon S3 (Simple Cloud Storage Service)</description>
+    <example>AmazonS3</example>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.product" value="S3"/>
+  </fingerprint>
   <fingerprint pattern="^cloudflare-nginx$">
     <description>CloudFlare web load balancer endpoint</description>
     <example>cloudflare-nginx</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2159,6 +2159,12 @@
     <param pos="0" name="service.vendor" value="Amazon"/>
     <param pos="0" name="service.product" value="S3"/>
   </fingerprint>
+  <fingerprint pattern="^Amazon SimpleDB$">
+    <description>Amazon SimpleDB / Simple Database Service</description>
+    <example>Amazon SimpleDB</example>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.product" value="SimpleDB"/>
+  </fingerprint>
   <fingerprint pattern="^AmazonSnowball$">
     <description>Amazon Snowball</description>
     <example>AmazonSnowball</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2153,6 +2153,12 @@
     <param pos="0" name="service.vendor" value="Amazon"/>
     <param pos="0" name="service.product" value="S3"/>
   </fingerprint>
+  <fingerprint pattern="^AmazonSnowball$">
+    <description>Amazon Snowball</description>
+    <example>AmazonSnowball</example>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.product" value="Snowball"/>
+  </fingerprint>
   <fingerprint pattern="^cloudflare-nginx$">
     <description>CloudFlare web load balancer endpoint</description>
     <example>cloudflare-nginx</example>


### PR DESCRIPTION
## Description

This adds HTTP fingerprints for AWS S3, Snowball, Drive and SimpleDB, which are known to listen on the public Internet in a variety of capacities.

## Motivation and Context

AWS.

## How Has This Been Tested?


Existing and new tests.

## Types of changes

- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
