### PR TITLE
verify that parameters from capture groups are tested by examples

### DIFF
--- a/features/data/successful_tests.xml
+++ b/features/data/successful_tests.xml
@@ -2,7 +2,7 @@
 <fingerprints>
    <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
       <description>Cisco SIPGateway</description>
-      <example>Cisco-SIPGateway/IOS-12.x</example>
+      <example os.version="12.x">Cisco-SIPGateway/IOS-12.x</example>
       <param pos="0" name="os.vendor" value="Cisco"/>
       <param pos="0" name="os.product" value="IOS"/>
       <param pos="1" name="os.version"/>

--- a/features/data/tests_with_warnings.xml
+++ b/features/data/tests_with_warnings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <fingerprints>
   <fingerprint pattern="^-{10} Welcome to Pure-FTPd (.*)-{10}$">
-    <example>---------- Welcome to Pure-FTPd ----------</example>
+    <example pureftpd.config="">---------- Welcome to Pure-FTPd ----------</example>
     <description>Pure-FTPd</description>
     <param pos="1" name="pureftpd.config"/>
     <param pos="0" name="service.family" value="Pure-FTPd"/>

--- a/features/verify.feature
+++ b/features/verify.feature
@@ -18,9 +18,10 @@ Feature: Verify
     Then it should fail with:
       """
       WARN: 'Pure-FTPd' has no test cases
-      SUMMARY: Test completed with 1 successful, 1 warnings, and 0 failures
+      WARN: 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' messsage which is derived from a capture group
+      SUMMARY: Test completed with 1 successful, 2 warnings, and 0 failures
       """
-    And the exit status should be 1
+    And the exit status should be 2
 
   Scenario: Tests with warnings, warnings disabled
     When I run `recog_verify --no-warnings tests_with_warnings.xml`
@@ -40,5 +41,3 @@ Feature: Verify
       SUMMARY: Test completed with 0 successful, 0 warnings, and 4 failures
       """
     And the exit status should be 4
-
-

--- a/spec/data/verification_fingerprints.xml
+++ b/spec/data/verification_fingerprints.xml
@@ -1,0 +1,86 @@
+<fingerprints>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - no params</description>
+    <example>Dovecot ready.</example>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - no params defined by capture group</description>
+    <example>Dovecot ready.</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - no example</description>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - one parameter, one example</description>
+    <example host.name="domain">Dovecot ready. &lt;abc11.1.1234abcd.abdcabcdabcd@domain&gt;</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - two paremeters, one example</description>
+    <example host.name="domain" os.vendor="Ubuntu">Dovecot (Ubuntu) ready. &lt;abc11.1.1234abcd.abdcabcdabcd@domain&gt;</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+    <param pos="1" name="os.vendor"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - two parameters, two examples</description>
+    <example host.name="domain">Dovecot ready. &lt;abc11.1.1234abcd.abdcabcdabcd@domain&gt;</example>
+    <example os.vendor="Ubuntu">Dovecot (Ubuntu) ready.</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+    <param pos="1" name="os.vendor"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - two parameters, one example, one missing param</description>
+    <example host.name="domain">Dovecot ready. &lt;abc11.1.1234abcd.abdcabcdabcd@domain&gt;</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+    <param pos="1" name="os.vendor"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - two parameters, one example, two missing params</description>
+    <example>Dovecot ready. &lt;abc11.1.1234abcd.abdcabcdabcd@domain&gt;</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+    <param pos="1" name="os.vendor"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - two parameters, two examples, one missing param</description>
+    <example host.name="domain">Dovecot ready. &lt;abc11.1.1234abcd.abdcabcdabcd@domain&gt;</example>
+    <example>Dovecot (Ubuntu) ready.</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+    <param pos="1" name="os.vendor"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^[dD]ovecot (?:\((.*)\) )?(?:DA )?ready\.(?: &lt;.+@(.+)&gt;)?$">
+    <description>Dovecot Secure POP Server - two parameters, two examples, two missing params</description>
+    <example>Dovecot ready. &lt;abc11.1.1234abcd.abdcabcdabcd@domain&gt;</example>
+    <example>Dovecot (Ubuntu) ready.</example>
+    <param pos="0" name="service.family" value="Dovecot"/>
+    <param pos="0" name="service.product" value="Dovecot"/>
+    <param pos="1" name="os.vendor"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+</fingerprints>

--- a/spec/lib/recog/fingerprint_spec.rb
+++ b/spec/lib/recog/fingerprint_spec.rb
@@ -17,6 +17,95 @@ describe Recog::Fingerprint do
     end
   end
 
+  describe "#verification" do
+    let(:xml_file) { File.expand_path(File.join('spec', 'data', 'verification_fingerprints.xml')) }
+    let(:doc) { Nokogiri::XML(IO.read(xml_file)) }
+
+    context "0 params" do
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[0]) }
+
+      it "does not yield if a fingerprint has 0 parameters" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.not_to yield_control
+      end
+    end
+
+    context "0 capture groups" do
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[1]) }
+
+      it "does not yield if a fingerprint has parameters, but 0 are defined by a capture group " do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.not_to yield_control
+      end
+    end
+
+    context "0 examples" do
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[2]) }
+
+      it "does not yield if a fingerprint has 0 examples" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.not_to yield_control
+      end
+    end
+
+    context "1 capture group, 1 example" do
+
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[3]) }
+
+      it "does not yield when one capture group parameter is tested for in one example" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.not_to yield_control
+      end
+    end
+
+    context "2 capture groups, 1 example" do
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[4]) }
+
+      it "does not yield when two capture group parameters are tested for in one example" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.not_to yield_control
+      end
+    end
+
+    context "2 capture groups, 2 examples, 1 in each" do
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[5]) }
+
+      it "does not yield when two capture group parameters are tested for in two examples, one parameter in each" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.not_to yield_control
+      end
+    end
+
+    context "1 missing capture group, 1 example" do
+
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[6]) }
+
+      it "identifies when a parameter defined by a capture group is not included in one example" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String])
+      end
+    end
+
+    context "2 missing capture groups, 1 example" do
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[7]) }
+
+      it "identifies when two parameters defined by a capture groups are not included in one example" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String], [:warn, String])
+      end
+    end
+
+    context "1 missing capture group, 2 examples" do
+
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[8]) }
+
+      it "identifies when a parameter defined by a capture group is not included in one example" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String])
+      end
+    end
+
+    context "2 missing capture groups, 2 examples" do
+      let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[9]) }
+
+      it "identifies when two parameters defined by a capture groups are not included in one example" do
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String], [:warn, String])
+      end
+    end
+
+  end
+
   skip  "value interpolation" do
     # TODO
   end


### PR DESCRIPTION
## Description
Added a method `verify_tests_have_capture_groups` to `lib/recog/fingerprint.rb` which loops over the parameters provided by a fingerprint, finds the parameters that are defined by capture groups, and then raises a warning if there is not at least one example for each parameter defined by a capture group.

Before the `verify_tests_have_capture_groups` was added, running `bin/recog_verify xml/pop_banners.xml` produced:
```
WARN: 'Dovecot Secure POP Server' has no test cases
SUMMARY: Test completed with 32 successful, 1 warnings, and 0 failures
```

Now, with the `verify_tests_have_capture_groups` method called from the `verify_tests` method in `lib/recog/fingerprint.rb`, running `bin/recog_verify xml/pop_banners.xml` produces:
```
WARN: 'Qpopper with Sphera mods' is missing an example that checks for parameter 'service.version' messsage which is derived from a capture group
WARN: 'Qpopper with Sphera mods' is missing an example that checks for parameter 'host.domain' messsage which is derived from a capture group
WARN: 'Qpopper with MySQL auth module' is missing an example that checks for parameter 'service.version' messsage which is derived from a capture group
WARN: 'Qpopper with MySQL auth module' is missing an example that checks for parameter 'service.component.version' messsage which is derived from a capture group
WARN: 'Qpopper with MySQL auth module' is missing an example that checks for parameter 'host.domain' messsage which is derived from a capture group
WARN: 'Qpopper missing version info' is missing an example that checks for parameter 'service.version' messsage which is derived from a capture group
WARN: 'Qpopper missing version info' is missing an example that checks for parameter 'host.domain' messsage which is derived from a capture group
WARN: 'Qpopper with missing version info' is missing an example that checks for parameter 'qpopper.version' messsage which is derived from a capture group
WARN: 'Qpopper with missing version info' is missing an example that checks for parameter 'host.domain' messsage which is derived from a capture group
WARN: 'Microsoft Exchange Server 2003' is missing an example that checks for parameter 'service.version' messsage which is derived from a capture group
WARN: 'Microsoft Exchange Server 2003' is missing an example that checks for parameter 'host.name' messsage which is derived from a capture group
WARN: 'Microsoft Exchange Server 2000' is missing an example that checks for parameter 'service.version' messsage which is derived from a capture group
WARN: 'Microsoft Exchange Server 2000' is missing an example that checks for parameter 'host.name' messsage which is derived from a capture group
WARN: 'Microsoft Exchange Server' is missing an example that checks for parameter 'service.version' messsage which is derived from a capture group
WARN: 'Microsoft POP3 Services on Windows 2003' is missing an example that checks for parameter 'host.name' messsage which is derived from a capture group
WARN: 'Dovecot Secure POP Server' has no test cases
WARN: 'Dovecot Secure POP Server' is missing an example that checks for parameter 'host.name' messsage which is derived from a capture group
WARN: 'VMware Zimbra POP with version' is missing an example that checks for parameter 'service.version' messsage which is derived from a capture group
WARN: 'Generic masked POP3 server' is missing an example that checks for parameter 'host.name' messsage which is derived from a capture group
WARN: 'Apple Open Directory' is missing an example that checks for parameter 'os.version' messsage which is derived from a capture group
SUMMARY: Test completed with 32 successful, 20 warnings, and 0 failures
```
A PR to address these new warnings (among others) is forthcoming.

## Motivation and Context
The changes in this PR make it easy to identify fingerprints that have examples that do not fully test for all the `param` objects that are defined by a capture group. As a result, we can update those examples to make sure the fingerprints actually define capture groups that capture the data we expect.

## How Has This Been Tested?
* added `spec/data/verification_fingerprints.xml` which enumerates several different scenarios for the relationship between parameters and examples
* added several tests to `spec/lib/recog/fingerprint_spec.rb` that uses the test fingerprints from `spec/data/verification_fingerprints.xml` to verify that the `verify_tests_have_capture_groups` method works as expected
* updated `features/verify.feature` and associated data files to make sure that output looks as expected

running `rspec ./spec/lib/recog/fingerprint_spec.rb` yields:
```
...
Recog::Fingerprint
  value interpolation (PENDING: No reason given)
  #verification
    2 capture groups, 2 examples, 1 in each
      does not yield when two capture group parameters are tested for in two examples, one parameter in each
    2 capture groups, 1 example
      does not yield when two capture group parameters are tested for in one example
    1 missing capture group, 1 example
      identifies when a parameter defined by a capture group is not included in one example
    0 examples
      does not yield if a fingerprint has 0 examples
    0 capture groups
      does not yield if a fingerprint has parameters, but 0 are defined by a capture group
    1 missing capture group, 2 examples
      identifies when a parameter defined by a capture group is not included in one example
    2 missing capture groups, 1 example
      identifies when two parameters defined by a capture groups are not included in one example
    2 missing capture groups, 2 examples
      identifies when two parameters defined by a capture groups are not included in one example
    0 params
      does not yield if a fingerprint has 0 parameters
    1 capture group, 1 example
      does not yield when one capture group parameter is tested for in one example
...
```
With other messages about other pre-existing test case warnings.

Running `rspec` yields:
```
...
Finished in 30.4 seconds (files took 12.53 seconds to load)
123130 examples, 0 failures, 1 pending
...
```
Again, the pending test is prexisting.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
