### PR TITLE
Adds 2018 Mac mini and 2019 MBP to MDNS

### DIFF
--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -161,6 +161,18 @@
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
   <!-- MacBookPro - Reference for the following: https://support.apple.com/en-us/HT201300 -->
+  <fingerprint pattern="^model=MacBookPro15,3$">
+    <description>MacBook Pro (15-inch, 2019)</description>
+    <example>model=MacBookPro15,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, 2019)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>  
   <fingerprint pattern="^model=MacBookPro15,2$">
     <description>MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)</description>
     <example>model=MacBookPro15,2</example>
@@ -403,6 +415,18 @@
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
   <!-- MacMini - Reference for the following: https://support.apple.com/en-us/HT201894 -->
+  <fingerprint pattern="^model=Macmini8,1$">
+    <description>Mac mini (Late 2018)</description>
+    <example>model=Macmini8,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Late 2018)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>  
   <fingerprint pattern="^model=Macmini7,1$">
     <description>Mac mini (Late 2014)</description>
     <example>model=Macmini7,1</example>


### PR DESCRIPTION
## Description

Coverage for 2018 Mac mini and 2019 15" MacBook Pro

## Motivation and Context

Minor fingerprint addition


## How Has This Been Tested?

rspec and using the recog-go harness

## Types of changes
- Support for newer MacBook Pro and Mac mini devices.


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [X] I have updated the documentation accordingly (or changes are not required).
- [X] I have added tests to cover my changes (or new tests are not required).
- [X] All new and existing tests passed.
