### PR TITLE
DCA-17416: Updated Xerox recog fingeprint for Urgent/11

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -617,19 +617,19 @@ more text</example>
     <param pos="0" name="hw.device" value="Multifunction Device"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="Xerox WorkCentre (\d+).*$" certainty="1.0">
+  <fingerprint pattern="^Xerox WorkCentre ([A-Za-z0-9]+).*$" certainty="1.0">
     <description>Xerox WorkCentre</description>
-    <example hw.version="6605">Xerox WorkCentre 6605DN</example>
-    <example hw.version="3615">Xerox WorkCentre 3615</example>
-    <example hw.version="6505">Xerox WorkCentre 6505ND</example>
-    <example hw.version="6505">Xerox WorkCentre 6505N</example>
+    <example hw.product="6605DN">Xerox WorkCentre 6605DN</example>
+    <example hw.product="3615">Xerox WorkCentre 3615</example>
+    <example hw.product="6505DN">Xerox WorkCentre 6505DN</example>
+    <example hw.product="6505N">Xerox WorkCentre 6505N</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="hw.family" value="WorkCentre"/>
     <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.version"/>    
+    <param pos="1" name="hw.product"/>    
   </fingerprint>
   <fingerprint pattern="^Xerox Phaser (\S+)$" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -617,6 +617,20 @@ more text</example>
     <param pos="0" name="hw.device" value="Multifunction Device"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
+  <fingerprint pattern="Xerox WorkCentre (\d+).*$" certainty="1.0">
+    <description>Xerox WorkCentre</description>
+    <example hw.version="6605">Xerox WorkCentre 6605DN</example>
+    <example hw.version="3615">Xerox WorkCentre 3615</example>
+    <example hw.version="6505">Xerox WorkCentre 6505ND</example>
+    <example hw.version="6505">Xerox WorkCentre 6505N</example>
+    <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="os.family" value="Phaser"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="WorkCentre"/>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="1" name="hw.version"/>    
+  </fingerprint>
   <fingerprint pattern="^Xerox Phaser (\S+)$" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>
     <example>Xerox Phaser 6130N</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6218,42 +6218,42 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               XEROX
    =======================================================================-->
-  <fingerprint pattern="^Xerox Phaser (\d+)MFP;\sOS\s(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
-    <description>Xerox Phaser 3000 MFP Series </description>
-    <example hw.version="3300" os.version="1.50.00.17">Xerox Phaser 3300MFP; OS 1.50.00.17   05-07-2013, Engine 1.05.44, NIC V4.03.01(P3300MFP), PCL5e 6.08.01 11-10-2009, PCL6 5.98  09-23-2009, PS3 V2.19.06 12-15-2010, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.22 09-24-2009</example>
-    <example hw.version="3300" os.version="1.50.00.14">Xerox Phaser 3300MFP; OS 1.50.00.14   07-16-2009, Engine 1.05.44, NIC V4.02.06(P3300MFP) 07-16-2009, PCL5e 5.93 03-19-2009, PCL6 5.94  05-11-2009, PS3 V1.99.06 04-09-2009, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.20 02-03-2009</example>
+  <fingerprint pattern="^Xerox Phaser ([^;]+);\sOS\s(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+    <description>Xerox Phaser 3000MFP Series </description>
+    <example hw.product="3300MFP" os.version="1.50.00.17">Xerox Phaser 3300MFP; OS 1.50.00.17   05-07-2013, Engine 1.05.44, NIC V4.03.01(P3300MFP), PCL5e 6.08.01 11-10-2009, PCL6 5.98  09-23-2009, PS3 V2.19.06 12-15-2010, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.22 09-24-2009</example>
+    <example hw.product="3300MFP" os.version="1.50.00.14">Xerox Phaser 3300MFP; OS 1.50.00.14   07-16-2009, Engine 1.05.44, NIC V4.02.06(P3300MFP) 07-16-2009, PCL5e 5.93 03-19-2009, PCL6 5.94  05-11-2009, PS3 V1.99.06 04-09-2009, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.20 02-03-2009</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="hw.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.version"/>
+    <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^Xerox WorkCentre (\d+).*?SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+  <fingerprint pattern="^Xerox WorkCentre ([^;]+);\s+SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
     <description>Xerox WorkCentre 3345/3335 Printers</description>
-    <example hw.version="3335" os.version="60.004.00.000">Xerox WorkCentre 3335; SS 60.004.00.000, NC 4.00.50.73, UI V5.51.00.31.00_17030801, ME V0.00.39, CCOS 6.9.P</example>
-    <example hw.version="3345" os.version="60.001.01.000">Xerox WorkCentre 3345; SS 60.001.01.000, NC 4.00.50.46, UI V5.51.00.29.00_16052717, ME V0.00.37, CCOS 6.9.P</example>
+    <example hw.product="3335" os.version="60.004.00.000">Xerox WorkCentre 3335; SS 60.004.00.000, NC 4.00.50.73, UI V5.51.00.31.00_17030801, ME V0.00.39, CCOS 6.9.P</example>
+    <example hw.product="3345" os.version="60.001.01.000">Xerox WorkCentre 3345; SS 60.001.01.000, NC 4.00.50.46, UI V5.51.00.29.00_16052717, ME V0.00.37, CCOS 6.9.P</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="WorkCentre"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="hw.family" value="WorkCentre"/>
     <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.version"/>
+    <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
-  <fingerprint pattern="^Xerox B(\d+).*?SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+  <fingerprint pattern="^Xerox (B\d+) Multifunction Printer; SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
     <description>Xerox B series Multfunction Printer</description>
-    <example hw.version="1025" os.version="75.000.77.000">Xerox B1025 Multifunction Printer; SS 75.000.77.000, NC V4.00.50, UI V5.52.00.08.00_18032319, ME V0.00.25 03-20-2018, CCOS 6.9.P</example>
+    <example hw.product="B1025" os.version="75.000.77.000">Xerox B1025 Multifunction Printer; SS 75.000.77.000, NC V4.00.50, UI V5.52.00.08.00_18032319, ME V0.00.25 03-20-2018, CCOS 6.9.P</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="B"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="hw.family" value="B"/>
     <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.version"/>
+    <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^Xerox (Phaser [^;]+).*[, ]OS ([^;,]+).*$" certainty="1.0">

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6223,8 +6223,11 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example hw.version="3300" os.version="1.50.00.17">Xerox Phaser 3300MFP; OS 1.50.00.17   05-07-2013, Engine 1.05.44, NIC V4.03.01(P3300MFP), PCL5e 6.08.01 11-10-2009, PCL6 5.98  09-23-2009, PS3 V2.19.06 12-15-2010, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.22 09-24-2009</example>
     <example hw.version="3300" os.version="1.50.00.14">Xerox Phaser 3300MFP; OS 1.50.00.14   07-16-2009, Engine 1.05.44, NIC V4.02.06(P3300MFP) 07-16-2009, PCL5e 5.93 03-19-2009, PCL6 5.94  05-11-2009, PS3 V1.99.06 04-09-2009, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.20 02-03-2009</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
+    <param pos="0" name="hw.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="hw.version"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -6235,6 +6238,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="WorkCentre"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="WorkCentre"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="hw.version"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -6242,8 +6248,11 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Xerox B series Multfunction Printer</description>
     <example hw.version="1025" os.version="75.000.77.000">Xerox B1025 Multifunction Printer; SS 75.000.77.000, NC V4.00.50, UI V5.52.00.08.00_18032319, ME V0.00.25 03-20-2018, CCOS 6.9.P</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
-    <param pos="0" name="os.family" value="WorkCentre"/>
+    <param pos="0" name="os.family" value="B"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="B"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="hw.version"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -6260,6 +6269,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Phaser"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -6269,6 +6281,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Phaser"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -6280,6 +6295,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Phaser"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Xerox Document Centre Multi-function System.*$">
@@ -6291,6 +6309,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.product" value="Document Centre"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="snmp.fpmib.oid.1" value="1.3.6.1.2.1.25.6.3.1.2.2"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="Document Centre"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^Xerox DocuPrint (\S+) Network Laser Printer - (\S+)$" certainty="1.0">
     <description>Xerox DocuPrint Laser Printer</description>
@@ -6313,6 +6334,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.family" value="WorkCentre Pro"/>
     <param pos="0" name="os.product" value="WorkCentre Pro"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="WorkCentre Pro"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^Xerox (WorkCentre [^\s;]+).*$" certainty="1.0">
     <description>Xerox WorkCentre</description>
@@ -6322,6 +6346,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.family" value="WorkCentre"/>
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
+    <param pos="0" name="hw.family" value="WorkCentre"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^Xerox (\S+ [^\s;]+).*$" certainty="1.0">
     <description>Xerox Default</description>
@@ -6329,16 +6356,20 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Xerox DocuTech 6115; DocuSP CP.4205.90</example>
     <example>Xerox DocuColor 250 with EFI Fiery Controller; SW1.1,Controller ROM1.231.15, IOT 8.26.0, FIN C16.25.0, IIT 11.56.1, IIT D12.3.2, ADF 11.8.0</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
   <fingerprint pattern="^XEROX (\d{4} WIDE FORMAT) PRINTER; ACCXES (\d+.\d+) \d+, IOT .*$" certainty="1.0">
     <description>Xerox Wide Format Printer</description>
     <example>XEROX 6204 WIDE FORMAT PRINTER; ACCXES 15.0 136, IOT 01.01.07</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Wide Format Printer"/>
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <fingerprint pattern="^XEROX (WIDE FORMAT \d{4}) PRINTER; ACCXES (\d+.\d+) \d+, IOT .*$" certainty="1.0">
@@ -6346,9 +6377,12 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>XEROX WIDE FORMAT 6605 PRINTER; ACCXES 14.0 142, IOT 01.01.04XXXXXX</example>
     <example>XEROX WIDE FORMAT 6604 PRINTER; ACCXES 14.0 142, IOT 01.01.04XXXXXX</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.family" value="Wide Format Printer"/>
+    <param pos="0" name="hw.family" value="Wide Format Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="hw.device" value="Printer"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
   <!--======================================================================

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6248,10 +6248,10 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Xerox B series Multfunction Printer</description>
     <example hw.product="B1025" os.version="75.000.77.000">Xerox B1025 Multifunction Printer; SS 75.000.77.000, NC V4.00.50, UI V5.52.00.08.00_18032319, ME V0.00.25 03-20-2018, CCOS 6.9.P</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
-    <param pos="0" name="os.family" value="B"/>
+    <param pos="0" name="os.family" value="Multifunction"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
-    <param pos="0" name="hw.family" value="B"/>
+    <param pos="0" name="hw.family" value="Multifunction"/>
     <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6218,6 +6218,35 @@ Copyright (c) 1995-2005 by Cisco Systems
   <!--======================================================================
                               XEROX
    =======================================================================-->
+  <fingerprint pattern="^Xerox Phaser (\d+)MFP;\sOS\s(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+    <description>Xerox Phaser 3000 MFP Series </description>
+    <example hw.version="3300" os.version="1.50.00.17">Xerox Phaser 3300MFP; OS 1.50.00.17   05-07-2013, Engine 1.05.44, NIC V4.03.01(P3300MFP), PCL5e 6.08.01 11-10-2009, PCL6 5.98  09-23-2009, PS3 V2.19.06 12-15-2010, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.22 09-24-2009</example>
+    <example hw.version="3300" os.version="1.50.00.14">Xerox Phaser 3300MFP; OS 1.50.00.14   07-16-2009, Engine 1.05.44, NIC V4.02.06(P3300MFP) 07-16-2009, PCL5e 5.93 03-19-2009, PCL6 5.94  05-11-2009, PS3 V1.99.06 04-09-2009, SPL 5.24 03-27-2006, PDF V1.00.32 02-25-2006, IBM/EPSON 5.20 02-03-2009</example>
+    <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="os.family" value="Phaser"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="1" name="hw.version"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Xerox WorkCentre (\d+).*?SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+    <description>Xerox WorkCentre 3345/3335 Printers</description>
+    <example hw.version="3335" os.version="60.004.00.000">Xerox WorkCentre 3335; SS 60.004.00.000, NC 4.00.50.73, UI V5.51.00.31.00_17030801, ME V0.00.39, CCOS 6.9.P</example>
+    <example hw.version="3345" os.version="60.001.01.000">Xerox WorkCentre 3345; SS 60.001.01.000, NC 4.00.50.46, UI V5.51.00.29.00_16052717, ME V0.00.37, CCOS 6.9.P</example>
+    <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="os.family" value="WorkCentre"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="1" name="hw.version"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+  <fingerprint pattern="^Xerox B(\d+).*?SS\s+(\d+\.\d+\.\d+\.\d+).*$" certainty="1.0">
+    <description>Xerox B series Multfunction Printer</description>
+    <example hw.version="1025" os.version="75.000.77.000">Xerox B1025 Multifunction Printer; SS 75.000.77.000, NC V4.00.50, UI V5.52.00.08.00_18032319, ME V0.00.25 03-20-2018, CCOS 6.9.P</example>
+    <param pos="0" name="os.vendor" value="Xerox"/>
+    <param pos="0" name="os.family" value="WorkCentre"/>
+    <param pos="0" name="os.device" value="Printer"/>
+    <param pos="1" name="hw.version"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
   <fingerprint pattern="^Xerox (Phaser [^;]+).*[, ]OS ([^;,]+).*$" certainty="1.0">
     <description>Xerox Phaser Laser Printer - OS variant</description>
     <example>Xerox Phaser 5500DN;PS G02.10,Net 22.42.11.22.2004,Eng 11.42.00,OS 4.46;SN RET570148</example>


### PR DESCRIPTION
## Description
Might be better to have an example fingerprint from Phaser 3635MFP instead of just 3300 - couldn't find any on Shodan, maybe sonar could help us out on Monday if we want to boost confidence.

```
Software releases are available for:

WorkCentre 3335/3345 on 9/6/19
Xerox B1022/B1025 on 9/19/19
Xerox Phaser 3635MFP on 10/2/19
```
https://security.business.xerox.com/en-us/news/wind-river-vxworks-ipnet-tcp-ip-stack-vulnerabilities/

## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.

## How Has This Been Tested?
Rake Tests pass after latest commit `be696ff`:
```
9 scenarios (9 passed)
20 steps (20 passed)
0m2.787s
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
