### PR TITLE
Whitespace cleanup/interpolation changes

### DIFF
--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -74,9 +74,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.3"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(2\.3\.0) (FreeBSD localisations 20010713)$">
     <description>OpenSSH running on FreeBSD 4.4</description>
     <example service.version="2.3.0" openssh.comment="FreeBSD localisations 20010713">OpenSSH_2.3.0 FreeBSD localisations 20010713</example>
@@ -90,9 +89,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.4"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.4"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(2\.9) (FreeBSD localisations 20011202)$">
     <description>OpenSSH running on FreeBSD 4.5</description>
     <example service.version="2.9" openssh.comment="FreeBSD localisations 20011202">OpenSSH_2.9 FreeBSD localisations 20011202</example>
@@ -106,9 +104,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.5"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.4p1) (FreeBSD 20020702)$">
     <description>OpenSSH running on FreeBSD 4.6.2</description>
     <example service.version="3.4p1" openssh.comment="FreeBSD 20020702">OpenSSH_3.4p1 FreeBSD 20020702</example>
@@ -122,9 +119,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.6.2"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.6.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(2\.9) (FreeBSD localisations 20020307)$">
     <description>OpenSSH running on FreeBSD 4.6</description>
     <example service.version="2.9" openssh.comment="FreeBSD localisations 20020307">OpenSSH_2.9 FreeBSD localisations 20020307</example>
@@ -138,9 +134,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.6"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.6"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.4p1) (FreeBSD-20020702)$">
     <description>OpenSSH running on FreeBSD 4.7</description>
     <example service.version="3.4p1" openssh.comment="FreeBSD-20020702">OpenSSH_3.4p1 FreeBSD-20020702</example>
@@ -154,9 +149,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.7"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.7"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20030201)$">
     <description>OpenSSH running on FreeBSD 4.8</description>
     <example service.version="3.5p1" openssh.comment="FreeBSD-20030201">OpenSSH_3.5p1 FreeBSD-20030201</example>
@@ -170,9 +164,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.8"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.8"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Multiple minor version match, assert the oldest version -->
   <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20030924)$">
     <description>OpenSSH running on FreeBSD 4.9/4.10 (sometimes 4.11)</description>
@@ -187,12 +180,11 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.9"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.9"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20060930)$">
     <description>OpenSSH running on FreeBSD 4.11</description>
-    <example service.version="3.5p1" openssh.comment="FreeBSD-20060930">OpenSSH_3.5p1 FreeBSD-20060930</example>    
+    <example service.version="3.5p1" openssh.comment="FreeBSD-20060930">OpenSSH_3.5p1 FreeBSD-20060930</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -203,9 +195,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="4.11"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.11"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20021029)$">
     <description>OpenSSH running on FreeBSD 5.0</description>
     <example service.version="3.5p1" openssh.comment="FreeBSD-20021029">OpenSSH_3.5p1 FreeBSD-20021029</example>
@@ -219,9 +210,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="5.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.6\.1p1) (FreeBSD-20030423)$">
     <description>OpenSSH running on FreeBSD 5.1</description>
     <example service.version="3.6.1p1" openssh.comment="FreeBSD-20030423">OpenSSH_3.6.1p1 FreeBSD-20030423</example>
@@ -235,9 +225,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="5.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.6\.1p1) (FreeBSD-20030924)$">
     <description>OpenSSH running on FreeBSD 5.2</description>
     <example service.version="3.6.1p1" openssh.comment="FreeBSD-20030924">OpenSSH_3.6.1p1 FreeBSD-20030924</example>
@@ -251,9 +240,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="5.2"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Multiple minor version match, assert the oldest version -->
   <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (FreeBSD-20040419)$">
     <description>OpenSSH running on FreeBSD 5.3/5.4</description>
@@ -268,9 +256,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="5.3"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (FreeBSD-20060123)$">
     <description>OpenSSH running on FreeBSD 5.5</description>
     <example service.version="3.8.1p1" openssh.comment="FreeBSD-20060123">OpenSSH_3.8.1p1 FreeBSD-20060123</example>
@@ -284,9 +271,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="5.5"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Multiple minor version match, assert the oldest version -->
   <fingerprint pattern="^OpenSSH_(4\.2p1) (FreeBSD-20050903)$">
     <description>OpenSSH running on FreeBSD 6.0/6.1</description>
@@ -301,9 +287,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:6.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Spans major versions, do not assert a version number -->
   <fingerprint pattern="^OpenSSH_(4\.5p1) (FreeBSD-20061110)$">
     <description>OpenSSH running on FreeBSD 6.2/6.3/6.4/7.0</description>
@@ -319,7 +304,6 @@
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
   </fingerprint>
-
   <!-- Multiple minor version match, assert the oldest version -->
   <fingerprint pattern="^OpenSSH_(5\.1p1) (FreeBSD-20080901)$">
     <description>OpenSSH running on FreeBSD 7.1/7.2/7.3/7.4</description>
@@ -334,9 +318,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="7.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:7.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(5\.2p1) (FreeBSD-20090522)$">
     <description>OpenSSH running on FreeBSD 8.0</description>
     <example service.version="5.2p1" openssh.comment="FreeBSD-20090522">OpenSSH_5.2p1 FreeBSD-20090522</example>
@@ -350,9 +333,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="8.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Multiple minor version match, assert the oldest version -->
   <fingerprint pattern="^OpenSSH_(5\.4p1) (FreeBSD-20100308)$">
     <description>OpenSSH running on FreeBSD 8.1/8.2</description>
@@ -367,9 +349,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="8.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(5\.4p1_hpn13v11) (FreeBSD-20100308)$">
     <description>OpenSSH running on FreeBSD 8.3</description>
     <example service.version="5.4p1_hpn13v11" openssh.comment="FreeBSD-20100308">OpenSSH_5.4p1_hpn13v11 FreeBSD-20100308</example>
@@ -383,9 +364,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="8.3"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(6\.1_hpn13v11) (FreeBSD-20120901)$">
     <description>OpenSSH running on FreeBSD 8.4</description>
     <example service.version="6.1_hpn13v11" openssh.comment="FreeBSD-20120901">OpenSSH_6.1_hpn13v11 FreeBSD-20120901</example>
@@ -399,9 +379,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="8.4"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:8.4"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Multiple minor version match, assert the oldest version -->
   <fingerprint pattern="^OpenSSH_(5\.8p2_hpn13v11) (FreeBSD-20110503)$">
     <description>OpenSSH running on FreeBSD 9.0/9.1</description>
@@ -416,9 +395,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="9.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:9.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(6\.2_hpn13v11) (FreeBSD-20130515)$">
     <description>OpenSSH running on FreeBSD 9.2</description>
     <example service.version="6.2_hpn13v11" openssh.comment="FreeBSD-20130515">OpenSSH_6.2_hpn13v11 FreeBSD-20130515</example>
@@ -432,9 +410,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="9.2"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:9.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Spans major versions, do not assert a version number -->
   <fingerprint pattern="^OpenSSH_(6\.6\.1_hpn13v11) (FreeBSD-20140420)$">
     <description>OpenSSH running on FreeBSD 9.3/10.1/10.2</description>
@@ -450,7 +427,6 @@
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(6\.4_hpn13v11) (FreeBSD-20131111)$">
     <description>OpenSSH running on FreeBSD 10.0</description>
     <example service.version="6.4_hpn13v11" openssh.comment="FreeBSD-20131111">OpenSSH_6.4_hpn13v11 FreeBSD-20131111</example>
@@ -464,9 +440,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="10.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:10.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Spans major versions, do not assert a version number -->
   <fingerprint pattern="^OpenSSH_(7\.2) (FreeBSD-20160310)$">
     <description>OpenSSH running on FreeBSD 10.3/11.0</description>
@@ -482,7 +457,6 @@
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(7\.3) (FreeBSD-20170902)$">
     <description>OpenSSH running on FreeBSD 10.4</description>
     <example service.version="7.3" openssh.comment="FreeBSD-20170902">OpenSSH_7.3 FreeBSD-20170902</example>
@@ -496,9 +470,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="10.4"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:10.4"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(7\.2) (FreeBSD-20161230)$">
     <description>OpenSSH running on FreeBSD 11.1</description>
     <example service.version="7.2" openssh.comment="FreeBSD-20161230">OpenSSH_7.2 FreeBSD-20161230</example>
@@ -512,9 +485,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="11.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:11.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <!-- Multiple minor version match, assert the oldest version -->
   <fingerprint pattern="^OpenSSH_(7\.5) (FreeBSD-20170903)$">
     <description>OpenSSH running on FreeBSD 11.2/11.3</description>
@@ -529,9 +501,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="11.2"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:11.2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_(7\.8) (FreeBSD-20180909)$">
     <description>OpenSSH running on FreeBSD 12.0</description>
     <example service.version="7.8" openssh.comment="FreeBSD-20180909">OpenSSH_7.8 FreeBSD-20180909</example>
@@ -545,9 +516,8 @@
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.version" value="12.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:12.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(FreeBSD[ -].*)$">
     <description>OpenSSH running on FreeBSD</description>
     <example service.version="7.2" openssh.comment="FreeBSD-20160311">OpenSSH_7.2 FreeBSD-20160311</example>
@@ -562,7 +532,7 @@
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:-"/>
   </fingerprint>
-  <!-- NetBSD -->  
+  <!-- NetBSD -->
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(NetBSD(?:_Secure_Shell)?[ -].*)$">
     <description>OpenSSH running on NetBSD</description>
     <example service.version="7.2" openssh.comment="NetBSD-20100308">OpenSSH_7.2 NetBSD-20100308</example>
@@ -592,7 +562,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="4.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:4.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(3\.9p1) (Debian-1ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 5.04</description>
@@ -607,8 +577,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:5.04"/>
-  </fingerprint>   
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_(4\.1p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 5.10</description>
     <example>OpenSSH_4.1p1 Debian-7ubuntu4</example>
@@ -622,7 +592,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:5.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(4\.2p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 6.04</description>
@@ -638,7 +608,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:6.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(4\.3p2) (Debian-8ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 7.04</description>
@@ -653,7 +623,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:7.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(4\.6p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 7.10</description>
@@ -671,7 +641,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:7.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(4\.7p1) (Debian-8ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 8.04</description>
@@ -687,7 +657,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:8.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 8.10</description>
@@ -702,7 +672,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:8.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 9.04</description>
@@ -717,7 +687,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="9.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:9.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-6ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 9.10</description>
@@ -732,7 +702,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="9.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:9.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.3p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 10.04 (lucid)</description>
@@ -752,7 +722,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:10.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.5p1) (Debian-4ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 10.10</description>
@@ -769,7 +739,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:10.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-1ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 11.04</description>
@@ -784,7 +754,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="11.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:11.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-7ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 11.10</description>
@@ -799,7 +769,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="11.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:11.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.9p1) (Debian-5ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 12.04</description>
@@ -815,7 +785,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:12.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.0p1) (Debian-3ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 12.10</description>
@@ -831,7 +801,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:12.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.1p1) (Debian-4)$">
     <description>OpenSSH running on Ubuntu 13.04</description>
@@ -846,7 +816,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:13.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.2p2) (Ubuntu-6unbuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 13.10</description>
@@ -861,8 +831,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:13.10"/>
-  </fingerprint>  
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)[_|-](hpn\d+v\d+)$">
     <description>OpenSSH with HPN patches</description>
     <example service.version="6.1" openssh.comment="hpn13v11">OpenSSH_6.1_hpn13v11</example>
@@ -889,7 +859,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.6\.1p1) (Ubuntu-8)$">
     <description>OpenSSH running on Ubuntu 14.10</description>
@@ -904,8 +874,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.10"/>
-  </fingerprint>  
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.7p1) (Ubuntu-5ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 15.04 (vivid)</description>
     <example service.version="6.7p1" openssh.comment="Ubuntu-5ubuntu1">OpenSSH_6.7p1 Ubuntu-5ubuntu1</example>
@@ -919,7 +889,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="15.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:15.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.9p1) (Ubuntu-2)$">
     <description>OpenSSH running on Ubuntu 15.10</description>
@@ -934,7 +904,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="15.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:15.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.2p2) (Ubuntu-4ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 16.04 (vivid)</description>
@@ -949,11 +919,11 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="16.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.3p1) (Ubuntu-1)$">
     <description>OpenSSH running on Ubuntu 16.10</description>
-    <example>OpenSSH_7.3p1 Ubuntu-1</example>
+    <example service.version="7.3p1">OpenSSH_7.3p1 Ubuntu-1</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -964,11 +934,11 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="16.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.4p1) (Ubuntu-10)$">
     <description>OpenSSH running on Ubuntu 17.04</description>
-    <example>OpenSSH_7.4p1 Ubuntu-10</example>
+    <example service.version="7.4p1">OpenSSH_7.4p1 Ubuntu-10</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -979,7 +949,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="17.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:17.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.5p1) (Ubuntu-10ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 17.10</description>
@@ -994,7 +964,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="17.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:17.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.6p1) (Ubuntu-4ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 18.04</description>
@@ -1009,8 +979,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="18.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:18.04"/>
-  </fingerprint>  
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.7p1) (Ubuntu-4)$">
     <description>OpenSSH running on Ubuntu 18.10</description>
     <example>OpenSSH_7.7p1 Ubuntu-4</example>
@@ -1024,7 +994,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="18.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:18.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.9p1) (Ubuntu-10)$">
     <description>OpenSSH running on Ubuntu 19.04</description>
@@ -1039,7 +1009,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="19.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:19.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(8\.0p1) (Ubuntu-6build1)$">
     <description>OpenSSH running on Ubuntu 19.10</description>
@@ -1054,7 +1024,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="19.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:19.10"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Ubuntu-\d\d?)$">
     <description>OpenSSH running on Ubuntu (unknown release)</description>
@@ -1084,7 +1054,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.certainty" value="0.75"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
-  </fingerprint>  
+  </fingerprint>
   <!-- Debian -->
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+woody.*)$">
     <description>OpenSSH running on Debian 3.0 (woody)</description>
@@ -1099,8 +1069,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:3.0"/>
-  </fingerprint>    
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+sarge.*)$">
     <description>OpenSSH running on Debian 3.1 (sarge)</description>
     <example service.version="3.8.1p1" openssh.comment="Debian-8.sarge.4">OpenSSH_3.8.1p1 Debian-8.sarge.4</example>
@@ -1114,7 +1084,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="3.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:3.1"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(4\.3p2) (Debian-9.*)$">
     <description>OpenSSH running on Debian 4.0 (etch)</description>
@@ -1130,7 +1100,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="4.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:4.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-5)$">
     <description>OpenSSH running on Debian 5.0 (also 5.10)</description>
@@ -1145,7 +1115,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="5.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:5.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+[+~]squeeze.*)$">
     <description>OpenSSH running on Debian 6.0 (squeeze)</description>
@@ -1162,8 +1132,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:6.0"/>
-  </fingerprint>  
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_(5\.5p1) (Debian-6)$">
     <description>OpenSSH running on Debian 6.0 (w/o squeeze in banner)</description>
     <example service.version="5.5p1" openssh.comment="Debian-6">OpenSSH_5.5p1 Debian-6</example>
@@ -1177,9 +1147,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="6.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:6.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
-
   <!-- More specific than and should preceed the 7.0 match -->
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-4\+deb7u2)$">
     <description>OpenSSH running on Debian 7.8 (wheezy)</description>
@@ -1194,9 +1163,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.8"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:7.8"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-4(?:\+deb7u\d+)?)$">
     <description>OpenSSH running on Debian 7.x (wheezy)</description>
     <example service.version="6.0p1" openssh.comment="Debian-4">OpenSSH_6.0p1 Debian-4</example>
@@ -1211,9 +1179,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:7.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
-
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d~bpo7\d?\+\d+)$">
     <description>OpenSSH backport running on Debian 7.x (wheezy)</description>
     <example service.version="6.6.1p1" openssh.comment="Debian-4~bpo70+1">OpenSSH_6.6.1p1 Debian-4~bpo70+1</example>
@@ -1228,7 +1195,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:7.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-5\+deb8u\d+.*)$">
     <description>OpenSSH running on Debian 8.x (jessie)</description>
@@ -1245,7 +1212,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:8.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d\d?\+deb9u\d+)$">
     <description>OpenSSH running on Debian 9.x (stretch)</description>
@@ -1261,7 +1228,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="9.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:9.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10|Debian-\d\d?\+deb10u\d+)$">
     <description>OpenSSH running on Debian 10.x (buster)</description>
@@ -1277,7 +1244,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(8\.1p1) (Debian-1|Debian-\d\d?\+deb11u\d+)$">
     <description>OpenSSH running on Debian 11.x (bullseye)</description>
@@ -1293,8 +1260,8 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="11.0"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:11.0"/>
-  </fingerprint>  
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+(?:[~]?bpo[.]?\d+)?)$">
     <description>OpenSSH running on Debian (unknown release)</description>
     <example service.version="4.3p2" openssh.comment="Debian-5~bpo.1">OpenSSH_4.3p2 Debian-5~bpo.1</example>
@@ -1326,7 +1293,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.0"/>
-  </fingerprint>  
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-\d\d?\+deb9u\d+)$">
     <description>OpenSSH running on Raspbian (Debian 9 "Stretch" based)</description>
     <example service.version="7.4p1" openssh.comment="Raspbian-10+deb9u1">OpenSSH_7.4p1 Raspbian-10+deb9u1</example>
@@ -1371,7 +1338,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="11.0"/>
-  </fingerprint>     
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-\d\d?)$">
     <description>OpenSSH running on Raspbian (Debian, unknown release)</description>
     <example service.version="7.5p1" openssh.comment="Raspbian-10">OpenSSH_7.5p1 Raspbian-10</example>


### PR DESCRIPTION
## Description
This PR

- Changes `os.cpe23` in `ssh_banners.xml` to use `{os.version}` instead of static strings where possible.
- Cleans up a few whitespace issues


## Motivation and Context
Code consistency and to reduce copy/paste errors by removing static strings in favor of interpolation.


## How Has This Been Tested?
`rspec`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
