### PR TITLE
Add a few ftp and ssh banners and a little cleanup

### DIFF
--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -769,7 +769,6 @@ more text</example>
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:windriver:vxworks:-{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^ADC iScale$">
     <description>ADC iScale</description>
     <example>ADC iScale</example>
@@ -1486,7 +1485,8 @@ more text</example>
     <param pos="0" name="os.product" value="Linux AMI"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
-  <!-- Idea is an ISP service, and not likely a product on its own. -->
+  <!-- Below are banners for FTP service providers, not necessarily
+       specific FTP servers-->
   <fingerprint pattern="^Idea FTP Server ([\d\.]+) \((.*)\) \[(.+)\]$">
     <description>Idea FTP Server</description>
     <example service.version="0.83.213" host.name="localhost" host.ip="1.2.3.4">Idea FTP Server 0.83.213 (localhost) [1.2.3.4]</example>
@@ -1496,5 +1496,17 @@ more text</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="host.name"/>
     <param pos="3" name="host.ip"/>
+  </fingerprint>
+  <fingerprint pattern="^Amazon Ftp$">
+    <description>Amazon FTP endpoint</description>
+    <example>Amazon Ftp</example>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.product" value="FTP Server"/>
+  </fingerprint>
+  <fingerprint pattern="^Dreamhost FTP Server$">
+    <description>Dreamhost FTP endpoint</description>
+    <example>Dreamhost FTP Server</example>
+    <param pos="0" name="service.vendor" value="Dreamhost"/>
+    <param pos="0" name="service.product" value="FTP Server"/>
   </fingerprint>
 </fingerprints>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -285,9 +285,10 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
   </fingerprint>
-  <fingerprint pattern="^ProFTPD$">
+  <fingerprint pattern="^ProFTPD\s*$">
     <description>ProFTPD with no version info, super short form</description>
     <example>ProFTPD</example>
+    <example>ProFTPD </example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -265,16 +265,17 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
   </fingerprint>
-  <fingerprint pattern="^ProFTPD Server \(.*\) \[(.+)\]$">
+  <fingerprint pattern="^ProFTPD Server \(.*\) \[([a-f\d.:]+)\]$">
     <description>ProFTPD with no version info, parenthetical form</description>
-    <example host.name="1.2.3.4">ProFTPD Server (ProFTPD) [1.2.3.4]</example>
-    <example host.name="1.2.3.4">ProFTPD Server (ProFTPD Default Installation) [1.2.3.4]</example>
-    <example host.name="1.2.3.4">ProFTPD Server (pair Networks, Inc FTP server) [1.2.3.4]</example>
+    <example host.ip="1.2.3.4">ProFTPD Server (ProFTPD) [1.2.3.4]</example>
+    <example host.ip="1.2.3.4">ProFTPD Server (ProFTPD Default Installation) [1.2.3.4]</example>
+    <example host.ip="1.2.3.4">ProFTPD Server (pair Networks, Inc FTP server) [1.2.3.4]</example>
+    <example host.ip="::ffff:192.168.1.1">ProFTPD Server (ProFTPD) [::ffff:192.168.1.1]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
-    <param pos="1" name="host.name"/>
+    <param pos="1" name="host.ip"/>
   </fingerprint>
   <fingerprint pattern="^ProFTPD Server$">
     <description>ProFTPD with no version info, short form</description>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -247,15 +247,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="2" name="proftpd.server.name"/>
     <param pos="3" name="host.name"/>
   </fingerprint>
-  <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server (.+)$">
-    <description>ProFTPD with version info but no obvious OS info, take 2</description>
-    <example service.version="1.3.2d" host.name="localhost">ProFTPD 1.3.2d Server localhost</example>
-    <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
-    <param pos="0" name="service.product" value="ProFTPD"/>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="host.name"/>
-  </fingerprint>
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server ready\.$">
     <description>ProFTPD with only version info</description>
     <example service.version="1.3.0rc2">ProFTPD 1.3.0rc2 Server ready.</example>
@@ -322,6 +313,15 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:{service.version}"/>
     <param pos="2" name="proftpd.server.name"/>
+  </fingerprint>
+  <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server ([\w.-]+)$">
+    <description>ProFTPD with version info but no obvious OS info, take 2</description>
+    <example service.version="1.3.2d" host.name="localhost">ProFTPD 1.3.2d Server localhost</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="host.name"/>
   </fingerprint>
   <fingerprint pattern="^=\(&lt;\*&gt;\)=-\.:\. \(\( Welcome to Pure-FTPd ([\d.]+) \)\) \.:\.-=\(&lt;\*&gt;\)=-" flags="REG_MULTILINE">
     <description>Pure-FTPd versions &lt;= 1.0.13 (at least as far back as 1.0.11)</description>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1486,6 +1486,7 @@ more text</example>
     <param pos="0" name="os.product" value="Linux AMI"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
+  <!-- Idea is an ISP service, and not likely a product on its own. -->
   <fingerprint pattern="^Idea FTP Server ([\d\.]+) \((.*)\) \[(.+)\]$">
     <description>Idea FTP Server</description>
     <example service.version="0.83.213" host.name="localhost" host.ip="1.2.3.4">Idea FTP Server 0.83.213 (localhost) [1.2.3.4]</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -247,6 +247,15 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="2" name="proftpd.server.name"/>
     <param pos="3" name="host.name"/>
   </fingerprint>
+  <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server (.+)$">
+    <description>ProFTPD with version info but no obvious OS info, take 2</description>
+    <example service.version="1.3.2d" host.name="localhost">ProFTPD 1.3.2d Server localhost</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server ready\.$">
     <description>ProFTPD with only version info</description>
     <example service.version="1.3.0rc2">ProFTPD 1.3.0rc2 Server ready.</example>
@@ -265,9 +274,28 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
   </fingerprint>
+  <fingerprint pattern="^ProFTPD Server \(.*\) \[(.+)\]$">
+    <description>ProFTPD with no version info, parenthetical form</description>
+    <example host.name="1.2.3.4">ProFTPD Server (ProFTPD) [1.2.3.4]</example>
+    <example host.name="1.2.3.4">ProFTPD Server (ProFTPD Default Installation) [1.2.3.4]</example>
+    <example host.name="1.2.3.4">ProFTPD Server (pair Networks, Inc FTP server) [1.2.3.4]</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
   <fingerprint pattern="^ProFTPD Server$">
     <description>ProFTPD with no version info, short form</description>
     <example>ProFTPD Server</example>
+    <param pos="0" name="service.family" value="ProFTPD"/>
+    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
+    <param pos="0" name="service.product" value="ProFTPD"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
+  </fingerprint>
+  <fingerprint pattern="^ProFTPD">
+    <description>ProFTPD with no version info, super short form</description>
+    <example>ProFTPD</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -284,7 +284,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.product" value="ProFTPD"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
   </fingerprint>
-  <fingerprint pattern="^ProFTPD">
+  <fingerprint pattern="^ProFTPD$">
     <description>ProFTPD with no version info, super short form</description>
     <example>ProFTPD</example>
     <param pos="0" name="service.family" value="ProFTPD"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -657,7 +657,7 @@ more text</example>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="hw.family" value="WorkCentre"/>
     <param pos="0" name="hw.device" value="Printer"/>
-    <param pos="1" name="hw.product"/>    
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Xerox Phaser (\S+)$" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1051,7 +1051,7 @@ more text</example>
     <param pos="0" name="os.product" value="Fastmark M5"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="system.time.format" value="MMM dd HH:mm::ss"/>
+    <param pos="0" name="system.time.format" value="MMM dd HH:mm:ss"/>
     <param pos="2" name="system.time"/>
     <param pos="0" name="hw.vendor" value="AMTDatasouth"/>
     <param pos="0" name="hw.product" value="Fastmark M5"/>
@@ -1412,7 +1412,7 @@ more text</example>
     <param pos="0" name="hw.family" value="S500 Range"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="host.id"/>
-    <param pos="0" name="system.time.format" value="HH:mm::ss dd/MM/yy"/>
+    <param pos="0" name="system.time.format" value="HH:mm:ss dd/MM/yy"/>
     <param pos="3" name="system.time"/>
   </fingerprint>
   <fingerprint pattern="^TiMOS-[CB]-([\S]+) cpm\/[\w]+ ALCATEL (SR [\S]+) Copyright .{1,4}$">

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1376,6 +1376,13 @@ more text</example>
     <example>Welcome to TP-LINK FTP server</example>
     <param pos="0" name="hw.vendor" value="TP-LINK"/>
   </fingerprint>
+  <fingerprint pattern="^TP-LINK FTP version ([\d\.]+)">
+    <description>FTPD on a TP-LINK device with version, but no host info</description>
+    <example service.version="1.0">TP-LINK FTP version 1.0 ready at Wed May  1 20:51:49 2019</example>
+    <param pos="0" name="hw.vendor" value="TP-LINK"/>
+    <param pos="0" name="service.product" value="FTPD"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
   <fingerprint pattern="^ucftpd\((\w{3}\s+\d{1,2} \d{4}-\d\d:\d\d:\d\d)\) FTP server ready\.$">
     <description>ucftpd with version</description>
     <example service.version="Jul  2 2012-22:13:49">ucftpd(Jul  2 2012-22:13:49) FTP server ready.</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1484,4 +1484,14 @@ more text</example>
     <param pos="0" name="os.product" value="Linux AMI"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
+  <fingerprint pattern="^Idea FTP Server ([\d\.]+) \((.*)\) \[(.+)\]$">
+    <description>Idea FTP Server</description>
+    <example service.version="0.83.213" host.name="localhost" host.ip="1.2.3.4">Idea FTP Server 0.83.213 (localhost) [1.2.3.4]</example>
+    <example service.version="0.80" host.name="subdomain.home.pl" host.ip="1.2.3.4">Idea FTP Server 0.80 (subdomain.home.pl) [1.2.3.4]</example>
+    <param pos="0" name="service.vendor" value="Idea"/>
+    <param pos="0" name="service.product" value="FTP Server"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="host.name"/>
+    <param pos="3" name="host.ip"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1150,6 +1150,9 @@
     <param pos="0" name="os.product" value="RouterOS"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:mikrotik:routeros:-"/>
   </fingerprint>
+  <!-- xlightftpd is an ftp server that also supports SFTP. The SFTP
+       server appears in ssh studies, thus this banner is here, and
+       not in ftp_banners.xml-->
   <fingerprint pattern="^xlightftpd_release_([\d.]+)$">
     <description>Xlight FTP Server</description>
     <example service.version="3.8.3.6.1">xlightftpd_release_3.8.3.6.1</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -644,6 +644,18 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="HipServ"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_for_Windows_([\d.]+)$">
+    <description>OpenSSH running on Windows</description>
+    <example service.version="7.7">OpenSSH_for_Windows_7.7</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_(.*) in DesktopAuthority (?:.*)$">
     <description>DesktopAuthority SSH</description>
     <example service.version="3.8">OpenSSH_3.8 in DesktopAuthority 7.1.091</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1175,6 +1175,27 @@
     <param pos="0" name="service.vendor" value="libssh"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:libssh:libssh:{service.version}"/>
   </fingerprint>
+  <fingerprint pattern="^WeOnlyDo ([\d.]+)$">
+    <description>WeOnlyDo with version</description>
+    <example service.version="1.2.7">WeOnlyDo 1.2.7</example>
+    <example service.version="2.0.1">WeOnlyDo 2.0.1</example>
+    <example service.version="2.5.4">WeOnlyDo 2.5.4</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.family" value="WeOnlyDo"/>
+    <param pos="0" name="service.vendor" value="WeOnlyDo"/>
+    <param pos="0" name="service.product" value="WeOnlyDo SSH Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:weonlydo:weonlydo:{service.version}"/>
+  </fingerprint>
+  <fingerprint pattern="^WeOnlyDo ([\d.]+) \(FIPS\)$">
+    <description>WeOnlyDo with version with FIPS mode enabled</description>
+    <example service.version="2.2.9">WeOnlyDo 2.2.9 (FIPS)</example>
+    <example service.version="2.4.3">WeOnlyDo 2.4.3 (FIPS)</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.family" value="WeOnlyDo"/>
+    <param pos="0" name="service.vendor" value="WeOnlyDo"/>
+    <param pos="0" name="service.product" value="WeOnlyDo SSH Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:weonlydo:weonlydo:{service.version}"/>
+  </fingerprint>
   <!--
 1.2.22j4rad
 2.40

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1141,11 +1141,9 @@
     <param pos="0" name="os.product" value="Tru64 Unix"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:tru64:-"/>
   </fingerprint>
-  <fingerprint pattern="^(?:SSH-(\d\.\d)-)?ROSSSH$">
+  <fingerprint pattern="^ROSSSH$">
     <description>MikroTik RouterOS sshd</description>
     <example>ROSSSH</example>
-    <example service.version="2.0">SSH-2.0-ROSSSH</example>
-    <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="MikroTik"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="RouterOS"/>


### PR DESCRIPTION
## Description
This PR cleans up a few banners and adds some new ones:

* ftp:
  * 3 ProFTPD variants
  * 1 TP-Link banner
  * 3 banners for FTP services providers (Amazon, DreamHost, home.pl)
* ssh:
  * OpenSSH for Windows
  * WeOnlyDo

## Motivation and Context
These banners provide more coverage for several banners seen in the wild that have not already been fingerprinted.


## How Has This Been Tested?
I ran `rspec`, `rake tests` and `recoc_verify` none of which reported errors.


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
- [x] I have updated the documentation accordingly (or **changes are not required**).
- [x] I have added tests to cover my changes (or **new tests are not required**).
- [x] All new and existing tests passed.
