### PR TITLE
DCA-17412: Updated Xerox recog fingeprint for Urgent/11

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5452,16 +5452,18 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SonicWall
    =======================================================================-->
-  <fingerprint pattern="^SonicWALL (.*?)\s+\(SonicOS \S+ (\d[^\)]+)\)\s*$">
+  <fingerprint pattern="^SonicWALL (\S+)\s(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
     <description>SonicWall - SonicOS Enhanced variant</description>
     <example>SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
     <example>SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>
     <example>SonicWALL TZ190 Enhanced (SonicOS Enhanced 3.6.0.4-30e)</example>
+    <example>SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="SonicOS"/>
-    <param pos="1" name="os.product"/>
-    <param pos="2" name="os.version"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="hw.model"/>
+    <param pos="3" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^SonicWALL (.*?)\s+\(([^\)]+)\)\s*$">
     <description>SonicWall</description>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5460,7 +5460,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example hw.product="SuperMassive" hw.model="9200" os.version="6.2.5.3-35n">SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
-    <param pos="0" name="os.family" value="SonicOS"/>
+    <param pos="0" name="os.product" value="SonicOS"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="hw.model"/>
     <param pos="3" name="os.version"/>
@@ -5477,7 +5477,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>SonicWALL I80X86 / 800 Mhz (PRO 2040 Standa)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
-    <param pos="0" name="os.family" value="SonicOS"/>
+    <param pos="0" name="os.product" value="SonicOS"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.product"/>
   </fingerprint>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5452,7 +5452,7 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SonicWall
    =======================================================================-->
-  <fingerprint pattern="^SonicWALL (\S+)\s(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
+  <fingerprint pattern="^SonicWALL (\S+)\s+(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
     <description>SonicWall - SonicOS Enhanced variant</description>
     <example>SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
     <example>SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6351,7 +6351,6 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-
   <!--======================================================================
                                     Xyplex
    =======================================================================-->

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6218,6 +6218,35 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               XEROX
    =======================================================================-->
+  <fingerprint pattern="^Xerox Phaser (\d+)MFP;\sOS\s(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+    <description>Xerox Phaser 3000 MFP Series </description>
+    <example hw.version="3300" os.version="1.50.00.17">Xerox Phaser 3300MFP; OS 1.50.00.17   05-07-2013, Engine 1.05.44, NIC V4.03.01(P3300MFP), PCL5e 6.08.01 11-10-2009, PCL6 5.98  09-23-2009, PS3 V2.19.06 12-15-2010, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.22 09-24-2009</example>
+    <example hw.version="3300" os.version="1.50.00.14">Xerox Phaser 3300MFP; OS 1.50.00.14   07-16-2009, Engine 1.05.44, NIC V4.02.06(P3300MFP) 07-16-2009, PCL5e 5.93 03-19-2009, PCL6 5.94  05-11-2009, PS3 V1.99.06 04-09-2009, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.20 02-03-2009</example>
+    <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="os.family" value="Phaser"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="1" name="hw.version"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Xerox WorkCentre (\d+).*?SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+    <description>Xerox WorkCentre 3345/3335 Printers</description>
+    <example hw.version="3335" os.version="60.004.00.000">Xerox WorkCentre 3335; SS 60.004.00.000, NC 4.00.50.73, UI V5.51.00.31.00_17030801, ME V0.00.39, CCOS 6.9.P</example>
+    <example hw.version="3345" os.version="60.001.01.000">Xerox WorkCentre 3345; SS 60.001.01.000, NC 4.00.50.46, UI V5.51.00.29.00_16052717, ME V0.00.37, CCOS 6.9.P</example>
+    <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="os.family" value="WorkCentre"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="1" name="hw.version"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Xerox B(\d+).*?SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+    <description>Xerox B series Multfunction Printer</description>
+    <example hw.version="1025" os.version="75.000.77.000">Xerox B1025 Multifunction Printer; SS 75.000.77.000, NC V4.00.50, UI V5.52.00.08.00_18032319, ME V0.00.25 03-20-2018, CCOS 6.9.P</example>
+    <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="os.family" value="WorkCentre"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="1" name="hw.version"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
   <fingerprint pattern="^Xerox (Phaser [^;]+).*[, ]OS ([^;,]+).*$" certainty="1.0">
     <description>Xerox Phaser Laser Printer - OS variant</description>
     <example>Xerox Phaser 5500DN;PS G02.10,Net 22.42.11.22.2004,Eng 11.42.00,OS 4.46;SN RET570148</example>
@@ -6322,6 +6351,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
+
   <!--======================================================================
                                     Xyplex
    =======================================================================-->

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5452,12 +5452,12 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               SonicWall
    =======================================================================-->
-  <fingerprint pattern="^SonicWALL (\S+)\s+(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
+  <fingerprint pattern="^SonicWALL (\S+)\s*(\d+).*?\(SonicOS \S+ (\d[^\)]+)\)\s*$">
     <description>SonicWall - SonicOS Enhanced variant</description>
-    <example>SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
-    <example>SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>
+    <example hw.product="NSA" hw.model="220" os.version="5.8.1.2-20o">SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
+    <example hw.product="TZ" hw.model="215" os.version="5.8.1.2-6o">SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>
     <example>SonicWALL TZ190 Enhanced (SonicOS Enhanced 3.6.0.4-30e)</example>
-    <example>SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
+    <example hw.product="SuperMassive" hw.model="9200" os.version="6.2.5.3-35n">SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="SonicOS"/>


### PR DESCRIPTION
## Description
Might be better to have an example fingerprint from Phaser 3635MFP instead of just 3300 - couldn't find any on Shodan, maybe sonar could help us out on Monday if we want to boost confidence.

```
Software releases are available for:

WorkCentre 3335/3345 on 9/6/19
Xerox B1022/B1025 on 9/19/19
Xerox Phaser 3635MFP on 10/2/19
```
https://security.business.xerox.com/en-us/news/wind-river-vxworks-ipnet-tcp-ip-stack-vulnerabilities/

## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.

## How Has This Been Tested?
Rake Tests pass:
```
9 scenarios (9 passed)
20 steps (20 passed)
0m2.782s
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
