### PR TITLE
Ensure consistency of os.device and hw.device when both present

### DIFF
--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -33,6 +33,11 @@ describe Recog::DB do
 
         context "#{fp.name}" do
           param_names = []
+          it "has consistent os.device and hw.device" do
+            if fp.params['os.device'] && fp.params['hw.device'] && (fp.params['os.device'] != fp.params['hw.device'])
+              fail "#{fp.name} has both hw.device and os.device but with differing values"
+            end
+          end
           fp.params.each do |param_name, pos_value|
             pos, value = pos_value
             it "has valid looking fingerprint parameter names" do

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1207,7 +1207,7 @@
     <param pos="0" name="os.device" value="Storage"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:-"/>
     <param pos="0" name="hw.vendor" value="Netgear"/>
-    <param pos="0" name="hw.device" value="General"/>
+    <param pos="0" name="hw.device" value="Storage"/>
     <param pos="0" name="hw.family" value="ReadyNAS"/>
     <param pos="0" name="hw.product" value="ReadyNAS"/>
   </fingerprint>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2708,7 +2708,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="TippingPoint"/>
     <param pos="0" name="os.device" value="IPS"/>
-    <param pos="0" name="hw.device" value="TippingPoint Core Controller"/>
+    <param pos="0" name="hw.device" value="IPS"/>
   </fingerprint>
   <fingerprint pattern="^Integrated Lights-Out (\d) \d+\.\d+ [A-Za-z]{3} \d{1,2} \d{4}$">
     <description>HP Integrated Lights-Out (iLO) with firmware version</description>


### PR DESCRIPTION
## Description

Currently many fingerprints assert the device type through one or more of `os` and `hw`.  Only two use both but with inconsistent values and this seems like a mistake.  So, I've corrected the two problematic fingerprints and put a test in place to enforce this going forward.

## Motivation and Context

See description


## How Has This Been Tested?

Existing tests pass, new tests pass and were used to catch the two problematic fingerprints in the first place.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
