### PR TITLE
DCA-17412: Updated SonicOS recog fingeprint

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5452,16 +5452,18 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SonicWall
    =======================================================================-->
-  <fingerprint pattern="^SonicWALL (.*?)\s+\(SonicOS \S+ (\d[^\)]+)\)\s*$">
+  <fingerprint pattern="^SonicWALL (\S+)\s(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
     <description>SonicWall - SonicOS Enhanced variant</description>
     <example>SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
     <example>SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>
     <example>SonicWALL TZ190 Enhanced (SonicOS Enhanced 3.6.0.4-30e)</example>
+    <example>SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="SonicOS"/>
-    <param pos="1" name="os.product"/>
-    <param pos="2" name="os.version"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="hw.model"/>
+    <param pos="3" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^SonicWALL (.*?)\s+\(([^\)]+)\)\s*$">
     <description>SonicWall</description>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5460,7 +5460,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example hw.product="SuperMassive" hw.model="9200" os.version="6.2.5.3-35n">SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
-    <param pos="0" name="os.family" value="SonicOS"/>
+    <param pos="0" name="os.product" value="SonicOS"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="hw.model"/>
     <param pos="3" name="os.version"/>
@@ -5477,7 +5477,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>SonicWALL I80X86 / 800 Mhz (PRO 2040 Standa)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
-    <param pos="0" name="os.family" value="SonicOS"/>
+    <param pos="0" name="os.product" value="SonicOS"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.product"/>
   </fingerprint>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5452,7 +5452,7 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SonicWall
    =======================================================================-->
-  <fingerprint pattern="^SonicWALL (\S+)\s(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
+  <fingerprint pattern="^SonicWALL (\S+)\s+(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
     <description>SonicWall - SonicOS Enhanced variant</description>
     <example>SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
     <example>SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5452,12 +5452,12 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SonicWall
    =======================================================================-->
-  <fingerprint pattern="^SonicWALL (\S+)\s+(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
+  <fingerprint pattern="^SonicWALL (\S+)\s*(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
     <description>SonicWall - SonicOS Enhanced variant</description>
-    <example>SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
-    <example>SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>
+    <example hw.product="NSA" hw.model="220" os.version="5.8.1.2-20o">SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
+    <example hw.product="TZ" hw.model="215" os.version="5.8.1.2-6o">SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>
     <example>SonicWALL TZ190 Enhanced (SonicOS Enhanced 3.6.0.4-30e)</example>
-    <example>SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
+    <example hw.product="SuperMassive" hw.model="9200" os.version="6.2.5.3-35n">SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="SonicOS"/>


### PR DESCRIPTION
## Description
Updated the SonicOS fingerprinter so we can capture the hardware model version separately from the hardware model name


## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?
New Fingerprint matches all examples given as expected:

Match # | Group index | Start index | End index | Group content
-- | -- | -- | -- | --
1 | 0 | 0 | 58 | SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)
1 | 1 | 10 | 22 | SuperMassive
1 | 2 | 23 | 27 | 9200
1 | 3 | 46 | 57 | 6.2.5.3-35n

Rake tests pass
```
9 scenarios (9 passed)
20 steps (20 passed)
0m2.782s
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
