### PR TITLE
Add AWS ELB fingerprint

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2288,6 +2288,13 @@
     <param pos="0" name="service.vendor" value="Amazon"/>
     <param pos="0" name="service.product" value="Snowball"/>
   </fingerprint>
+  <fingerprint pattern="^awselb/([\d.rc]+)$">
+    <description>Amazon Elastic Load Balancing</description>
+    <example service.version="2.0">awselb/2.0</example>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.product" value="Elastic Load Balancing"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
   <fingerprint pattern="^cloudflare(?:-nginx)?$">
     <description>CloudFlare web load balancer endpoint</description>
     <example>cloudflare-nginx</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2292,7 +2292,7 @@
     <description>Amazon Elastic Load Balancing</description>
     <example service.version="2.0">awselb/2.0</example>
     <param pos="0" name="service.vendor" value="Amazon"/>
-    <param pos="0" name="service.product" value="Elastic Load Balancing"/>
+    <param pos="0" name="service.family" value="Elastic Load Balancing"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^cloudflare(?:-nginx)?$">


### PR DESCRIPTION
## Description
Added a new fingerprint to http server header field, based on a server header I saw in the wild:
awselb/2.0

Links to forums to people who have also seen the header:
https://forums.aws.amazon.com/thread.jspa?threadID=239290
https://www.reddit.com/r/aws/comments/9rl50j/elb_possible_to_suppress_server_awselb20_header/

## Motivation and Context
Seen in the wild thought it be a small add.


## How Has This Been Tested?
Locally:
```
$ echo 'awselb/2.0' | ./bin/recog_match xml/http_servers.xml
MATCH: {"matched"=>"Amazon Elastic Load Balancing", "service.vendor"=>"Amazon", "service.product"=>"Elastic Load Balancing", "service.version"=>"2.0", "service.protocol"=>"http", "fingerprint_db"=>"http_header.server", "data"=>"awselb/2.0"}

```

& results of  ```rake tests```

```
9 scenarios (9 passed)
20 steps (20 passed)
0m3.847s
```

## Types of changes
Added a new xml snippet



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [X ] I have updated the documentation accordingly (or changes are not required).
- [ Not required] I have added tests to cover my changes (or new tests are not required).
- [ X] All new and existing tests passed.

