### PR TITLE
Improve Huawei coverage in SIP, SSH, UPnP

### DIFF
--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -101,6 +101,14 @@
     <param pos="0" name="hw.product" value="DuraFon"/>
     <param pos="0" name="hw.device" value="VoIP"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^Huawei (SoftX\d+) (?:V\d.*)$">
+    <description>Huawei Softswitch</description>
+    <example hw.model="SoftX3000">Huawei SoftX3000 V300R006</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.device" value="Telecom"/>
+    <param pos="0" name="hw.product" value="Softswitch"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
   <fingerprint pattern="^M5T SIP(?: Stack|-UA SAFE)/v?([\d\.]+)">
     <description>Media5 Corporation SIP Stack</description>
     <example service.version="4.1.2.2">M5T SIP Stack/4.1.2.2</example>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -109,6 +109,11 @@
     <param pos="0" name="hw.product" value="Softswitch"/>
     <param pos="1" name="hw.model"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^SIP/1.0 \(Huawei\)$">
+    <description>Huawei generic</description>
+    <example>SIP/1.0 (Huawei)</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+  </fingerprint>
   <fingerprint pattern="^M5T SIP(?: Stack|-UA SAFE)/v?([\d\.]+)">
     <description>Media5 Corporation SIP Stack</description>
     <example service.version="4.1.2.2">M5T SIP Stack/4.1.2.2</example>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -89,10 +89,17 @@
   <fingerprint pattern="(?i)^Huawei-EchoLife (HG.*)/V(?:\d.*)$">
     <description>Huawei EchoLife Home Gateway</description>
     <example hw.model="HG8121H">HUAWEI-EchoLife HG8121H/V3R018C00S110</example>
-    <example hw.model="">HUAWEI-850A/V100R001C01</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.device" value="Broadband router"/>
     <param pos="0" name="hw.product" value="EchoLife Home Gateway"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+  <fingerprint pattern="(?i)^Huawei (SoftX\d+) (?:V\d.*)$">
+    <description>Huawei Softswitch</description>
+    <example hw.model="SoftX3000">Huawei SoftX3000 V300R010</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.device" value="Telecom"/>
+    <param pos="0" name="hw.product" value="Softswitch"/>
     <param pos="1" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="^Mitel-(\S+)-SIP-Phone ([\d\.]+) (.{12})$">

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -73,6 +73,23 @@
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
+   <!-- Huawei devices -->
+   <fingerprint pattern="(?i)^Huawei-HomeGateway/V(?:\d.*)$">
+    <description>Huawei Home Gateway</description>
+    <example>Huawei-HomeGateway/V100R001</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+    <param pos="0" name="hw.product" value="Home Gateway"/>
+  </fingerprint>
+  <fingerprint pattern="(?i)^Huawei-EchoLife (HG.*)/V(?:\d.*)$">
+    <description>Huawei EchoLife Home Gateway</description>
+    <example hw.model="HG8121H">HUAWEI-EchoLife HG8121H/V3R018C00S110</example>
+    <example hw.model="">HUAWEI-850A/V100R001C01</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+    <param pos="0" name="hw.product" value="EchoLife Home Gateway"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
   <fingerprint pattern="^Mitel-(\S+)-SIP-Phone ([\d\.]+) (.{12})$">
     <description>Mitel SIP Phones</description>
     <example hw.product="5320" hw.version="06.05.00.11" host.mac="010203040506">Mitel-5320-SIP-Phone 06.05.00.11 010203040506</example>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -74,6 +74,11 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
    <!-- Huawei devices -->
+   <fingerprint pattern="(?i)^Huawei$">
+    <description>Huawei generic</description>
+    <example>Huawei</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+  </fingerprint>
    <fingerprint pattern="(?i)^Huawei-HomeGateway/V(?:\d.*)$">
     <description>Huawei Home Gateway</description>
     <example>Huawei-HomeGateway/V100R001</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -752,6 +752,13 @@
     <example>HUAWEI-1.5</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
   </fingerprint>
+  <fingerprint pattern="^HUAWEI-UMG(\d+)">
+    <description>Huawei Universal Media Gateway</description>
+    <example hw.model="8900">HUAWEI-UMG8900</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.product" value="Universal Media Gateway"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
   <fingerprint pattern="^HUAWEI.VRP.([\d\.]+)$">
     <description>Huawei Versatile Routing Platform (VRP)</description>
     <example os.version="3.10" service.version="3.10">HUAWEI-VRP-3.10</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -757,6 +757,7 @@
     <example hw.model="8900">HUAWEI-UMG8900</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
     <param pos="0" name="hw.product" value="Universal Media Gateway"/>
+    <param pos="0" name="hw.device" value="Telecom"/>
     <param pos="1" name="hw.model"/>
   </fingerprint>
   <fingerprint pattern="^HUAWEI.VRP.([\d\.]+)$">

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -747,9 +747,10 @@
     <param pos="0" name="os.product" value="ScreenOS"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:juniper:screenos:-"/>
   </fingerprint>
-  <fingerprint pattern="^(?:HUAWEI-VRP-?|VRP-)(.*)$">
+  <fingerprint pattern="^HUAWEI.VRP.([\d\.]+)$">
     <description>Huawei Versatile Routing Platform (VRP)</description>
     <example os.version="3.10" service.version="3.10">HUAWEI-VRP-3.10</example>
+    <example os.version="8.0" service.version="8.0">HUAWEI_VRPV8.0</example>
     <param pos="0" name="service.vendor" value="Huawei"/>
     <param pos="0" name="service.family" value="VRP"/>
     <param pos="0" name="service.product" value="VRP"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -747,6 +747,11 @@
     <param pos="0" name="os.product" value="ScreenOS"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:juniper:screenos:-"/>
   </fingerprint>
+  <fingerprint pattern="^HUAWEI-(?:[\d\.]+)$">
+    <description>Huawei generic</description>
+    <example>HUAWEI-1.5</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+  </fingerprint>
   <fingerprint pattern="^HUAWEI.VRP.([\d\.]+)$">
     <description>Huawei Versatile Routing Platform (VRP)</description>
     <example os.version="3.10" service.version="3.10">HUAWEI-VRP-3.10</example>

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -49,6 +49,12 @@
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>
+  <fingerprint pattern="(?i)Linux UPnP/\d\.\d Huawei-ATP-IGD$">
+    <description>Huawei Echolife / Home Gateway (and possibly other) devices with UPnP</description>
+    <example>Linux UPnP/1.0 Huawei-ATP-IGD</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="hw.device" value="Broadband router"/>
+  </fingerprint>
   <fingerprint pattern="(?i)^OpenWRT/kamikaze UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>OpenWRT Kamikaze WAP UPnP Server</description>
     <example>OpenWRT/kamikaze UPnP/1.0 MiniUPnPd/1.5</example>


### PR DESCRIPTION
## Description

Using recent Sonar data for SIP, SSH and UPnP, I've updated the coverage of Huawei products in recog.  It was something I had meant to come back to after recent Huawei Home Gateway / Echolife updates in similar/other databases.

@brudis-r7

## Motivation and Context

Better fingerprints


## How Has This Been Tested?

GPR

## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
