### PR TITLE
Add basic support for identifying Huawei kit in cpe

### DIFF
--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -211,6 +211,7 @@
     <param pos="0" name="os.device" value="Broadband router"/>
     <param pos="0" name="os.family" value="MT"/>
     <param pos="1" name="os.product"/>
+    <param pos="0" name="os.cpe23" value="cpe:2.3:o:huawei:-"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;HuaweiHomeGateway&quot;.*$">
     <description>Huawei Home Gateway Routers</description>
@@ -218,6 +219,7 @@
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="0" name="hw.product" value="Home Gateway"/>
+    <param pos="0" name="os.cpe23" value="cpe:2.3:o:huawei:-"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;EchoLife .*&quot;.*$">
     <description>Huawei EchoLife Home Gateways</description>
@@ -226,6 +228,7 @@
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="0" name="hw.product" value="EchoLife Home Gateway"/>
+    <param pos="0" name="os.cpe23" value="cpe:2.3:o:huawei:-"/>
   </fingerprint>
   <fingerprint pattern="^(?:Basic|Digest) realm=.WRT54G.$">
     <description>Linksys WRT54G wireless access point

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -759,6 +759,7 @@
     <param pos="0" name="os.family" value="VRP"/>
     <param pos="0" name="os.product" value="VRP"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:huawei:versatile_routing_platform:-"/>
   </fingerprint>
   <fingerprint pattern="^([\d.]+)[ _]sshlib:? (?i:GlobalScape)$">
     <description>GlobalScape SSH (which uses Bitvise sshlib)</description>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -562,6 +562,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="os.cpe23" value="cpe:2.3:o:huawei:-"/>
   </fingerprint>
   <fingerprint pattern="^(?:\r|\n)*Warning: Telnet is not a secure protocol, and it is recommended to use Stelnet.(?:(?:\r|\n)+Login authentication)?(?:\r|\n)+Username:$">
     <description>Huawei Router</description>
@@ -573,6 +574,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="os.cpe23" value="cpe:2.3:o:huawei:-"/>
   </fingerprint>
   <fingerprint pattern="^(?:\r|\n)*(?:% Password expiration warning.\r\n)?-+\r\nCisco Configuration Professional \(Cisco CP\) is installed on this device. \r\nThis feature requires the one-time use of the username">
     <description>Cisco router - Cisco Configuration Pro  variant</description>


### PR DESCRIPTION
## Description

While not perfect, `http_wwwauth.xml`, `ssh_banners.xml`, `telnet_banners.xml` will now enable measuring exposure of Huawei router-ish devices on well-known ports. 

## Motivation and Context

Needed primarily for CyberThreatAlliance "Edge" collab research paper but will be valuable for other research.

## How Has This Been Tested?

xmllint shows no errors and syntax matches other CPE

## Types of changes

Addition of basic CPE to Huawei signatures in three files

## Checklist:

- [X] I have updated the documentation accordingly (or changes are not required).
- [X] I have added tests to cover my changes (or new tests are not required).
- [X] All new and existing tests passed.
