### PR TITLE
Add Ubuntu, Debian, and FreeBSD fingerprints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ rvm:
   - '2.5.3'
   - '2.6.1'
   - 'jruby-9.1.9.0'
+jdk:
+  - openjdk8
+matrix:
+  allow_failures:
+    - rvm: 'jruby-9.1.9.0'
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - rake --version

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1295,6 +1295,21 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:-"/>
   </fingerprint>
   <!-- Raspbian -->
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-5\+deb8u\d+)$">
+    <description>OpenSSH running on Raspbian (Debian 8 "Jessie" based)</description>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u1">OpenSSH_6.7p1 Raspbian-5+deb8u1</example>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u2">OpenSSH_6.7p1 Raspbian-5+deb8u2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Raspbian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="8.0"/>
+  </fingerprint>  
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-\d\d?\+deb9u\d+)$">
     <description>OpenSSH running on Raspbian (Debian 9 "Stretch" based)</description>
     <example service.version="7.4p1" openssh.comment="Raspbian-10+deb9u1">OpenSSH_7.4p1 Raspbian-10+deb9u1</example>
@@ -1310,10 +1325,10 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="9.0"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-5\+deb8u\d+)$">
-    <description>OpenSSH running on Raspbian (Debian 8 "Jessie" based)</description>
-    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u1">OpenSSH_6.7p1 Raspbian-5+deb8u1</example>
-    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u2">OpenSSH_6.7p1 Raspbian-5+deb8u2</example>
+  <fingerprint pattern="^OpenSSH_(7\.9p1)\s+(Raspbian-(?:10|\d\d?\+deb10u\d+))$">
+    <description>OpenSSH running on Raspbian (Debian 10 "Buster" based)</description>
+    <example service.version="7.9p1" openssh.comment="Raspbian-10">OpenSSH_7.9p1 Raspbian-10</example>
+    <example service.version="7.9p1" openssh.comment="Raspbian-10+deb10u1">OpenSSH_7.9p1 Raspbian-10+deb10u1</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -1323,8 +1338,23 @@
     <param pos="0" name="os.vendor" value="Raspbian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="8.0"/>
+    <param pos="0" name="os.version" value="10.0"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_(8\.1p1)\s+(Raspbian-(?:1|\d\d?\+deb11u\d+))$">
+    <description>OpenSSH running on Raspbian (Debian 11 "Bullseye" based)</description>
+    <example service.version="8.1p1" openssh.comment="Raspbian-1">OpenSSH_8.1p1 Raspbian-1</example>
+    <example service.version="8.1p1" openssh.comment="Raspbian-1+deb11u1">OpenSSH_8.1p1 Raspbian-1+deb11u1</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Raspbian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="11.0"/>
+  </fingerprint>     
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-\d\d?)$">
     <description>OpenSSH running on Raspbian (Debian, unknown release)</description>
     <example service.version="7.5p1" openssh.comment="Raspbian-10">OpenSSH_7.5p1 Raspbian-10</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1263,9 +1263,10 @@
     <param pos="0" name="os.version" value="9.0"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:9.0"/>
   </fingerprint>
-<fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10)$">
+  <fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10|Debian-\d\d?\+deb10u\d+)$">
     <description>OpenSSH running on Debian 10.x (buster)</description>
     <example service.version="7.9p1" openssh.comment="Debian-10">OpenSSH_7.9p1 Debian-10</example>
+    <example service.version="7.9p1" openssh.comment="Debian-10+deb10u6">OpenSSH_7.9p1 Debian-10+deb10u6</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -1278,6 +1279,22 @@
     <param pos="0" name="os.version" value="10.0"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.0"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_(8\.1p1) (Debian-1|Debian-\d\d?\+deb11u\d+)$">
+    <description>OpenSSH running on Debian 11.x (bullseye)</description>
+    <example service.version="8.1p1" openssh.comment="Debian-1">OpenSSH_8.1p1 Debian-1</example>
+    <example service.version="8.1p1" openssh.comment="Debian-1+deb11u1">OpenSSH_8.1p1 Debian-1+deb11u1</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="11.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:11.0"/>
+  </fingerprint>  
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+(?:[~]?bpo[.]?\d+)?)$">
     <description>OpenSSH running on Debian (unknown release)</description>
     <example service.version="4.3p2" openssh.comment="Debian-5~bpo.1">OpenSSH_4.3p2 Debian-5~bpo.1</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -996,6 +996,21 @@
     <param pos="0" name="os.version" value="17.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:17.10"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_(7\.6p1) (Ubuntu-4ubuntu\d(?:\.\d)?)$">
+    <description>OpenSSH running on Ubuntu 18.04</description>
+    <example service.version="7.6p1" openssh.comment="Ubuntu-4ubuntu0.3">OpenSSH_7.6p1 Ubuntu-4ubuntu0.3</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="18.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:18.04"/>
+  </fingerprint>  
   <fingerprint pattern="^OpenSSH_(7\.7p1) (Ubuntu-4)$">
     <description>OpenSSH running on Ubuntu 18.10</description>
     <example>OpenSSH_7.7p1 Ubuntu-4</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -89,6 +89,37 @@
     <param pos="0" name="os.product" value="NetBSD"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:netbsd:netbsd:-"/>
   </fingerprint>
+  <!-- Ubuntu -->
+  <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (Debian-11ubuntu\d+(?:\.\d+)?)$">
+    <description>OpenSSH running on Ubuntu 4.10</description>
+    <example>OpenSSH_3.8.1p1 Debian-11ubuntu3</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="4.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:4.10"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(3\.9p1) (Debian-1ubuntu\d+(?:\.\d+)?)$">
+    <description>OpenSSH running on Ubuntu 5.04</description>
+    <example>OpenSSH_3.9p1 Debian-1ubuntu2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="5.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:5.04"/>
+  </fingerprint>   
   <fingerprint pattern="^OpenSSH_(4\.1p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 5.10</description>
     <example>OpenSSH_4.1p1 Debian-7ubuntu4</example>
@@ -140,21 +171,7 @@
     <example>OpenSSH_4.6p1 Debian-5ubuntu0.2</example>
     <example>OpenSSH_4.6p1 Debian-5ubuntu0.5</example>
     <example>OpenSSH_4.6p1 Debian-5ubuntu0.6</example>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
-    <param pos="0" name="service.vendor" value="OpenBSD"/>
-    <param pos="0" name="service.family" value="OpenSSH"/>
-    <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="7.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:7.10"/>
-  </fingerprint>
-  <fingerprint pattern="^OpenSSH_(4\.6p1) (Debian-5build1)$">
-    <description>OpenSSH running on very early versions of Ubuntu 7.10</description>
-    <example service.version="4.6p1" openssh.comment="Debian-5build1">OpenSSH_4.6p1 Debian-5build1</example>
+    <example>OpenSSH_4.6p1 Debian-5ubuntu0</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -314,6 +331,7 @@
   <fingerprint pattern="^OpenSSH_(6\.0p1) (Debian-3ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 12.10</description>
     <example>OpenSSH_6.0p1 Debian-3ubuntu1</example>
+    <example>OpenSSH_6.0p1 Debian-3ubuntu1.2</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -341,6 +359,21 @@
     <param pos="0" name="os.version" value="13.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:13.04"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_(6\.2p2) (Ubuntu-6unbuntu\d(?:\.\d)?)$">
+    <description>OpenSSH running on Ubuntu 13.10</description>
+    <example>OpenSSH_6.2p2 Ubuntu-6unbuntu0.4</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="13.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:13.10"/>
+  </fingerprint>  
   <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)[_|-](hpn\d+v\d+)$">
     <description>OpenSSH with HPN patches</description>
     <example service.version="6.1" openssh.comment="hpn13v11">OpenSSH_6.1_hpn13v11</example>
@@ -369,6 +402,21 @@
     <param pos="0" name="os.version" value="14.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.04"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_(6\.6\.1p1) (Ubuntu-8)$">
+    <description>OpenSSH running on Ubuntu 14.10</description>
+    <example>OpenSSH_6.6.1p1 Ubuntu-8</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="14.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.10"/>
+  </fingerprint>  
   <fingerprint pattern="^OpenSSH_(6\.7p1) (Ubuntu-5ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 15.04 (vivid)</description>
     <example service.version="6.7p1" openssh.comment="Ubuntu-5ubuntu1">OpenSSH_6.7p1 Ubuntu-5ubuntu1</example>
@@ -384,9 +432,128 @@
     <param pos="0" name="os.version" value="15.04"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:15.04"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_(6\.9p1) (Ubuntu-2)$">
+    <description>OpenSSH running on Ubuntu 15.10</description>
+    <example>OpenSSH_6.9p1 Ubuntu-2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="15.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:15.10"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(7\.2p2) (Ubuntu-4ubuntu\d(?:\.\d)?)$">
+    <description>OpenSSH running on Ubuntu 16.04 (vivid)</description>
+    <example service.version="7.2p2" openssh.comment="Ubuntu-4ubuntu2.7">OpenSSH_7.2p2 Ubuntu-4ubuntu2.7</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="16.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.04"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(7\.3p1) (Ubuntu-1)$">
+    <description>OpenSSH running on Ubuntu 16.10</description>
+    <example>OpenSSH_7.3p1 Ubuntu-1</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="16.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.10"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(7\.4p1) (Ubuntu-10)$">
+    <description>OpenSSH running on Ubuntu 17.04</description>
+    <example>OpenSSH_7.4p1 Ubuntu-10</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="17.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:17.04"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(7\.5p1) (Ubuntu-10ubuntu\d(?:\.\d)?)$">
+    <description>OpenSSH running on Ubuntu 17.10</description>
+    <example service.version="7.5p1" openssh.comment="Ubuntu-10ubuntu0.1">OpenSSH_7.5p1 Ubuntu-10ubuntu0.1</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="17.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:17.10"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(7\.7p1) (Ubuntu-4)$">
+    <description>OpenSSH running on Ubuntu 18.10</description>
+    <example>OpenSSH_7.7p1 Ubuntu-4</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="18.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:18.10"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(7\.9p1) (Ubuntu-10)$">
+    <description>OpenSSH running on Ubuntu 19.04</description>
+    <example>OpenSSH_7.9p1 Ubuntu-10</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="19.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:19.04"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(8\.0p1) (Ubuntu-6build1)$">
+    <description>OpenSSH running on Ubuntu 19.10</description>
+    <example>OpenSSH_8.0p1 Ubuntu-6build1</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="19.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:19.10"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Ubuntu-\d\d?)$">
     <description>OpenSSH running on Ubuntu (unknown release)</description>
-    <example service.version="7.4p1" openssh.comment="Ubuntu-10">OpenSSH_7.4p1 Ubuntu-10</example>
     <example service.version="7.6p1" openssh.comment="Ubuntu-2">OpenSSH_7.6p1 Ubuntu-2</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
@@ -399,11 +566,137 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+((?:Debian|Ubuntu).+ubuntu.*)$">
+    <description>OpenSSH running on Ubuntu</description>
+    <example service.version="7.2p3" openssh.comment="Ubuntu-4ubuntu2.2">OpenSSH_7.2p3 Ubuntu-4ubuntu2.2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.certainty" value="0.75"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
+  </fingerprint>  
+  <!-- Debian -->
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+woody.*)$">
+    <description>OpenSSH running on Debian 3.0 (woody)</description>
+    <example service.version="3.4p1" openssh.comment="Debian 1:3.4p1-1.woody.3">OpenSSH_3.4p1 Debian 1:3.4p1-1.woody.3</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="3.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:3.0"/>
+  </fingerprint>    
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+sarge.*)$">
+    <description>OpenSSH running on Debian 3.1 (sarge)</description>
+    <example service.version="3.8.1p1" openssh.comment="Debian-8.sarge.4">OpenSSH_3.8.1p1 Debian-8.sarge.4</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="3.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:3.1"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(4\.3p2) (Debian-9.*)$">
+    <description>OpenSSH running on Debian 4.0 (etch)</description>
+    <example service.version="4.3p2" openssh.comment="Debian-9">OpenSSH_4.3p2 Debian-9</example>
+    <example service.version="4.3p2" openssh.comment="Debian-9etch3">OpenSSH_4.3p2 Debian-9etch3</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="4.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:4.0"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-5)$">
+    <description>OpenSSH running on Debian 5.0 (also 5.10)</description>
+    <example service.version="5.1p1" openssh.comment="Debian-5">OpenSSH_5.1p1 Debian-5</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="5.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:5.0"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+[+~]squeeze.*)$">
+    <description>OpenSSH running on Debian 6.0 (squeeze)</description>
+    <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>
+    <example service.version="5.5p1" openssh.comment="Debian-26+squeeze7">OpenSSH_5.5p1 Debian-26+squeeze7</example>
+    <example service.version="5.8p1" openssh.comment="Debian-4~squeeze+1">OpenSSH_5.8p1 Debian-4~squeeze+1</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="6.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:6.0"/>
+  </fingerprint>  
+  <fingerprint pattern="^OpenSSH_(5\.5p1) (Debian-6)$">
+    <description>OpenSSH running on Debian 6.0 (w/o squeeze in banner)</description>
+    <example service.version="5.5p1" openssh.comment="Debian-6">OpenSSH_5.5p1 Debian-6</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="6.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:6.0"/>
+  </fingerprint>
+
+  <!-- More specific than and should preceed the 7.0 match -->
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-4\+deb7u2)$">
+    <description>OpenSSH running on Debian 7.8 (wheezy)</description>
+    <example service.version="6.0p1" openssh.comment="Debian-4+deb7u2">OpenSSH_6.0p1 Debian-4+deb7u2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="7.8"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:7.8"/>
+  </fingerprint>
+
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-4(?:\+deb7u\d+)?)$">
     <description>OpenSSH running on Debian 7.x (wheezy)</description>
     <example service.version="6.0p1" openssh.comment="Debian-4">OpenSSH_6.0p1 Debian-4</example>
     <example service.version="6.0p1" openssh.comment="Debian-4+deb7u1">OpenSSH_6.0p1 Debian-4+deb7u1</example>
-    <example service.version="6.0p1" openssh.comment="Debian-4+deb7u2">OpenSSH_6.0p1 Debian-4+deb7u2</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -416,6 +709,7 @@
     <param pos="0" name="os.version" value="7.0"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:7.0"/>
   </fingerprint>
+
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d~bpo7\d?\+\d+)$">
     <description>OpenSSH backport running on Debian 7.x (wheezy)</description>
     <example service.version="6.6.1p1" openssh.comment="Debian-4~bpo70+1">OpenSSH_6.6.1p1 Debian-4~bpo70+1</example>
@@ -436,6 +730,7 @@
     <description>OpenSSH running on Debian 8.x (jessie)</description>
     <example service.version="6.7p1" openssh.comment="Debian-5+deb8u2">OpenSSH_6.7p1 Debian-5+deb8u2</example>
     <example service.version="6.7p1" openssh.comment="Debian-5+deb8u1~ui80+7">OpenSSH_6.7p1 Debian-5+deb8u1~ui80+7</example>
+    <example service.version="6.7p1" openssh.comment="Debian-5+deb8u8">OpenSSH_6.7p1 Debian-5+deb8u8</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -464,11 +759,9 @@
     <param pos="0" name="os.version" value="9.0"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:9.0"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+[+~]squeeze.*)$">
-    <description>OpenSSH running on Debian 6.0 (squeeze)</description>
-    <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>
-    <example service.version="5.5p1" openssh.comment="Debian-26+squeeze7">OpenSSH_5.5p1 Debian-26+squeeze7</example>
-    <example service.version="5.8p1" openssh.comment="Debian-4~squeeze+1">OpenSSH_5.8p1 Debian-4~squeeze+1</example>
+<fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10)$">
+    <description>OpenSSH running on Debian 10.x (buster)</description>
+    <example service.version="7.9p1" openssh.comment="Debian-10">OpenSSH_7.9p1 Debian-10</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -478,72 +771,11 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:6.0"/>
-  </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+((?:Debian|Ubuntu).+ubuntu.*)$">
-    <description>OpenSSH running on Ubuntu</description>
-    <example service.version="7.2p2" openssh.comment="Ubuntu-4ubuntu2.2">OpenSSH_7.2p2 Ubuntu-4ubuntu2.2</example>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
-    <param pos="0" name="service.vendor" value="OpenBSD"/>
-    <param pos="0" name="service.family" value="OpenSSH"/>
-    <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.certainty" value="0.75"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
-  </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+etch.*)$">
-    <description>OpenSSH running on Debian 4.0 (etch)</description>
-    <example service.version="4.3p2" openssh.comment="Debian-9etch3">OpenSSH_4.3p2 Debian-9etch3</example>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
-    <param pos="0" name="service.vendor" value="OpenBSD"/>
-    <param pos="0" name="service.family" value="OpenSSH"/>
-    <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Debian"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="4.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:4.0"/>
-  </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+sarge.*)$">
-    <description>OpenSSH running on Debian 3.1 (sarge)</description>
-    <example service.version="3.8.1p1" openssh.comment="Debian-8.sarge.4">OpenSSH_3.8.1p1 Debian-8.sarge.4</example>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
-    <param pos="0" name="service.vendor" value="OpenBSD"/>
-    <param pos="0" name="service.family" value="OpenSSH"/>
-    <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Debian"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="3.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:3.1"/>
-  </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+woody.*)$">
-    <description>OpenSSH running on Debian 3.0 (woody)</description>
-    <example service.version="3.4p1" openssh.comment="Debian 1:3.4p1-1.woody.3">OpenSSH_3.4p1 Debian 1:3.4p1-1.woody.3</example>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
-    <param pos="0" name="service.vendor" value="OpenBSD"/>
-    <param pos="0" name="service.family" value="OpenSSH"/>
-    <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Debian"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="3.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:3.0"/>
+    <param pos="0" name="os.version" value="10.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.0"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+(?:[~]?bpo[.]?\d+)?)$">
     <description>OpenSSH running on Debian (unknown release)</description>
-    <example service.version="5.5p1" openssh.comment="Debian-6">OpenSSH_5.5p1 Debian-6</example>
     <example service.version="4.3p2" openssh.comment="Debian-5~bpo.1">OpenSSH_4.3p2 Debian-5~bpo.1</example>
     <example service.version="4.2p1" openssh.comment="Debian-4bpo1">OpenSSH_4.2p1 Debian-4bpo1</example>
     <example service.version="7.4p1" openssh.comment="Debian-10">OpenSSH_7.4p1 Debian-10</example>
@@ -558,6 +790,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:-"/>
   </fingerprint>
+  <!-- Raspbian -->
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-\d\d?\+deb9u\d+)$">
     <description>OpenSSH running on Raspbian (Debian 9 "Stretch" based)</description>
     <example service.version="7.4p1" openssh.comment="Raspbian-10+deb9u1">OpenSSH_7.4p1 Raspbian-10+deb9u1</example>
@@ -602,6 +835,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
+  <!-- Miscellaneous -->
   <fingerprint pattern="^OpenSSH_(.*)\+(CAN-[0-9]{4}-[0-9]{4})$">
     <description>OpenSSH with CVE patch, as seen in Mac OS X</description>
     <example service.version="3.4p1" openssh.cvepatch="CAN-2004-0175">OpenSSH_3.4p1+CAN-2004-0175</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -60,8 +60,416 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:windriver:vxworks:{os.version}"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(FreeBSD[ -].*)$">
-    <description>OpenSSH running on FreeBSD</description>
+  <!-- FreeBSD -->
+  <fingerprint pattern="^OpenSSH_(2\.3\.0) (green@FreeBSD.org 20010321)$">
+    <description>OpenSSH running on FreeBSD 4.3</description>
+    <example service.version="2.3.0" openssh.comment="green@FreeBSD.org 20010321">OpenSSH_2.3.0 green@FreeBSD.org 20010321</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.3"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(2\.3\.0) (FreeBSD localisations 20010713)$">
+    <description>OpenSSH running on FreeBSD 4.4</description>
+    <example service.version="2.3.0" openssh.comment="FreeBSD localisations 20010713">OpenSSH_2.3.0 FreeBSD localisations 20010713</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.4"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.4"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(2\.9) (FreeBSD localisations 20011202)$">
+    <description>OpenSSH running on FreeBSD 4.5</description>
+    <example service.version="2.9" openssh.comment="FreeBSD localisations 20011202">OpenSSH_2.9 FreeBSD localisations 20011202</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.5"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.4p1) (FreeBSD 20020702)$">
+    <description>OpenSSH running on FreeBSD 4.6.2</description>
+    <example service.version="3.4p1" openssh.comment="FreeBSD 20020702">OpenSSH_3.4p1 FreeBSD 20020702</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.6.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.6.2"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(2\.9) (FreeBSD localisations 20020307)$">
+    <description>OpenSSH running on FreeBSD 4.6</description>
+    <example service.version="2.9" openssh.comment="FreeBSD localisations 20020307">OpenSSH_2.9 FreeBSD localisations 20020307</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.6"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.6"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.4p1) (FreeBSD-20020702)$">
+    <description>OpenSSH running on FreeBSD 4.7</description>
+    <example service.version="3.4p1" openssh.comment="FreeBSD-20020702">OpenSSH_3.4p1 FreeBSD-20020702</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.7"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.7"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20030201)$">
+    <description>OpenSSH running on FreeBSD 4.8</description>
+    <example service.version="3.5p1" openssh.comment="FreeBSD-20030201">OpenSSH_3.5p1 FreeBSD-20030201</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.8"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.8"/>
+  </fingerprint>
+
+  <!-- Multiple minor version match, assert the oldest version -->
+  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20030924)$">
+    <description>OpenSSH running on FreeBSD 4.9/4.10 (sometimes 4.11)</description>
+    <example service.version="3.5p1" openssh.comment="FreeBSD-20030924">OpenSSH_3.5p1 FreeBSD-20030924</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.9"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.9"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20060930)$">
+    <description>OpenSSH running on FreeBSD 4.11</description>
+    <example service.version="3.5p1" openssh.comment="FreeBSD-20060930">OpenSSH_3.5p1 FreeBSD-20060930</example>    
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="4.11"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.11"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20021029)$">
+    <description>OpenSSH running on FreeBSD 5.0</description>
+    <example service.version="3.5p1" openssh.comment="FreeBSD-20021029">OpenSSH_3.5p1 FreeBSD-20021029</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="5.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.0"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.6\.1p1) (FreeBSD-20030423)$">
+    <description>OpenSSH running on FreeBSD 5.1</description>
+    <example service.version="3.6.1p1" openssh.comment="FreeBSD-20030423">OpenSSH_3.6.1p1 FreeBSD-20030423</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="5.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.1"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.6\.1p1) (FreeBSD-20030924)$">
+    <description>OpenSSH running on FreeBSD 5.2</description>
+    <example service.version="3.6.1p1" openssh.comment="FreeBSD-20030924">OpenSSH_3.6.1p1 FreeBSD-20030924</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="5.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.2"/>
+  </fingerprint>
+
+  <!-- Multiple minor version match, assert the oldest version -->
+  <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (FreeBSD-20040419)$">
+    <description>OpenSSH running on FreeBSD 5.3/5.4</description>
+    <example service.version="3.8.1p1" openssh.comment="FreeBSD-20040419">OpenSSH_3.8.1p1 FreeBSD-20040419</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="5.3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.3"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (FreeBSD-20060123)$">
+    <description>OpenSSH running on FreeBSD 5.5</description>
+    <example service.version="3.8.1p1" openssh.comment="FreeBSD-20060123">OpenSSH_3.8.1p1 FreeBSD-20060123</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="5.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.5"/>
+  </fingerprint>
+
+  <!-- Multiple minor version match, assert the oldest version -->
+  <fingerprint pattern="^OpenSSH_(4\.2p1) (FreeBSD-20050903)$">
+    <description>OpenSSH running on FreeBSD 6.0/6.1</description>
+    <example service.version="4.2p1" openssh.comment="FreeBSD-20050903">OpenSSH_4.2p1 FreeBSD-20050903</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="6.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:6.0"/>
+  </fingerprint>
+
+  <!-- Spans major versions, do not assert a version number -->
+  <fingerprint pattern="^OpenSSH_(4\.5p1) (FreeBSD-20061110)$">
+    <description>OpenSSH running on FreeBSD 6.2/6.3/6.4/7.0</description>
+    <example service.version="4.5p1" openssh.comment="FreeBSD-20061110">OpenSSH_4.5p1 FreeBSD-20061110</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
+  </fingerprint>
+
+  <!-- Multiple minor version match, assert the oldest version -->
+  <fingerprint pattern="^OpenSSH_(5\.1p1) (FreeBSD-20080901)$">
+    <description>OpenSSH running on FreeBSD 7.1/7.2/7.3/7.4</description>
+    <example service.version="5.1p1" openssh.comment="FreeBSD-20080901">OpenSSH_5.1p1 FreeBSD-20080901</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="7.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:7.1"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(5\.2p1) (FreeBSD-20090522)$">
+    <description>OpenSSH running on FreeBSD 8.0</description>
+    <example service.version="5.2p1" openssh.comment="FreeBSD-20090522">OpenSSH_5.2p1 FreeBSD-20090522</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="8.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.0"/>
+  </fingerprint>
+
+  <!-- Multiple minor version match, assert the oldest version -->
+  <fingerprint pattern="^OpenSSH_(5\.4p1) (FreeBSD-20100308)$">
+    <description>OpenSSH running on FreeBSD 8.1/8.2</description>
+    <example service.version="5.4p1" openssh.comment="FreeBSD-20100308">OpenSSH_5.4p1 FreeBSD-20100308</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="8.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.1"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(5\.4p1_hpn13v11) (FreeBSD-20100308)$">
+    <description>OpenSSH running on FreeBSD 8.3</description>
+    <example service.version="5.4p1_hpn13v11" openssh.comment="FreeBSD-20100308">OpenSSH_5.4p1_hpn13v11 FreeBSD-20100308</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="8.3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.3"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(6\.1_hpn13v11) (FreeBSD-20120901)$">
+    <description>OpenSSH running on FreeBSD 8.4</description>
+    <example service.version="6.1_hpn13v11" openssh.comment="FreeBSD-20120901">OpenSSH_6.1_hpn13v11 FreeBSD-20120901</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="8.4"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.4"/>
+  </fingerprint>
+
+  <!-- Multiple minor version match, assert the oldest version -->
+  <fingerprint pattern="^OpenSSH_(5\.8p2_hpn13v11) (FreeBSD-20110503)$">
+    <description>OpenSSH running on FreeBSD 9.0/9.1</description>
+    <example service.version="5.8p2_hpn13v11" openssh.comment="FreeBSD-20110503">OpenSSH_5.8p2_hpn13v11 FreeBSD-20110503</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="9.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:9.0"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(6\.2_hpn13v11) (FreeBSD-20130515)$">
+    <description>OpenSSH running on FreeBSD 9.2</description>
+    <example service.version="6.2_hpn13v11" openssh.comment="FreeBSD-20130515">OpenSSH_6.2_hpn13v11 FreeBSD-20130515</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="9.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:9.2"/>
+  </fingerprint>
+
+  <!-- Spans major versions, do not assert a version number -->
+  <fingerprint pattern="^OpenSSH_(6\.6\.1_hpn13v11) (FreeBSD-20140420)$">
+    <description>OpenSSH running on FreeBSD 9.3/10.1/10.2</description>
+    <example service.version="6.6.1_hpn13v11" openssh.comment="FreeBSD-20140420">OpenSSH_6.6.1_hpn13v11 FreeBSD-20140420</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(6\.4_hpn13v11) (FreeBSD-20131111)$">
+    <description>OpenSSH running on FreeBSD 10.0</description>
+    <example service.version="6.4_hpn13v11" openssh.comment="FreeBSD-20131111">OpenSSH_6.4_hpn13v11 FreeBSD-20131111</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="10.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:10.0"/>
+  </fingerprint>
+
+  <!-- Spans major versions, do not assert a version number -->
+  <fingerprint pattern="^OpenSSH_(7\.2) (FreeBSD-20160310)$">
+    <description>OpenSSH running on FreeBSD 10.3/11.0</description>
     <example service.version="7.2" openssh.comment="FreeBSD-20160310">OpenSSH_7.2 FreeBSD-20160310</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
@@ -74,6 +482,87 @@
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
   </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(7\.3) (FreeBSD-20170902)$">
+    <description>OpenSSH running on FreeBSD 10.4</description>
+    <example service.version="7.3" openssh.comment="FreeBSD-20170902">OpenSSH_7.3 FreeBSD-20170902</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="10.4"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:10.4"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(7\.2) (FreeBSD-20161230)$">
+    <description>OpenSSH running on FreeBSD 11.1</description>
+    <example service.version="7.2" openssh.comment="FreeBSD-20161230">OpenSSH_7.2 FreeBSD-20161230</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="11.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:11.1"/>
+  </fingerprint>
+
+  <!-- Multiple minor version match, assert the oldest version -->
+  <fingerprint pattern="^OpenSSH_(7\.5) (FreeBSD-20170903)$">
+    <description>OpenSSH running on FreeBSD 11.2/11.3</description>
+    <example service.version="7.5" openssh.comment="FreeBSD-20170903">OpenSSH_7.5 FreeBSD-20170903</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="11.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:11.2"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_(7\.8) (FreeBSD-20180909)$">
+    <description>OpenSSH running on FreeBSD 12.0</description>
+    <example service.version="7.8" openssh.comment="FreeBSD-20180909">OpenSSH_7.8 FreeBSD-20180909</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.version" value="12.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:12.0"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(FreeBSD[ -].*)$">
+    <description>OpenSSH running on FreeBSD</description>
+    <example service.version="7.2" openssh.comment="FreeBSD-20160311">OpenSSH_7.2 FreeBSD-20160311</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="FreeBSD"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
+  </fingerprint>
+  <!-- NetBSD -->  
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(NetBSD(?:_Secure_Shell)?[ -].*)$">
     <description>OpenSSH running on NetBSD</description>
     <example service.version="7.2" openssh.comment="NetBSD-20100308">OpenSSH_7.2 NetBSD-20100308</example>


### PR DESCRIPTION
## Description

This changeset adds missing fingerprints for Ubuntu, Debian, and FreeBSD versions.

## Motivation and Context

The existing fingerprint coverage was missing quite a few versions.

## How Has This Been Tested?

`recog_verify` and `rspec`

## Types of changes

New OS fingerprints for Ubuntu, Debian, and FreeBSD

## Checklist:
- [X] I have updated the documentation accordingly (or changes are not required).
- [X] I have added tests to cover my changes (or new tests are not required).
- [X] All new and existing tests passed.
