### PR TITLE
Fix Jetty vendor and fingerprints

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1077,12 +1077,15 @@
       TODO:
 
       Sun_WebServer/2.1
-     -->
-  <fingerprint pattern="^Jetty/(\d+\.[\d.]+)(?: \((.*)\))?$">
+  -->
+  <!-- Mort Bay Jetty 1.0 to 6.x  -->
+  <fingerprint pattern="^Jetty\/([1-6]\.[\w.]+)(?: \(([^)]*))?">
     <description>Mort Bay Jetty with info</description>
-    <example>Jetty/4.0.1 (SunOS 5.8 sparc)</example>
-    <example>Jetty/4.2.23 (SunOS/5.9 sparc java/1.4.2_04)</example>
-    <example>Jetty/5.1.10 (Linux/2.6.12 i386 java/1.5.0_05)</example>
+    <example service.version="4.0.1" jetty.info="SunOS 5.8 sparc">Jetty/4.0.1 (SunOS 5.8 sparc)</example>
+    <example service.version="4.2.23" jetty.info="SunOS/5.9 sparc java/1.4.2_04">Jetty/4.2.23 (SunOS/5.9 sparc java/1.4.2_04)</example>
+    <example service.version="4.2.x" jetty.info="VxWorks/WIND version 2.9 ppc java/1.1-rr-std-b12">Jetty/4.2.x (VxWorks/WIND version 2.9 ppc java/1.1-rr-std-b12)</example>
+    <example service.version="5.1.4" jetty.info="Windows Server 2008 R2/6.1 x86 java/1.5.0_22">Jetty/5.1.4 (Windows Server 2008 R2/6.1 x86 java/1.5.0_22</example>
+    <example service.version="5.1.10" jetty.info="Linux/2.6.12 i386 java/1.5.0_05">Jetty/5.1.10 (Linux/2.6.12 i386 java/1.5.0_05)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
     <param pos="0" name="service.family" value="Jetty"/>
@@ -1090,25 +1093,30 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
     <param pos="2" name="jetty.info"/>
   </fingerprint>
-  <!-- Catch-all for Jetty versions using the Jetty/version format. -->
-  <fingerprint pattern="^Jetty/(\S+) \(.*$">
-    <description>Jetty</description>
-    <example>Jetty/4.2.x (VxWorks/WIND version 2.9 ppc java/1.1-rr-std-b12)</example>
+  <fingerprint pattern="^Jetty\(([1-6]\S+)\)$">
+    <description>Mort Bay Jetty</description>
+    <example service.version="1.4.5">Jetty(1.4.5)</example>
+    <example service.version="6.1.12.rc2">Jetty(6.1.12.rc2)</example>
     <param pos="0" name="service.vendor" value="Mort Bay"/>
     <param pos="0" name="service.product" value="Jetty"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
   </fingerprint>
+  <!--
+    Jetty moved to Eclipse.org at version 7, CVEs after this version are
+    associated with Eclipse CPEs.
+  -->
   <fingerprint pattern="^Jetty\((\S+)\)$">
-    <description>Mort Bay Jetty</description>
-    <example>Jetty(6.1.7)</example>
-    <example>Jetty(9.4.z-SNAPSHOT)</example>
-    <param pos="0" name="service.vendor" value="Mort Bay"/>
+    <description>Eclipse Jetty</description>
+    <example service.version="7.6.9.v20130131">Jetty(7.6.9.v20130131)</example>
+    <example service.version="8.1.10.v20130312">Jetty(8.1.10.v20130312)</example>
+    <example service.version="9.4.z-SNAPSHOT">Jetty(9.4.z-SNAPSHOT)</example>
+    <param pos="0" name="service.vendor" value="Eclipse"/>
     <param pos="0" name="service.product" value="Jetty"/>
     <param pos="0" name="service.family" value="Jetty"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mortbay:jetty:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:eclipse:jetty:{service.version}"/>
   </fingerprint>
   <fingerprint pattern="^(?i)squid/(\d+\.[\w.\-\+]+)$">
     <description>Squid Web Proxy with a version</description>


### PR DESCRIPTION
## Description
This PR:

- Addresses the fact that Jetty changed hands / stewardship from Mort Bay to Eclipse in version 7. By fixing this we ensure that the CPEs that are generated are correct and are likely to be able to use to match vulnerabilities.
- Collapses two fingerprints into one by taking into account that some versions have non-decimals in them (`4.2.x`) and that some version strings left off the trailing `)` in the info section.
- Adds capture tests for the examples.

```
$ echo 'Jetty(9.4.z-SNAPSHOT)' | bin/recog_match xml/http_servers.xml 
MATCH: {"matched"=>"Eclipse Jetty", "service.vendor"=>"Eclipse", "service.product"=>"Jetty", "service.family"=>"Jetty", "service.version"=>"9.4.z-SNAPSHOT", "service.cpe23"=>"cpe:/a:eclipse:jetty:9.4.z-SNAPSHOT", "service.protocol"=>"http", "fingerprint_db"=>"http_header.server", "data"=>"Jetty(9.4.z-SNAPSHOT)"}

$ echo 'Jetty/5.1.10 (Linux/4.9.0-3-amd64 amd64 java/1.7.0_21' | bin/recog_match xml/http_servers.xml 
MATCH: {"matched"=>"Mort Bay Jetty with info", "service.vendor"=>"Mort Bay", "service.product"=>"Jetty", "service.family"=>"Jetty", "service.version"=>"5.1.10", "service.cpe23"=>"cpe:/a:mortbay:jetty:5.1.10", "jetty.info"=>"Linux/4.9.0-3-amd64 amd64 java/1.7.0_21", "service.protocol"=>"http", "fingerprint_db"=>"http_header.server", "data"=>"Jetty/5.1.10 (Linux/4.9.0-3-amd64 amd64 java/1.7.0_21"}
```



![image](https://user-images.githubusercontent.com/20306699/57143239-0c3dd400-6d84-11e9-9482-90c46927440a.png)


References:
1. https://www.eclipse.org/jetty/documentation/current/what-jetty-version.html#d0e203
1. https://en.wikipedia.org/wiki/Jetty_(web_server)
1. https://www.cvedetails.com/vendor/1294/Jetty.html
1. https://www.cvedetails.com/product/34824/Eclipse-Jetty.html?vendor_id=10410
1. https://www.cvedetails.com/version-list/10410/34824/1/Eclipse-Jetty.html
1. https://nvd.nist.gov/products/cpe/search/results?keyword=Jetty+mort&status=FINAL&orderBy=CPEURI&namingFormat=2.3&startIndex=0
1. https://nvd.nist.gov/products/cpe/search/results?keyword=Jetty+eclipse&status=FINAL&orderBy=CPEURI&namingFormat=2.3
1. https://nvd.nist.gov/products/cpe/search/results?keyword=Jetty+codehaus&status=FINAL&orderBy=CPEURI&namingFormat=2.3
1. https://nvd.nist.gov/products/cpe/search/results?keyword=Jetty+sourceforge&status=FINAL&orderBy=CPEURI&namingFormat=2.3




## Motivation and Context
To improve the accuracy of the results.


## How Has This Been Tested?
`example` values + `rspec`
Version runs of a recent Project Sonar study of `8080/tcp` which is the default port.


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
