### PR TITLE
Additional Apple devices

### DIFF
--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -823,6 +823,43 @@
     <param pos="0" name="hw.product" value="Mac mini (Mid 2007)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
   </fingerprint>
+  <!-- MacPro - Reference for the following: https://support.apple.com/en-us/HT202888 -->
+  <fingerprint pattern="^model=MacPro6,1$">
+    <description>Mac Pro (Late 2013)</description>
+    <example>model=MacPro6,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="Mac Pro (Late 2013)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacPro5,1$">
+    <description>Mac Pro (Mid 2012)</description>
+    <example>model=MacPro5,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="Mac Pro (Mid 2012)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacPro4,1$">
+    <description>Mac Pro (Early 2009)</description>
+    <example>model=MacPro6,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="Mac Pro (Early 2009)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
   <!-- iMAC - Reference for the following: https://support.apple.com/en-us/HT201634 -->
   <fingerprint pattern="^model=iMac19,1$">
     <description>iMac (Retina 5K, 27-inch, 2019)</description>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -158,7 +158,7 @@
   </fingerprint>
   <!-- AirPort Express -->
   <!-- TODO: Break this down into specific models and generations -->
-  <fingerprint pattern="^model=AirPort4(?:,10[47])?$">
+  <fingerprint pattern="^model=AirPort4(?:,\d+)?$">
     <description>AirPort Express</description>
     <example>model=AirPort4</example>
     <example>model=AirPort4,104</example>
@@ -1520,5 +1520,276 @@
     <param pos="0" name="hw.family" value="Apple TV"/>
     <param pos="0" name="hw.product" value="Apple TV (2nd generation)"/>
     <param pos="0" name="hw.device" value="Media Server"/>
-  </fingerprint>    
+  </fingerprint>
+  <!-- iPad Pro - Reference for the following: https://www.theiphonewiki.com/ -->
+  <fingerprint pattern="^model=D331p?AP$">
+    <description>iPhone XS Max</description>
+    <example>model=D331pAP</example>
+    <example>model=D331AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone XS Max"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=D321AP$">
+    <description>iPhone XS</description>
+    <example>model=D321AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone XS"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N841AP$">
+    <description>iPhone XR</description>
+    <example>model=N841AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone XR"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=D221?AP$">
+    <description>iPhone X</description>
+    <example>model=D221AP</example>
+    <example>model=D22AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone X"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=D211?A?AP$">
+    <description>iPhone 8 Plus</description>
+    <example>model=D21AP</example>
+    <example>model=D21AAP</example>
+    <example>model=D211AP</example>
+    <example>model=D211AAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 8 Plus"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=D201?A?AP$">
+    <description>iPhone 8</description>
+    <example>model=D20AP</example>
+    <example>model=D20AAP</example>
+    <example>model=D201AP</example>
+    <example>model=D201AAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 8"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=D111?AP$">
+    <description>iPhone 7 Plus</description>
+    <example>model=D11AP</example>
+    <example>model=D111AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 7 Plus"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=D101?AP$">
+    <description>iPhone 7</description>
+    <example>model=D10AP</example>
+    <example>model=D101AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 7"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N69u?AP$">
+    <description>iPhone SE</description>
+    <example>model=N69AP</example>
+    <example>model=N69uAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone SE"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N66m?AP$">
+    <description>iPhone 6s Plus</description>
+    <example>model=N66mAP</example>
+    <example>model=N66AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 6s Plus"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N71m?AP$">
+    <description>iPhone 6s</description>
+    <example>model=N71mAP</example>
+    <example>model=N71AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 6s"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N56AP$">
+    <description>iPhone 6 Plus</description>
+    <example>model=N56AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 6 Plus"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N61AP$">
+    <description>iPhone 6</description>
+    <example>model=N61AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 6"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N5[13]AP$">
+    <description>iPhone 5s</description>
+    <example>model=N51AP</example>
+    <example>model=N53AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 5s"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N4[89]AP$">
+    <description>iPhone 5c</description>
+    <example>model=N48AP</example>
+    <example>model=N49AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 5c"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N4[12]AP$">
+    <description>iPhone 5</description>
+    <example>model=N41AP</example>
+    <example>model=N42AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 5"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N94AP$">
+    <description>iPhone 4s</description>
+    <example>model=N94AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 4s"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N9[02]B?AP$">
+    <description>iPhone 4</description>
+    <example>model=N90AP</example>
+    <example>model=N90BAP</example>
+    <example>model=N92AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 4"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N88AP$">
+    <description>iPhone 3GS</description>
+    <example>model=N88AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 3GS"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=N82AP$">
+    <description>iPhone 3G</description>
+    <example>model=N82AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone 3G"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
+  <fingerprint pattern="^model=M68AP$">
+    <description>iPhone</description>
+    <example>model=M68AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone"/>
+    <param pos="0" name="hw.device" value="Mobile Phone"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1351,4 +1351,18 @@
     <param pos="0" name="hw.product" value="iPad mini"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
+  <!-- HomePod -->
+  <fingerprint pattern="^model=B238a?AP$">
+    <description>HomePod</description>
+    <example>model=B238aAP</example>
+    <example>model=B238AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="audioOS"/>
+    <param pos="0" name="os.product" value="audioOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:audio_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="HomePod"/>
+    <param pos="0" name="hw.product" value="HomePod"/>
+    <param pos="0" name="hw.device" value="Media Server"/>
+  </fingerprint>  
 </fingerprints>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1496,9 +1496,10 @@
     <param pos="0" name="hw.product" value="Apple TV (4th generation)"/>
     <param pos="0" name="hw.device" value="Media Server"/>
   </fingerprint>
-  <fingerprint pattern="^model=J33I?AP$">
+  <fingerprint pattern="^model=J33[Ii]?AP$">
     <description>Apple TV (3rd generation)</description>
     <example>model=J33IAP</example>
+    <example>model=J33iAP</example>
     <example>model=J33AP</example>    
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="tvOS"/>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1291,7 +1291,7 @@
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
   <!-- iPad mini -->
-<fingerprint pattern="^model=J21[01]AP$">
+  <fingerprint pattern="^model=J21[01]AP$">
     <description>iPad mini (5th generation)</description>
     <example>model=J210AP</example>
     <param pos="0" name="os.vendor" value="Apple"/>
@@ -1303,7 +1303,7 @@
     <param pos="0" name="hw.product" value="iPad mini (5th generation)"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
-<fingerprint pattern="^model=J9[67]AP$">
+  <fingerprint pattern="^model=J9[67]AP$">
     <description>iPad mini 4</description>
     <example>model=J97AP</example>
     <param pos="0" name="os.vendor" value="Apple"/>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -374,6 +374,151 @@
     <param pos="0" name="hw.product" value="MacBook Pro (Retina, 15-inch, Early 2013)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
+  <fingerprint pattern="^model=MacBookPro9,2$">
+    <description>MacBook Pro (13-inch, Mid 2012)</description>
+    <example>model=MacBookPro9,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, Mid 2012)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+    <fingerprint pattern="^model=MacBookPro8,3$">
+    <description>MacBook Pro (17-inch, Late 2011)</description>
+    <example>model=MacBookPro8,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (17-inch, Late 2011)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro8,2$">
+    <description>MacBook Pro (15-inch, Late 2011)</description>
+    <example>model=MacBookPro8,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, Late 2011)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro8,1$">
+    <description>MacBook Pro (13-inch, Late 2011)</description>
+    <example>model=MacBookPro8,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, Late 2011)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro7,1$">
+    <description>MacBook Pro (13-inch, Mid 2010)</description>
+    <example>model=MacBookPro7,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, Mid 2010)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+ <fingerprint pattern="^model=MacBookPro6,2$">
+    <description>MacBook Pro (15-inch, Mid 2010)</description>
+    <example>model=MacBookPro6,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, Mid 2010)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro6,1$">
+    <description>MacBook Pro (17-inch, Mid 2010)</description>
+    <example>model=MacBookPro6,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (17-inch, Mid 2010)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+
+  <fingerprint pattern="^model=MacBookPro5,5$">
+    <description>MacBook Pro (13-inch, Mid 2009)</description>
+    <example>model=MacBookPro5,5</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, Mid 2009)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro5,3$">
+    <description>MacBook Pro (15-inch, Mid 2009)</description>
+    <example>model=MacBookPro5,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, Mid 2009)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro5,2$">
+    <description>MacBook Pro (17-inch, Mid 2009)</description>
+    <example>model=MacBookPro5,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (17-inch, Mid 2009)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro5,1$">
+    <description>MacBook Pro (15-inch, Late 2008)</description>
+    <example>model=MacBookPro5,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (15-inch, Late 2008)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookPro4,1$">
+    <description>MacBook Pro (17-inch, Early 2008)</description>
+    <example>model=MacBookPro4,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (17-inch, Early 2008)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
   <!-- MacBook - Reference for the following: https://support.apple.com/en-us/HT201608 -->
   <fingerprint pattern="^model=MacBook10,1$">
     <description>MacBook (Retina, 12-inch, 2017)</description>
@@ -385,18 +530,6 @@
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="MacBook"/>
     <param pos="0" name="hw.product" value="MacBook (Retina, 12-inch, 2017)"/>
-    <param pos="0" name="hw.device" value="Laptop"/>
-  </fingerprint>
-  <fingerprint pattern="^model=MacBookPro9,2$">
-    <description>MacBook Pro (13-inch, Mid 2012)</description>
-    <example>model=MacBookPro9,2</example>
-    <param pos="0" name="os.vendor" value="Apple"/>
-    <param pos="0" name="os.family" value="Mac OS X"/>
-    <param pos="0" name="os.product" value="Mac OS X"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
-    <param pos="0" name="hw.vendor" value="Apple"/>
-    <param pos="0" name="hw.family" value="MacBook Pro"/>
-    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, Mid 2012)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
   <fingerprint pattern="^model=MacBook9,1$">

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1364,5 +1364,55 @@
     <param pos="0" name="hw.family" value="HomePod"/>
     <param pos="0" name="hw.product" value="HomePod"/>
     <param pos="0" name="hw.device" value="Media Server"/>
-  </fingerprint>  
+  </fingerprint>
+  <!-- Apple TV -->
+  <fingerprint pattern="^model=J105aAP$">
+    <description>Apple TV 4K</description>
+    <example>model=J105aAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="tvOS"/>
+    <param pos="0" name="os.product" value="tvOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:tv_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Apple TV"/>
+    <param pos="0" name="hw.product" value="Apple TV 4K"/>
+    <param pos="0" name="hw.device" value="Media Server"/>
+  </fingerprint>
+  <fingerprint pattern="^model=J42dAP$">
+    <description>Apple TV (4th generation)</description>
+    <example>model=J42dAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="tvOS"/>
+    <param pos="0" name="os.product" value="tvOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:tv_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Apple TV"/>
+    <param pos="0" name="hw.product" value="Apple TV (4th generation)"/>
+    <param pos="0" name="hw.device" value="Media Server"/>
+  </fingerprint>
+  <fingerprint pattern="^model=J33I?AP$">
+    <description>Apple TV (3rd generation)</description>
+    <example>model=J33IAP</example>
+    <example>model=J33AP</example>    
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="tvOS"/>
+    <param pos="0" name="os.product" value="tvOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:tv_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Apple TV"/>
+    <param pos="0" name="hw.product" value="Apple TV (3rd generation)"/>
+    <param pos="0" name="hw.device" value="Media Server"/>
+  </fingerprint>
+  <fingerprint pattern="^model=K66AP$">
+    <description>Apple TV (2nd generation)</description>
+    <example>model=K66AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="tvOS"/>
+    <param pos="0" name="os.product" value="tvOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:tv_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Apple TV"/>
+    <param pos="0" name="hw.product" value="Apple TV (2nd generation)"/>
+    <param pos="0" name="hw.device" value="Media Server"/>
+  </fingerprint>    
 </fingerprints>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -824,6 +824,18 @@
     <param pos="0" name="hw.device" value="Desktop"/>
   </fingerprint>
   <!-- MacPro - Reference for the following: https://support.apple.com/en-us/HT202888 -->
+  <fingerprint pattern="^model=MacPro7,1$">
+    <description>Mac Pro (Late 2019)</description>
+    <example>model=MacPro7,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="Mac Pro (Late 2019)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
   <fingerprint pattern="^model=MacPro6,1$">
     <description>Mac Pro (Late 2013)</description>
     <example>model=MacPro6,1</example>
@@ -850,7 +862,7 @@
   </fingerprint>
   <fingerprint pattern="^model=MacPro4,1$">
     <description>Mac Pro (Early 2009)</description>
-    <example>model=MacPro6,1</example>
+    <example>model=MacPro4,1</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="Mac OS X"/>
     <param pos="0" name="os.product" value="Mac OS X"/>
@@ -858,6 +870,45 @@
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="Mac Pro (Early 2009)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <!-- MacPro older models listed at https://en.wikipedia.org/wiki/Mac_Pro -->
+  <fingerprint pattern="^model=MacPro3,1$">
+    <description>Mac Pro (Early 2008)</description>
+    <example>model=MacPro3,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="Mac Pro (Early 2008)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacPro2,1$">
+    <description>Mac Pro (Mid 2007)</description>
+    <example>model=MacPro2,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="Mac Pro (Mid 2007)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <!-- MacPro with no model assumed to early 1,1 -->
+  <fingerprint pattern="^model=MacPro(?:1,1)?$">
+    <description>Mac Pro (Mid 2006)</description>
+    <example>model=MacPro1,1</example>
+    <example>model=MacPro</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="Mac Pro (Mid 2006)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
   </fingerprint>
   <!-- iMAC - Reference for the following: https://support.apple.com/en-us/HT201634 -->

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1165,6 +1165,32 @@
     <param pos="0" name="hw.device" value="Desktop"/>
   </fingerprint>
   <!-- iPad Pro - Reference for the following: https://www.theiphonewiki.com/ -->
+  <fingerprint pattern="^model=J32[01]x?AP$">
+    <description>iPad Pro (12.9-inch)</description>
+    <example>model=J320AP</example>
+    <example>model=J321xAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Pro"/>
+    <param pos="0" name="hw.product" value="iPad Pro (12.9-inch)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <fingerprint pattern="^model=J31[78]x?AP$">
+    <description>iPad Pro (11-inch)</description>
+    <example>model=J317AP</example>
+    <example>model=J318xAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Pro"/>
+    <param pos="0" name="hw.product" value="iPad Pro (11-inch)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
   <fingerprint pattern="^model=J20[78]AP$">
     <description>iPad Pro (10.5-inch)</description>
     <example>model=J207AP</example>
@@ -1189,19 +1215,20 @@
     <param pos="0" name="hw.product" value="iPad Pro (9.7-inch)"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
-  <fingerprint pattern="^model=J121AP$">
-    <description>iPad Pro (12.9-inch)</description>
-    <example>model=J121AP</example>
+  <!-- iPad -->
+  <fingerprint pattern="^model=J7[12]bAP$">
+    <description>iPad 6th generation)</description>
+    <example>model=J72bAP</example>
+    <example>model=J71bAP</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="iOS"/>
     <param pos="0" name="os.product" value="iOS"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
-    <param pos="0" name="hw.family" value="iPad Pro"/>
-    <param pos="0" name="hw.product" value="iPad Pro (12.9-inch)"/>
+    <param pos="0" name="hw.family" value="iPad"/>
+    <param pos="0" name="hw.product" value="iPad (6th generation)"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
-  <!-- iPad -->
   <fingerprint pattern="^model=J71[ts]AP$">
     <description>iPad (5th generation)</description>
     <example>model=J71tAP</example>
@@ -1214,17 +1241,29 @@
     <param pos="0" name="hw.product" value="iPad (5th generation)"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
+  <fingerprint pattern="^model=P10[123]AP$">
+    <description>iPad (4th generation)</description>
+    <example>model=P103AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad"/>
+    <param pos="0" name="hw.product" value="iPad (4th generation)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>  
   <!-- iPad Air -->
-  <fingerprint pattern="^model=J7[123]AP$">
-    <description>iPad Air</description>
-    <example>model=J72AP</example>
+  <fingerprint pattern="^model=J21[78]AP$">
+    <description>iPad Air (3rd generation)</description>
+    <example>model=J218AP</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="iOS"/>
     <param pos="0" name="os.product" value="iOS"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPad Air"/>
-    <param pos="0" name="hw.product" value="iPad Air"/>
+    <param pos="0" name="hw.product" value="iPad Air (3rd generation)"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
   <fingerprint pattern="^model=J8[12]AP$">
@@ -1237,6 +1276,18 @@
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPad Air"/>
     <param pos="0" name="hw.product" value="iPad Air 2"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>  
+  <fingerprint pattern="^model=J7[123]AP$">
+    <description>iPad Air</description>
+    <example>model=J72AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad Air"/>
+    <param pos="0" name="hw.product" value="iPad Air"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
   <!-- iPad mini -->

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -484,6 +484,247 @@
     <param pos="0" name="hw.product" value="Mac mini (Late 2012)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
   </fingerprint>
+  <!-- iMAC - Reference for the following: https://support.apple.com/en-us/HT201634 -->
+  <fingerprint pattern="^model=iMac19,1$">
+    <description>iMac (Retina 5K, 27-inch, 2019)</description>
+    <example>model=iMac19,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (Retina 5K, 27-inch, 2019)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac19,2$">
+    <description>iMac (Retina 4K, 21.5-inch, 2019)</description>
+    <example>model=iMac19,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (Retina 4K, 21.5-inch, 2019)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac18,3$">
+    <description>iMac (Retina 5K, 27-inch, 2017)</description>
+    <example>model=iMac18,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (Retina 5K, 27-inch, 2017)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac18,2$">
+    <description>iMac (Retina 4K, 21.5-inch, 2017)</description>
+    <example>model=iMac18,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (Retina 4K, 21.5-inch, 2017)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac18,1$">
+    <description>iMac (21.5-inch, 2017)</description>
+    <example>model=iMac18,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (21.5-inch, 2017)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac17,1$">
+    <description>iMac (Retina 5K, 27-inch, Late 2015)</description>
+    <example>model=iMac17,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (Retina 5K, 27-inch, Late 2015)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac16,2$">
+    <description>iMac (Retina 4K, 21.5-inch, Late 2015)</description>
+    <example>model=iMac16,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (Retina 4K, 21.5-inch, Late 2015)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac16,1$">
+    <description>iMac (21.5-inch, Late 2015)</description>
+    <example>model=iMac16,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (21.5-inch, Late 2015)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac15,1$">
+    <description>iMac (Retina 5K, 27-inch, Mid 2015)</description>
+    <example>model=iMac15,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (Retina 5K, 27-inch, Mid 2015)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac14,4$">
+    <description>iMac (21.5-inch, Mid 2014)</description>
+    <example>model=iMac14,4</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (21.5-inch, Mid 2014)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac14,2$">
+    <description>iMac (27-inch, Late 2013)</description>
+    <example>model=iMac14,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (27-inch, Late 2013)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac14,1$">
+    <description>iMac (21.5-inch, Late 2013)</description>
+    <example>model=iMac14,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (21.5-inch, Late 2013)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac13,2$">
+    <description>iMac (27-inch, Late 2012)</description>
+    <example>model=iMac13,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (27-inch, Late 2012)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac13,1$">
+    <description>iMac (21.5-inch, Late 2012)</description>
+    <example>model=iMac13,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (21.5-inch, Late 2012)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac12,2$">
+    <description>iMac (27-inch, Mid 2011)</description>
+    <example>model=iMac12,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (27-inch, Mid 2011)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac12,1$">
+    <description>iMac (21.5-inch, Mid 2011)</description>
+    <example>model=iMac12,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (21.5-inch, Mid 2011)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac11,3$">
+    <description>iMac (27-inch, Mid 2010)</description>
+    <example>model=iMac11,3</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (27-inch, Mid 2010)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac11,2$">
+    <description>iMac (21.5-inch, Mid 2010)</description>
+    <example>model=iMac11,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (21.5-inch, Mid 2010)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac10,1$">
+    <description>iMac (27-inch, Late 2009)</description>
+    <example>model=iMac10,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (27-inch, Late 2009)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=iMac9,1$">
+    <description>iMac (24-inch, Early 2009)</description>
+    <example>model=iMac9,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac (24-inch, Early 2009)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
   <!-- iPad Pro - Reference for the following: https://www.theiphonewiki.com/ -->
   <fingerprint pattern="^model=J20[78]AP$">
     <description>iPad Pro (10.5-inch)</description>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -691,6 +691,18 @@
     <param pos="0" name="hw.product" value="iMac (Retina 4K, 21.5-inch, 2019)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
   </fingerprint>
+  <fingerprint pattern="^model=iMacPro1,1$">
+    <description>iMac Pro (Retina 5K, Late 2017)</description>
+    <example>model=iMacPro1,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iMac"/>
+    <param pos="0" name="hw.product" value="iMac Pro (Retina 5K, Late 2017)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
   <fingerprint pattern="^model=iMac18,3$">
     <description>iMac (Retina 5K, 27-inch, 2017)</description>
     <example>model=iMac18,3</example>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -159,7 +159,7 @@
   <!-- AirPort Express -->
   <!-- TODO: Break this down into specific models and generations -->
   <fingerprint pattern="^model=AirPort4(?:,10[47])?$">
-    <description>AirPort</description>
+    <description>AirPort Express</description>
     <example>model=AirPort4</example>
     <example>model=AirPort4,104</example>
     <example>model=AirPort4,107</example>
@@ -175,7 +175,7 @@
   <!-- AirPort Extreme -->
   <!-- TODO: Break this down into specific models and generations -->
   <fingerprint pattern="^model=AirPort5?(?:,\d+)?$">
-    <description>AirPort</description>
+    <description>AirPort Extreme</description>
     <example>model=AirPort</example>
     <example>model=AirPort5</example>
     <example>model=AirPort5,104</example>
@@ -191,7 +191,7 @@
   </fingerprint>
   <!-- TimeCapsule aka AirPort 6 -->
   <!-- TODO: Break this down into specific models and generations -->
-    <fingerprint pattern="^model=(AirPort6|TimeCapsule).*$">
+    <fingerprint pattern="^model=(?:AirPort6|TimeCapsule).*$">
     <description>Time Capsule</description>
     <example>model=AirPort6</example>
     <example>model=AirPort6,106</example>
@@ -949,6 +949,73 @@
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="Mac Pro (Mid 2006)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <!-- XServe - Reference for the following: https://en.wikipedia.org/wiki/Xserve -->
+  <fingerprint pattern="^model=Xserve3,1$">
+    <description>Xserve (Early 2009)</description>
+    <example>model=Xserve3,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Xserve"/>
+    <param pos="0" name="hw.product" value="Xserve (Early 2009)"/>
+  </fingerprint>
+  <fingerprint pattern="^model=Xserve2,1$">
+    <description>Xserve (Early 2008)</description>
+    <example>model=Xserve2,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Xserve"/>
+    <param pos="0" name="hw.product" value="Xserve (Early 2008)"/>
+  </fingerprint>
+  <fingerprint pattern="^model=Xserve1,1$">
+    <description>Xserve (Late 2006)</description>
+    <example>model=Xserve1,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Xserve"/>
+    <param pos="0" name="hw.product" value="Xserve (Late 2006)"/>
+  </fingerprint>
+  <fingerprint pattern="^model=RackMac3,1$">
+    <description>Xserve G5</description>
+    <example>model=RackMac3,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Xserve"/>
+    <param pos="0" name="hw.product" value="Xserve G5"/>
+  </fingerprint>
+  <fingerprint pattern="^model=RackMac1,2$">
+    <description>Xserve G4 (Slot Load)</description>
+    <example>model=RackMac1,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Xserve"/>
+    <param pos="0" name="hw.product" value="Xserve G4 (Slot Load)"/>
+  </fingerprint>
+  <fingerprint pattern="^model=RackMac1,1$">
+    <description>Xserve G4</description>
+    <example>model=RackMac1,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Xserve"/>
+    <param pos="0" name="hw.product" value="Xserve G4"/>
   </fingerprint>
   <!-- iMAC - Reference for the following: https://support.apple.com/en-us/HT201634 -->
   <fingerprint pattern="^model=iMac19,1$">

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1291,6 +1291,42 @@
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
   <!-- iPad mini -->
+<fingerprint pattern="^model=J21[01]AP$">
+    <description>iPad mini (5th generation)</description>
+    <example>model=J210AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad mini"/>
+    <param pos="0" name="hw.product" value="iPad mini (5th generation)"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+<fingerprint pattern="^model=J9[67]AP$">
+    <description>iPad mini 4</description>
+    <example>model=J97AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad mini"/>
+    <param pos="0" name="hw.product" value="iPad mini 4"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <fingerprint pattern="^model=J8[567]mAP$">
+    <description>iPad mini 3</description>
+    <example>model=J87mAP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad mini"/>
+    <param pos="0" name="hw.product" value="iPad mini 3"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
   <fingerprint pattern="^model=J8[567]AP$">
     <description>iPad mini 2</description>
     <example>model=J85AP</example>
@@ -1301,6 +1337,18 @@
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPad mini"/>
     <param pos="0" name="hw.product" value="iPad mini 2"/>
+    <param pos="0" name="hw.device" value="Tablet"/>
+  </fingerprint>
+  <fingerprint pattern="^model=P10[567]AP$">
+    <description>iPad mini</description>
+    <example>model=P105AP</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="iOS"/>
+    <param pos="0" name="os.product" value="iOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="iPad mini"/>
+    <param pos="0" name="hw.product" value="iPad mini"/>
     <param pos="0" name="hw.device" value="Tablet"/>
   </fingerprint>
 </fingerprints>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -170,6 +170,18 @@
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
   <!-- MacBookPro - Reference for the following: https://support.apple.com/en-us/HT201300 -->
+  <fingerprint pattern="^model=MacBookPro15,4$">
+    <description>MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)</description>
+    <example>model=MacBookPro15,4</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook Pro"/>
+    <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
   <fingerprint pattern="^model=MacBookPro15,3$">
     <description>MacBook Pro (15-inch, 2019)</description>
     <example>model=MacBookPro15,3</example>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -484,6 +484,55 @@
     <param pos="0" name="hw.product" value="Mac mini (Late 2012)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
   </fingerprint>
+  <fingerprint pattern="^model=Macmini5,[12]$">
+    <description>Mac mini (Mid 2011)</description>
+    <example>model=Macmini5,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Mid 2011)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=Macmini4,1$">
+    <description>Mac mini (Mid 2010)</description>
+    <example>model=Macmini4,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Mid 2010)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=Macmini3,1$">
+    <description>Mac mini (Late 2009)</description>
+    <example>model=Macmini3,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Late 2009)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
+  <!-- Listed at https://en.wikipedia.org/wiki/Mac_Mini#2nd_generation_(Intel-based,_2006-2009) -->
+  <fingerprint pattern="^model=Macmini2,1$">
+    <description>Mac mini (Mid 2007)</description>
+    <example>model=Macmini2,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Mac mini"/>
+    <param pos="0" name="hw.product" value="Mac mini (Mid 2007)"/>
+    <param pos="0" name="hw.device" value="Desktop"/>
+  </fingerprint>
   <!-- iMAC - Reference for the following: https://support.apple.com/en-us/HT201634 -->
   <fingerprint pattern="^model=iMac19,1$">
     <description>iMac (Retina 5K, 27-inch, 2019)</description>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -156,17 +156,56 @@
     <param pos="0" name="os.version" value="10.0"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.0"/>
   </fingerprint>
-  <!-- The entry below is very likely an AirPort Extreme but I can't find a reference. -->
-  <fingerprint pattern="^model=AirPort.*$">
+  <!-- AirPort Express -->
+  <!-- TODO: Break this down into specific models and generations -->
+  <fingerprint pattern="^model=AirPort4(?:,10[47])?$">
     <description>AirPort</description>
-    <example>model=AirPort5,114</example>
+    <example>model=AirPort4</example>
+    <example>model=AirPort4,104</example>
+    <example>model=AirPort4,107</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="AirPort"/>
     <param pos="0" name="os.product" value="AirPort Base Station Firmware"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:airport_base_station_firmware:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="AirPort"/>
-    <param pos="0" name="hw.product" value="AirPort"/>
+    <param pos="0" name="hw.product" value="AirPort Express"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+  </fingerprint>
+  <!-- AirPort Extreme -->
+  <!-- TODO: Break this down into specific models and generations -->
+  <fingerprint pattern="^model=AirPort5?(?:,\d+)?$">
+    <description>AirPort</description>
+    <example>model=AirPort</example>
+    <example>model=AirPort5</example>
+    <example>model=AirPort5,104</example>
+    <example>model=AirPort5,117</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="AirPort"/>
+    <param pos="0" name="os.product" value="AirPort Base Station Firmware"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:airport_base_station_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="AirPort"/>
+    <param pos="0" name="hw.product" value="AirPort Extreme"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+  </fingerprint>
+  <!-- TimeCapsule aka AirPort 6 -->
+  <!-- TODO: Break this down into specific models and generations -->
+    <fingerprint pattern="^model=(AirPort6|TimeCapsule).*$">
+    <description>Time Capsule</description>
+    <example>model=AirPort6</example>
+    <example>model=AirPort6,106</example>
+    <example>model=TimeCapsule</example>
+    <example>model=TimeCapsule6</example>
+    <example>model=TimeCapsule6,109</example>
+    <example>model=TimeCapsule6,116</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Time Capsule"/>
+    <param pos="0" name="os.product" value="Time Capsule Firmware"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:time_capsule_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Time Capsule"/>
+    <param pos="0" name="hw.product" value="Time Capsule"/>
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
   <!-- MacBookPro - Reference for the following: https://support.apple.com/en-us/HT201300 -->

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -12,6 +12,15 @@
      The number specified after osxvers= is equivalent to the major
      version of OS X plus 4. E.g. osxvers=13 means OS X 10.9
    -->
+  <fingerprint pattern="^osxvers=19">
+    <description>OS X 10.15 (Catalina)</description>
+    <example>osxvers=19</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.version" value="10.15"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.15"/>
+  </fingerprint>
   <fingerprint pattern="^osxvers=18">
     <description>OS X 10.14 (Mojave)</description>
     <example>osxvers=18</example>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -568,6 +568,163 @@
     <param pos="0" name="hw.product" value="MacBook (13-inch, Mid 2010)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
   </fingerprint>
+<!-- MacBookAir - Reference for the following: https://support.apple.com/en-us/HT201862 -->
+  <fingerprint pattern="^model=MacBookAir8,2$">
+    <description>MacBook Air (Retina, 13-inch, 2019)</description>
+    <example>model=MacBookAir8,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (Retina, 13-inch, 2019)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir8,1$">
+    <description>MacBook Air (Retina, 13-inch, 2018)</description>
+    <example>model=MacBookAir8,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (Retina, 13-inch, 2018)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir7,2$">
+    <description>MacBook Air (13-inch, 2017)</description>
+    <example>model=MacBookAir7,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (13-inch, 2017)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir7,1$">
+    <description>MacBook Air (11-inch, Early 2015)</description>
+    <example>model=MacBookAir7,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (11-inch, Early 2015)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir6,2$">
+    <description>MacBook Air (13-inch, Early 2014)</description>
+    <example>model=MacBookAir6,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (13-inch, Early 2014)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir6,1$">
+    <description>MacBook Air (11-inch, Early 2014)</description>
+    <example>model=MacBookAir6,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (11-inch, Early 2014)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir5,2$">
+    <description>MacBook Air (13-inch, Mid 2012)</description>
+    <example>model=MacBookAir5,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (13-inch, Mid 2012)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir5,1$">
+    <description>MacBook Air (11-inch, Mid 2012)</description>
+    <example>model=MacBookAir5,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (11-inch, Mid 2012)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir4,2$">
+    <description>MacBook Air (13-inch, Mid 2011)</description>
+    <example>model=MacBookAir4,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (13-inch, Mid 2011)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir4,1$">
+    <description>MacBook Air (11-inch, Mid 2011)</description>
+    <example>model=MacBookAir4,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (11-inch, Mid 2011)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir3,2$">
+    <description>MacBook Air (13-inch, Late 2010)</description>
+    <example>model=MacBookAir3,2</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (13-inch, Late 2010)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir3,1$">
+    <description>MacBook Air (11-inch, Late 2010)</description>
+    <example>model=MacBookAir3,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (11-inch, Late 2010)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
+  <fingerprint pattern="^model=MacBookAir2,1$">
+    <description>MacBook Air (Mid 2009)</description>
+    <example>model=MacBookAir2,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS X"/>
+    <param pos="0" name="os.product" value="Mac OS X"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="MacBook"/>
+    <param pos="0" name="hw.product" value="MacBook Air (Mid 2009)"/>
+    <param pos="0" name="hw.device" value="Laptop"/>
+  </fingerprint>
   <!-- MacMini - Reference for the following: https://support.apple.com/en-us/HT201894 -->
   <fingerprint pattern="^model=Macmini8,1$">
     <description>Mac mini (Late 2018)</description>


### PR DESCRIPTION
## Description

This PR includes a number of new Apple MDNS fingerprints (laptops, desktops, servers, devices, mobile phones, tablets, TVs, and homepod).

## Motivation and Context

This resolves missing fingerprints for a wide range of Apple products.

## How Has This Been Tested?

Use of rspec, recog_verify, and testing against real device fingerprints.

## Types of changes
- Support for a wide range of Apple devices


## Checklist:
- [X] I have updated the documentation accordingly (**changes are not required**).
- [X] I have added tests to cover my changes (or new tests are not required).
- [X] All new and existing tests passed.
