### PR TITLE
Improve HTTP WWW-Authenticate header fingerprinting

### DIFF
--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -299,6 +299,13 @@
     <example>Digest realm="SERCOMM CPE Authentication"</example>
     <param pos="0" name="hw.vendor" value="Sercomm"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TiVo DVR&quot;.*$">
+    <description>Tivo DVR</description>
+    <example>Digest realm=&quot;TiVo DVR&quot;</example>
+    <param pos="0" name="hw.vendor" value="Tivo"/>
+    <param pos="0" name="hw.family" value="DVR"/>
+    <param pos="0" name="hw.device" value="DVR"/>
+  </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;UBEE&quot;.*$">
     <description>Ubee Cable Modems</description>
     <example>Digest qop=&quot;auth&quot;, realm=&quot;Ubee&quot;, nonce=&quot;1544738973&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -106,6 +106,7 @@
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;GoAhead&quot;.*$">
     <description>GoAhead webserver</description>
+    <example>Basic realm=&quot;GoAhead&quot;</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
     <param pos="0" name="service.product" value="GoAhead Webserver"/>
     <param pos="0" name="service.family" value="GoAhead Webserver"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -95,7 +95,7 @@
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;Broadband Router&quot;.*$">
     <description>Generic Broadband modems/routers</description>
     <example>Basic realm=&quot;Broadband Router&quot;</example>
-    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;DSL\S* (?:Modem|Router|Modem/Router)&quot;.*$">
     <description>Generic DSL modems/routers</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -56,6 +56,7 @@
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;Cisco_CCSP_CWMP_TCPCR&quot;.*$">
     <description>Generic Cisco CWMP/CPE equipment</description>
+    <example>Basic realm=&quot;Cisco_CCSP_CWMP_TCPCR&quot;</example>
     <param pos="0" name="hw.vendor" value="Cisco"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.FW-1.      Reason: no user      Server .$">

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -194,7 +194,7 @@
     <example>Basic realm=&quot;HuaweiHomeGateway&quot;</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.device" value="Broadband router"/>
-    <param pos="0" name="os.product" value="Home Gateway"/>
+    <param pos="0" name="hw.product" value="Home Gateway"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;EchoLife .*&quot;.*$">
     <description>Huawei EchoLife Home Gateways</description>
@@ -202,7 +202,7 @@
     <example>Basic realm=&quot;EchoLife Home Gateway&quot;</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.device" value="Broadband router"/>
-    <param pos="0" name="os.product" value="EchoLife Home Gateway"/>
+    <param pos="0" name="hw.product" value="EchoLife Home Gateway"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.WRT54G.$">
     <description>Linksys WRT54G wireless access point

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -135,7 +135,7 @@
     <param pos="0" name="service.family" value="GoAhead Webserver"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;kubernetes-master&quot;.*$">
-    <description>Kuberentes master nodes</description>
+    <description>Kubernetes master nodes</description>
     <example>Basic realm=&quot;kubernetes-master&quot;</example>
     <param pos="0" name="service.vendor" value="Kubernetes"/>
   </fingerprint>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -105,9 +105,11 @@
     <example>Basic realm=&quot;Wireless Access Point&quot;</example>
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
-  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;IPCamera(?: Login)?&quot;.*$">
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;(?:(?:Cube|(?:Mini )?Dome|Day/Night|PAN/Tilt|POE|IR|HD|H.264|Surveillance|Wired|Wireless(?: N)?|Network|Internet|(?:IP(?:[\s_-])?)?Cameras?[\s_]*\d*) ?){1,4}?(?: Login)?&quot;.*$">
     <description>Generic IP Cameras</description>
+    <example>Basic realm=&quot;camera&quot;</example>
     <example>Basic realm=&quot;IPCamera Login&quot;</example>
+    <example>Basic realm=&quot;Mini Dome IP Camera&quot;</example>
     <param pos="0" name="hw.device" value="Camera"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(DCS-[^&quot;]+)&quot;.*$">

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -268,6 +268,11 @@
     <param pos="0" name="service.product" value="XML DB"/>
     <param pos="0" name="service.family" value="Oracle"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;cpe@zte.com&quot;.*$">
+    <description>Assorted ZTE CPE devices</description>
+    <example>Digest realm=&quot;cpe@zte.com&quot;</example>
+    <param pos="0" name="hw.vendor" value="ZTE"/>
+  </fingerprint>
   <!-- a variety of headers we currently just ignore -->
   <fingerprint pattern="(?i)^NTLM$">
     <description>Ignore NTLM-only</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -142,13 +142,6 @@
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="^(?:Basic|Digest) realm=.TP-LINK.*Router ([A-Z0-9\-\+]+).*$">
-    <description>TP-LINK SoHo Router</description>
-    <example>Basic realm="TP-LINK Wireless N Router WR841N"</example>
-    <param pos="0" name="os.vendor" value="TP-LINK"/>
-    <param pos="0" name="os.device" value="Router"/>
-    <param pos="1" name="os.product"/>
-  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.TP-LINK.*(?:Access Point|Extender|AP) ([A-Z0-9\-\+]+).*$">
     <description>TP-LINK SoHo Router</description>
     <example>Basic realm="TP-LINK Wireless N Access Point WA801N"</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -372,7 +372,7 @@
     <description>Ignore Negotiate-only</description>
     <example>Negotiate</example>
   </fingerprint>
-  <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;(?:/|\.|null|index.html?)?&quot;">
+  <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;(?:/|\.|null|/?index.html?)?&quot;">
     <description>Ignore null/empty/period/index.</description>
     <example>Basic realm="null"</example>
     <example>Basic realm="."</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -252,7 +252,7 @@
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
-  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TP-LINK.*Router.*&quot;.*$">
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TP-LINK (.*Router.*)&quot;.*$">
     <description>TP-LINK Routers</description>
     <example>Basic realm=&quot;TP-LINK Wireless N Router WR841N&quot;</example>
     <example>Basic realm=&quot;TP-LINK Gigabit Broadband VPN Router R600VPN&quot;</example>
@@ -266,7 +266,6 @@
     <example>Basic realm=&quot;TP-LINK IP-Camera&quot;</example>
     <param pos="0" name="hw.vendor" value="TP-Link"/>
     <param pos="0" name="hw.device" value="Camera"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest) .*realm=&quot;Broadcom Management Service&quot;.*$">
     <description>Supposedly part of Broadcom Advanced Control Suite 3 (BACS3) or something similar</description>
@@ -359,6 +358,7 @@
     <param pos="0" name="hw.vendor" value="ZTE"/>
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="0" name="hw.family" value="ZXHN"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;(ZXV\S* \S+)&quot;.*$">
     <description>ZTE ZXV router</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -273,6 +273,13 @@
     <example>Digest realm=&quot;cpe@zte.com&quot;</example>
     <param pos="0" name="hw.vendor" value="ZTE"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;ZXHN (\S+)&quot;.*$">
+    <description>ZTE ZXHN router</description>
+    <example>Basic realm=&quot;ZXHN H108L&quot;</example>
+    <param pos="0" name="hw.vendor" value="ZTE"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.family" value="ZXHN"/>
+  </fingerprint>
   <!-- a variety of headers we currently just ignore -->
   <fingerprint pattern="(?i)^NTLM$">
     <description>Ignore NTLM-only</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -116,6 +116,13 @@
     <param pos="0" name="os.family" value="MT"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;HuaweiHomeGateway&quot;.*$">
+    <description>Huawei Home Gateway Routers</description>
+    <example>Basic realm=&quot;HuaweiHomeGateway&quot;</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+    <param pos="0" name="os.product" value="Home Gateway"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.WRT54G.$">
     <description>Linksys WRT54G wireless access point
          (dozen of variants of the product)</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -99,6 +99,12 @@
     <param pos="0" name="hw.device" value="Camera"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;GoAhead&quot;.*$">
+    <description>GoAhead webserver</description>
+    <param pos="0" name="service.vendor" value="Oracle"/>
+    <param pos="0" name="service.product" value="GoAhead Webserver"/>
+    <param pos="0" name="service.family" value="GoAhead Webserver"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;kubernetes-master&quot;.*$">
     <description>Kuberentes master nodes</description>
     <example>Basic realm=&quot;kubernetes-master&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -70,6 +70,12 @@
     <param pos="0" name="os.family" value="Firewall-1"/>
     <param pos="0" name="os.product" value="Firewall-1"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;cpanel&quot;.*">
+    <description>cPanel</description>
+    <example>Basic realm=&quot;cPanel&quot;</example>
+    <param pos="0" name="service.vendor" value="cPanel"/>
+    <param pos="0" name="service.product" value="cPanel"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.APC Management Card.$">
     <description>APC device</description>
     <param pos="0" name="service.vendor" value="APC"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -318,6 +318,14 @@
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="0" name="hw.family" value="ZXHN"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;(ZXV\S* \S+)&quot;.*$">
+    <description>ZTE ZXV router</description>
+    <example hw.product="ZXV10 W300">Basic realm=&quot;ZXV10 W300&quot;</example>
+    <param pos="0" name="hw.vendor" value="ZTE"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.family" value="ZXV"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
   <!-- a variety of headers we currently just ignore -->
   <fingerprint pattern="(?i)^NTLM$">
     <description>Ignore NTLM-only</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -99,6 +99,11 @@
     <param pos="0" name="hw.device" value="Camera"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;kubernetes-master&quot;.*$">
+    <description>Kuberentes master nodes</description>
+    <example>Basic realm=&quot;kubernetes-master&quot;</example>
+    <param pos="0" name="service.vendor" value="Kubernetes"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.SpeedTouch \(([0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2})\).$">
     <description>Thomson SpeedTouch xDSL routers</description>
     <param pos="0" name="service.vendor" value="Thomson"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -73,6 +73,14 @@
     <param pos="0" name="os.product" value="Unknown"/>
     <param pos="0" name="os.device" value="Power device"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;ADSL\S* (?:Modem|Router|Modem/Router)&quot;.*$">
+    <description>Generic ADSL modems/routers</description>
+    <example>Basic realm=&quot;ADSL Modem&quot;</example>
+    <example>Basic realm=&quot;ADSL Modem/Router&quot;</example>
+    <example>Basic realm=&quot;ADSL Router&quot;</example>
+    <example>Basic realm=&quot;ADSL2+ Router&quot;</example>
+    <param pos="0" name="hw.device" value="ADSL Modem"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;DVR&quot;.*$">
     <description>Generic DVR</description>
     <example>Basic realm=&quot;DVR&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -101,6 +101,11 @@
     <example>Basic realm=&quot;Wireless Access Point&quot;</example>
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;IPCamera(?: Login)?&quot;.*$">
+    <description>Generic IP Cameras</description>
+    <example>Basic realm=&quot;IPCamera Login&quot;</example>
+    <param pos="0" name="hw.device" value="Camera"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(DCS-[^&quot;]+)&quot;.*$">
     <description>D-Link DCS IP Cameras</description>
     <example hw.product="DCS-5222LB1">Basic realm=&quot;DCS-5222LB1&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -73,6 +73,14 @@
     <param pos="0" name="os.product" value="Unknown"/>
     <param pos="0" name="os.device" value="Power device"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(DCS-[^&quot;]+)&quot;.*$">
+    <description>D-Link DCS IP Cameras</description>
+    <example hw.product="DCS-5222LB1">Basic realm=&quot;DCS-5222LB1&quot;</example>
+    <example hw.product="DCS-2530L">Basic realm=&quot;DCS-2530L&quot;</example>
+    <param pos="0" name="hw.vendor" value="D-Link"/>
+    <param pos="0" name="hw.device" value="Camera"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.SpeedTouch \(([0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2})\).$">
     <description>Thomson SpeedTouch xDSL routers</description>
     <param pos="0" name="service.vendor" value="Thomson"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -173,6 +173,13 @@
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TP-LINK IP-Camera&quot;.*$">
+    <description>TP-LINK IP-Cameras</description>
+    <example>Basic realm=&quot;TP-LINK IP-Camera&quot;</example>
+    <param pos="0" name="hw.vendor" value="TP-Link"/>
+    <param pos="0" name="hw.device" value="Camera"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest) .*realm=&quot;Broadcom Management Service&quot;.*$">
     <description>Supposedly part of Broadcom Advanced Control Suite 3 (BACS3) or something similar</description>
     <example>Digest qop="auth", realm="Broadcom Management Service", nonce="AAAAAAAAAAAAAP//DwHpMwYy1zc=", algorithm="MD5"</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -226,6 +226,12 @@
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;UBEE&quot;.*$">
+    <description>Ubee Cable Modems</description>
+    <example>Digest qop=&quot;auth&quot;, realm=&quot;Ubee&quot;, nonce=&quot;1544738973&quot;</example>
+    <param pos="0" name="hw.vendor" value="Ubee"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;XDB&quot;$">
     <description>Web server providing web services for Oracle's XML DB.</description>
     <example>Basic realm="XDB"</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -73,6 +73,11 @@
     <param pos="0" name="os.product" value="Unknown"/>
     <param pos="0" name="os.device" value="Power device"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;DVR&quot;.*$">
+    <description>Generic DVR</description>
+    <example>Basic realm=&quot;DVR&quot;</example>
+    <param pos="0" name="hw.device" value="DVR"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(DCS-[^&quot;]+)&quot;.*$">
     <description>D-Link DCS IP Cameras</description>
     <example hw.product="DCS-5222LB1">Basic realm=&quot;DCS-5222LB1&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -336,11 +336,13 @@
     <description>Ignore Negotiate-only</description>
     <example>Negotiate</example>
   </fingerprint>
-  <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;(?:\.|null)?&quot;">
-    <description>Ignore null/empty/period</description>
+  <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;(?:/|\.|null|index.html?)?&quot;">
+    <description>Ignore null/empty/period/index.</description>
     <example>Basic realm="null"</example>
     <example>Basic realm="."</example>
     <example>Basic realm=""</example>
+    <example>Basic realm="/"</example>
+    <example>Basic realm="index.html"</example>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)&quot;.*$">
     <description>Ignore realms with an IPv4 address</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -290,9 +290,11 @@
     <description>Ignore Negotiate-only</description>
     <example>Negotiate</example>
   </fingerprint>
-  <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;null&quot;">
-    <description>Ignore null</description>
+  <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;(?:\.|null)?&quot;">
+    <description>Ignore null/empty/period</description>
     <example>Basic realm="null"</example>
+    <example>Basic realm="."</example>
+    <example>Basic realm=""</example>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) .*realm=&quot;(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)&quot;.*$">
     <description>Ignore realms with an IPv4 address</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -164,6 +164,15 @@
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TP-LINK.*Router.*&quot;.*$">
+    <description>TP-LINK Routers</description>
+    <example>Basic realm=&quot;TP-LINK Wireless N Router WR841N&quot;</example>
+    <example>Basic realm=&quot;TP-LINK Gigabit Broadband VPN Router R600VPN&quot;</example>
+    <example>Basic realm=&quot;TP-LINK Wireless Lite N Router WR740N/WR741ND&quot;</example>
+    <param pos="0" name="hw.vendor" value="TP-Link"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest) .*realm=&quot;Broadcom Management Service&quot;.*$">
     <description>Supposedly part of Broadcom Advanced Control Suite 3 (BACS3) or something similar</description>
     <example>Digest qop="auth", realm="Broadcom Management Service", nonce="AAAAAAAAAAAAAP//DwHpMwYy1zc=", algorithm="MD5"</example>
@@ -218,15 +227,6 @@
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
-  </fingerprint>
-  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TP-LINK.*Router.*&quot;.*$">
-    <description>TP-LINK Routers</description>
-    <example>Basic realm=&quot;TP-LINK Wireless N Router WR841N&quot;</example>
-    <example>Basic realm=&quot;TP-LINK Gigabit Broadband VPN Router R600VPN&quot;</example>
-    <example>Basic realm=&quot;TP-LINK Wireless Lite N Router WR740N/WR741ND&quot;</example>
-    <param pos="0" name="hw.vendor" value="TP-Link"/>
-    <param pos="0" name="hw.device" value="Router"/>
-    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;UBEE&quot;.*$">
     <description>Ubee Cable Modems</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -123,6 +123,14 @@
     <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="0" name="os.product" value="Home Gateway"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;EchoLife .*&quot;.*$">
+    <description>Huawei EchoLife Home Gateways</description>
+    <example>Basic realm=&quot;EchoLife Portal de Inicio&quot;</example>
+    <example>Basic realm=&quot;EchoLife Home Gateway&quot;</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+    <param pos="0" name="os.product" value="EchoLife Home Gateway"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.WRT54G.$">
     <description>Linksys WRT54G wireless access point
          (dozen of variants of the product)</description>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -81,6 +81,11 @@
     <example>Basic realm=&quot;ADSL2+ Router&quot;</example>
     <param pos="0" name="hw.device" value="ADSL Modem"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;Broadband Router&quot;.*$">
+    <description>Generic Broadband modems/routers</description>
+    <example>Basic realm=&quot;Broadband Router&quot;</example>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;DSL\S* (?:Modem|Router|Modem/Router)&quot;.*$">
     <description>Generic DSL modems/routers</description>
     <example>Basic realm=&quot;DSL Modem&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -114,6 +114,13 @@
     <param pos="1" name="os.product"/>
     <param pos="2" name="host.mac"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest).*realm=&quot;Thomson(?: Gateway)?&quot;.*$">
+    <description>Thomson generic devices</description>
+    <example>Digest realm=&quot;Thomson Gateway&quot;</example>
+    <example>Basic realm=&quot;Thomson&quot;</example>
+    <param pos="0" name="hw.vendor" value="Thomson"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.(?:SmartAX )?(MT\d+[^ ]*)(?: ADSL Router)?.$">
     <description>Huawei xDSL routers</description>
     <param pos="0" name="service.vendor" value="Huawei"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -81,6 +81,11 @@
     <example>Basic realm=&quot;ADSL2+ Router&quot;</example>
     <param pos="0" name="hw.device" value="ADSL Modem"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;DSL\S* (?:Modem|Router|Modem/Router)&quot;.*$">
+    <description>Generic DSL modems/routers</description>
+    <example>Basic realm=&quot;DSL Modem&quot;</example>
+    <param pos="0" name="hw.device" value="DSL Modem"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;DVR&quot;.*$">
     <description>Generic DVR</description>
     <example>Basic realm=&quot;DVR&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -91,6 +91,11 @@
     <example>Basic realm=&quot;DVR&quot;</example>
     <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;Wireless Access Point&quot;.*$">
+    <description>Generic WAP</description>
+    <example>Basic realm=&quot;Wireless Access Point&quot;</example>
+    <param pos="0" name="hw.device" value="WAP"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(DCS-[^&quot;]+)&quot;.*$">
     <description>D-Link DCS IP Cameras</description>
     <example hw.product="DCS-5222LB1">Basic realm=&quot;DCS-5222LB1&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -250,6 +250,11 @@
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;SERCOMM CPE Authentication&quot;.*$">
+    <description>Assorted Sercomm CPE devices</description>
+    <example>Digest realm="SERCOMM CPE Authentication"</example>
+    <param pos="0" name="hw.vendor" value="Sercomm"/>
+  </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;UBEE&quot;.*$">
     <description>Ubee Cable Modems</description>
     <example>Digest qop=&quot;auth&quot;, realm=&quot;Ubee&quot;, nonce=&quot;1544738973&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -226,6 +226,15 @@
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TP-LINK.*Router.*&quot;.*$">
+    <description>TP-LINK Routers</description>
+    <example>Basic realm=&quot;TP-LINK Wireless N Router WR841N&quot;</example>
+    <example>Basic realm=&quot;TP-LINK Gigabit Broadband VPN Router R600VPN&quot;</example>
+    <example>Basic realm=&quot;TP-LINK Wireless Lite N Router WR740N/WR741ND&quot;</example>
+    <param pos="0" name="hw.vendor" value="TP-Link"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
   <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;UBEE&quot;.*$">
     <description>Ubee Cable Modems</description>
     <example>Digest qop=&quot;auth&quot;, realm=&quot;Ubee&quot;, nonce=&quot;1544738973&quot;</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -54,6 +54,10 @@
     <param pos="0" name="os.version" value="12"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:12"/>
   </fingerprint>
+  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;Cisco_CCSP_CWMP_TCPCR&quot;.*$">
+    <description>Generic Cisco CWMP/CPE equipment</description>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+  </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.FW-1.      Reason: no user      Server .$">
     <description>Check Point FireWall-1</description>
     <param pos="0" name="service.vendor" value="Check Point"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1379,7 +1379,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="760 Series"/>
     <param pos="0" name="os.product" value="761"/>
-    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="os.device" value="Broadband router"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Cisco Systems, Inc\./VPN 3000 Concentrator(?: Series)? Version (\S+) built.*$">
@@ -4411,7 +4411,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Netopia R9100 v4.8.2</example>
     <param pos="0" name="os.vendor" value="Netopia"/>
     <param pos="0" name="os.family" value="Netopia"/>
-    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="os.device" value="Broadband router"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -6553,20 +6553,20 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Prestige 642R-13</example>
     <param pos="0" name="os.vendor" value="ZyXEL"/>
     <param pos="0" name="os.product" value="Prestige 642R-13"/>
-    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="os.device" value="Broadband router"/>
   </fingerprint>
   <fingerprint pattern="^Prestige 660ME-61$">
     <description>ZxXEL Prestige 660ME-61 ADSL router</description>
     <example>Prestige 660ME-61</example>
     <param pos="0" name="os.vendor" value="ZyXEL"/>
     <param pos="0" name="os.product" value="Prestige 660ME-61"/>
-    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="os.device" value="Broadband router"/>
   </fingerprint>
   <fingerprint pattern="^Prestige 650R-T3$">
     <description>ZxXEL Prestige 650R-T3 ADSL router</description>
     <example>Prestige 650R-T3</example>
     <param pos="0" name="os.vendor" value="ZyXEL"/>
     <param pos="0" name="os.product" value="Prestige 650R-T3"/>
-    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="os.device" value="Broadband router"/>
   </fingerprint>
 </fingerprints>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -986,7 +986,7 @@
       Rmxvd1BvaW50LzIyMDAgU0RTTCBbQVRNXSBSb3V0ZXIgZnAyMjAwLTEyIHYzLjAuMiBSZWFkeQpMb2dpbjog
     </example>
     <param pos="0" name="os.vendor" value="Flowpoint"/>
-    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="0" name="hw.product" value="DSL router"/>
     <param pos="1" name="hw.model"/>
     <param pos="2" name="os.version"/>
@@ -999,7 +999,7 @@
       MpIDIwMDEtMjAwMyBieSBHbG9iZXNwYW5WaXJhdGEsIEluYy4KCgpsb2dpbjog
     </example>
     <param pos="0" name="os.vendor" value="Conexant"/>
-    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^VxWorks login:">


### PR DESCRIPTION
## Description

This adds a large number of fingerprints related to the HTTP `WWW-Authenticate` header used during authentication.  These new fingerprints were taken from a variety of Sonar studies of HTTP endpoints.  This includes a lot of CPE equipment, cameras, routers, etc, plus general cleanup.  Individual chunks can be seen in the specific commits.

I've tried to stay as consistent as possible while not introducing any net-new problems here.  Also note that I'm not necessarily cleaning up all problems while here.  This was just a run through the top 100 or so big clusters of things I know we don't fingerprint.

## Motivation and Context

More fingerprints!


## How Has This Been Tested?

I've added examples for everything I added, and they all pass.

## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
