### PR TITLE
Added basic fingerprint for OpenSMTPD detection

### DIFF
--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -1668,4 +1668,14 @@
     <example>ESMTP READY</example>
     <param pos="1" name="host.name"/>
   </fingerprint>
+  <fingerprint pattern="^([^ ]+) ESMTP OpenSMTPD$">
+    <description>OpenSMPTD</description>
+    <example>mail.example.com ESMTP OpenSMTPD</example>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSMTPD"/>
+    <param pos="0" name="service.product" value="OpenSMTPD"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:openbsd:openbsd:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:opensmtpd:-"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
 </fingerprints>


### PR DESCRIPTION
## Description

Added a simple fingerprint for detecting OpenSMTPD servers.

## Motivation and Context
RCE in OpenSMTPD (https://www.helpnetsecurity.com/2020/01/29/cve-2020-7247/) so having this in recog is faster/cleaner than regexp_like'ing a banner string

## How Has This Been Tested?

`bin/recog_verify xml/smtp_banners.xml | grep -i opensmtpd` (came up clean)

```
echo 'merovingian.attackbadger.com ESMTP OpenSMTPD' | bin/recog_match xml/smtp_banners.xml
MATCH: {"matched"=>"OpenSMPTD", "service.vendor"=>"OpenBSD", "service.family"=>"OpenSMTPD", "service.product"=>"OpenSMTPD", "os.cpe23"=>"cpe:/o:openbsd:openbsd:-", "service.cpe23"=>"cpe:/a:openbsd:opensmtpd:-", "host.name"=>"merovingian.attackbadger.com", "service.protocol"=>"smtp", "fingerprint_db"=>"smtp.banner", "data"=>"merovingian.attackbadger.com ESMTP OpenSMTPD"}
```

Tested a number of OpenSMTPD banners from January 2020 Sonar SMTP scans just like ^^.

## Types of changes
- New feature: OpenSMTPD detection

## Checklist:
- [X] I have updated the documentation accordingly (or changes are not required).
- [X] I have added tests to cover my changes (or new tests are not required).
- [X] All new and existing tests passed.
