### PR TITLE
Add more fingerprints for MDNS Apple products

### DIFF
--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -362,8 +362,8 @@
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
-    <param pos="0" name="hw.family" value="MacBook"/>
-    <param pos="0" name="hw.product" value="MacBook (13-inch, Mid 2012)"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, Mid 2012)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
   <fingerprint pattern="^model=MacBook9,1$">
@@ -453,7 +453,7 @@
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
   <fingerprint pattern="^model=J12[78]AP$">
-    <description>iPad Pro (9.7-inch))</description>
+    <description>iPad Pro (9.7-inch)</description>
     <example>model=J127AP</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
@@ -465,7 +465,7 @@
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
   <fingerprint pattern="^model=J121AP$">
-    <description>iPad Pro (12.9-inch))</description>
+    <description>iPad Pro (12.9-inch)</description>
     <example>model=J121AP</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -257,6 +257,18 @@
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
+  <fingerprint pattern="^model=MacBookPro12,1$">
+    <description>MacBook Pro (Retina, 13-inch, Early 2015)</description>
+    <example>model=MacBookPro12,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (Retina, 13-inch, Early 2015)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
   <fingerprint pattern="^model=MacBookPro11,4$">
     <description>MacBook Pro (Retina, 15-inch, Mid 2015)</description>
     <example>model=MacBookPro11,4</example>
@@ -340,6 +352,18 @@
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="MacBook"/>
     <param pos="0" name="hw.product" value="MacBook (Retina, 12-inch, 2017)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro9,2$">
+    <description>MacBook Pro (13-inch, Mid 2012)</description>
+    <example>model=MacBookPro9,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook (13-inch, Mid 2012)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
   <fingerprint pattern="^model=MacBook9,1$">
@@ -440,6 +464,18 @@
     <param pos="0" name="hw.product" value="iPad Pro (9.7-inch)"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
+  <fingerprint pattern="^model=J121AP$">
+    <description>iPad Pro (12.9-inch))</description>
+    <example>model=J121AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Pro"/>
+    <param pos="0" name="hw.product" value="iPad Pro (12.9-inch)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
   <!-- iPad -->
   <fingerprint pattern="^model=J71[ts]AP$">
     <description>iPad (5th generation)</description>
@@ -464,6 +500,18 @@
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPad Air"/>
     <param pos="0" name="hw.product" value="iPad Air"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <fingerprint pattern="^model=J8[12]AP$">
+    <description>iPad Air 2</description>
+    <example>model=J81AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Air"/>
+    <param pos="0" name="hw.product" value="iPad Air 2"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
   <!-- iPad mini -->


### PR DESCRIPTION
## Description
Adding additional MDNS fingerprints for Apple products (iPad/Macbook/Pro)

## Motivation and Context
Internal capture showed these missing. 

## How Has This Been Tested?
Manual local testing from capture logs. 

Verify with 
- https://support.apple.com/en-us/HT201300
- https://www.theiphonewiki.com/wiki/J121AP

## Types of changes
- Adding fingerprints
