### PR TITLE
Rollup of recent fingerprint changes & additions

### DIFF
--- a/lib/recog/version.rb
+++ b/lib/recog/version.rb
@@ -1,3 +1,3 @@
 module Recog
-  VERSION = '2.3.5'
+  VERSION = '2.3.6'
 end

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -221,6 +221,15 @@
     <param pos="0" name="hw.product" value="Hue"/>
     <param pos="0" name="hw.device" value="Light Bulb"/>
   </fingerprint>
+
+  <fingerprint pattern="LANDesk\(R\) Management Agent$">
+    <description>LANDesk Management Agent</description>
+    <param pos="0" name="service.vendor" value="LANDesk"/>
+    <param pos="0" name="service.product" value="Management Agent"/>
+    <param pos="0" name="service.family" value="Management Agent"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:landesk:management_agent:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:Parallels )?Plesk (?:(?:Onyx|Panel) )?([\d\.]+)$">
     <description>Plesk web hosting platform with a version</description>
     <example service.version="12.0.18">Plesk 12.0.18</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fingerprints matches="html_title" database_type="service" preference="0.90">
+
   <!-- HTML Title elements found in HTTP response bodies are matched against these patterns to fingerprint HTTP servers. -->
+
   <fingerprint pattern="^Index of /">
     <description>Apache HTTPD indexes</description>
     <example>Index of /</example>
@@ -9,6 +11,7 @@
     <param pos="0" name="service.family" value="Apache"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:http_server:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Test Page for the Nginx HTTP Server on (?:the )?Amazon Linux(?: AMI)?$">
     <description>Apache HTTPD default installation on Amazon Linux</description>
     <example>Test Page for the Nginx HTTP Server on the Amazon Linux AMI</example>
@@ -21,6 +24,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux AMI"/>
   </fingerprint>
+
   <fingerprint pattern="^Apache HTTP Server Test Page powered by CentOS$">
     <description>Apache HTTPD default installation on CentOS</description>
     <example>Apache HTTP Server Test Page powered by CentOS</example>
@@ -33,6 +37,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:centos:centos:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Apache2 Debian Default Page: It works$">
     <description>Apache HTTPD default installation on Debian</description>
     <example>Apache2 Debian Default Page: It works</example>
@@ -44,6 +49,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Apache2 Ubuntu Default Page: It works$">
     <description>Apache HTTPD default installation on Ubuntu</description>
     <example>Apache2 Ubuntu Default Page: It works</example>
@@ -55,6 +61,7 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Apache Tomcat$">
     <description>Apache Tomcat with no version</description>
     <example>Apache Tomcat</example>
@@ -63,6 +70,7 @@
     <param pos="0" name="service.family" value="Tomcat"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Apache Tomcat/(\S+)$">
     <description>Apache tomcat with minimal version information</description>
     <example service.version="8.0.32">Apache Tomcat/8.0.32</example>
@@ -72,12 +80,14 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:{service.version}"/>
   </fingerprint>
+
   <fingerprint pattern="^AiCloud">
     <description>ASUS AiCloud</description>
     <example>AiCloud</example>
     <param pos="0" name="hw.vendor" value="Asus"/>
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
+
   <!-- HiSilicon is OEMd by a number of DVR manufacturers -->
   <fingerprint pattern="^DVR Components Download$">
     <description>Web server found on DVR and webcam servers sourced from HiSilicon</description>
@@ -88,6 +98,7 @@
     <param pos="0" name="os.device" value="DVR"/>
     <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
+
   <fingerprint pattern="^FRITZ!Box$">
     <description>AVM FRITZ!Box</description>
     <example>FRITZ!Box</example>
@@ -95,18 +106,48 @@
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.family" value="FRITZ!Box"/>
   </fingerprint>
+
+  <fingerprint pattern="^FRITZ!Powerline$">
+    <description>AVM FRITZ!Powerline</description>
+    <example>FRITZ!Powerline</example>
+    <param pos="0" name="hw.vendor" value="AVM"/>
+    <param pos="0" name="hw.device" value="Powerline"/>
+    <param pos="0" name="hw.family" value="FRITZ!Powerline"/>
+  </fingerprint>
+
+  <fingerprint pattern="^FRITZ!WLAN Repeater$">
+    <description>FRITZ!WLAN Repeater</description>
+    <example>FRITZ!WLAN Repeater</example>
+    <param pos="0" name="hw.vendor" value="AVM"/>
+    <param pos="0" name="hw.device" value="WLAN Repeater"/>
+    <param pos="0" name="hw.family" value="FRITZ!WLAN Repeater"/>
+  </fingerprint>
+
   <fingerprint pattern="^cPanel Login$">
     <description>cPanel</description>
     <example>cPanel Login</example>
     <param pos="0" name="service.vendor" value="cPanel"/>
     <param pos="0" name="service.product" value="cPanel"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cpanel:cpanel:-"/>
   </fingerprint>
+
   <fingerprint pattern="^WHM Login$">
     <description>cPanel Web Host Manager</description>
     <example>WHM Login</example>
     <param pos="0" name="service.vendor" value="cPanel"/>
     <param pos="0" name="service.product" value="WHM"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cpanel:whm:-"/>
   </fingerprint>
+
+  <fingerprint pattern="^Windows CE$">
+    <description>Windows CE</description>
+    <example>Windows CE</example>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows CE"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows-ce:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^IIS7$">
     <description>Default IIS 7</description>
     <example>IIS7</example>
@@ -120,6 +161,7 @@
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Microsoft Internet Information Services 8">
     <description>Default IIS 8</description>
     <example>Microsoft Internet Information Services 8</example>
@@ -133,6 +175,23 @@
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
+
+  <fingerprint pattern="^IIS (\d\.\d) Detailed Error">
+    <description>IIS Detailed Error</description>
+    <example service.version="7.0">IIS 7.0 Detailed Error - 401.2 - Unauthorized</example>
+    <example service.version="8.0">IIS 8.0 Detailed Error - 403.14 - Forbidden</example>
+    <example service.version="8.5">IIS 8.5 Detailed Error - 403.14 - Forbidden</example>
+    <param pos="0" name="service.vendor" value="Microsoft"/>
+    <param pos="0" name="service.product" value="IIS"/>
+    <param pos="0" name="service.family" value="IIS"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^IIS Windows(?: Server)?$">
     <description>Default IIS</description>
     <example>IIS Windows</example>
@@ -145,6 +204,7 @@
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
+
   <fingerprint pattern="^(?:NETIASPOT Management Console|Konsola zarzdzania NETIASPOT)$">
     <description>Netia Spot wireless router</description>
     <example>Konsola zarzdzania NETIASPOT</example>
@@ -153,6 +213,7 @@
     <param pos="0" name="hw.product" value="Spot"/>
     <param pos="0" name="hw.product" value="WAP"/>
   </fingerprint>
+
   <fingerprint pattern="^hue personal wireless lighting$">
     <description>Philips Hue Personal Wireless Lighting</description>
     <example>hue personal wireless lighting</example>
@@ -169,19 +230,23 @@
     <param pos="0" name="service.vendor" value="Plesk"/>
     <param pos="0" name="service.product" value="Plesk"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:plesk:plesk:{service.version}"/>
   </fingerprint>
+
   <fingerprint pattern="^(?:Parallels )?Plesk (?:(?:Onyx|Panel) )?([\d\.]+) for Microsoft Windows$">
     <description>Plesk web hosting platform with a version on Windows</description>
-    <example>Plesk 12.5.30 for Microsoft Windows</example>
-    <example>Parallels Plesk Panel 11.5.30 for Microsoft Windows</example>
+    <example service.version="12.5.30">Plesk 12.5.30 for Microsoft Windows</example>
+    <example service.version="11.5.30">Parallels Plesk Panel 11.5.30 for Microsoft Windows</example>
     <param pos="0" name="service.vendor" value="Plesk"/>
     <param pos="0" name="service.product" value="Plesk"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:plesk:plesk:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
+
   <fingerprint pattern="^(?i)Default (?:Parallels )?Plesk (?:Panel )?Page$">
     <description>Plesk web hosting platform with no version</description>
     <example>Default Parallels Plesk Panel Page</example>
@@ -189,13 +254,16 @@
     <example>Default PLESK Page</example>
     <param pos="0" name="service.vendor" value="Plesk"/>
     <param pos="0" name="service.product" value="Plesk"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:plesk:plesk:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Web Viewer for Samsung DVR$">
     <description>Samsung DVRs</description>
     <example>Web Viewer for Samsung DVR</example>
     <param pos="0" name="hw.vendor" value="Samsung"/>
     <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
+
   <fingerprint pattern="^(?i)(?:Dell )?Sonicwall - Authentication$">
     <description>Sonicwall firewalls</description>
     <example>SonicWall - Authentication</example>
@@ -203,7 +271,8 @@
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.family" value="SonicOS"/>
   </fingerprint>
-  <fingerprint pattern="^(.*)&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation$">
+
+  <fingerprint pattern="^(.*).nbsp;-.nbsp;Synology.nbsp;DiskStation$">
     <description>Synology DiskStation</description>
     <example host.name="DiskStation">DiskStation&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
     <example host.name="DS218">DS218&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
@@ -216,6 +285,7 @@
     <param pos="0" name="os.vendor" value="Synology"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
+
   <fingerprint pattern="Synology Web Station!$">
     <description>Synology with WebStation web hosting</description>
     <example>Hello! Welcome to Synology Web Station!</example>
@@ -228,6 +298,7 @@
     <param pos="0" name="os.product" value="DSM"/>
     <param pos="0" name="os.vendor" value="Synology"/>
   </fingerprint>
+
   <fingerprint pattern="^Web Filter Block Override$">
     <description>Fortinet FortiGate/Fortiguard Web Filter</description>
     <example>Web Filter Block Override</example>
@@ -240,23 +311,27 @@
     <param pos="0" name="hw.family" value="FortiGate"/>
     <param pos="0" name="hw.device" value="Firewall"/>
   </fingerprint>
+
   <!-- Various products by Ubiquiti networks -->
   <fingerprint pattern="^Ubiquiti Networks$">
     <description>Generic products by Ubiquiti Networks</description>
     <example>Ubiquiti Networks</example>
     <param pos="0" name="hw.vendor" value="Ubiquiti"/>
   </fingerprint>
+
   <fingerprint pattern="^EdgeOS$">
     <description>Ubiquiti EdgeRouter/EdgeSwitch/etc</description>
     <example>EdgeOS</example>
     <param pos="0" name="hw.vendor" value="Ubiquiti"/>
   </fingerprint>
+
   <fingerprint pattern="^CloudKey$">
     <description>Ubiquiti UniFi Cloud Key</description>
     <example>CloudKey</example>
     <param pos="0" name="hw.vendor" value="Ubiquiti"/>
     <param pos="0" name="hw.product" value="UniFi Cloud Key"/>
   </fingerprint>
+
   <fingerprint pattern="^airCube$">
     <description>Ubiquiti airCube WAP</description>
     <example>airCube</example>
@@ -264,13 +339,15 @@
     <param pos="0" name="hw.product" value="airCube"/>
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
+
   <fingerprint pattern="^UniFi Video$">
     <description>Various UniFi Video products by Ubiquiti Networks</description>
     <example>UniFi Video</example>
     <param pos="0" name="hw.vendor" value="Ubiquiti"/>
     <param pos="0" name="hw.family" value="UniFi"/>
-    <param pos="0" name="hw.device" value="Web cam"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
   </fingerprint>
+
   <fingerprint pattern="^UniFi NVR: Software Portal$">
     <description>UniFi NVR for recording from UniFi video cameras</description>
     <example>UniFi NVR: Software Portal</example>
@@ -279,6 +356,7 @@
     <param pos="0" name="hw.family" value="UniFi NVR"/>
     <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
+
   <fingerprint pattern="^RomPager Embedded Web Server Toolkit$">
     <description>Embedded HTTP server used by many vendors and device
       types, including APC, 3Com, Andover Controls, Cisco VoIP, D-Link,
@@ -289,6 +367,7 @@
     <param pos="0" name="service.vendor" value="Allegro Software"/>
     <param pos="0" name="service.product" value="RomPager"/>
   </fingerprint>
+
   <fingerprint pattern="^RouterOS router configuration page$">
     <description>MikroTik RouterOS router configuration page</description>
     <example>RouterOS router configuration page</example>
@@ -299,6 +378,7 @@
     <param pos="0" name="hw.vendor" value="MikroTik"/>
     <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>
+
   <fingerprint pattern="^(?:Welcome to nginx!|Test Page for the Nginx HTTP Server)$">
     <description>Default OS-agnostic nginx</description>
     <example>Welcome to nginx!</example>
@@ -308,6 +388,7 @@
     <param pos="0" name="service.vendor" value="nginx"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Test Page for the Nginx HTTP Server on (?:Fedora|EPEL)$">
     <description>Default nginx on Fedora</description>
     <example>Test Page for the Nginx HTTP Server on Fedora</example>
@@ -320,6 +401,7 @@
     <param pos="0" name="os.product" value="Fedora Core Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:-"/>
   </fingerprint>
+
   <fingerprint pattern="^Welcome to nginx on Debian!$">
     <description>Default nginx on Debian</description>
     <example>Welcome to nginx on Debian!</example>
@@ -331,4 +413,907 @@
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:-"/>
   </fingerprint>
+
+  <!-- Netgear Products -->
+  <fingerprint pattern="^(?:NETGEAR|NetGear) ([a-zA-Z0-9\-\+]+)$">
+    <description>Netgear Switches</description>
+    <example hw.product="GS108T">NETGEAR GS108T</example>
+    <example hw.product="M4100-24G-POE+">NETGEAR M4100-24G-POE+</example>
+    <example hw.product="GS748T">NetGear GS748T</example>
+    <param pos="0" name="hw.vendor" value="Netgear"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:NETGEAR|NetGear) Router ([a-zA-Z0-9\-\+]+)$">
+    <description>Netgear Routers</description>
+    <example hw.product="WNR2000v4">NETGEAR Router WNR2000v4</example>
+    <example hw.product="R6100">NETGEAR Router R6100</example>
+    <param pos="0" name="hw.vendor" value="Netgear"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Netgear Prosafe Plus Switch$">
+    <description>Netgear Prosafe Plus Switch</description>
+    <example>Netgear Prosafe Plus Switch</example>
+    <param pos="0" name="hw.vendor" value="Netgear"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="Prosafe Plus"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(.*).nbsp;Configuration and Management$">
+    <description>Digi Terminal Servers</description>
+    <example hw.product="Digi One SP">Digi One SP&amp;nbsp;Configuration and Management</example>
+    <example hw.product="PortServer TS 4">PortServer TS 4&amp;nbsp;Configuration and Management</example>
+    <example hw.product="PortServer TS 4 H MEI">PortServer TS 4 H MEI&amp;nbsp;Configuration and Management</example>
+    <param pos="0" name="hw.vendor" value="Digi"/>
+    <param pos="0" name="hw.device" value="Device Server"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Digi"/>
+    <param pos="0" name="os.device" value="Device Server"/>
+    <param pos="0" name="os.product" value="NET+OS"/>
+  </fingerprint>
+
+  <fingerprint pattern="^NPort Web Console$">
+    <description>Moxa NPort Terminal Servers</description>
+    <example>NPort Web Console</example>
+    <param pos="0" name="hw.vendor" value="Moxa"/>
+    <param pos="0" name="hw.device" value="Device Server"/>
+    <param pos="0" name="hw.product" value="NPort"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Lantronix (SL[BC].*)$">
+    <description>Lantronix terminal server</description>
+    <example hw.product="SLB882/8824">Lantronix SLB882/8824</example>
+    <example hw.product="SLB">Lantronix SLB</example>
+    <example hw.product="SLC 8048">Lantronix SLC 8048</example>
+    <param pos="0" name="hw.vendor" value="Lantronix"/>
+    <param pos="0" name="hw.device" value="Device Server"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(KN\S+) - Cover$">
+    <description>ATEN KVM over IP</description>
+    <example hw.product="KN4140v">KN4140v - Cover</example>
+    <example hw.product="KN4132">KN4132 - Cover</example>
+    <param pos="0" name="hw.vendor" value="ATEN"/>
+    <param pos="0" name="hw.device" value="KVM"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Ethernet Relay Module$">
+    <description>AVT.pl Ethernet Relay Module</description>
+    <example>Ethernet Relay Module</example>
+    <param pos="0" name="hw.vendor" value="AVT"/>
+    <param pos="0" name="hw.device" value="Power Relay"/>
+    <param pos="0" name="hw.product" value="Ethernet Relay Module"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Inveo Lantick Ethernet Relay Controller$">
+    <description>Inveo Lantick Ethernet Relay Controller</description>
+    <example>Inveo Lantick Ethernet Relay Controller</example>
+    <param pos="0" name="hw.vendor" value="Inveo"/>
+    <param pos="0" name="hw.device" value="Power Relay"/>
+    <param pos="0" name="hw.product" value="Lantick Ethernet Relay Controller"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(myUTN(?:-[a-zA-Z0-9]+)?) Control Center$">
+    <description>myUTN Device Server</description>
+    <example hw.product="myUTN-50a">myUTN-50a Control Center</example>
+    <example hw.product="myUTN">myUTN Control Center</example>
+    <param pos="0" name="hw.vendor" value="SEH Technology"/>
+    <param pos="0" name="hw.device" value="Device Server"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^iCOM Control Board$">
+    <description>Liebert iCOM Cooling Unit Control Board</description>
+    <example>iCOM Control Board</example>
+    <param pos="0" name="hw.vendor" value="Liebert"/>
+    <param pos="0" name="hw.device" value="Environment Control"/>
+    <param pos="0" name="hw.product" value="iCOM Control Panel"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Sigma Control 2$">
+    <description>Sigma Control 2 Air Compressor Controls</description>
+    <example>Sigma Control 2</example>
+    <param pos="0" name="hw.vendor" value="Kaeser Compressors"/>
+    <param pos="0" name="hw.device" value="Environment Control"/>
+    <param pos="0" name="hw.product" value="Sigma Control 2"/>
+  </fingerprint>
+
+
+
+
+  <fingerprint pattern="^WebPower$">
+    <description>Eltek Power Controller</description>
+    <example>WebPower</example>
+    <param pos="0" name="hw.vendor" value="Eltek"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+  </fingerprint>
+
+  <fingerprint pattern="(Expert Power Control NET \d+x\d+) - (.*)$">
+    <description>Gude Expert Power Control</description>
+    <example host.name="Rack42" hw.product="Expert Power Control NET 2x6">Expert Power Control NET 2x6 - Rack42</example>
+    <param pos="0" name="hw.vendor" value="Gude"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Sentry Switched CDU$">
+    <description>Sentry Switched CDU</description>
+    <example>Sentry Switched CDU</example>
+    <param pos="0" name="hw.vendor" value="ServerTech"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="hw.product" value="Sentry Switched CDU"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Emerson Network Power Rack PDU Card$">
+    <description>Emerson Network Power Rack PDU Card</description>
+    <example>Emerson Network Power Rack PDU Card</example>
+    <param pos="0" name="hw.vendor" value="Emerson"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="hw.product" value="Rack PDU Card"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(.*) IntelliSlot Web(?:/\d+)? Card?$">
+    <description>Emerson Network Power IntelliSlot Web Card and rebrands</description>
+    <example hw.vendor="Emerson Network Power">Emerson Network Power IntelliSlot Web Card</example>
+    <example hw.vendor="Emerson Network Power">Emerson Network Power IntelliSlot Web/485 Card</example>
+    <example hw.vendor="Vertiv">Vertiv IntelliSlot Web Card</example>
+    <example hw.vendor="Liebert">Liebert IntelliSlot Web Card</example>
+    <param pos="1" name="hw.vendor"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="hw.product" value="IntelliSlot Web Card"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ConnectUPS Web/SNMP Card$">
+    <description>ConnectUPS Web/SNMP Card</description>
+    <example>ConnectUPS Web/SNMP Card</example>
+    <param pos="0" name="hw.vendor" value="APC"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="hw.product" value="ConnectUPS Web Card"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Calient Technologies Inc\.$">
+    <description>Calient Photonic Switch</description>
+    <example>Calient Technologies Inc.</example>
+    <param pos="0" name="hw.vendor" value="Calient"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="Photonic Switch"/>
+    <param pos="0" name="os.vendor" value="Calient"/>
+    <param pos="0" name="os.device" value="Switch"/>
+    <param pos="0" name="os.family" value="Linux"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Google Fiber Network Box Diagnostics$">
+    <description>Google Fiber Router</description>
+    <example>Google Fiber Network Box Diagnostics</example>
+    <param pos="0" name="hw.vendor" value="Google"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.product" value="Fiber Network Box"/>
+  </fingerprint>
+
+  <fingerprint pattern="ServerView.* (iRMC S\d+) Web Server">
+    <description>Fujitsu iRMC BMC</description>
+    <example hw.product="iRMC S3" os.product="iRMC S3">ServerView Remote Management iRMC S3 Web Server</example>
+    <example hw.product="iRMC S4" os.product="iRMC S4">ServerView&amp;reg;&amp;nbsp;Remote Management iRMC S4 Web Server Redirecting ...</example>
+    <example hw.product="iRMC S2" os.product="iRMC S2">ServerView Remote Management iRMC S2 Web Server</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="Fujitsu"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Fujitsu"/>
+    <param pos="1" name="os.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco UCS KVM Direct$">
+    <description>Cisco UCS KVM Direct</description>
+    <example>Cisco UCS KVM Direct</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.product" value="UCS Manager"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="NX-OS"/>
+    <param pos="0" name="os.certainty" value="0.8"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco UCS Manager$">
+    <description>Cisco UCS Manager</description>
+    <example>Cisco UCS Manager</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.product" value="UCS Manager"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="NX-OS"/>
+    <param pos="0" name="os.certainty" value="0.8"/>
+  </fingerprint>
+
+  <fingerprint pattern="^HPE Virtual Connect Manager$">
+    <description>HPE Virtual Connect Manager</description>
+    <example>HPE Virtual Connect Manager</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="HPE"/>
+    <param pos="0" name="hw.product" value="Virtual Connect Manager"/>
+    <param pos="0" name="os.vendor" value="HPE"/>
+    <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.product" value="iLO"/>
+  </fingerprint>
+
+  <fingerprint pattern="^HPE BladeSystem Onboard Administrator$">
+    <description>HPE BladeSystem Onboard Administrator</description>
+    <example>HPE BladeSystem Onboard Administrator</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="HPE"/>
+    <param pos="0" name="hw.product" value="BladeSystem Onboard Administrator"/>
+  </fingerprint>
+
+  <fingerprint pattern="^HPE System Management Homepage$">
+    <description>HPE System Management Homepage</description>
+    <example>HPE System Management Homepage</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="HPE"/>
+    <param pos="0" name="hw.product" value="System Management"/>
+    <param pos="0" name="os.vendor" value="HPE"/>
+    <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.product" value="iLO"/>
+  </fingerprint>
+
+  <fingerprint pattern="^HP Integrated Lights-Out$">
+    <description>HP Integrated Lights-Out</description>
+    <example>HP Integrated Lights-Out</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.product" value="iLO"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.family" value="iLO"/>
+    <param pos="0" name="os.product" value="iLO"/>
+  </fingerprint>
+
+  <fingerprint pattern="^HP Integrated Lights-Out 2$">
+    <description>HP Integrated Lights-Out 2</description>
+    <example>HP Integrated Lights-Out 2</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.product" value="iLO"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.family" value="iLO"/>
+    <param pos="0" name="os.product" value="iLO 2"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(iLO \d+)$">
+    <description>HP Integrated Lights-Out 3+</description>
+    <example hw.product="iLO 3" os.product="iLO 3">iLO 3</example>
+    <example hw.product="iLO 4" os.product="iLO 4">iLO 4</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.family" value="iLO"/>
+    <param pos="1" name="os.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^HPE SimpliVity OmniStack$">
+    <description>HPE SimpliVity OmniStack</description>
+    <example>HPE SimpliVity OmniStack</example>
+    <param pos="0" name="hw.device" value="NAS"/>
+    <param pos="0" name="hw.vendor" value="HPE"/>
+    <param pos="0" name="hw.product" value="SimpliVity OmniStack"/>
+  </fingerprint>
+
+  <fingerprint pattern="^HPE (StoreEver \S+)$">
+    <description>HPE StoreEver</description>
+    <example hw.product="StoreEver MSL3040">HPE StoreEver MSL3040</example>
+    <param pos="0" name="hw.device" value="Tape Library"/>
+    <param pos="0" name="hw.vendor" value="HPE"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Dell OpenManage Switch Administrator$">
+    <description>Dell OpenManage Switch Administrator</description>
+    <example>Dell OpenManage Switch Administrator</example>
+    <param pos="0" name="hw.vendor" value="Dell"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="OpenManage Switch"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(\S+)\s+-\s+ProCurve Switch (\S+) \((.*)\)$">
+    <description>HPE ProCurve Switch w/Hostname</description>
+    <example host.name="SW1" hw.product="4204vl" procurve.model="J8770A">SW1 - ProCurve Switch 4204vl (J8770A)</example>
+    <param pos="0" name="hw.vendor" value="HPE"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="2" name="hw.product"/>
+    <param pos="1" name="host.name"/>
+    <param pos="3" name="procurve.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ProCurve Switch (\S+) \((.*)\)$">
+    <description>HPE ProCurve Switch w/o Hostname</description>
+    <example hw.product="2610-24/12PWR" procurve.model="J9086A">ProCurve Switch 2610-24/12PWR (J9086A)</example>
+    <param pos="0" name="hw.vendor" value="HPE"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="procurve.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^FlexiPacket Hub$">
+    <description>Nokia Siemens FlexiPacket Hub</description>
+    <example>FlexiPacket Hub</example>
+    <param pos="0" name="hw.vendor" value="Nokia-Siemens"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="FlexiPacket Hub"/>
+  </fingerprint>
+
+  <fingerprint pattern="^R&amp;S Instrument VNC desktop$">
+    <description>Rohde and Schwarz Remote Instrument (vnc)</description>
+    <example>R&amp;S Instrument VNC desktop</example>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.vendor" value="Rohde &amp; Schwarz"/>
+    <param pos="0" name="os.device" value="Test Instrument"/>
+    <param pos="0" name="os.vendor" value="Rohde &amp; Schwarz"/>
+    <param pos="0" name="os.family" value="Linux"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Rohde &amp; Schwarz remote instrument$">
+    <description>Rohde and Schwarz Remote Instrument (web admin)</description>
+    <example>Rohde &amp; Schwarz remote instrument</example>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.vendor" value="Rohde &amp; Schwarz"/>
+  </fingerprint>
+
+  <fingerprint pattern="^EXA$">
+    <description>Keysight EXA Signal Analyzer</description>
+    <example>EXA</example>
+    <param pos="0" name="hw.vendor" value="Keysight"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="EXA Signal Analyzer"/>
+    <param pos="0" name="os.device" value="Test Instrument"/>
+  </fingerprint>
+
+  <fingerprint pattern="^MXA$">
+    <description>Keysight MXA Signal Analyzer</description>
+    <example>MXA</example>
+    <param pos="0" name="hw.vendor" value="Keysight"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="MXA Signal Analyzer"/>
+    <param pos="0" name="os.device" value="Test Instrument"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Paragon-100G$">
+    <description>Calnex Paragon-100G</description>
+    <example>Paragon-100G</example>
+    <param pos="0" name="hw.vendor" value="Calnex"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="Paragon-100G"/>
+  </fingerprint>
+
+  <fingerprint pattern="^33521A$">
+    <description>Keysight 33521A Waveform Generator</description>
+    <example>33521A</example>
+    <param pos="0" name="hw.vendor" value="Keysight"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="33521A Waveform Generator"/>
+  </fingerprint>
+
+  <fingerprint pattern="^34972A$">
+    <description>Keysight 34972A Data Logger</description>
+    <example>34972A</example>
+    <param pos="0" name="hw.vendor" value="Keysight"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="34972A Data Logger"/>
+  </fingerprint>
+
+  <fingerprint pattern="^53230A$">
+    <description>Agilent 53230A Frequency Counter</description>
+    <example>53230A</example>
+    <param pos="0" name="hw.vendor" value="Agilent"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="53230A Frequency Counter"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Agilent 33220A \((.*)\)$">
+    <description>Agilent 33220A</description>
+    <example agilent.serial="MY44041111">Agilent 33220A (MY44041111)</example>
+    <param pos="0" name="hw.vendor" value="Agilent"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="33220A Waveform Generator"/>
+    <param pos="1" name="agilent.serial"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Agilent N5172B (?:EXG )?(MY\S+)$">
+    <description>Agilent N5172B</description>
+    <example agilent.serial="MY44041111">Agilent N5172B EXG MY44041111</example>
+    <param pos="0" name="hw.vendor" value="Agilent"/>
+    <param pos="0" name="hw.device" value="Test Instrument"/>
+    <param pos="0" name="hw.product" value="N5172B Signal Generator"/>
+    <param pos="1" name="agilent.serial"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Polycom - Configuration Utility$">
+    <description>Polycom IP Phone</description>
+    <example>Polycom - Configuration Utility</example>
+    <param pos="0" name="hw.vendor" value="Polycom"/>
+    <param pos="0" name="hw.family" value="SoundPoint"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="0" name="os.vendor" value="Polycom"/>
+    <param pos="0" name="os.product" value="Polycom"/>
+  </fingerprint>
+
+
+  <fingerprint pattern="^Digium Phone Settings$">
+    <description>Digium Phone Settings</description>
+    <example>Digium Phone Settings</example>
+    <param pos="0" name="hw.vendor" value="Digium"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(SPA\S+) Configuration Utility$">
+    <description>Cisco IP Phone - SPA504G Configuration Utility</description>
+    <example hw.product="SPA504G">SPA504G Configuration Utility</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco (?:SPA Configuration|IP Phone)$">
+    <description>Cisco IP Phone </description>
+    <example>Cisco SPA Configuration</example>
+    <example>Cisco IP Phone</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco IP Camera$">
+    <description>Cisco IP Camera</description>
+    <example>Cisco IP Camera</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco TelePresence MCU">
+    <description>Cisco TelePresence MCU - Home page</description>
+    <example>Cisco TelePresence MCU - Home page</example>
+    <example>Cisco TelePresence MCU MSE - Home page</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.product" value="TelePresence MCU"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco (Nexus \d+\S+)$">
+    <description>Cisco Nexus Virtual Switch</description>
+    <example hw.product="Nexus 1000V">Cisco Nexus 1000V</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco Catalyst Switch - Home$">
+    <description>Cisco Catalyst Switch</description>
+    <example>Cisco Catalyst Switch - Home</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="Catalyst"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.product" value="CatOS"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco MDS 9000(?: and Nexus 5000)? Management Modules (\d+\.\d+\S+)$">
+    <description>Cisco MDS 9000/Nexus 5000</description>
+    <example os.version="7.3(1)D1(1)">Cisco MDS 9000 and Nexus 5000 Management Modules 7.3(1)D1(1)</example>
+    <example os.version="6.2(13a)">Cisco MDS 9000 and Nexus 5000 Management Modules 6.2(13a)</example>
+    <example os.version="3.3(2)">Cisco MDS 9000 Management Modules 3.3(2)</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Switch"/>
+    <param pos="0" name="hw.product" value="MDS 9000"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.device" value="Switch"/>
+    <param pos="0" name="os.product" value="MDS 9000"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(LinxVII-\S+) Remote Access$">
+    <description>LinxVII-5S Data Terminal</description>
+    <example hw.product="LinxVII-5S">LinxVII-5S Remote Access</example>
+    <param pos="0" name="hw.vendor" value="LINX"/>
+    <param pos="0" name="hw.device" value="Data Terminal"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Datalogic Mobile Portable$">
+    <description>Datalogic Mobile Portable</description>
+    <example>Datalogic Mobile Portable</example>
+    <param pos="0" name="hw.vendor" value="Datalogic Mobile"/>
+    <param pos="0" name="hw.device" value="Handheld Scanner"/>
+  </fingerprint>
+
+  <fingerprint pattern="^AXIS$">
+    <description>Axis Communications Web Cam</description>
+    <example>AXIS</example>
+    <param pos="0" name="hw.vendor" value="AXIS"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
+    <param pos="0" name="os.vendor" value="AXIS"/>
+    <param pos="0" name="os.device" value="Web Cam"/>
+    <param pos="0" name="os.family" value="Linux"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Hanwha Techwin$">
+    <description>Hanwha Techwin IP Camera</description>
+    <example>Hanwha Techwin</example>
+    <param pos="0" name="hw.vendor" value="Hanwha Techwin"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
+    <param pos="0" name="os.vendor" value="Hanwha Techwin"/>
+    <param pos="0" name="os.device" value="Web Cam"/>
+    <param pos="0" name="os.family" value="Linux"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(WV-NS\S+) Network Camera$">
+    <description>WV-NS202A Network Camera</description>
+    <example hw.product="WV-NS202A">WV-NS202A Network Camera</example>
+    <example hw.product="WV-NS954">WV-NS954 Network Camera</example>
+    <param pos="0" name="hw.vendor" value="Panasonic"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Panasonic"/>
+    <param pos="0" name="os.device" value="Web Cam"/>
+    <param pos="0" name="os.family" value="Linux"/>
+  </fingerprint>
+
+  <fingerprint pattern="^KACE Systems Management Appliance">
+    <description>KACE Systems Management Appliances</description>
+    <example>KACE Systems Management Appliance Service Center</example>
+    <example>KACE Systems Management Appliance Administrator Console</example>
+    <param pos="0" name="hw.vendor" value="KACE"/>
+    <param pos="0" name="hw.device" value="Support Appliance"/>
+    <param pos="0" name="os.vendor" value="KACE"/>
+    <param pos="0" name="os.family" value="FreeBSD"/>
+  </fingerprint>
+
+  <fingerprint pattern="Portal.*Powered by BOMGAR$">
+    <description>Bomgar Appliances</description>
+    <example>Remote Support Portal | Powered by BOMGAR</example>
+    <example>Customer Support Portal Powered by BOMGAR</example>
+    <param pos="0" name="hw.vendor" value="Bomgar"/>
+    <param pos="0" name="hw.device" value="Support Appliance"/>
+    <param pos="0" name="os.vendor" value="Bomgar"/>
+    <param pos="0" name="os.family" value="Linux"/>
+  </fingerprint>
+
+  <fingerprint pattern="^XRoads Network Appliance Administration$">
+    <description>XRoads SD-WAN Network Appliance </description>
+    <example>XRoads Network Appliance Administration</example>
+    <param pos="0" name="hw.vendor" value="XRoads"/>
+    <param pos="0" name="hw.device" value="SD-WAN Appliance"/>
+    <param pos="0" name="os.vendor" value="XRoads"/>
+    <param pos="0" name="os.family" value="Linux"/>
+  </fingerprint>
+
+  <!-- An OEM of the Quantum Corporation SuperLoader 3 -->
+  <fingerprint pattern="^On Board Remote Management$">
+    <description>PowerVault 124T Tape Library</description>
+    <example>On Board Remote Management</example>
+    <param pos="0" name="hw.vendor" value="Dell"/>
+    <param pos="0" name="hw.device" value="Tape Library"/>
+    <param pos="0" name="hw.product" value="PowerVault 124T"/>
+    <param pos="0" name="os.vendor" value="Dell"/>
+  </fingerprint>
+
+ <fingerprint pattern="^(HD-RX-\S+)$">
+    <description>Crestron Multiformat Receivers</description>
+    <example hw.product="HD-RX-201-C-E">HD-RX-201-C-E</example>
+    <param pos="0" name="hw.vendor" value="Crestron"/>
+    <param pos="0" name="hw.device" value="Media Receiver"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Crestron"/>
+  </fingerprint>
+
+ <fingerprint pattern="^Lencore Sound Manager 2$">
+    <description>Lencore Sound Manager 2</description>
+    <example>Lencore Sound Manager 2</example>
+    <param pos="0" name="hw.vendor" value="Lencore"/>
+    <param pos="0" name="hw.device" value="Media Receiver"/>
+    <param pos="0" name="hw.product" value="Lencore Sound Manager 2"/>
+    <param pos="0" name="os.vendor" value="i.LON"/>
+    <param pos="0" name="os.product" value="SmartServer"/>
+  </fingerprint>
+
+ <!-- Various ICS/OT -->
+
+ <fingerprint pattern="^CTI (25\S+) Main Menu$">
+    <description>Siemens 257x Ethernet Adapter (CTI Branded)</description>
+    <example hw.product="2572-A">CTI 2572-A Main Menu</example>
+    <param pos="0" name="hw.vendor" value="Siemens"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Siemens"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(25\S+) Ethernet TCP/IP Module$">
+    <description>Siemens 257x Ethernet Adapter</description>
+    <example hw.product="2572-B">2572-B Ethernet TCP/IP Module</example>
+    <param pos="0" name="hw.vendor" value="Siemens"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Siemens"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ECOM100 Main$">
+    <description>DirectLOGIC DL205 communication module</description>
+    <example>ECOM100 Main</example>
+    <param pos="0" name="hw.vendor" value="DirectLOGIC"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="0" name="hw.product" value="ECOM100"/>
+    <param pos="0" name="os.vendor" value="DirectLOGIC"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(1794-\S+) FLEX Ethernet Adapter$">
+    <description>Allen-Bradley 1794-AENTR FLEX Ethernet Adapter</description>
+    <example hw.product="1794-AENTR">1794-AENTR FLEX Ethernet Adapter</example>
+    <param pos="0" name="hw.vendor" value="Allen-Bradley"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Allen-Bradley"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Anybus-CC EtherNet/IP$">
+    <description>Anybus-CC EtherNet/IP</description>
+    <example>Anybus-CC EtherNet/IP</example>
+    <param pos="0" name="hw.vendor" value="AnyBus"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="0" name="hw.product" value="CC EtherNet/IP"/>
+    <param pos="0" name="os.vendor" value="AnyBus"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Symmetry 2DBC">
+    <description>AMAG Technology Symmetry EN-2DBC Access Controller</description>
+    <example>Symmetry 2DBC STD APP (EN2DBC_00_EF_4F)</example>
+    <param pos="0" name="hw.vendor" value="AMAG Technology"/>
+    <param pos="0" name="hw.device" value="Access Control"/>
+    <param pos="0" name="hw.product" value="Symmetry EN-2DBC"/>
+    <param pos="0" name="os.vendor" value="AMAG Technology"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(1747-\S+) Home Page$">
+    <description>Allen-Bradley 1747-LXXX SLC 5/05 Controller</description>
+    <example hw.product="1747-L551">1747-L551 Home Page</example>
+    <example hw.product="1747-L551/C">1747-L551/C Home Page</example>
+    <example hw.product="1747-L552/C">1747-L552/C Home Page</example>
+    <param pos="0" name="hw.vendor" value="Allen-Bradley"/>
+    <param pos="0" name="hw.device" value="HMI Controller"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Allen-Bradley"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(1766-\S+) (B/\S+)$">
+    <description>Allen-Bradley 1766-L32BXB PLC</description>
+    <example hw.product="1766-L32BXB" os.product="1766-L32BXB" os.version="B/11.00">1766-L32BXB B/11.00</example>
+    <param pos="0" name="hw.vendor" value="Allen-Bradley"/>
+    <param pos="0" name="hw.device" value="PLC"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Allen-Bradley"/>
+    <param pos="0" name="os.device" value="PLC"/>
+    <param pos="1" name="os.product"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^PLC-5 Ethernet Base Page$">
+    <description>PLC-5 Ethernet Interface Module</description>
+    <example>PLC-5 Ethernet Base Page</example>
+    <param pos="0" name="hw.vendor" value="Rockwell Automation"/>
+    <param pos="0" name="hw.device" value="PLC"/>
+    <param pos="0" name="hw.product" value="PLC-5"/>
+    <param pos="0" name="os.vendor" value="Rockwell Automation"/>
+    <param pos="0" name="os.device" value="PLC"/>
+    <param pos="0" name="os.product" value="PLC-5"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(1761-NET-\S+)$">
+    <description>Allen-Bradley Ethernet Module</description>
+    <example hw.product="1761-NET-EN">1761-NET-EN</example>
+    <example hw.product="1761-NET-ENIW">1761-NET-ENIW</example>
+    <param pos="0" name="hw.vendor" value="Allen-Bradley"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Allen-Bradley"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(1785-\S+) Ethernet Base Page$">
+    <description>Allen-Bradley 1785 Ethernet Module</description>
+    <example hw.product="1785-ENET">1785-ENET Ethernet Base Page</example>
+    <param pos="0" name="hw.vendor" value="Allen-Bradley"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="os.vendor" value="Allen-Bradley"/>
+  </fingerprint>
+
+  <fingerprint pattern="^NFT S7 - DALI-Gateway\(Ethernet\)$">
+    <description>NFT DALI S7 Ethernet Module</description>
+    <example>NFT S7 - DALI-Gateway(Ethernet)</example>
+    <param pos="0" name="hw.vendor" value="NFT"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="0" name="hw.product" value="S7 DALI Gateway"/>
+    <param pos="0" name="os.vendor" value="NFT"/>
+  </fingerprint>
+
+  <fingerprint pattern="^IBHLink S7\+\+$">
+    <description>IBHsofte IBHLink S7++</description>
+    <example>IBHLink S7++</example>
+    <param pos="0" name="hw.vendor" value="IBHsofte"/>
+    <param pos="0" name="hw.device" value="Ethernet Adapter"/>
+    <param pos="0" name="hw.product" value="IBHLink S7++"/>
+    <param pos="0" name="os.vendor" value="IBHsofte"/>
+  </fingerprint>
+
+
+  <!-- Software and Appliances -->
+
+  <fingerprint pattern="^S7/S5 OPC Server$">
+    <description>Softing Industrial S7/S5 OPC Server</description>
+    <example>S7/S5 OPC Server</example>
+    <param pos="0" name="service.vendor" value="Softing"/>
+    <param pos="0" name="service.product" value="S7/S5 OPC Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:softing:s7-s5-opc-server:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Nessus$">
+    <description>Nessus</description>
+    <example>Nessus</example>
+    <param pos="0" name="service.vendor" value="Tenable"/>
+    <param pos="0" name="service.product" value="Nessus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:tenable:nessus:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Tenable Appliance$">
+    <description>Tenable Appliance</description>
+    <example>Tenable Appliance</example>
+    <param pos="0" name="hw.vendor" value="Tenable"/>
+    <param pos="0" name="hw.device" value="Security Appliance"/>
+    <param pos="0" name="hw.product" value="Tenable Appliance"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:Welcome to Citrix )?XenServer ([0-9\.]+)$">
+    <description>XenServer</description>
+    <example service.version="7.2.0">Welcome to Citrix XenServer 7.2.0</example>
+    <example service.version="6.2.5">XenServer 6.2.5</example>
+    <param pos="0" name="service.vendor" value="Citrix"/>
+    <param pos="0" name="service.product" value="XenServer"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:citrix:xenserver:{service.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^RabbitMQ Management$">
+    <description>RabbitMQ Management</description>
+    <example>RabbitMQ Management</example>
+    <param pos="0" name="service.vendor" value="RabbitMQ"/>
+    <param pos="0" name="service.product" value="Management Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:rabbitmq:rabbitmq-manager:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Statistics Report for HAProxy$">
+    <description>HAProxy Stats Server</description>
+    <example>Statistics Report for HAProxy</example>
+    <param pos="0" name="service.vendor" value="HAProxy"/>
+    <param pos="0" name="service.product" value="HAProxy Stats Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:haproxy:stats-server:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Open Manage&amp;trade;$">
+    <description>Dell Open Manage Admin</description>
+    <example>Open Manage&amp;trade;</example>
+    <param pos="0" name="service.vendor" value="Dell"/>
+    <param pos="0" name="service.product" value="Open Manage"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:dell:openmanage:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^TightVNC desktop \[(.*)\]$">
+    <description>TightVNC Web Server</description>
+    <example host.name="teller01">TightVNC desktop [teller01]</example>
+    <param pos="0" name="service.vendor" value="TightVNC"/>
+    <param pos="0" name="service.product" value="Desktop"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:tightvnc:desktop:-"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^noVNC$">
+    <description>noVNC Web Server</description>
+    <example>noVNC</example>
+    <param pos="0" name="service.vendor" value="noVNC"/>
+    <param pos="0" name="service.product" value="noVNC"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:novnc:novnc:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^.* \[Jenkins\]$">
+    <description>Jenkins Customized Dashboard</description>
+    <example>Continuous Integrations [Jenkins]</example>
+    <example>Dashboard [Jenkins]</example>
+    <param pos="0" name="service.vendor" value="Jenkins"/>
+    <param pos="0" name="service.product" value="Jenkins"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:jenkins:jenkins:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Shell In A Box$">
+    <description>Shell In A Box (OSS Project)</description>
+    <example>Shell In A Box</example>
+    <param pos="0" name="service.vendor" value="ShellInABox"/>
+    <param pos="0" name="service.product" value="ShellInABox"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:shellinabox:shellinabox:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^AgilentLicenseManagerService Service$">
+    <description>Agilent License Manager Service</description>
+    <example>AgilentLicenseManagerService Service</example>
+    <param pos="0" name="service.vendor" value="Agilent"/>
+    <param pos="0" name="service.product" value="License Manager"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:agilent:license-manager-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Red Hat OpenStack Platform Director$">
+    <description>Red Hat OpenStack Platform Director</description>
+    <example>Red Hat OpenStack Platform Director</example>
+    <param pos="0" name="service.vendor" value="Red Hat"/>
+    <param pos="0" name="service.product" value="Open Stack Platform Director"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openstack:platform-director:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^splunkd$">
+    <description>Splunk HTTP server used in the web interface, forwarders, indexers and more</description>
+    <example>splunkd</example>
+    <param pos="0" name="service.vendor" value="Splunk"/>
+    <param pos="0" name="service.product" value="Splunkd"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:splunk:splunkd:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^VMware Horizon$">
+    <description>VMware Horizon</description>
+    <example>VMware Horizon</example>
+    <param pos="0" name="service.vendor" value="VMWare"/>
+    <param pos="0" name="service.product" value="Horizon"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:vmware:horizon:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Graylog Web Interface$">
+    <description>Graylog Web Interface</description>
+    <example>Graylog Web Interface</example>
+    <param pos="0" name="service.vendor" value="Graylog"/>
+    <param pos="0" name="service.product" value="Graylog"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:graylog:graylog:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Symantec Endpoint Protection Manager$">
+    <description>Symantec Endpoint Protection Manager</description>
+    <example>Symantec Endpoint Protection Manager</example>
+    <param pos="0" name="service.vendor" value="Symantec"/>
+    <param pos="0" name="service.product" value="Endpoint Protection Manager"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:symantec:endpoint-protection-manager:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Login Gateway - Kiwi Syslog Web Access$">
+    <description>Kiwi Syslog Web Access</description>
+    <example>Login Gateway - Kiwi Syslog Web Access</example>
+    <param pos="0" name="service.vendor" value="Solarwinds"/>
+    <param pos="0" name="service.product" value="Kiwi Syslog Web Access"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:solarwinds:kiwi-syslog-web:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Hadoop Administration$">
+    <description>Hadoop Administration Web Service</description>
+    <example>Hadoop Administration</example>
+    <param pos="0" name="service.vendor" value="Hadoop"/>
+    <param pos="0" name="service.product" value="Hadoop Web Admin"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:hadoop:web-admin:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ManageEngine OpManager$">
+    <description>ManageEngine OpManager</description>
+    <example>ManageEngine OpManager</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="OpManager"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:manageengine:opmanager:-"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -131,6 +131,14 @@
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler"/>
   </fingerprint>
+  <fingerprint pattern="^DSSignInURL=/">
+    <description>Pulse Secure VPN</description>
+    <example>DSSignInURL=/; path=/; secure</example>
+    <param pos="0" name="os.vendor" value="Pulse Secure"/>
+    <param pos="0" name="os.family" value="SSL VPN"/>
+    <param pos="0" name="os.device" value="SSL VPN"/>
+    <param pos="0" name="os.product" value="SSL VPN"/>
+  </fingerprint>
   <fingerprint pattern="^(EktGUID|ecm)=.*">
     <description>Ektron CMS400.net</description>
     <param pos="1" name="cookie"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -123,7 +123,7 @@
     <param pos="0" name="service.family" value="Application Protection System"/>
     <param pos="0" name="service.product" value="Application Protection System, Enterprise"/>
   </fingerprint>
-  <fingerprint pattern="^NSC_(?:AAAC|CERT|DLGE|EPAC|TASS|TEMP|TMA[APS])=.*">
+  <fingerprint pattern="^NSC_(?:AAAC|CERT|DLGE|EPAC|TASS|TEMP|TMA[APS]|PERS)=.*">
     <description>Citrix NetScaler</description>
     <example>NSC_AAAC=xyz;</example>
     <param pos="0" name="os.vendor" value="Citrix"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1618,6 +1618,13 @@
     <param pos="0" name="service.family" value="ePolicy Orchestrator"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:mcafee:epolicy_orchestrator:-"/>
   </fingerprint>
+  <fingerprint pattern="^LANDesk Management Agent/.*$">
+    <description>LANDesk Management Agent</description>
+    <param pos="0" name="service.vendor" value="LANDesk"/>
+    <param pos="0" name="service.product" value="Management Agent"/>
+    <param pos="0" name="service.family" value="Management Agent"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:landesk:management_agent:-"/>
+  </fingerprint>
   <fingerprint pattern="^EWS-NIC\d/(\S+)$">
     <description>Xerox Embedded Web Server (EWS)</description>
     <example service.version="6.31">EWS-NIC3/6.31</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fingerprints matches="http_header.server" protocol="http" database_type="service" preference="0.90">
   <!-- HTTP Server headers are matched against these patterns to fingerprint HTTP servers. -->
+  <!-- These fingerprints are also used for RTSP and SIP response headers -->
   <fingerprint pattern="(?i)^AirTunes/([\d\.]+)$">
     <description>Apple AirTunes/AirPlay, more generally RTSP used by a variety of wireless a/v products</description>
     <example service.version="220.68">AirTunes/220.68</example>
@@ -3050,4 +3051,268 @@
     <param pos="0" name="hw.device" value="NAS"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
+  <fingerprint pattern="^NetData Embedded HTTP Server v([a-zA-Z0-9\-\.]+)$">
+    <description>NetData Embedded HTTP Server</description>
+    <example service.version="1.16.1-146-g2f5e36ef">NetData Embedded HTTP Server v1.16.1-146-g2f5e36ef</example>
+    <param pos="0" name="service.vendor" value="NetData"/>
+    <param pos="0" name="service.product" value="NetData"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco MediaSense Media Server$">
+    <description>Cisco MediaSense Media Server (RTSP)</description>
+    <example>Cisco MediaSense Media Server</example>
+    <param pos="0" name="service.vendor" value="Cisco"/>
+    <param pos="0" name="service.product" value="MediaSense Media Server"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="VOS"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="SIP Gateway"/>
+    <param pos="0" name="hw.product" value="MediaSense Server"/>
+  </fingerprint>
+
+
+  <!-- SIP -->
+
+  <fingerprint pattern="^MediaSense/(\d+)\.x$">
+    <description>Cisco MediaSense SIP Server</description>
+    <example os.version="11">MediaSense/11.x</example>
+    <param pos="0" name="service.vendor" value="Cisco"/>
+    <param pos="0" name="service.product" value="MediaSense SIP Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:mediasense-sip:{os.version}"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="VOS"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/a:cisco:mediasense:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="MediaSense"/>
+    <param pos="0" name="hw.device" value="SIP Gateway"/>
+    <param pos="0" name="hw.product" value="MediaSense Server"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco-SIPGateway/IOS-(\S+)\.x$">
+    <description>Cisco IOS SIP Gateway w/ Vague Version</description>
+    <example os.version="12">Cisco-SIPGateway/IOS-12.x</example>
+    <param pos="0" name="service.vendor" value="Cisco"/>
+    <param pos="0" name="service.family" value="IOS"/>
+    <param pos="0" name="service.product" value="IOS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:{os.version}"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="IOS"/>
+    <param pos="0" name="os.product" value="IOS"/>
+    <param pos="0" name="os.certainty" value="0.8"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Router"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco-SIPGateway/IOS-(\S+)$">
+    <description>Cisco IOS SIP Gateway w/ Full Version</description>
+    <example os.version="15.2.4.M3">Cisco-SIPGateway/IOS-15.2.4.M3</example>
+    <param pos="0" name="service.vendor" value="Cisco"/>
+    <param pos="0" name="service.family" value="IOS"/>
+    <param pos="0" name="service.product" value="IOS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:{os.version}"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="IOS"/>
+    <param pos="0" name="os.product" value="IOS"/>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Router"/>
+  </fingerprint>
+
+ <fingerprint pattern="^CISCO-SBC/\S+$">
+    <description>Cisco IOS SBC</description>
+    <example>CISCO-SBC/2.x</example>
+    <param pos="0" name="service.vendor" value="Cisco"/>
+    <param pos="0" name="service.family" value="IOS"/>
+    <param pos="0" name="service.product" value="IOS"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="IOS"/>
+    <param pos="0" name="os.product" value="IOS"/>
+    <param pos="0" name="os.certainty" value="0.7"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:ios:-"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Router"/>
+  </fingerprint>
+
+  <fingerprint pattern="^TANDBERG/(\d+) \((.*)\) Cisco-(\S+)$">
+    <description>Cisco/Tandberg TelePresence w/Cisco Model Name</description>
+    <example os.version="TC7.3.7.01c84fd" tandberg.model="528" hw.product="EX60">TANDBERG/528 (TC7.3.7.01c84fd) Cisco-EX60</example>
+    <example os.version="ce9.6.0.76c1685b70e" tandberg.model="529" hw.product="RoomKitMini">TANDBERG/529 (ce9.6.0.76c1685b70e) Cisco-RoomKitMini</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="1" name="tandberg.model"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:telepresence:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="TelePresence"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+    <param pos="3" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(TANDBERG/(\d+)) \((\S+).*\)$">
+    <description>Cisco/Tandberg TelePresence</description>
+    <example os.version="TC7.0.2.aecf2d9" tandberg.model="519" hw.product="TANDBERG/519">TANDBERG/519 (TC7.0.2.aecf2d9)</example>
+    <example os.version="X12.5.2" tandberg.model="4137" hw.product="TANDBERG/4137">TANDBERG/4137 (X12.5.2 (TEST SW))</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="2" name="tandberg.model"/>
+    <param pos="3" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:telepresence:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="TelePresence"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Acano CallBridge$">
+    <description>Cisco (Acano) Meeting Server</description>
+    <example hw.product="Meeting Server">Acano CallBridge</example>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="TelePresence"/>
+    <param pos="0" name="os.product" value="Meeting Server"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="TelePresence"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.product" value="Meeting Server"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco-CUCM(.*)$">
+    <description>Cisco Unified Communications Manager</description>
+    <example os.version="11.5">Cisco-CUCM11.5</example>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.product" value="UCM"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="SIP Gateway"/>
+    <param pos="0" name="hw.product" value="UCM"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Aastra ([^/]+)/([a-zA-Z0-9\.\-]+)$">
+    <description>Aastra IP Phone</description>
+    <example hw.product="6865i" os.version="4.2.0.2023">Aastra 6865i/4.2.0.2023</example>
+    <param pos="0" name="os.vendor" value="Aastra"/>
+    <param pos="0" name="os.family" value="VoIP"/>
+    <param pos="0" name="os.product" value="VoIP"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Aastra"/>
+    <param pos="0" name="hw.family" value="VoIP"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:Audiocodes-Sip-Gateway-)?(\S+) FX[A-Z_]+/v.(\S+)$">
+    <description>Audiocodes-Sip-Gateway</description>
+    <example hw.product="MP-124" os.version="6.00A.034.003">Audiocodes-Sip-Gateway-MP-124 FXS/v.6.00A.034.003</example>
+    <example hw.product="MP-124" os.version="6.60A.342.003">MP-124 FXS/v.6.60A.342.003</example>
+    <example hw.product="MP-114" os.version="6.60A.241.010">MP-114 FXS_FXO/v.6.60A.241.010</example>
+    <param pos="0" name="os.vendor" value="Audiocodes"/>
+    <param pos="0" name="os.family" value="SIP Gateway"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Audiocodes"/>
+    <param pos="0" name="hw.family" value="SIP Gateway"/>
+    <param pos="0" name="hw.device" value="SIP Gateway"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Wildix GW-(\S+)$">
+    <description>Wildix SIP Gateway</description>
+    <example os.version="5.0.3.42145">Wildix GW-5.0.3.42145</example>
+    <param pos="0" name="os.vendor" value="Wildix"/>
+    <param pos="0" name="os.family" value="SIP Gateway"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Wildix"/>
+    <param pos="0" name="hw.family" value="SIP Gateway"/>
+    <param pos="0" name="hw.device" value="SIP Gateway"/>
+    <param pos="0" name="hw.product" value="SIP Gateway"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Wildix GW$">
+    <description>Wildix SIP Gateway w/o Version</description>
+    <example>Wildix GW</example>
+    <param pos="0" name="os.vendor" value="Wildix"/>
+    <param pos="0" name="os.family" value="SIP Gateway"/>
+    <param pos="0" name="hw.vendor" value="Wildix"/>
+    <param pos="0" name="hw.family" value="SIP Gateway"/>
+    <param pos="0" name="hw.device" value="SIP Gateway"/>
+    <param pos="0" name="hw.product" value="SIP Gateway"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Asterisk PBX (\S+)$">
+    <description>Asterisk PBX w/ Version</description>
+    <example service.version="13.18.0-6.7.1.1.rl.1538157944.1c65507">Asterisk PBX 13.18.0-6.7.1.1.rl.1538157944.1c65507</example>
+    <example service.version="16.2.1~dfsg-1">Asterisk PBX 16.2.1~dfsg-1</example>
+    <param pos="0" name="service.vendor" value="Asterisk"/>
+    <param pos="0" name="service.family" value="PBX"/>
+    <param pos="0" name="service.product" value="PBX"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:asterisk:asterisk:{service.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Asterisk PBX$">
+    <description>Asterisk PBX w/o Version</description>
+    <example>Asterisk PBX</example>
+    <param pos="0" name="service.vendor" value="Asterisk"/>
+    <param pos="0" name="service.family" value="PBX"/>
+    <param pos="0" name="service.product" value="PBX"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:asterisk:asterisk:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^FPBX-(\S+)$">
+    <description>FreePBX</description>
+    <example service.version="12.0.70(11.20.0)">FPBX-12.0.70(11.20.0)</example>
+    <example service.version="2.11.0(11.20.0)">FPBX-2.11.0(11.20.0)</example>
+    <param pos="0" name="service.vendor" value="FreePBX"/>
+    <param pos="0" name="service.family" value="PBX"/>
+    <param pos="0" name="service.product" value="PBX"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:freepbx:freepbx:{service.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^kamailio \((\S+) \((.*)\)\)$">
+    <description>Kamailio SIP Server</description>
+    <example service.version="4.4.4" kamailio.platform="x86_64/linux">kamailio (4.4.4 (x86_64/linux))</example>
+    <param pos="0" name="service.vendor" value="Kamailio"/>
+    <param pos="0" name="service.family" value="SIP Server"/>
+    <param pos="0" name="service.product" value="SIP Server"/>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="kamailio.platform"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:kamailio:kamailio:{service.version}"/>
+  </fingerprint>
+
+  <!-- This match covers multiple product families and should be split up further -->
+  <fingerprint pattern="^Algo-([^/]+)/(.*)$">
+    <description>Algo SIP Device</description>
+    <example hw.product="8186" os.version="1.7">Algo-8186/1.7</example>
+    <param pos="0" name="os.vendor" value="Algo"/>
+    <param pos="0" name="os.family" value="SIP Device"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Algo"/>
+    <param pos="0" name="hw.family" value="SIP Device"/>
+    <param pos="0" name="hw.device" value="SIP Device"/>
+    <param pos="1" name="hw.product"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:SIParator|Ingate-Firewall)/(\S+)$">
+    <description>Ingate SIParator Firewall</description>
+    <example os.version="5.0.10">Ingate-Firewall/5.0.10</example>
+    <example os.version="6.0.4">SIParator/6.0.4</example>
+    <param pos="0" name="os.vendor" value="Ingate"/>
+    <param pos="0" name="os.family" value="SIP Gateway"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Ingate"/>
+    <param pos="0" name="hw.family" value="SIP Gateway"/>
+    <param pos="0" name="hw.device" value="SIP Gateway"/>
+    <param pos="0" name="hw.product" value="SIParator Firewall"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -124,16 +124,20 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="hw.device" value="VoIP"/>
   </fingerprint>
-  <fingerprint pattern="^TANDBERG/\d+ \(([a-zA-Z]+\d+(?:\.\d+)+).*\)">
+  <fingerprint pattern="^(TANDBERG/\d+) \((.*)\)">
     <description>Cisco TelePresence</description>
     <example os.version="X8.2.1">TANDBERG/4130 (X8.2.1)</example>
-    <example os.version="XC2.2.1">TANDBERG/4353 (XC2.2.1-b2bua-1.0)</example>
+    <example os.version="XC2.2.1-b2bua-1.0">TANDBERG/4353 (XC2.2.1-b2bua-1.0)</example>
     <example os.version="TC5.1.4.295090">TANDBERG/516 (TC5.1.4.295090)</example>
     <example os.version="TCNC5.1.4.295090">TANDBERG/517 (TCNC5.1.4.295090)</example>
     <example os.version="S5.30">TANDBERG/80 (S5.30)</example>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="1" name="os.version"/>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>    
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Tilgin Vood ([^_\s]+)">
     <description>Tilgin Vood</description>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -881,7 +881,7 @@
     <example>ESP-8 MI V3.13</example>
     <example>ESP-8 MI V3.14b</example>
     <param pos="0" name="os.vendor" value="Avocent"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1572,7 +1572,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>ACOLA CoBox Snr 6818376 04.5b5 (010430)</example>
     <example>ACOLA CoBox Snr 784-208 V3.6</example>
     <param pos="0" name="os.vendor" value="aCola"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="0" name="os.product" value="CoBox"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
@@ -1585,7 +1585,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>CoBox for Recognition Systems, Snr  6925226 05.6 (040825)</example>
     <example>CoBox for Recognition Systems, Snr  7107590 04.5 (011218)</example>
     <param pos="0" name="os.vendor" value="Pronet"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="0" name="os.product" value="CoBox"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
@@ -1741,7 +1741,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Digi Connect ES serie 800 SB Version 82002147_A 02/09/2009</example>
     <example>Digi One TS Version 82000747_N2 02/25/2005</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1749,7 +1749,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Digi Serial PortServer II</description>
     <example>Digi International PortServer II v3.1.12 Jan 21 2003</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1757,7 +1757,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Digi Connect Unknown</description>
     <example>Digi Connect Device, Version Unknown</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Digi (TransPort \S+) Ser#:\S+ Software Build Ver([^\.]+). .* MAC:(\S+)$">
@@ -1769,7 +1769,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Digi TransPort WR44-HXA3-DE1-XX Ser#:176625 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02b1f1</example>
     <example>Digi TransPort WR44-HXA3-DE1-XX Ser#:182788 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02ca04</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
     <param pos="3" name="host.mac"/>
@@ -3261,7 +3261,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix LRS2 Version V1.3/4(980529)</example>
     <example>LANTRONIX ETS-16 Version V2.2/45(940822)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3270,7 +3270,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Lantronix terminal server - model only variant</description>
     <example>Lantronix EDS16PR</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
   </fingerprint>
@@ -3278,7 +3278,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Lantronix modbus bridge</description>
     <example>Lantronix Inc. - Modbus Bridge</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Lantronix (U[TD]S\S*) (?:Snr )?(?:[\-\dA-Za-z]+\s+)?V?(\S+)(?: \d+\.\S+)?(?: \(.*\))?\s*$">
@@ -3289,7 +3289,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix UDS V6.6.21.0RC3 (080919)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="UDS"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3298,7 +3298,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix UDS</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="UDS"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Lantronix (X[pP]ort \S+) V(\S+) \(.*\)\s*$">
@@ -3314,7 +3314,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix Xport Pro V5.2.0.0R20 (07112097T8TOVI)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPort"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3323,7 +3323,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix XPort AR</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPort"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Lantronix (XPress \S+) V(\S+) \(.*\)\s*$">
@@ -3331,7 +3331,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix XPress DR+ V6.1.0.1 (060404)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPress"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3350,7 +3350,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix MatchPort b/g Pro V1.3.0.0R9 (07102327J7IUK5)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="MatchPort"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3364,7 +3364,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix WiBox V6.7.0.0 (100118)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="WiBox"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3376,7 +3376,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix SDS1101 V6.5.0.0 (070402)</example>
     <example>Lantronix SDS2101 V6.5.0.0 (070402)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3387,7 +3387,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix SLSLP 030001</example>
     <example>Lantronix SLSLP 030005</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3397,7 +3397,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix NTS 0239032 04.4 (010817)</example>
     <example>Lantronix NTS 1145416 04.4 (010817)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3406,7 +3406,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Lantronix NTS - variant 1</description>
     <example>Lantronix NTS1536-076 V3.8</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -5051,7 +5051,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Rectifier Technologies Pacific WebCSU 169-412 V1.30</example>
     <param pos="0" name="os.vendor" value="Rectifier Technologies"/>
     <param pos="0" name="os.family" value="RTP Power Controller"/>
-    <param pos="0" name="os.device" value="Power Device"/>
+    <param pos="0" name="os.device" value="Power device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -5060,7 +5060,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Rectifier SNMP Server</example>
     <param pos="0" name="os.vendor" value="Rectifier Technologies"/>
     <param pos="0" name="os.family" value="RTP Power Controller"/>
-    <param pos="0" name="os.device" value="Power Device"/>
+    <param pos="0" name="os.device" value="Power device"/>
     <param pos="0" name="os.product" value="WebCSU"/>
   </fingerprint>
   <!--======================================================================
@@ -6396,8 +6396,8 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>WVN720D.WVNET.EDU - WVN720D Xyplex hardware CSERV-20 00.02.00 Rom 4C0000 Xyplex software Terminal Server V6.1 </example>
     <example>Xyplex hardware CSERV-20 08.00.00 Rom 4A0000nXyplex software Terminal Server V6.0.1</example>
     <param pos="0" name="os.vendor" value="Xyplex"/>
-    <param pos="0" name="os.family" value="Terminal Server"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.family" value="Device Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1313,62 +1313,79 @@
   <!--======================================================================
                               CISCO
    =======================================================================-->
-  <fingerprint pattern="^(?:Cisco|TANDBERG) Codec SoftW: (.*\d+[\.\d+]+)(?:(?: )?Beta\d)? (?:\w* )?MCU: (?:Cisco|TANDBERG) (?:\w* )?(\d+MXP|[A-Z]+\d+) .*?">
+  <fingerprint pattern="^(?:Cisco|TANDBERG) Codec SoftW:\s+(\S+).*\s+MCU:\s+(?:Cisco TelePresence|TANDBERG)\s+(.*)\s+Date:">
     <description>Cisco TelePresence - verbose variant</description>
-    <example os.version="TC5.1.0.280662" hw.series="SX20">Cisco Codec SoftW: TC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT16070041 BootSW: Board: 101790-6 [28]</example>
-    <example os.version="TC4.2.0.259927" hw.series="MX200">TANDBERG Codec SoftW: TC4.2.0.259927 MCU: Cisco TelePresence MX200 Date: 2011-06-30 S/N: FTT1530000O BootSW: Board: 101770-4 [20]</example>
-    <example os.version="TC5.1.3.292001" hw.series="MX300">TANDBERG Codec SoftW: TC5.1.3.292001 MCU: Cisco TelePresence MX300 Date: 2012-06-21 S/N: FTT16030013 BootSW: Board: 101770-5 [22]</example>
-    <example os.version="TC5.1.0.279658" hw.series="SX20">Cisco Codec SoftW: TC5.1.0.279658Beta7 MCU: Cisco TelePresence SX20 Date: 2012-02-03 S/N: FTT1616005D BootSW: Board: 101790-6 [B0]</example>
-    <example os.version="TC6.0.0" hw.series="SX20">Cisco Codec SoftW: TC6.0.0 Beta7 MCU: Cisco TelePresence SX20 Date: 2012-09-17 S/N: FTT163100A3 BootSW: Board: 101790-6 [B0]</example>
-    <example os.version="TC4.2.0.255978" hw.series="MX200">TANDBERG Codec SoftW: TC4.2.0.255978Beta2 MCU: Cisco TelePresence MX200 Date: 2011-05-23 S/N: FTT1524000I BootSW: Board: 101770-4 [00]</example>
-    <example os.version="TCNC5.0.1.275220" hw.series="MX200">TANDBERG Codec SoftW: TCNC5.0.1.275220 MCU: Cisco TelePresence MX200 Date: 2011-12-19 S/N: FTT1615003S BootSW: Board: 101770-5 [22]</example>
-    <example os.version="TCNC5.1.0.280662" hw.series="SX20">Cisco Codec SoftW: TCNC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT161300A0 BootSW: Board: 101790-6 [A0]</example>
-    <example os.version="F8.1" hw.series="6000MXP">TANDBERG Codec SoftW: F8.1 PAL MCU: TANDBERG Profile 6000MXP Date: 2009-09-07 S/N: 25A46936 BootSW: Rev. 1.15, 2008-01-04 Board: 100670 rev. 07</example>
-    <example os.version="F9.1" hw.series="6000MXP">TANDBERG Codec SoftW: F9.1 NTSC MCU: TANDBERG 6000MXP PORTABLE Date: 2011-06-08 S/N: 25A07029 BootSW: Rev. 1.16, 2009-01-21 Board: 100670 rev. 07</example>
-    <example os.version="TC4.2.0.260857" hw.series="C40">TANDBERG Codec SoftW: TC4.2.0.260857 MCU: TANDBERG Codec C40 Date: 2011-07-11 S/N: B1AV02D00182 BootSW: Board: 101681-1 [04]</example>
-    <example os.version="TC4.2.1.265253" hw.series="EX60">TANDBERG Codec SoftW: TC4.2.1.265253 MCU: TANDBERG EX60 Date: 2011-09-06 S/N: A1AZ02E00212 BootSW: Board: 101620-6 [22]</example>
-    <example os.version="TE1.0.0.175435" hw.series="E20">TANDBERG Codec SoftW: TE1.0.0.175435 MCU: TANDBERG E20 Date: 2009-02-09 S/N: A1AA11B00658 BootSW: Board: 101390-6</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="0" name="os.device" value="Codec"/>
+    <example os.version="TC5.1.0.280662" hw.product="SX20">Cisco Codec SoftW: TC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT16070041 BootSW: Board: 101790-6 [28]</example>
+    <example os.version="TC4.2.0.259927" hw.product="MX200">TANDBERG Codec SoftW: TC4.2.0.259927 MCU: Cisco TelePresence MX200 Date: 2011-06-30 S/N: FTT1530000O BootSW: Board: 101770-4 [20]</example>
+    <example os.version="TC5.1.3.292001" hw.product="MX300">TANDBERG Codec SoftW: TC5.1.3.292001 MCU: Cisco TelePresence MX300 Date: 2012-06-21 S/N: FTT16030013 BootSW: Board: 101770-5 [22]</example>
+    <example os.version="TC5.1.0.279658Beta7" hw.product="SX20">Cisco Codec SoftW: TC5.1.0.279658Beta7 MCU: Cisco TelePresence SX20 Date: 2012-02-03 S/N: FTT1616005D BootSW: Board: 101790-6 [B0]</example>
+    <example os.version="TC6.0.0" hw.product="SX20">Cisco Codec SoftW: TC6.0.0 Beta7 MCU: Cisco TelePresence SX20 Date: 2012-09-17 S/N: FTT163100A3 BootSW: Board: 101790-6 [B0]</example>
+    <example os.version="TC4.2.0.255978Beta2" hw.product="MX200">TANDBERG Codec SoftW: TC4.2.0.255978Beta2 MCU: Cisco TelePresence MX200 Date: 2011-05-23 S/N: FTT1524000I BootSW: Board: 101770-4 [00]</example>
+    <example os.version="TCNC5.0.1.275220" hw.product="MX200">TANDBERG Codec SoftW: TCNC5.0.1.275220 MCU: Cisco TelePresence MX200 Date: 2011-12-19 S/N: FTT1615003S BootSW: Board: 101770-5 [22]</example>
+    <example os.version="TCNC5.1.0.280662" hw.product="SX20">Cisco Codec SoftW: TCNC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT161300A0 BootSW: Board: 101790-6 [A0]</example>
+    <example os.version="F8.1" hw.product="Profile 6000MXP">TANDBERG Codec SoftW: F8.1 PAL MCU: TANDBERG Profile 6000MXP Date: 2009-09-07 S/N: 25A46936 BootSW: Rev. 1.15, 2008-01-04 Board: 100670 rev. 07</example>
+    <example os.version="F9.1" hw.product="6000MXP PORTABLE">TANDBERG Codec SoftW: F9.1 NTSC MCU: TANDBERG 6000MXP PORTABLE Date: 2011-06-08 S/N: 25A07029 BootSW: Rev. 1.16, 2009-01-21 Board: 100670 rev. 07</example>
+    <example os.version="TC4.2.0.260857" hw.product="Codec C40">TANDBERG Codec SoftW: TC4.2.0.260857 MCU: TANDBERG Codec C40 Date: 2011-07-11 S/N: B1AV02D00182 BootSW: Board: 101681-1 [04]</example>
+    <example os.version="TC4.2.1.265253" hw.product="EX60">TANDBERG Codec SoftW: TC4.2.1.265253 MCU: TANDBERG EX60 Date: 2011-09-06 S/N: A1AZ02E00212 BootSW: Board: 101620-6 [22]</example>
+    <example os.version="TE1.0.0.175435" hw.product="E20">TANDBERG Codec SoftW: TE1.0.0.175435 MCU: TANDBERG E20 Date: 2009-02-09 S/N: A1AA11B00658 BootSW: Board: 101390-6</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
     <param pos="1" name="os.version"/>
-    <param pos="2" name="hw.series"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>    
+    <param pos="2" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^Cisco TelePresence (?:(?:HD )?MCU) ((?:MSE )?\d+)">
-    <description>Cisco TelePresence</description>
-    <example hw.series="4205">Cisco TelePresence MCU 4205</example>
-    <example hw.series="MSE 8420">Cisco TelePresence MCU MSE 8420</example>
-    <example hw.series="4520">Cisco TelePresence HD MCU 4520</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="0" name="os.device" value="Bridge"/>
-    <param pos="1" name="hw.series"/>
+  <fingerprint pattern="^Cisco TelePresence ((?:HD )?MCU(?: MSE)? \d+)">
+    <description>Cisco TelePresence w/Model</description>
+    <example hw.product="MCU 4205">Cisco TelePresence MCU 4205</example>
+    <example hw.product="MCU MSE 8420">Cisco TelePresence MCU MSE 8420</example>
+    <example hw.product="HD MCU 4520">Cisco TelePresence HD MCU 4520</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>    
+    <param pos="1" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^Cisco TelePresence (Conductor|Supervisor)(?: (MSE \d+))?">
-    <description>Cisco TelePresence Conductor</description>
-    <example os.device="Conductor">Cisco TelePresence Conductor</example>
-    <example os.device="Supervisor" hw.series="MSE 8050">Cisco TelePresence Supervisor MSE 8050</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="1" name="os.device"/>
-    <param pos="2" name="hw.series"/>
+  <fingerprint pattern="^Cisco TelePresence (?:Conductor|Supervisor)\s+((?:MCU )?(?:MSE )?\d+)">
+    <description>Cisco TelePresence Conductor/Supervisor w/Model</description>
+    <example hw.product="MSE 8050">Cisco TelePresence Supervisor MSE 8050</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>    
+    <param pos="1" name="hw.product"/>
   </fingerprint>
+  <fingerprint pattern="^Cisco TelePresence (?:Conductor|Supervisor)">
+    <description>Cisco TelePresence Conductor/Supervisor w/o Model</description>
+    <example>Cisco TelePresence Conductor</example>
+    <example>Cisco TelePresence Supervisor</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+  </fingerprint>  
   <fingerprint pattern="^TANDBERG Codec$">
-    <description>Tandberg videoconferencing device</description>
+    <description>Tandberg Codec videoconferencing device</description>
     <example>TANDBERG Codec</example>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="0" name="os.device" value="Codec"/>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
   </fingerprint>
-  <fingerprint pattern="^TANDBERG MPS-MCU$">
-    <description>Tandberg videoconferencing bridge</description>
-    <example>TANDBERG MPS-MCU</example>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="MPS-MCU"/>
-    <param pos="0" name="os.device" value="VoIP"/>
+  <fingerprint pattern="^TANDBERG (MPS-MCU)$">
+    <description>Tandberg MPS-MCU</description>
+    <example hw.product="MPS-MCU">TANDBERG MPS-MCU</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Cisco Adaptive Security Appliance Version (\d+\.\d+\(\d+\)\d*)">
     <description>Cisco Adaptive Security Appliance</description>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -756,7 +756,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Moxa"/>
     <param pos="0" name="hw.family" value="NPort"/>
-    <param pos="0" name="hw.device" value="Terminal Server"/>
+    <param pos="0" name="hw.device" value="Device Server"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Model name\s+: NPort (IA-\d+)(?:\r|\n|\x00)+MAC address\s+: ([\w:]+)(?:\r|\n|\x00)+Serial No.\s+: (\d+)(?:\r|\n|\x00)+Firmware version : ([\d.]+) Build (\d+)(?:\r|\n|\x00)+System uptime">

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -88,13 +88,13 @@
     <param pos="0" name="os.vendor" value="Yealink"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Yealink"/>
   </fingerprint>
   <fingerprint pattern="^CN=[a-zA-Z0-9]+,OU=Internally Generated Certificate,O=American Power Conversion Corp,L=Default Locality,ST=Default State,C=US$">
     <description>APC UPS</description>
     <example>CN=ZA1117619249,OU=Internally Generated Certificate,O=American Power Conversion Corp,L=Default Locality,ST=Default State,C=US</example>
-    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="hw.device" value="Power device"/>
     <param pos="0" name="hw.vendor" value="APC"/>
   </fingerprint>
   <fingerprint pattern="^CN=Temporary CA [a-fA-F0-9]{8}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{12},OU=Temporary CA">

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -929,6 +929,16 @@
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.product" value="Sensor"/>
   </fingerprint>
+  <fingerprint pattern="^CN=HiveAP,OU=Default,O=Aerohive,ST=California,C=US$">
+    <description>Aerohive Access Point</description>
+    <example>CN=HiveAP,OU=Default,O=Aerohive,ST=California,C=US</example>
+    <param pos="0" name="hw.vendor" value="Aerohive"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="hw.product" value="Access Point"/>
+    <param pos="0" name="os.vendor" value="Aerohive"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+  </fingerprint>
   <fingerprint pattern="^CN=(usg[^_]+)_([a-fA-F0-9]{12})$">
     <description>ZyWall Router</description>
     <example hw.product="usg20w" host.mac="5CF4AB615FAC">CN=usg20w_5CF4AB615FAC</example>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -71,10 +71,11 @@
     <param pos="2" name="hw.product"/>
     <param pos="1" name="host.mac"/>
   </fingerprint>
-  <fingerprint pattern="^SERIALNUMBER=PID:([^ ]+) SN:([^,]+),CN=(?:[a-zA-Z0-9\-]+)-SEP([a-fA-F0-9]{12}),OU=CTG,O=Cisco Systems Inc\.$">
-    <description>Cisco / Linksys Router with serial number</description>
+  <fingerprint pattern="^SERIALNUMBER=PID:([^ ]+) SN:([^,]+),CN=(?:[a-zA-Z0-9\-]+)-SEP([a-fA-F0-9]{12}),OU=[CV]TG,O=Cisco Systems Inc\.$">
+    <description>Cisco IP phone with serial number</description>
     <example host.mac="B07D47D33A1C" hw.product="CP-8851" cisco.serial_number="FCH1924AHCA">SERIALNUMBER=PID:CP-8851 SN:FCH1924AHCA,CN=CP-8851-SEPB07D47D33A1C,OU=CTG,O=Cisco Systems Inc.</example>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <example host.mac="64D989000000" hw.product="CP-9951" cisco.serial_number="FCH15200000">SERIALNUMBER=PID:CP-9951 SN:FCH15200000,CN=CP-9951-SEP64D989000000,OU=VTG,O=Cisco Systems Inc.</example>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="cisco.serial_number"/>
@@ -805,18 +806,18 @@
     <description>NEC DT Series IP Phone</description>
     <example>CN=DT800 Series,O=NEC Corporation,ST=Tokyo,C=JP</example>
     <param pos="0" name="os.vendor" value="NEC"/>
-    <param pos="0" name="os.device" value="IP Phone"/>
+    <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="NEC"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^CN=([a-fA-F0-9]{12}),O=Polycom Inc\.$">
     <description>Polycom SoundPoint IP Phone</description>
     <example host.mac="64167F169981">CN=64167F169981,O=Polycom Inc.</example>
     <param pos="0" name="os.vendor" value="Polycom"/>
-    <param pos="0" name="os.device" value="IP Phone"/>
+    <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Polycom"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.product" value="SoundPoint"/>
     <param pos="1" name="host.mac"/>
   </fingerprint>
@@ -824,9 +825,9 @@
     <description>Siemens EN Software</description>
     <example>CN=EN Software Production &amp; Release,OU=Enterprise Networks,O=Siemens AG,L=Munich,ST=Germany,C=DE</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
-    <param pos="0" name="os.device" value="IP Phone"/>
+    <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
   </fingerprint>
   <fingerprint pattern="^CN=SecureConnect server,O=Quest,ST=CA,C=US$">
     <description>SecureConnect SSL VPN</description>


### PR DESCRIPTION
## Description

This is a roll-up PR of changes we have accumulated since December. The big ones:

1) Rename `Terminal Server` to `Device Server` for consistency across fingerprints.
2) Major updates to IP Phone, VoIP bridges, and video conferencing signatures
3) A scattering of small typo fixes and signature improvements
4) Clarification that the http_servers.xml is also used for SIP and RTSP
5) Fix missing NetScaler/Pulse VPN detection by HTTP Cookie

## Motivation and Context

Consistency and improved coverage across the board

## How Has This Been Tested?

Real-world testing (shipping in Rumble since December) along with rspec and the recog_verify script.

## Types of changes

See above

## Checklist:

- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
