### PR TITLE
FTP: stop matching empty banners

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1359,12 +1359,11 @@ more text</example>
     <param pos="1" name="host.name"/>
     <param pos="2" name="service.version"/>
   </fingerprint>
-  <fingerprint pattern="(?i)^(?:FTP[\- ])?(?:server|service)?(?:(?: is)? ready)?\.?$">
+  <fingerprint pattern="(?i)^FTP[\- ]+(?:server|service)?(?:(?: is)? ready)?\.?$">
     <description>Generic FTP fingerprint without a hostname</description>
     <example>FTP server is ready.</example>
     <example>FTP Server ready.</example>
     <example>FTP Server Ready</example>
-    <example>Server Ready</example>
     <example>FTP-Server</example>
     <example>FTP Server</example>
     <example>FTP service ready.</example>


### PR DESCRIPTION
## Description
This PR adjusts an FTP fingerprint so as to no longer match on empty strings.

#### Before
```shell
echo '' |  ./bin/recog_match xml/ftp_banners.xml 

MATCH: {"matched"=>"Generic FTP fingerprint without a hostname", "service.protocol"=>"ftp", "fingerprint_db"=>"ftp.banner", "data"=>""}
```

#### After
```shell
echo '' |  ./bin/recog_match xml/ftp_banners.xml 
FAIL: 
```

The trade off is that we no longer match `Server Ready`. Given that this banner is not product or service specific I consider this an acceptable trade off. Our most Sonar data set from May 1 showed 0 hits for this banner.

## How Has This Been Tested?
rspec


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
