### PR TITLE
RCG-30: Description deduplication

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -260,9 +260,8 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Microsoft-WinCE/(\d\.\d+)$">
-    <description>Windows CE embedded devices, including HP iPAQ,
-      Palm Treo, Motorola phones, and many more</description>
-    <example>Microsoft-WinCE/4.10</example>
+    <description>Windows CE embedded devices, including HP iPAQ, Palm Treo, Motorola phones, and many more</description>
+    <example os.version="4.10">Microsoft-WinCE/4.10</example>
     <example>Microsoft-WinCE/4.20</example>
     <example>Microsoft-WinCE/5.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
@@ -311,8 +310,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Apache[ -]Coyote/(\d\.\d)$">
-    <description>HTTP connector for Apache Tomcat to run as a standalone
-      HTTP server</description>
+    <description>HTTP connector for Apache Tomcat to run as a standalone HTTP server - Coyote variant</description>
     <example>Apache-Coyote/1.1</example>
     <example>Apache Coyote/1.0</example>
     <param pos="0" name="service.vendor" value="Apache"/>
@@ -333,7 +331,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:-"/>
   </fingerprint>
   <fingerprint pattern="^Servlet [\d\.]+; JBoss-(\S+) \(build: .*\)/Tomcat-(\S+)$">
-    <description>JBoss with embedded tomcat</description>
+    <description>JBoss with embedded Tomcat</description>
     <example service.version="4.0.4.GA" service.component.version="5.5">Servlet 2.4; JBoss-4.0.4.GA (build: CVSTag=JBoss_4_0_4_GA date=200605151000)/Tomcat-5.5</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
@@ -346,7 +344,7 @@
     <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:{service.component.version}"/>
   </fingerprint>
   <fingerprint pattern="^Servlet [\d\.]+; Tomcat-(\S+)/JBoss-(\S+) \(build: .*\)$">
-    <description>JBoss with embedded tomcat</description>
+    <description>JBoss with embedded Tomcat - Tomcat build variant</description>
     <example service.version="4.0.1sp1" service.component.version="5.0.28">Servlet 2.4; Tomcat-5.0.28/JBoss-4.0.1sp1 (build: CVSTag=JBoss_4_0_1_SP1 date=200502160314)</example>
     <param pos="0" name="service.vendor" value="Red Hat"/>
     <param pos="0" name="service.product" value="JBoss EAP"/>
@@ -388,11 +386,10 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Apache Tomcat/(\d\.[\d.]+)(?:-LE-jdk14)? \(HTTP/1.1 Connector\)$">
-    <description>HTTP connector for Apache Tomcat to run as a standalone
-      HTTP server</description>
-    <example>Apache Tomcat/4.0.6 (HTTP/1.1 Connector)</example>
-    <example>Apache Tomcat/4.1.12 (HTTP/1.1 Connector)</example>
-    <example>Apache Tomcat/4.1.27-LE-jdk14 (HTTP/1.1 Connector)</example>
+    <description>HTTP connector for Apache Tomcat to run as a standalone HTTP server - Apache variant</description>
+    <example service.version="4.0.6">Apache Tomcat/4.0.6 (HTTP/1.1 Connector)</example>
+    <example service.version="4.1.12">Apache Tomcat/4.1.12 (HTTP/1.1 Connector)</example>
+    <example service.version="4.1.27">Apache Tomcat/4.1.27-LE-jdk14 (HTTP/1.1 Connector)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="0" name="service.product" value="Tomcat"/>
@@ -403,8 +400,7 @@
     <param pos="0" name="service.component.product" value="Apache Tomcat HTTP Connector"/>
   </fingerprint>
   <fingerprint pattern="^Tomcat Web Server/(\d\.[\dA-Z.]+)(?: Final)?(?:\s\(([^\)]+)\))?$">
-    <description>HTTP connector for Apache Tomcat to run as a standalone
-      HTTP server</description>
+    <description>HTTP connector for Apache Tomcat to run as a standalone HTTP server</description>
     <example>Tomcat Web Server/3.2.2 (JSP 1.1; Servlet 2.2; Java 1.3.1; Windows 2000 5.0 x86; java.vendor=Sun Microsystems Inc.)</example>
     <example>Tomcat Web Server/3.2.2 (JSP 1.1; Servlet 2.2; Java 1.4.2_13; Windows 2003 5.2 x86; java.vendor=Sun Microsystems Inc.)</example>
     <example>Tomcat Web Server/3.1M1 (JSP 1.1; Servlet 2.2; Java 1.3.1; AIX 5.3 ppc; java.vendor=IBM Corporation)</example>
@@ -503,7 +499,7 @@
     <param pos="1" name="apache.variant.version"/>
   </fingerprint>
   <fingerprint pattern="^Oracle HTTP Server Powered by Apache/([12][\d.]*)\s*(.*)$">
-    <description>Oracle HTTP Server (powered by Apache)</description>
+    <description>Oracle HTTP Server (powered by Apache) - version string variant</description>
     <example>Oracle HTTP Server Powered by Apache/1.3.12 (Unix) ApacheJServ/1.1 mod_ssl/2.6.4 OpenSSL/0.9.5a</example>
     <example>Oracle HTTP Server Powered by Apache/1.3.19 (Unix) mod_plsql/3.0.9.8.3b PHP/4.3.10 mod_fastcgi/2.2.10 mod_perl/1.25 mod_oprocmgr/1.0</example>
     <example>Oracle HTTP Server Powered by Apache/1.3.19 (Win32) mod_ssl/2.8.1 OpenSSL/0.9.5a mod_fastcgi/2.2.10 mod_oprocmgr/1.0 mod_perl/1.25</example>
@@ -780,7 +776,7 @@
     <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>
   <fingerprint pattern="^Helix Server Version ([0-9.]*) \(win32\) \(RealServer compatible\)$">
-    <description>RealMedia Helix Server</description>
+    <description>RealMedia Helix Server - Windows</description>
     <example>Helix Server Version 9.0.4.960 (win32) (RealServer compatible)</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -792,7 +788,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Helix Server Version ([0-9.]*) \(linux-\S+\) \(RealServer compatible\)$">
-    <description>RealMedia Helix Server</description>
+    <description>RealMedia Helix Server - Linux</description>
     <example>Helix Server Version 9.0.4.960 (linux-2.2-libc6-i586-server) (RealServer compatible)</example>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -959,8 +955,7 @@
    Netscape/Sun's Application Server
    -->
   <fingerprint pattern="^Sun[ -]Java[ -]System[ /]Application[ -]Server( \d\.[\d_]+)?$">
-    <description>Sun Java System Application Server (formerly iPlanet Application Server,
-         Sun ONE Application Server)</description>
+    <description>Sun Java System Application Server (formerly iPlanet Application Server, Sun ONE Application Server)</description>
     <example>Sun-Java-System/Application-Server</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Application Server"/>
@@ -968,11 +963,10 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_application_server:{service.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Sun[ -]Java[ -]System[ /]Application[ -]Server Platform Edition( \d\.[\d_]+)?$">
-    <description>Sun Java System Application Server (formerly iPlanet Application Server,
-         Sun ONE Application Server)</description>
+  <fingerprint pattern="^Sun[ -]Java[ -]System[ /]Application[ -]Server Platform Edition (\d\.[\d_]+)?$">
+    <description>Sun Java System Application Server Platform Edition(formerly iPlanet Application Server, Sun ONE Application Server)</description>
     <example>Sun Java System Application Server Platform Edition 9.0</example>
-    <example>Sun Java System Application Server Platform Edition 9.0_01</example>
+    <example service.version="9.0_01">Sun Java System Application Server Platform Edition 9.0_01</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Application Server"/>
     <param pos="0" name="service.product" value="Java System Application Server Platform Edition"/>
@@ -995,8 +989,7 @@
    Netscape/Sun's Web Server
    -->
   <fingerprint pattern="^Netscape-Enterprise/(\d+\.[\w\s.]+)$">
-    <description>Netscape Enterprise Server (subsequently iPlanet Web Server,
-         Sun ONE Web Server, presently Sun Java System Web Server)</description>
+    <description>Netscape Enterprise Server (subsequently iPlanet Web Server, Sun ONE Web Server, presently Sun Java System Web Server)</description>
     <example>Netscape-Enterprise/3.5.1</example>
     <example>Netscape-Enterprise/3.6 SP3</example>
     <example>Netscape-Enterprise/6.0</example>
@@ -1007,8 +1000,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^(?:Sun-Java-System-Web-Server|Sun-ONE-Web-Server)/(?:\d\.[\d_]+)$">
-    <description>Sun Java System Web Server (formerly Netscape Enterprise Server, iPlanet Web
-         Server and Sun ONE Web Server)</description>
+    <description>Sun Java System Web Server (formerly Netscape Enterprise Server, iPlanet Web Server and Sun ONE Web Server)</description>
     <example>Sun-Java-System-Web-Server/7.0</example>
     <example>Sun-ONE-Web-Server/6.1</example>
     <param pos="0" name="service.vendor" value="Sun"/>
@@ -1030,10 +1022,9 @@
    there seems to be no relation between 3.54 and "3.6 Service Pack 4".
    -->
   <fingerprint pattern="^iPlanet-Web-Proxy-Server/(.*)$">
-    <description>iPlanet WebProxy Server (subsequently Sun ONE WebProxy Server,
-         presently Sun Java System Web Proxy Server)</description>
+    <description>iPlanet WebProxy Server (subsequently Sun ONE WebProxy Server, presently Sun Java System Web Proxy Server)</description>
     <example>iPlanet-Web-Proxy-Server/3.6</example>
-    <example>iPlanet-Web-Proxy-Server/3.6-SP5</example>
+    <example service.version="3.6-SP5">iPlanet-Web-Proxy-Server/3.6-SP5</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
@@ -1041,37 +1032,26 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Sun-ONE-Web-Proxy-Server/(.*)$">
-    <description>Sun ONE WebProxy Server (formerly iPlanet WebProxy Server,
-         presently Sun Java System Web Proxy Server)</description>
-    <example>Sun-ONE-Web-Proxy-Server/3.6-SP4</example>
+    <description>Sun ONE WebProxy Server (formerly iPlanet WebProxy Server, presently Sun Java System Web Proxy Server)</description>
+    <example service.version="3.6-SP4">Sun-ONE-Web-Proxy-Server/3.6-SP4</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
   </fingerprint>
-  <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/([^.]+\.[^.]+\.[^.]+)$">
-    <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server,
-         Sun ONE WebProxy Server) with full version info</description>
+  <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/(\d\.[\d.]+)$">
+    <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server, Sun ONE WebProxy Server)</description>
     <example>Sun-Java-System-Web-Proxy-Server/4.0.2</example>
-    <param pos="0" name="service.vendor" value="Sun"/>
-    <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
-    <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
-  </fingerprint>
-  <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/(?:4\.\d+)$">
-    <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server,
-         Sun ONE WebProxy Server) with partial version info</description>
     <example>Sun-Java-System-Web-Proxy-Server/4.0</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:-"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sun:java_system_web_proxy_server:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^Sun-ILOM-Web-Server/(?:\d\.[\d._]+)$">
-    <description>Sun Integrated Lights Out Manager (ILOM) usually
-      bundled with Sun Fire servers</description>
+    <description>Sun Integrated Lights Out Manager (ILOM) usually bundled with Sun Fire servers</description>
     <example>Sun-ILOM-Web-Server/1.0</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.product" value="Integrated Lights Out Manager"/>
@@ -1080,11 +1060,7 @@
     <param pos="0" name="hw.family" value="Sun Fire"/>
   </fingerprint>
   <fingerprint pattern="^HP-iLO-Server/(?:[\S]+)">
-    <description>
-        HP Integrated Lights Out Manager (iLO).  The version in the Server
-        header is the firmware version and is not currently used.  Furthermore,
-        this header value only seems to be present in iLO 4
-      </description>
+    <description>HP Integrated Lights Out Manager (iLO).  Version in the Server header (found on in iLO4) is the firmware version and is not currently used.</description>
     <example>HP-iLO-Server/1.30</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="iLO"/>
@@ -1103,7 +1079,7 @@
       Sun_WebServer/2.1
      -->
   <fingerprint pattern="^Jetty/(\d+\.[\d.]+)(?: \((.*)\))?$">
-    <description>Mort Bay Jetty</description>
+    <description>Mort Bay Jetty with info</description>
     <example>Jetty/4.0.1 (SunOS 5.8 sparc)</example>
     <example>Jetty/4.2.23 (SunOS/5.9 sparc java/1.4.2_04)</example>
     <example>Jetty/5.1.10 (Linux/2.6.12 i386 java/1.5.0_05)</example>
@@ -1127,6 +1103,7 @@
   <fingerprint pattern="^Jetty\((\S+)\)$">
     <description>Mort Bay Jetty</description>
     <example>Jetty(6.1.7)</example>
+    <example>Jetty(9.4.z-SNAPSHOT)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
     <param pos="0" name="service.family" value="Jetty"/>
@@ -1225,9 +1202,9 @@
   </fingerprint>
   <fingerprint pattern="^WebLogic (?:WebLogic )?Server (\d+\.\d+(?:\s+SP\d+)?)\s+.*$">
     <description>BEA WebLogic</description>
-    <example>WebLogic Server 8.1 SP3 Tue Jun 29 23:11:19 PDT 2004 404973</example>
-    <example>WebLogic Server 7.0 SP4 Tue Aug 12 11:22:26 PDT 2003</example>
-    <example>WebLogic WebLogic Server 6.1 SP4  11/08/2002 21:50:43 #221641</example>
+    <example service.version="8.1 SP3">WebLogic Server 8.1 SP3 Tue Jun 29 23:11:19 PDT 2004 404973</example>
+    <example service.version="7.0 SP4">WebLogic Server 7.0 SP4 Tue Aug 12 11:22:26 PDT 2003</example>
+    <example service.version="6.1 SP4">WebLogic WebLogic Server 6.1 SP4  11/08/2002 21:50:43 #221641</example>
     <param pos="0" name="service.vendor" value="BEA"/>
     <param pos="0" name="service.product" value="WebLogic"/>
     <param pos="0" name="service.family" value="WebLogic"/>
@@ -1236,8 +1213,8 @@
   </fingerprint>
   <fingerprint pattern="^WebSphere Application Server/(\d+\.\d+)$">
     <description>IBM WebSphere</description>
-    <example>WebSphere Application Server/5.0</example>
-    <example>WebSphere Application Server/6.1</example>
+    <example service.version="5.0">WebSphere Application Server/5.0</example>
+    <example service.version="6.1">WebSphere Application Server/6.1</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="WebSphere"/>
     <param pos="0" name="service.family" value="WebSphere"/>
@@ -1270,8 +1247,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Abyss/(\d\.[\d.]+)-X1-Win32 AbyssLib/(?:\d\.[\d.]+)$">
-    <description>Aprelium Technologies Abyss Web Server X1
-      (free personal edition) on Windows</description>
+    <description>Aprelium Technologies Abyss Web Server X1 (free personal edition) on Windows</description>
     <example>Abyss/2.0.0.20-X1-Win32 AbyssLib/2.0.0.20</example>
     <example>Abyss/2.3.2-X1-Win32 AbyssLib/2.3.2</example>
     <param pos="0" name="service.vendor" value="Aprelium Technologies"/>
@@ -1284,8 +1260,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
   <fingerprint pattern="^Abyss/(\d\.[\d.]+)-X2-Win32 AbyssLib/(?:\d\.[\d.]+)$">
-    <description>Aprelium Technologies Abyss Web Server X2
-      (licensed professional edition) on Windows</description>
+    <description>Aprelium Technologies Abyss Web Server X2 (licensed professional edition) on Windows</description>
     <param pos="0" name="service.vendor" value="Aprelium Technologies"/>
     <param pos="0" name="service.product" value="Abyss Web Server X1"/>
     <param pos="0" name="service.family" value="Abyss Web Server"/>
@@ -1413,9 +1388,8 @@
     <param pos="0" name="os.vendor" value="SonicWALL"/>
   </fingerprint>
   <fingerprint pattern="^NetCache appliance \(NetApp/+(\d+\.\d+[\w.]+)\)$">
-    <description>NetCache appliance (product line formerly owned by Network Appliances,
-      now owned by Blue Coat Systems).</description>
-    <example>NetCache appliance (NetApp/5.3.1R3)</example>
+    <description>NetCache appliance (product line formerly owned by Network Appliances, now owned by Blue Coat Systems).</description>
+    <example service.version="5.3.1R3">NetCache appliance (NetApp/5.3.1R3)</example>
     <example>NetCache appliance (NetApp/5.4R2D2)</example>
     <example>NetCache appliance (NetApp/5.6.1D22)</example>
     <example>NetCache appliance (NetApp/6.0.2P1)</example>
@@ -1626,9 +1600,9 @@
   </fingerprint>
   <fingerprint pattern="^EWS-NIC\d/(\S+)$">
     <description>Xerox Embedded Web Server (EWS)</description>
-    <example>EWS-NIC3/6.31</example>
-    <example>EWS-NIC4/13.40</example>
-    <example>EWS-NIC4/13.39</example>
+    <example service.version="6.31">EWS-NIC3/6.31</example>
+    <example service.version="13.40">EWS-NIC4/13.40</example>
+    <example service.version="13.39">EWS-NIC4/13.39</example>
     <param pos="0" name="service.vendor" value="Xerox"/>
     <param pos="0" name="service.family" value="EWS"/>
     <param pos="0" name="service.product" value="EWS"/>
@@ -1841,8 +1815,8 @@
    </fingerprint>
    -->
   <fingerprint pattern="^SentinelProtectionServer/((?:\d+\.)*\d+)$">
-    <description>Embedded web server in SafeNet's memory key dongles.</description>
-    <example>SentinelProtectionServer/7.1</example>
+    <description>Sentinel Protection Server - Embedded httpd in SafeNet's memory key dongles</description>
+    <example service.version="7.1">SentinelProtectionServer/7.1</example>
     <example>SentinelProtectionServer/7.3</example>
     <example>SentinelProtectionServer/7.0</example>
     <example>SentinelProtectionServer/7</example>
@@ -1852,8 +1826,8 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^SentinelKeysServer/((?:\d+\.)*\d+)$">
-    <description>Embedded web server in SafeNet's memory key dongles.</description>
-    <example>SentinelKeysServer/1.3.1</example>
+    <description>Sentinel Key Server - Embedded httpd in SafeNet's memory key dongles</description>
+    <example service.version="1.3.1">SentinelKeysServer/1.3.1</example>
     <example>SentinelKeysServer/1.0</example>
     <example>SentinelKeysServer/1</example>
     <param pos="0" name="service.vendor" value="SafeNet"/>
@@ -2097,7 +2071,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Oracle XML DB/Oracle\S+ Enterprise Edition Release ((?:\d+\.)*\d+) - Production$">
-    <description>Web server providing web services for Oracle's XML DB.</description>
+    <description>Web server providing web services for Oracle's XML DB - with version string</description>
     <example>Oracle XML DB/Oracle9i Enterprise Edition Release 9.2.0.1.0 - Production</example>
     <example>Oracle XML DB/Oracle9i Enterprise Edition Release 9 - Production</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
@@ -2106,15 +2080,14 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Oracle XML DB/Oracle Database$">
-    <description>Web server providing web services for Oracle's XML DB.</description>
+    <description>Web server providing web services for Oracle's XML DB</description>
     <example>Oracle XML DB/Oracle Database</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
     <param pos="0" name="service.product" value="XML DB"/>
     <param pos="0" name="service.family" value="Oracle"/>
   </fingerprint>
   <fingerprint pattern="^sfcHttpd$">
-    <description>Server for HTTP interface to sfcb, a lightweight CIM server.
-   </description>
+    <description>Server for HTTP interface to sfcb, a lightweight CIM server</description>
     <example>sfcHttpd</example>
     <param pos="0" name="service.vendor" value="SBLIM"/>
     <param pos="0" name="service.product" value="sfcb"/>
@@ -2221,8 +2194,7 @@
    </fingerprint>
    -->
   <fingerprint pattern="^(?:(?:\d+.){3}\d+):\d{1,4}$">
-    <description>A banner consisting of an IP address and port --
-         assert nothing.</description>
+    <description>A banner consisting of an IP address and port -- assert nothing.</description>
     <example>192.168.0.4:9999</example>
   </fingerprint>
   <fingerprint pattern="^Web-Server/(?:\d+\.+\d+)$">
@@ -2752,7 +2724,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^(\S+) \d+/Service Pack \d+, UPnP/[\d\.]+, TVersity Media Server$">
-    <description>TVersity Media Server UPnP Server</description>
+    <description>TVersity Media Server UPnP Server with Service Pack</description>
     <example>5.2.3790 2/Service Pack 1, UPnP/1.0, TVersity Media Server</example>
     <example>5.1.2600 2/Service Pack 3, UPnP/1.0, TVersity Media Server</example>
     <param pos="0" name="service.vendor" value="TVersity"/>
@@ -2781,7 +2753,7 @@
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>
   <fingerprint pattern="^Linux-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
-    <description>PlayStation3 Media Server UPnP Server</description>
+    <description>PlayStation3 Media Server UPnP Server - linux</description>
     <example>Linux-amd64-2.6.18-238.9.1.el5, UPnP/1.0, PMS/1.52.1</example>
     <example>Linux-i386-2.6.33.2, UPnP/1.0, PMS/1.21.1</example>
     <param pos="0" name="service.vendor" value="Sony"/>
@@ -2793,7 +2765,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^Windows_XP-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
-    <description>PlayStation3 Media Server UPnP Server</description>
+    <description>PlayStation3 Media Server UPnP Server - Windows XP</description>
     <example>Windows_XP-amd64-5.2, UPnP/1.0, PMS/1.54.0</example>
     <example>Windows_XP-x86-5.1, UPnP/1.0, PMS/1.20.400</example>
     <param pos="0" name="service.vendor" value="Sony"/>
@@ -2805,7 +2777,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_xp:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^Windows_7-x86-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
-    <description>PlayStation3 Media Server UPnP Server</description>
+    <description>PlayStation3 Media Server UPnP Server - Windows 7 x86</description>
     <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.20</example>
     <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.22.0</example>
     <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.25.1</example>
@@ -2834,7 +2806,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_7:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^Windows_7-x86_64-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
-    <description>PlayStation3 Media Server UPnP Server</description>
+    <description>PlayStation3 Media Server UPnP Server - Windows 7 x86_64</description>
     <param pos="0" name="service.vendor" value="Sony"/>
     <param pos="0" name="service.product" value="PMS"/>
     <param pos="2" name="service.version"/>
@@ -2851,7 +2823,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_8:-"/>
   </fingerprint>
   <fingerprint pattern="^Mac_OS_X-x86_64-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
-    <description>PlayStation3 Media Server UPnP Server</description>
+    <description>PlayStation3 Media Server UPnP Server - macOS x86_64</description>
     <example>Mac_OS_X-x86_64-10.5.8, UPnP/1.0, PMS/1.20</example>
     <param pos="0" name="service.vendor" value="Sony"/>
     <param pos="0" name="service.product" value="PMS"/>
@@ -2862,7 +2834,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^Linux/(\S+), UPnP/\S+, Free UPnP Entertainment Service/ReadyNAS$">
-    <description>Free UPnP Entertainment Service UPnP Server</description>
+    <description>Free UPnP Entertainment Service UPnP Server - Linux on ReadyNAS</description>
     <param pos="0" name="service.product" value="FUPPES"/>
     <param pos="0" name="os.vendor" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -2874,7 +2846,7 @@
     <param pos="0" name="hw.product" value="ReadyNAS"/>
   </fingerprint>
   <fingerprint pattern="^Linux/(\S+), UPnP/\S+, Free UPnP Entertainment Service/$">
-    <description>Free UPnP Entertainment Service UPnP Server</description>
+    <description>Free UPnP Entertainment Service UPnP Server - Linux</description>
     <param pos="0" name="service.product" value="FUPPES"/>
     <param pos="0" name="os.vendor" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -2882,7 +2854,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^FreeBSD/(\S+), UPnP/\S+, Free UPnP Entertainment Service/$">
-    <description>Free UPnP Entertainment Service UPnP Server</description>
+    <description>Free UPnP Entertainment Service UPnP Server - FreeBSD</description>
     <param pos="0" name="service.product" value="FUPPES"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -2934,7 +2906,7 @@
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
   <fingerprint pattern="^Linux/(\S+), UPnP/[\d\.]+, Portable SDK for UPnP devices/(\S+)$">
-    <description>Portable SDK for UPnP Server</description>
+    <description>Portable SDK for UPnP Server - Linux</description>
     <example>Linux/2.4.20-46.7asp, UPnP/1.0, Portable SDK for UPnP devices/1.6.17</example>
     <example>Linux/2.6.10-iop1-1, UPnP/1.0, Portable SDK for UPnP devices/1.4.1</example>
     <example>Linux/2.6.12-5.1-brcmstb-dm800, UPnP/1.0, Portable SDK for UPnP devices/1.6.0</example>
@@ -2960,7 +2932,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^Linux/(\S+) UPnP/[\d\.]+ DLNADOC/[\d\.]+ Portable SDK for UPnP devices/(\S+)$">
-    <description>DLNADOC Portable SDK for UPnP Server</description>
+    <description>DLNADOC Portable SDK for UPnP Server - Linux DNLADOC variant</description>
     <example>Linux/3.0.8 UPnP/1.0 DLNADOC/1.50 Portable SDK for UPnP devices/1.6.6</example>
     <example>Linux/2.6.23.17_stm23_0125dorade00 UPnP/1.0 DLNADOC/1.50 Portable SDK for UPnP devices/1.4.6-5</example>
     <param pos="0" name="service.product" value="libupnp"/>
@@ -2971,7 +2943,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^Linux/(\S+), UPnP/[\d\.]+, Intel SDK for UPnP devices ?/(\S+)$">
-    <description>Intel SDK for UPnP Server</description>
+    <description>Intel SDK for UPnP Server with verbose banner</description>
     <example>Linux/2.6.10_dev-malta-mips2_fp_le, UPnP/1.0, Intel SDK for UPnP devices /1.2</example>
     <example>Linux/2.4.18_mvl30-ixdp425, UPnP/1.0, Intel SDK for UPnP devices/1.3.1</example>
     <param pos="0" name="service.product" value="libupnp"/>
@@ -2988,8 +2960,8 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="^Darwin/(\S+), UPnP/\S+, Portable SDK for UPnP devices/(\S+)$">
-    <description>Portable SDK for UPnP Server</description>
-    <example>Darwin/10.2.0, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
+    <description>Portable SDK for UPnP Server - macOS</description>
+    <example service.version="1.6.6" os.version="10.2.0">Darwin/10.2.0, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
     <param pos="0" name="service.product" value="libupnp"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="os.vendor" value="Apple"/>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -144,7 +144,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.\d{1,2})-(?:Debian_)?\dubuntu(\d{1,2}\.\d\d)[.\d]*(?:-log)?$">
-    <description>Oracle MySQL on Ubuntu</description>
+    <description>Oracle MySQL on Ubuntu - Debian string variant</description>
     <example service.version="5.0.22" os.version="6.06">5.0.22-Debian_0ubuntu6.06.14-log</example>
     <example service.version="5.1.41" os.version="12.10">5.1.41-3ubuntu12.10</example>
     <param pos="1" name="service.version"/>
@@ -458,7 +458,7 @@
     <param pos="0" name="os.family" value="Windows"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})(?:-rc)?-enterprise" flags="REG_ICASE">
-    <description>Oracle MySQL Enterprise Edition</description>
+    <description>Oracle MySQL Enterprise Edition - variant 1</description>
     <example service.version="5.1.26">5.1.26-rc-enterprise-gpl-log</example>
     <example service.version="5.5.27">5.5.27-enterprise-commercial-advanced-log</example>
     <param pos="1" name="service.version"/>
@@ -469,7 +469,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:oracle:mysql:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-ndb-\d\.\d{1,2}\.[a-f\d]{1,3})" flags="REG_ICASE">
-    <description>Oracle MySQL Cluster Edition</description>
+    <description>Oracle MySQL Cluster Edition - nbd variant</description>
     <example service.version="5.1.30-ndb-6.3.20">5.1.30-ndb-6.3.20-cluster-gpl-log</example>
     <example service.version="5.5.20-ndb-7.2.5">5.5.20-ndb-7.2.5-gpl</example>
     <param pos="1" name="service.version"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -159,10 +159,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:pix_firewall_software:-"/>
   </fingerprint>
   <fingerprint pattern="^([^ ]+) +ESMTP CPMTA-([^ ]+)_([^ ]+)_([^ ]+)_([^ ]+) - NO UCE *$">
-    <description>Critical Path (aka InScribe) Messaging Server
-         http://www.cp.net/products/inscr_messagingserv_overview.html
-         Runs on Windows NT4/2k, Solaris 2.6, 2.7, and 2.8 Sparc/Intel, SGI IRIX 6.5.3 or later, and AIX
-      </description>
+    <description>Critical Path (aka InScribe) Messaging Server on Windows NT4/2k, Solaris 2.6/2.7/2.8 Sparc/Intel, SGI IRIX 6.5.3 or later, or AIX </description>
     <param pos="0" name="service.vendor" value="Critical Path"/>
     <param pos="0" name="service.family" value="Messaging Server"/>
     <param pos="0" name="service.product" value="Messaging Server"/>
@@ -370,11 +367,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^([^ ]+) +SMTP/smap Ready\.$">
-    <description>TIS FWTK and derivatives
-         http://www.tis.com/research/software/
-         This fingerprint may be ambiguous because other firewalls (like
-         Gauntlet) are derived from TIS
-      </description>
+    <description>TIS FWTK and derivatives (other firewalls, like Gauntlet, are derived from TIS)</description>
     <example host.name="foo.bar">foo.bar SMTP/smap Ready.</example>
     <param pos="0" name="service.vendor" value="TIS"/>
     <param pos="0" name="service.family" value="FWTK"/>
@@ -1255,7 +1248,7 @@
   </fingerprint>
   <fingerprint pattern="^([^ ]+) ESMTP MetaInfo Sendmail ([^ ]+) Build ([^ ]+) \(Berkeley ([^ ]+)\)/([^;]+); (.+)$">
     <description>Sendmail - MetaInfo</description>
-    <example>foo.bar ESMTP MetaInfo Sendmail 2.5 Build 2630 (Berkeley 8.8.6)/8.8.4; Mon, 30 Jul</example>
+    <example host.name="foo.bar" service.version="8.8.6">foo.bar ESMTP MetaInfo Sendmail 2.5 Build 2630 (Berkeley 8.8.6)/8.8.4; Mon, 30 Jul</example>
     <param pos="0" name="service.vendor" value="MetaInfo"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -38,15 +38,15 @@
   </fingerprint>
   <fingerprint pattern="^Serv-U_([\d\.]+)$">
     <description>Serv-U SSH</description>
-    <example>Serv-U_7.4.0.1</example>
+    <example service.version="7.4.0.1">Serv-U_7.4.0.1</example>
     <param pos="0" name="service.vendor" value="Rhino Software"/>
     <param pos="0" name="service.product" value="Serv-U"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
   <fingerprint pattern="WS_FTP-SSH_([\d\.]+)$">
     <description>WS_FTP Server with SSH</description>
-    <example>WS_FTP-SSH_6.1.1</example>
-    <example>WS_FTP-SSH_7.0</example>
+    <example service.version="6.1.1">WS_FTP-SSH_6.1.1</example>
+    <example service.version="7.0">WS_FTP-SSH_7.0</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="0" name="service.product" value="WS_FTP"/>
     <param pos="1" name="service.version"/>
@@ -705,8 +705,7 @@
    </fingerprint>-->
   <!-- TODO: Handle "vpn3" banners for Cisco 3000 VPN Concentrators (need example banners first) -->
   <fingerprint pattern="^Cisco-(.*)$">
-    <description>Cisco SSH banner (could be IOS or PIX).
-         The version always seems to be 1.25</description>
+    <description>Cisco SSH banner (could be IOS or PIX), The version always seems to be 1.25</description>
     <example service.version="1.25">Cisco-1.25</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="Cisco"/>
@@ -924,7 +923,7 @@
     <param pos="0" name="hw.vendor" value="Ruijie"/>
   </fingerprint>
   <fingerprint pattern="^VShell_(?:Special_Edition_)?(\d+)_(\d+)_(\d+)_(\d+) VShell$">
-    <description>VanDyke VShell</description>
+    <description>VanDyke VShell - detailed variant</description>
     <example service.version="3" service.version.version="6" service.version.version.version="2" service.version.version.version.version="446">VShell_3_6_2_446 VShell</example>
     <example service.version="2" service.version.version="5" service.version.version.version="0" service.version.version.version.version="204">VShell_Special_Edition_2_5_0_204 VShell</example>
     <param pos="1" name="service.version"/>
@@ -945,8 +944,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:vandyke:vshell:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^WRQReflection(?i:F)orSecureIT_(.*)$">
-    <description>Attachmate Reflection (formerly WRQ Reflection for Secure IT)
-      </description>
+    <description>Attachmate Reflection (formerly WRQ Reflection for Secure IT)</description>
     <example service.version="6.1 Build 21">WRQReflectionForSecureIT_6.1 Build 21</example>
     <example service.version="8.2 Build 117">WRQReflectionforSecureIT_8.2 Build 117</example>
     <param pos="1" name="service.version"/>
@@ -955,8 +953,7 @@
     <param pos="0" name="service.product" value="Reflection"/>
   </fingerprint>
   <fingerprint pattern="^([^\s]*)\s*F-Secure SSH\s*(?:.*)$">
-    <description>Attachmate Reflection (formerly F-Secure SSH)
-      </description>
+    <description>Attachmate Reflection (formerly F-Secure SSH)</description>
     <example service.version="3.2.3">3.2.3 F-Secure SSH Windows NT Server</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="Attachmate"/>
@@ -964,7 +961,7 @@
     <param pos="0" name="service.product" value="Reflection"/>
   </fingerprint>
   <fingerprint pattern="^([^\s]*)\s*SSH Tectia Server$">
-    <description>SSH Communications Security Tectia Server</description>
+    <description>SSH Communications Security Tectia Server - branded</description>
     <example service.version="6.4.12.353">6.4.12.353 SSH Tectia Server</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="SSH Communications Security"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -72,7 +72,7 @@
     <param pos="1" name="host.mac"/>
   </fingerprint>
   <fingerprint pattern="^SERIALNUMBER=PID:([^ ]+) SN:([^,]+),CN=(?:[a-zA-Z0-9\-]+)-SEP([a-fA-F0-9]{12}),OU=CTG,O=Cisco Systems Inc\.$">
-    <description>Cisco / Linksys Router</description>
+    <description>Cisco / Linksys Router with serial number</description>
     <example host.mac="B07D47D33A1C" hw.product="CP-8851" cisco.serial_number="FCH1924AHCA">SERIALNUMBER=PID:CP-8851 SN:FCH1924AHCA,CN=CP-8851-SEPB07D47D33A1C,OU=CTG,O=Cisco Systems Inc.</example>
     <param pos="0" name="hw.device" value="IP Phone"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
@@ -193,7 +193,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^CN=HP Service Processor,OU=UDU Service Tools,O=Hewlett-Packard Development Company\\, L\.P\.\\ ,L=Fremont,ST=California,C=US$">
-    <description>HP iLO</description>
+    <description>HP iLO - HP Service Processor</description>
     <example>CN=HP Service Processor,OU=UDU Service Tools,O=Hewlett-Packard Development Company\, L.P.\ ,L=Fremont,ST=California,C=US</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
@@ -221,7 +221,7 @@
     <param pos="1" name="host.mac"/>
   </fingerprint>
   <fingerprint pattern="^CN=([A-Za-z0-9\_\-\.]+),OU=Hewlett Packard Enterprise Network Management Software \(SMH\),O=Hewlett Packard Enterprise,L=Houston,ST=Texas,C=US$">
-    <description>HP iLO</description>
+    <description>HP iLO - Enterprise Mgmt variant</description>
     <example>CN=bigsrv99,OU=Hewlett Packard Enterprise Network Management Software (SMH),O=Hewlett Packard Enterprise,L=Houston,ST=Texas,C=US</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
@@ -267,7 +267,7 @@
     <param pos="0" name="os.vendor" value="Avocent"/>
   </fingerprint>
   <fingerprint pattern="^CN=Avocent Mergepoint Unity,O=Avocent Mergepoint Unity,L=Huntsville,ST=Alabama,C=US$">
-    <description>Avocent KVM</description>
+    <description>Avocent Mergepoint KVM</description>
     <example>CN=Avocent Mergepoint Unity,O=Avocent Mergepoint Unity,L=Huntsville,ST=Alabama,C=US</example>
     <param pos="0" name="hw.device" value="KVM"/>
     <param pos="0" name="hw.vendor" value="Avocent"/>
@@ -277,9 +277,9 @@
     <param pos="0" name="os.product" value="Mergepoint"/>
   </fingerprint>
   <fingerprint pattern="^CN=HP Jetdirect [a-zA-Z0-9]+,OU=([a-fA-F0-9]{12})\+OU=([a-zA-Z0-9]+),O=Hewlett-Packard Co\.$">
-    <description>HP Jet Direct</description>
-    <example>CN=HP Jetdirect 38831831,OU=2C413883186A+OU=J8028E,O=Hewlett-Packard Co.</example>
-    <example>CN=HP Jetdirect FBFA31E7,OU=8851FBE33ABB+OU=J8016E,O=Hewlett-Packard Co.</example>
+    <description>HP Jet Direct - with host MAC and product</description>
+    <example host.mac="2C413883186A" hw.product="J8028E">CN=HP Jetdirect 38831831,OU=2C413883186A+OU=J8028E,O=Hewlett-Packard Co.</example>
+    <example os.product="J8016E">CN=HP Jetdirect FBFA31E7,OU=8851FBE33ABB+OU=J8016E,O=Hewlett-Packard Co.</example>
     <param pos="0" name="hw.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="JetDirect"/>
@@ -451,7 +451,7 @@
     <param pos="0" name="hw.product" value="APIC"/>
   </fingerprint>
   <fingerprint pattern="^CN=APIC$">
-    <description>Cisco APIC</description>
+    <description>Cisco APIC - bare CN</description>
     <example>CN=APIC</example>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.product" value="APIC"/>
@@ -555,7 +555,7 @@
     <param pos="0" name="os.device" value="Appliance"/>
   </fingerprint>
   <fingerprint pattern="^CN=.*,OU=FortiManager,O=Fortinet,L=Sunnyvale,ST=California,C=US$">
-    <description>Fortinet FortiMail Appliance</description>
+    <description>Fortinet FortiManager Appliance</description>
     <example>CN=FMG-VM0000000000,OU=FortiManager,O=Fortinet,L=Sunnyvale,ST=California,C=US</example>
     <param pos="0" name="hw.vendor" value="Fortinet"/>
     <param pos="0" name="hw.device" value="Appliance"/>
@@ -587,7 +587,7 @@
     <param pos="1" name="host.mac"/>
   </fingerprint>
   <fingerprint pattern="^CN=unifi$">
-    <description>Ubiquiti Controller</description>
+    <description>Ubiquiti Controller - unifi bare</description>
     <example>CN=unifi</example>
     <param pos="0" name="hw.vendor" value="Ubiquiti"/>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
@@ -596,7 +596,7 @@
     <param pos="0" name="os.device" value="Wireless Controller"/>
   </fingerprint>
   <fingerprint pattern="^CN=UniFi,OU=UniFi,O=ubnt\.com,L=San Jose,ST=CA,C=US$">
-    <description>Ubiquiti Controller</description>
+    <description>Ubiquiti Controller - unifi</description>
     <example>CN=UniFi,OU=UniFi,O=ubnt.com,L=San Jose,ST=CA,C=US</example>
     <param pos="0" name="hw.vendor" value="Ubiquiti"/>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
@@ -755,7 +755,7 @@
     <param pos="0" name="os.family" value="Linux"/>
   </fingerprint>
   <fingerprint pattern="^CN=Canon (iR-[a-zA-Z0-9\.\-\_]+)$">
-    <description>Canon iR-ADV Printer</description>
+    <description>Canon iR-ADV Printer with product info</description>
     <example os.product="iR-ADV">CN=Canon iR-ADV</example>
     <param pos="0" name="hw.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="Canon"/>
@@ -814,7 +814,7 @@
     <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^CN=([a-fA-F0-9]{12}),O=Polycom Inc\.$">
-    <description>NEC DT Series IP Phone</description>
+    <description>Polycom SoundPoint IP Phone</description>
     <example host.mac="64167F169981">CN=64167F169981,O=Polycom Inc.</example>
     <param pos="0" name="os.vendor" value="Polycom"/>
     <param pos="0" name="os.device" value="IP Phone"/>
@@ -878,7 +878,7 @@
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
   <fingerprint pattern="^CN=axis-([a-fA-F0-9]{12}),O=Axis Communications AB$">
-    <description>OpenWRT WAP</description>
+    <description>OpenWRT WAP - Axis Communications variant</description>
     <example host.mac="accc8ea31abf">CN=axis-accc8ea31abf,O=Axis Communications AB</example>
     <param pos="0" name="hw.vendor" value="AXIS"/>
     <param pos="0" name="hw.device" value="Web Cam"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -878,7 +878,7 @@
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
   <fingerprint pattern="^CN=axis-([a-fA-F0-9]{12}),O=Axis Communications AB$">
-    <description>OpenWRT WAP - Axis Communications variant</description>
+    <description>Axis Communications Web Cam</description>
     <example host.mac="accc8ea31abf">CN=axis-accc8ea31abf,O=Axis Communications AB</example>
     <param pos="0" name="hw.vendor" value="AXIS"/>
     <param pos="0" name="hw.device" value="Web Cam"/>


### PR DESCRIPTION
## Description
This PR:

- Reduces the number of duplicate `description` fields. Duplicates in this field can cause issues when processing large number of banners and generating metrics on the fingerprint matches.
- Cleans up a few multi-line `description` fields, these are undesirable for similar metrics reasons.
- Adds a few `service.version` tests for `example` fields. Every regex should have every extracted value tested at least once. One of these new tests found an error in the regex for a fingerprint.

Expect a few more of these as time permits. I'm trying to avoid asking folks to review a wall of changes all at once.

## Motivation and Context
These changes improve the usability of `recog`


## How Has This Been Tested?
`rspec`

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
