### PR TITLE
Add SMB fingerprints for Mikrotik, Netreon, EMC Cellera and Apple devices

### DIFF
--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -50,4 +50,12 @@
     <example>Netreon LANMAN 1.0</example>
     <param pos="0" name="service.vendor" value="Netreon"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^MikrotikSMB$">
+    <description>Mikrotik</description>
+    <example>MikrotikSMB</example>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.family" value="RouterOS"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -45,4 +45,9 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:samba:samba:{service.version}"/>
   </fingerprint>
+  <fingerprint pattern="^Netreon LANMAN 1.0$">
+    <description>Netreon SAN software</description>
+    <example>Netreon LANMAN 1.0</example>
+    <param pos="0" name="service.vendor" value="Netreon"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -474,6 +474,11 @@
     <param pos="0" name="hw.device" value="Storage"/>
     <param pos="0" name="hw.product" value="Celerra"/>
   </fingerprint>
+  <fingerprint pattern="^Netreon OS 1.0$">
+    <description>Netreon SAN software</description>
+    <example>Netreon OS 1.0</example>
+    <param pos="0" name="service.vendor" value="Netreon"/>
+  </fingerprint>
   <!-- VisionFS -->
   <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ai(\d{4})">
     <description>AIX</description>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -456,9 +456,23 @@
   </fingerprint>
   <fingerprint pattern="^Apple Base Station$">
     <description>SMB exposed via SMB shared USB disks on Apple devices</description>
-    <example os.version="4" os.version.version="5" os.version.version.version="0">Apple Base Station</example>
+    <example>Apple Base Station</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
+  </fingerprint>
+  <fingerprint pattern="^EMC-SNAS:T([\d\.]+)?$">
+    <description>EMC Celerra</description>
+    <example service.version="7.1.80.7">EMC-SNAS:T7.1.80.7</example>
+    <param pos="0" name="service.vendor" value="EMC"/>
+    <param pos="0" name="service.product" value="Celerra"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="os.vendor" value="EMC"/>
+    <param pos="0" name="os.device" value="Storage"/>
+    <param pos="0" name="os.product" value="Celerra"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="EMC"/>
+    <param pos="0" name="hw.device" value="Storage"/>
+    <param pos="0" name="hw.product" value="Celerra"/>
   </fingerprint>
   <!-- VisionFS -->
   <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ai(\d{4})">

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -454,6 +454,12 @@
     <param pos="2" name="os.version.version"/>
     <param pos="3" name="os.version.version.version"/>
   </fingerprint>
+  <fingerprint pattern="^Apple Base Station$">
+    <description>SMB exposed via SMB shared USB disks on Apple devices</description>
+    <example os.version="4" os.version.version="5" os.version.version.version="0">Apple Base Station</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+  </fingerprint>
   <!-- VisionFS -->
   <fingerprint pattern="^(?:ax|i3|m8|mp|pa|pp|rs|sp)ai(\d{4})">
     <description>AIX</description>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -650,6 +650,14 @@
     <param pos="0" name="service.product" value="VisionFS"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
+  <fingerprint pattern="(?i)^MikrotikSMB$">
+    <description>Mikrotik</description>
+    <example>MikrotikSMB</example>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.family" value="RouterOS"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+  </fingerprint>
   <fingerprint pattern="^(?i:unix)$">
     <description>Generally some Samba variant, which reports Unix</description>
     <example>Unix</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -650,14 +650,6 @@
     <param pos="0" name="service.product" value="VisionFS"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="(?i)^MikrotikSMB$">
-    <description>Mikrotik</description>
-    <example>MikrotikSMB</example>
-    <param pos="0" name="os.vendor" value="MikroTik"/>
-    <param pos="0" name="os.device" value="Router"/>
-    <param pos="0" name="os.family" value="RouterOS"/>
-    <param pos="0" name="os.product" value="RouterOS"/>
-  </fingerprint>
   <fingerprint pattern="^(?i:unix)$">
     <description>Generally some Samba variant, which reports Unix</description>
     <example>Unix</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5384,7 +5384,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="1" name="os.product"/>
   </fingerprint>
   <!--======================================================================
-                              Mikrotik
+                              MikroTik
    =======================================================================-->
   <fingerprint pattern="^RouterOS (RB.*)$">
     <description>Miktorik RouterOS</description>
@@ -5404,7 +5404,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>RouterOS RB751G-2HnD</example>
     <example>RouterOS RB800</example>
     <example>RouterOS RB951-2n</example>
-    <param pos="0" name="os.vendor" value="Mikrotik"/>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
     <param pos="0" name="os.family" value="RouterOS"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -5414,7 +5414,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>RouterOS </example>
     <example>RouterOS x86</example>
     <example>RouterOS x86 </example>
-    <param pos="0" name="os.vendor" value="Mikrotik"/>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
     <param pos="0" name="os.family" value="RouterOS"/>
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>

--- a/xml/upnp_banners.xml
+++ b/xml/upnp_banners.xml
@@ -555,7 +555,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^RouterOS/(\S+)UPnP/1.0 MikroTik UPnP/1.0$">
-    <description>Mikrotik RouterOS</description>
+    <description>MikroTik RouterOS</description>
     <example os.version="6.43">RouterOS/6.43UPnP/1.0 MikroTik UPnP/1.0</example>
     <param pos="0" name="os.vendor" value="MikroTik"/>
     <param pos="0" name="os.device" value="Router"/>


### PR DESCRIPTION
## Description

This updates the SMB fingerprints for various products as seen in recent Sonar studies.

## Motivation and Context

More fingerprints, higher quality.

## How Has This Been Tested?

GPRs with examples

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
