### PR TITLE
Add fingerprinting for HTML titles

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1233,7 +1233,6 @@ more text</example>
     <param pos="0" name="service.cpe23" value="cpe:/a:bftpd_project:bftpd:{service.version}"/>
     <param pos="2" name="host.ip"/>
   </fingerprint>
-
   <fingerprint pattern="^NASFTPD Turbo station (?:2.x )?([\w.]+) Server \(ProFTPD\)(?: \[([a-f\d.:]+)\])?$">
     <description>ProFTPD on QNAP Turbo Station NAS</description>
     <example service.version="1.3.5a" host.ip="192.168.1.100">NASFTPD Turbo station 1.3.5a Server (ProFTPD) [192.168.1.100]</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints matches="http.html_title" protocol="http" database_type="service" preference="0.90">
+<fingerprints protocol="http" database_type="service" preference="0.90">
   <!-- HTML Title elements found in HTTP response bodies are matched against these patterns to fingerprint HTTP servers. -->
   <fingerprint pattern="^(.*)&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation$">
     <description>Synology DiskStation</description>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -26,9 +26,15 @@
     <param pos="0" name="hw.family" value="FortiGate"/>
     <param pos="0" name="hw.device" value="Firewall"/>
   </fingerprint>
+  <!-- Various products by Ubiquiti networks -->
   <fingerprint pattern="^Ubiquiti Networks$">
-    <description>Various products by Ubiquiti Networks</description>
+    <description>Generic products by Ubiquiti Networks</description>
     <example>Ubiquiti Networks</example>
+    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
+  </fingerprint>
+  <fingerprint pattern="^EdgeOS$">
+    <description>Ubiquiti EdgeRouter/EdgeSwitch/etc</description>
+    <example>EdgeOS</example>
     <param pos="0" name="hw.vendor" value="Ubiquiti"/>
   </fingerprint>
   <fingerprint pattern="^UniFi Video$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fingerprints protocol="http" database_type="service" preference="0.90">
+<fingerprints matches="html_title" database_type="service" preference="0.90">
   <!-- HTML Title elements found in HTTP response bodies are matched against these patterns to fingerprint HTTP servers. -->
   <fingerprint pattern="^(.*)&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation$">
     <description>Synology DiskStation</description>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fingerprints matches="http.html_title" protocol="http" database_type="service" preference="0.90">
+  <!-- HTML Title elements found in HTTP response bodies are matched against these patterns to fingerprint HTTP servers. -->
+  <fingerprint pattern="^Ubiquiti Networks$">
+    <description>Various products by Ubiquiti Networks</description>
+    <example>Ubiquiti Networks</example>
+    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
+  </fingerprint>
+  <fingerprint pattern="^(.*)&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation$">
+    <description>Synology DiskStation</description>
+    <example host.name="DiskStation">DiskStation&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
+    <param pos="0" name="hw.vendor" value="Synology"/>
+    <param pos="0" name="hw.family" value="DiskStation"/>
+    <param pos="0" name="hw.device" value="NAS"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+</fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -8,6 +8,10 @@
     <param pos="0" name="hw.vendor" value="Synology"/>
     <param pos="0" name="hw.family" value="DiskStation"/>
     <param pos="0" name="hw.device" value="NAS"/>
+    <param pos="0" name="os.device" value="NAS"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="DSM"/>
+    <param pos="0" name="os.vendor" value="Synology"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^Web Filter Block Override$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -32,4 +32,12 @@
     <param pos="0" name="hw.vendor" value="MikroTik"/>
     <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>
+  <fingerprint pattern="^Welcome to nginx!$">
+    <description>Default OS-agnostic nginx</description>
+    <example>Welcome to nginx!</example>
+    <param pos="0" name="service.product" value="nginx"/>
+    <param pos="0" name="service.family" value="nginx"/>
+    <param pos="0" name="service.vendor" value="nginx"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -10,6 +10,18 @@
     <param pos="0" name="hw.device" value="NAS"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
+  <fingerprint pattern="^Web Filter Block Override$">
+    <description>Fortinet FortiGate/Fortiguard Web Filter</description>
+    <example>Web Filter Block Override</example>
+    <param pos="0" name="os.vendor" value="Fortinet"/>
+    <param pos="0" name="os.family" value="FortiOS"/>
+    <param pos="0" name="os.product" value="FortiOS"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fortinet:fortios:-"/>
+    <param pos="0" name="hw.vendor" value="Fortinet"/>
+    <param pos="0" name="hw.family" value="FortiGate"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+  </fingerprint>
   <fingerprint pattern="^Ubiquiti Networks$">
     <description>Various products by Ubiquiti Networks</description>
     <example>Ubiquiti Networks</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -9,6 +9,7 @@
   <fingerprint pattern="^(.*)&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation$">
     <description>Synology DiskStation</description>
     <example host.name="DiskStation">DiskStation&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
+    <example host.name="DS218">DS218&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
     <param pos="0" name="hw.vendor" value="Synology"/>
     <param pos="0" name="hw.family" value="DiskStation"/>
     <param pos="0" name="hw.device" value="NAS"/>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fingerprints matches="http.html_title" protocol="http" database_type="service" preference="0.90">
   <!-- HTML Title elements found in HTTP response bodies are matched against these patterns to fingerprint HTTP servers. -->
-  <fingerprint pattern="^Ubiquiti Networks$">
-    <description>Various products by Ubiquiti Networks</description>
-    <example>Ubiquiti Networks</example>
-    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
-  </fingerprint>
   <fingerprint pattern="^(.*)&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation$">
     <description>Synology DiskStation</description>
     <example host.name="DiskStation">DiskStation&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
@@ -14,5 +9,17 @@
     <param pos="0" name="hw.family" value="DiskStation"/>
     <param pos="0" name="hw.device" value="NAS"/>
     <param pos="1" name="host.name"/>
+  </fingerprint>
+  <fingerprint pattern="^Ubiquiti Networks$">
+    <description>Various products by Ubiquiti Networks</description>
+    <example>Ubiquiti Networks</example>
+    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
+  </fingerprint>
+  <fingerprint pattern="^UniFi Video$">
+    <description>Various UniFi Video products by Ubiquiti Networks</description>
+    <example>UniFi Video</example>
+    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
+    <param pos="0" name="hw.family" value="UniFi"/>
+    <param pos="0" name="hw.device" value="Web cam"/>
   </fingerprint>
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -22,4 +22,14 @@
     <param pos="0" name="hw.family" value="UniFi"/>
     <param pos="0" name="hw.device" value="Web cam"/>
   </fingerprint>
+  <fingerprint pattern="^RouterOS router configuration page$">
+    <description>MikroTik RouterOS router configuration page</description>
+    <example>RouterOS router configuration page</example>
+    <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:mikrotik:routeros:-"/>
+    <param pos="0" name="hw.vendor" value="MikroTik"/>
+    <param pos="0" name="hw.device" value="Router"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -25,6 +25,7 @@
     <param pos="0" name="os.vendor" value="CentOS"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:centos:centos:-"/>
   </fingerprint>
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -73,13 +73,13 @@
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-   <!-- Huawei devices -->
-   <fingerprint pattern="(?i)^Huawei$">
+  <!-- Huawei devices -->
+  <fingerprint pattern="(?i)^Huawei$">
     <description>Huawei generic</description>
     <example>Huawei</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
   </fingerprint>
-   <fingerprint pattern="(?i)^Huawei-HomeGateway/V(?:\d.*)$">
+  <fingerprint pattern="(?i)^Huawei-HomeGateway/V(?:\d.*)$">
     <description>Huawei Home Gateway</description>
     <example>Huawei-HomeGateway/V100R001</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -57,5 +57,6 @@
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="RouterOS"/>
     <param pos="0" name="os.product" value="RouterOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:mikrotik:routeros:-"/>
   </fingerprint>
 </fingerprints>


### PR DESCRIPTION
## Description

This adds a new fingerprint database to recog that can be used to fingerprint based on the `Title` element present in HTML HTTP responses.  This adds just a few examples to get approval on the general idea as suggested by @hdm and others and we can add more in future PRs.

## Motivation and Context

This provides some great opportunities to fingerprint devices where other HTTP methods suffer.  


## How Has This Been Tested?

I've added tests for everything new.

## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
