### PR TITLE
RCG-30: Remove duplicate examples and add test

### DIFF
--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -136,7 +136,15 @@ describe Recog::DB do
             expect(fp.tests.length).to be <= 20
           end
 
+          fp_examples = []
           fp.tests.each do |example|
+            it "doesn't have a duplicate examples" do
+              if fp_examples.include?(example.content)
+                fail "'#{fp.name}' has duplicate example '#{example.content}'"
+              else
+                fp_examples << example.content
+              end
+            end
             it "Example '#{example.content}' matches this regex" do
               match = fp.match(example.content)
               expect(match).to_not be_nil, 'Regex did not match'

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -605,10 +605,7 @@ more text</example>
     <example>NRG MP 3350 FTP server (7.05) ready.</example>
     <example>NRG MP C3500 FTP server (5.17) ready.</example>
     <example>NRG MP 171 FTP server (9.02.1) ready.</example>
-    <example>NRG MP 3350 FTP server (7.05) ready.</example>
     <example>NRG MP C2550 FTP server (8.25) ready.</example>
-    <example>NRG MP C2800 FTP server (8.25) ready.</example>
-    <example>NRG MP C3500 FTP server (5.17) ready.</example>
     <example>NRG MP C3500 FTP server (5.19) ready.</example>
     <example>NRG MP C4000 FTP server (8.30) ready.</example>
     <example>NRG MP C4500 FTP server (5.14) ready.</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1152,8 +1152,7 @@
   <fingerprint pattern="^lighttpd(?:/(\d[\d.]+))?.*$">
     <description>Lighttpd</description>
     <example>lighttpd</example>
-    <example>lighttpd/1.4.16</example>
-    <example>lighttpd/1.4.16</example>
+    <example service.version="1.4.16">lighttpd/1.4.16</example>
     <example>lighttpd/1.3.7 (Mar 23 2007/16:00:15)</example>
     <param pos="0" name="service.product" value="lighttpd"/>
     <param pos="0" name="service.family" value="lighttpd"/>
@@ -2486,7 +2485,6 @@
   </fingerprint>
   <fingerprint pattern="(?i)^Netgear/\S+ UPnP/\S+ miniupnpd/(\S+)$">
     <description>Netgear DG834G or WNDR3300 WAP UPnP Server</description>
-    <example>Netgear/1.0 UPnP/1.0 miniupnpd/1.0</example>
     <example>Netgear/1.0 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.product" value="MiniUPnP"/>
     <param pos="1" name="service.version"/>

--- a/xml/mysql_error.xml
+++ b/xml/mysql_error.xml
@@ -52,7 +52,6 @@
   <fingerprint pattern="^^(?:#HY000)?Host '[^']+' is not allowed to connect to this MySQL server$$">
     <description>Oracle MySQL error ER_HOST_NOT_PRIVILEGED (eng)</description>
     <example>Host '10.10.10.10' is not allowed to connect to this MySQL server</example>
-    <example>Host '10.10.10.10' is not allowed to connect to this MySQL server</example>
     <example>#HY000Host '10.10.10.10' is not allowed to connect to this MySQL server</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
     <param pos="0" name="service.family" value="MySQL"/>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -17,7 +17,6 @@
     <example os.product="Windows Server 2008" os.edition="Enterprise" os.version="Service Pack 2">Windows Server 2008 Enterprise without Hyper-V Service Pack 2</example>
     <example os.product="Windows Server 2008" os.edition="Enterprise" os.version="SP1">Windows Server 2008 Enterprise with Hyper-V SP1</example>
     <example os.product="Windows Server 2012 R2" os.edition="Foundation">Windows Server 2012 R2 Foundation Edition</example>
-    <example os.product="Windows Storage Server 2012 R2">Windows Storage Server 2012 R2</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.product"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -879,7 +879,6 @@
     <example>ESP-4 MI V3.04</example>
     <example>ESP-8 MI V3.12b</example>
     <example>ESP-8 MI V3.13</example>
-    <example>ESP-8 MI V3.13</example>
     <example>ESP-8 MI V3.14b</example>
     <param pos="0" name="os.vendor" value="Avocent"/>
     <param pos="0" name="os.device" value="Terminal Server"/>
@@ -1811,13 +1810,10 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Evolution 2200</example>
     <example>Evolution 3000</example>
     <example>Evolution 650</example>
-    <example>Evolution 650</example>
     <example>Evolution 800</example>
-    <example>Evolution 850</example>
     <example>Evolution 850</example>
     <example>Evolution S 1750</example>
     <example>Evolution S 2500</example>
-    <example>Evolution S 3000</example>
     <example>Evolution S 3000</example>
     <example>Evolution Series - IP</example>
     <example>Evolution Series - METRO</example>
@@ -2578,7 +2574,6 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>HP StorageWorks P2000 G3 SAS</example>
     <example>HP StorageWorks P2000 G3 iSCSI</example>
     <example>HP StorageWorks P2000G3 FC/iSCSI</example>
-    <example>HP StorageWorks P2000G3 FC/iSCSI</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="StorageWorks"/>
     <param pos="1" name="os.product"/>
@@ -2586,7 +2581,6 @@ Copyright (c) 1995-2005 by Cisco Systems
   </fingerprint>
   <fingerprint pattern="^HP StorageWorks (\S+) Stackable Single Power Supply Fibre Channel Switch$">
     <description>HP StorageWorks Stackable FC Switch</description>
-    <example>HP StorageWorks SN6000 Stackable Single Power Supply Fibre Channel Switch</example>
     <example>HP StorageWorks SN6000 Stackable Single Power Supply Fibre Channel Switch</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="StorageWorks"/>
@@ -3480,14 +3474,12 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^Lexmark Forms Printer (\S+(?: plus)?) +version (\S+).*$">
     <description>Lexmark Forms Printer</description>
     <example>Lexmark Forms Printer 2580 version LC.CO.N061 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 2580 version LC.CO.N061 kernel 2.6.10 All-N-1</example>
     <example>Lexmark Forms Printer 2580 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
     <example>Lexmark Forms Printer 2581 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
     <example>Lexmark Forms Printer 2590 version LC.CO.N061 kernel 2.6.10 All-N-1</example>
     <example>Lexmark Forms Printer 2590 version LCL.CU.P103 kernel 2.6.10 All-N-1</example>
     <example>Lexmark Forms Printer 2590 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
     <example>Lexmark Forms Printer 2591 version LCL.CU.P103 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 4227 plus version LC.CO.N061 kernel 2.6.10 All-N-1</example>
     <example>Lexmark Forms Printer 4227 plus version LC.CO.N061 kernel 2.6.10 All-N-1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Lexmark"/>
@@ -5168,7 +5160,6 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>RICOH Aficio MP 5500 2.04 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
     <example>RICOH Aficio MP C2500 1.62.1 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
     <example>RICOH Aficio MP C2500 1.66 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 2035e 2.40 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
     <example>RICOH Aficio MP C3000 1.70 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
     <example>RICOH Aficio 2045 1.06s / RICOH Network Printer C model / RICOH Network Scanner C model</example>
     <example>RICOH Aficio SP C411DN 1.01 / RICOH Network Printer C model</example>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -136,10 +136,7 @@
     <example>CN=idrac-SVCTAG,OU=Remote Access Group,O=Dell Inc.,L=Round Rock,ST=Texas,C=US</example>
     <example>CN=idrac-prosit-laks,OU=Remote Access Group,O=Dell Inc.,L=Round Rock,ST=Texas,C=US</example>
     <example>CN=idrac-,OU=Remote Access Group,O=Dell Inc.,L=Round Rock,ST=Texas,C=US</example>
-    <example>CN=idrac-SVCTAG,OU=Remote Access Group,O=Dell Inc.,L=Round Rock,ST=Texas,C=US</example>
     <example>CN=idrac,OU=Remote Access Group,O=Dell Inc.,L=Round Rock,ST=Texas,C=US</example>
-    <example>CN=idrac,OU=Remote Access Group,O=Dell Inc.,L=Round Rock,ST=Texas,C=US</example>
-    <example>CN=idrac-SVCTAG,OU=Remote Access Group,O=Dell Inc.,L=Round Rock,ST=Texas,C=US</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="Dell"/>
     <param pos="0" name="hw.product" value="iDRAC"/>


### PR DESCRIPTION
## Description
This PR removes duplicate `example` entries and adds an `rspec` test to detect when they are added in the future.

Here is an example of the output when the new test fails due to a duplicate `example`:

```
Failures:

  1) Recog::DB#http_servers.xml (?i-mx:^Netgear\/\S+ UPnP\/\S+ miniupnpd\/(\S+)$) doesn't have a duplicate examples
     Failure/Error: fail "'#{fp.name}' has duplicate example '#{example.content}'"
     
     RuntimeError:
       'Netgear DG834G or WNDR3300 WAP UPnP Server' has duplicate example 'Netgear/1.0 UPnP/1.0 miniupnpd/1.0'
     # ./spec/lib/fingerprint_self_test_spec.rb:143:in `block (7 levels) in <top (required)>'

  2) Recog::DB#http_servers.xml (?-mix:^lighttpd(?:\/(\d[\d.]+))?.*$) doesn't have a duplicate examples
     Failure/Error: fail "'#{fp.name}' has duplicate example '#{example.content}'"
     
     RuntimeError:
       'Lighttpd' has duplicate example 'lighttpd/1.4.16'
     # ./spec/lib/fingerprint_self_test_spec.rb:143:in `block (7 levels) in <top (required)>'

  3) Recog::DB#snmp_sysdescr.xml (?-mix:^(ESP-\d+) MI V(\S+)$) doesn't have a duplicate examples
     Failure/Error: fail "'#{fp.name}' has duplicate example '#{example.content}'"
     
     RuntimeError:
       'Avocent ESP Serial Port' has duplicate example 'ESP-8 MI V3.13'
     # ./spec/lib/fingerprint_self_test_spec.rb:143:in `block (7 levels) in <top (required)>'

```

## Motivation and Context
These changes should reduce the number of tests that we run and, by detecting duplicates, perhaps indicate to a contributor that they forgot to tweak or change an example.


## How Has This Been Tested?
This code was tested via `rspec` and via `bin/recog_verify`

```shell
for filename in ./xml/*.xml; do ./bin/recog_verify -c "$filename" | grep -v 'no test cases'; done
```


## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
