### PR TITLE
Small updates for consistency and coverage

### DIFF
--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -221,6 +221,15 @@
     <param pos="0" name="hw.product" value="Hue"/>
     <param pos="0" name="hw.device" value="Light Bulb"/>
   </fingerprint>
+
+  <fingerprint pattern="LANDesk\(R\) Management Agent$">
+    <description>LANDesk Management Agent</description>
+    <param pos="0" name="service.vendor" value="LANDesk"/>
+    <param pos="0" name="service.product" value="Management Agent"/>
+    <param pos="0" name="service.family" value="Management Agent"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:landesk:management_agent:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:Parallels )?Plesk (?:(?:Onyx|Panel) )?([\d\.]+)$">
     <description>Plesk web hosting platform with a version</description>
     <example service.version="12.0.18">Plesk 12.0.18</example>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -123,13 +123,21 @@
     <param pos="0" name="service.family" value="Application Protection System"/>
     <param pos="0" name="service.product" value="Application Protection System, Enterprise"/>
   </fingerprint>
-  <fingerprint pattern="^NSC_(?:AAAC|CERT|DLGE|EPAC|TASS|TEMP|TMA[APS])=.*">
+  <fingerprint pattern="^NSC_(?:AAAC|CERT|DLGE|EPAC|TASS|TEMP|TMA[APS]|PERS)=.*">
     <description>Citrix NetScaler</description>
     <example>NSC_AAAC=xyz;</example>
     <param pos="0" name="os.vendor" value="Citrix"/>
     <param pos="0" name="os.family" value="NetScaler"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler"/>
+  </fingerprint>
+  <fingerprint pattern="^DSSignInURL=/">
+    <description>Pulse Secure VPN</description>
+    <example>DSSignInURL=/; path=/; secure</example>
+    <param pos="0" name="os.vendor" value="Pulse Secure"/>
+    <param pos="0" name="os.family" value="SSL VPN"/>
+    <param pos="0" name="os.device" value="SSL VPN"/>
+    <param pos="0" name="os.product" value="SSL VPN"/>
   </fingerprint>
   <fingerprint pattern="^(EktGUID|ecm)=.*">
     <description>Ektron CMS400.net</description>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1617,6 +1617,13 @@
     <param pos="0" name="service.family" value="ePolicy Orchestrator"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:mcafee:epolicy_orchestrator:-"/>
   </fingerprint>
+  <fingerprint pattern="^LANDesk Management Agent/.*$">
+    <description>LANDesk Management Agent</description>
+    <param pos="0" name="service.vendor" value="LANDesk"/>
+    <param pos="0" name="service.product" value="Management Agent"/>
+    <param pos="0" name="service.family" value="Management Agent"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:landesk:management_agent:-"/>
+  </fingerprint>
   <fingerprint pattern="^EWS-NIC\d/(\S+)$">
     <description>Xerox Embedded Web Server (EWS)</description>
     <example service.version="6.31">EWS-NIC3/6.31</example>
@@ -3050,4 +3057,12 @@
     <param pos="0" name="hw.device" value="NAS"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
+  <fingerprint pattern="^NetData Embedded HTTP Server v([a-zA-Z0-9\-\.]+)$">
+    <description>NetData Embedded HTTP Server</description>
+    <example service.version="1.16.1-146-g2f5e36ef">NetData Embedded HTTP Server v1.16.1-146-g2f5e36ef</example>
+    <param pos="0" name="service.vendor" value="NetData"/>
+    <param pos="0" name="service.product" value="NetData"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -881,7 +881,7 @@
     <example>ESP-8 MI V3.13</example>
     <example>ESP-8 MI V3.14b</example>
     <param pos="0" name="os.vendor" value="Avocent"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1313,62 +1313,79 @@
   <!--======================================================================
                               CISCO
    =======================================================================-->
-  <fingerprint pattern="^(?:Cisco|TANDBERG) Codec SoftW: (.*\d+[\.\d+]+)(?:(?: )?Beta\d)? (?:\w* )?MCU: (?:Cisco|TANDBERG) (?:\w* )?(\d+MXP|[A-Z]+\d+) .*?">
+  <fingerprint pattern="^(?:Cisco|TANDBERG) Codec SoftW:\s+(\S+).*\s+MCU:\s+(?:Cisco TelePresence|TANDBERG)\s+(.*)\s+Date:">
     <description>Cisco TelePresence - verbose variant</description>
-    <example os.version="TC5.1.0.280662" hw.series="SX20">Cisco Codec SoftW: TC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT16070041 BootSW: Board: 101790-6 [28]</example>
-    <example os.version="TC4.2.0.259927" hw.series="MX200">TANDBERG Codec SoftW: TC4.2.0.259927 MCU: Cisco TelePresence MX200 Date: 2011-06-30 S/N: FTT1530000O BootSW: Board: 101770-4 [20]</example>
-    <example os.version="TC5.1.3.292001" hw.series="MX300">TANDBERG Codec SoftW: TC5.1.3.292001 MCU: Cisco TelePresence MX300 Date: 2012-06-21 S/N: FTT16030013 BootSW: Board: 101770-5 [22]</example>
-    <example os.version="TC5.1.0.279658" hw.series="SX20">Cisco Codec SoftW: TC5.1.0.279658Beta7 MCU: Cisco TelePresence SX20 Date: 2012-02-03 S/N: FTT1616005D BootSW: Board: 101790-6 [B0]</example>
-    <example os.version="TC6.0.0" hw.series="SX20">Cisco Codec SoftW: TC6.0.0 Beta7 MCU: Cisco TelePresence SX20 Date: 2012-09-17 S/N: FTT163100A3 BootSW: Board: 101790-6 [B0]</example>
-    <example os.version="TC4.2.0.255978" hw.series="MX200">TANDBERG Codec SoftW: TC4.2.0.255978Beta2 MCU: Cisco TelePresence MX200 Date: 2011-05-23 S/N: FTT1524000I BootSW: Board: 101770-4 [00]</example>
-    <example os.version="TCNC5.0.1.275220" hw.series="MX200">TANDBERG Codec SoftW: TCNC5.0.1.275220 MCU: Cisco TelePresence MX200 Date: 2011-12-19 S/N: FTT1615003S BootSW: Board: 101770-5 [22]</example>
-    <example os.version="TCNC5.1.0.280662" hw.series="SX20">Cisco Codec SoftW: TCNC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT161300A0 BootSW: Board: 101790-6 [A0]</example>
-    <example os.version="F8.1" hw.series="6000MXP">TANDBERG Codec SoftW: F8.1 PAL MCU: TANDBERG Profile 6000MXP Date: 2009-09-07 S/N: 25A46936 BootSW: Rev. 1.15, 2008-01-04 Board: 100670 rev. 07</example>
-    <example os.version="F9.1" hw.series="6000MXP">TANDBERG Codec SoftW: F9.1 NTSC MCU: TANDBERG 6000MXP PORTABLE Date: 2011-06-08 S/N: 25A07029 BootSW: Rev. 1.16, 2009-01-21 Board: 100670 rev. 07</example>
-    <example os.version="TC4.2.0.260857" hw.series="C40">TANDBERG Codec SoftW: TC4.2.0.260857 MCU: TANDBERG Codec C40 Date: 2011-07-11 S/N: B1AV02D00182 BootSW: Board: 101681-1 [04]</example>
-    <example os.version="TC4.2.1.265253" hw.series="EX60">TANDBERG Codec SoftW: TC4.2.1.265253 MCU: TANDBERG EX60 Date: 2011-09-06 S/N: A1AZ02E00212 BootSW: Board: 101620-6 [22]</example>
-    <example os.version="TE1.0.0.175435" hw.series="E20">TANDBERG Codec SoftW: TE1.0.0.175435 MCU: TANDBERG E20 Date: 2009-02-09 S/N: A1AA11B00658 BootSW: Board: 101390-6</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="0" name="os.device" value="Codec"/>
+    <example os.version="TC5.1.0.280662" hw.product="SX20">Cisco Codec SoftW: TC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT16070041 BootSW: Board: 101790-6 [28]</example>
+    <example os.version="TC4.2.0.259927" hw.product="MX200">TANDBERG Codec SoftW: TC4.2.0.259927 MCU: Cisco TelePresence MX200 Date: 2011-06-30 S/N: FTT1530000O BootSW: Board: 101770-4 [20]</example>
+    <example os.version="TC5.1.3.292001" hw.product="MX300">TANDBERG Codec SoftW: TC5.1.3.292001 MCU: Cisco TelePresence MX300 Date: 2012-06-21 S/N: FTT16030013 BootSW: Board: 101770-5 [22]</example>
+    <example os.version="TC5.1.0.279658Beta7" hw.product="SX20">Cisco Codec SoftW: TC5.1.0.279658Beta7 MCU: Cisco TelePresence SX20 Date: 2012-02-03 S/N: FTT1616005D BootSW: Board: 101790-6 [B0]</example>
+    <example os.version="TC6.0.0" hw.product="SX20">Cisco Codec SoftW: TC6.0.0 Beta7 MCU: Cisco TelePresence SX20 Date: 2012-09-17 S/N: FTT163100A3 BootSW: Board: 101790-6 [B0]</example>
+    <example os.version="TC4.2.0.255978Beta2" hw.product="MX200">TANDBERG Codec SoftW: TC4.2.0.255978Beta2 MCU: Cisco TelePresence MX200 Date: 2011-05-23 S/N: FTT1524000I BootSW: Board: 101770-4 [00]</example>
+    <example os.version="TCNC5.0.1.275220" hw.product="MX200">TANDBERG Codec SoftW: TCNC5.0.1.275220 MCU: Cisco TelePresence MX200 Date: 2011-12-19 S/N: FTT1615003S BootSW: Board: 101770-5 [22]</example>
+    <example os.version="TCNC5.1.0.280662" hw.product="SX20">Cisco Codec SoftW: TCNC5.1.0.280662 MCU: Cisco TelePresence SX20 Date: 2012-02-14 S/N: FTT161300A0 BootSW: Board: 101790-6 [A0]</example>
+    <example os.version="F8.1" hw.product="Profile 6000MXP">TANDBERG Codec SoftW: F8.1 PAL MCU: TANDBERG Profile 6000MXP Date: 2009-09-07 S/N: 25A46936 BootSW: Rev. 1.15, 2008-01-04 Board: 100670 rev. 07</example>
+    <example os.version="F9.1" hw.product="6000MXP PORTABLE">TANDBERG Codec SoftW: F9.1 NTSC MCU: TANDBERG 6000MXP PORTABLE Date: 2011-06-08 S/N: 25A07029 BootSW: Rev. 1.16, 2009-01-21 Board: 100670 rev. 07</example>
+    <example os.version="TC4.2.0.260857" hw.product="Codec C40">TANDBERG Codec SoftW: TC4.2.0.260857 MCU: TANDBERG Codec C40 Date: 2011-07-11 S/N: B1AV02D00182 BootSW: Board: 101681-1 [04]</example>
+    <example os.version="TC4.2.1.265253" hw.product="EX60">TANDBERG Codec SoftW: TC4.2.1.265253 MCU: TANDBERG EX60 Date: 2011-09-06 S/N: A1AZ02E00212 BootSW: Board: 101620-6 [22]</example>
+    <example os.version="TE1.0.0.175435" hw.product="E20">TANDBERG Codec SoftW: TE1.0.0.175435 MCU: TANDBERG E20 Date: 2009-02-09 S/N: A1AA11B00658 BootSW: Board: 101390-6</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
     <param pos="1" name="os.version"/>
-    <param pos="2" name="hw.series"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>    
+    <param pos="2" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^Cisco TelePresence (?:(?:HD )?MCU) ((?:MSE )?\d+)">
-    <description>Cisco TelePresence</description>
-    <example hw.series="4205">Cisco TelePresence MCU 4205</example>
-    <example hw.series="MSE 8420">Cisco TelePresence MCU MSE 8420</example>
-    <example hw.series="4520">Cisco TelePresence HD MCU 4520</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="0" name="os.device" value="Bridge"/>
-    <param pos="1" name="hw.series"/>
+  <fingerprint pattern="^Cisco TelePresence ((?:HD )?MCU(?: MSE)? \d+)">
+    <description>Cisco TelePresence w/Model</description>
+    <example hw.product="MCU 4205">Cisco TelePresence MCU 4205</example>
+    <example hw.product="MCU MSE 8420">Cisco TelePresence MCU MSE 8420</example>
+    <example hw.product="HD MCU 4520">Cisco TelePresence HD MCU 4520</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>    
+    <param pos="1" name="hw.product"/>
   </fingerprint>
-  <fingerprint pattern="^Cisco TelePresence (Conductor|Supervisor)(?: (MSE \d+))?">
-    <description>Cisco TelePresence Conductor</description>
-    <example os.device="Conductor">Cisco TelePresence Conductor</example>
-    <example os.device="Supervisor" hw.series="MSE 8050">Cisco TelePresence Supervisor MSE 8050</example>
-    <param pos="0" name="os.certainty" value="0.85"/>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="1" name="os.device"/>
-    <param pos="2" name="hw.series"/>
+  <fingerprint pattern="^Cisco TelePresence (?:Conductor|Supervisor)\s+((?:MCU )?(?:MSE )?\d+)">
+    <description>Cisco TelePresence Conductor/Supervisor w/Model</description>
+    <example hw.product="MSE 8050">Cisco TelePresence Supervisor MSE 8050</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>    
+    <param pos="1" name="hw.product"/>
   </fingerprint>
+  <fingerprint pattern="^Cisco TelePresence (?:Conductor|Supervisor)">
+    <description>Cisco TelePresence Conductor/Supervisor w/o Model</description>
+    <example>Cisco TelePresence Conductor</example>
+    <example>Cisco TelePresence Supervisor</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+  </fingerprint>  
   <fingerprint pattern="^TANDBERG Codec$">
-    <description>Tandberg videoconferencing device</description>
+    <description>Tandberg Codec videoconferencing device</description>
     <example>TANDBERG Codec</example>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="TelePresence"/>
-    <param pos="0" name="os.device" value="Codec"/>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
   </fingerprint>
-  <fingerprint pattern="^TANDBERG MPS-MCU$">
-    <description>Tandberg videoconferencing bridge</description>
-    <example>TANDBERG MPS-MCU</example>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-    <param pos="0" name="os.product" value="MPS-MCU"/>
-    <param pos="0" name="os.device" value="VoIP"/>
+  <fingerprint pattern="^TANDBERG (MPS-MCU)$">
+    <description>Tandberg MPS-MCU</description>
+    <example hw.product="MPS-MCU">TANDBERG MPS-MCU</example>
+    <param pos="0" name="os.vendor" value="Tandberg"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Video Conferencing"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Cisco Adaptive Security Appliance Version (\d+\.\d+\(\d+\)\d*)">
     <description>Cisco Adaptive Security Appliance</description>
@@ -1572,7 +1589,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>ACOLA CoBox Snr 6818376 04.5b5 (010430)</example>
     <example>ACOLA CoBox Snr 784-208 V3.6</example>
     <param pos="0" name="os.vendor" value="aCola"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="0" name="os.product" value="CoBox"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
@@ -1585,7 +1602,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>CoBox for Recognition Systems, Snr  6925226 05.6 (040825)</example>
     <example>CoBox for Recognition Systems, Snr  7107590 04.5 (011218)</example>
     <param pos="0" name="os.vendor" value="Pronet"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="0" name="os.product" value="CoBox"/>
     <param pos="1" name="os.version"/>
   </fingerprint>
@@ -1741,7 +1758,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Digi Connect ES serie 800 SB Version 82002147_A 02/09/2009</example>
     <example>Digi One TS Version 82000747_N2 02/25/2005</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1749,7 +1766,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Digi Serial PortServer II</description>
     <example>Digi International PortServer II v3.1.12 Jan 21 2003</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -1757,7 +1774,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Digi Connect Unknown</description>
     <example>Digi Connect Device, Version Unknown</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Digi (TransPort \S+) Ser#:\S+ Software Build Ver([^\.]+). .* MAC:(\S+)$">
@@ -1769,7 +1786,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Digi TransPort WR44-HXA3-DE1-XX Ser#:176625 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02b1f1</example>
     <example>Digi TransPort WR44-HXA3-DE1-XX Ser#:182788 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02ca04</example>
     <param pos="0" name="os.vendor" value="Digi"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
     <param pos="3" name="host.mac"/>
@@ -3261,7 +3278,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix LRS2 Version V1.3/4(980529)</example>
     <example>LANTRONIX ETS-16 Version V2.2/45(940822)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3270,7 +3287,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Lantronix terminal server - model only variant</description>
     <example>Lantronix EDS16PR</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
   </fingerprint>
@@ -3278,7 +3295,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Lantronix modbus bridge</description>
     <example>Lantronix Inc. - Modbus Bridge</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Lantronix (U[TD]S\S*) (?:Snr )?(?:[\-\dA-Za-z]+\s+)?V?(\S+)(?: \d+\.\S+)?(?: \(.*\))?\s*$">
@@ -3289,7 +3306,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix UDS V6.6.21.0RC3 (080919)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="UDS"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3298,7 +3315,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix UDS</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="UDS"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Lantronix (X[pP]ort \S+) V(\S+) \(.*\)\s*$">
@@ -3314,7 +3331,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix Xport Pro V5.2.0.0R20 (07112097T8TOVI)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPort"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3323,7 +3340,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix XPort AR</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPort"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
   </fingerprint>
   <fingerprint pattern="^Lantronix (XPress \S+) V(\S+) \(.*\)\s*$">
@@ -3331,7 +3348,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix XPress DR+ V6.1.0.1 (060404)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPress"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3350,7 +3367,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix MatchPort b/g Pro V1.3.0.0R9 (07102327J7IUK5)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="MatchPort"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3364,7 +3381,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix WiBox V6.7.0.0 (100118)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="WiBox"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -3376,7 +3393,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix SDS1101 V6.5.0.0 (070402)</example>
     <example>Lantronix SDS2101 V6.5.0.0 (070402)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3387,7 +3404,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix SLSLP 030001</example>
     <example>Lantronix SLSLP 030005</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3397,7 +3414,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Lantronix NTS 0239032 04.4 (010817)</example>
     <example>Lantronix NTS 1145416 04.4 (010817)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -3406,7 +3423,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Lantronix NTS - variant 1</description>
     <example>Lantronix NTS1536-076 V3.8</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.family"/>
     <param pos="3" name="os.version"/>
@@ -5051,7 +5068,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Rectifier Technologies Pacific WebCSU 169-412 V1.30</example>
     <param pos="0" name="os.vendor" value="Rectifier Technologies"/>
     <param pos="0" name="os.family" value="RTP Power Controller"/>
-    <param pos="0" name="os.device" value="Power Device"/>
+    <param pos="0" name="os.device" value="Power device"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
   </fingerprint>
@@ -5060,7 +5077,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Rectifier SNMP Server</example>
     <param pos="0" name="os.vendor" value="Rectifier Technologies"/>
     <param pos="0" name="os.family" value="RTP Power Controller"/>
-    <param pos="0" name="os.device" value="Power Device"/>
+    <param pos="0" name="os.device" value="Power device"/>
     <param pos="0" name="os.product" value="WebCSU"/>
   </fingerprint>
   <!--======================================================================
@@ -6396,8 +6413,8 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>WVN720D.WVNET.EDU - WVN720D Xyplex hardware CSERV-20 00.02.00 Rom 4C0000 Xyplex software Terminal Server V6.1 </example>
     <example>Xyplex hardware CSERV-20 08.00.00 Rom 4A0000nXyplex software Terminal Server V6.0.1</example>
     <param pos="0" name="os.vendor" value="Xyplex"/>
-    <param pos="0" name="os.family" value="Terminal Server"/>
-    <param pos="0" name="os.device" value="Terminal Server"/>
+    <param pos="0" name="os.family" value="Device Server"/>
+    <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="os.version"/>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -756,7 +756,7 @@
     </example>
     <param pos="0" name="hw.vendor" value="Moxa"/>
     <param pos="0" name="hw.family" value="NPort"/>
-    <param pos="0" name="hw.device" value="Terminal Server"/>
+    <param pos="0" name="hw.device" value="Device Server"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^Model name\s+: NPort (IA-\d+)(?:\r|\n|\x00)+MAC address\s+: ([\w:]+)(?:\r|\n|\x00)+Serial No.\s+: (\d+)(?:\r|\n|\x00)+Firmware version : ([\d.]+) Build (\d+)(?:\r|\n|\x00)+System uptime">

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -88,13 +88,13 @@
     <param pos="0" name="os.vendor" value="Yealink"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Yealink"/>
   </fingerprint>
   <fingerprint pattern="^CN=[a-zA-Z0-9]+,OU=Internally Generated Certificate,O=American Power Conversion Corp,L=Default Locality,ST=Default State,C=US$">
     <description>APC UPS</description>
     <example>CN=ZA1117619249,OU=Internally Generated Certificate,O=American Power Conversion Corp,L=Default Locality,ST=Default State,C=US</example>
-    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="hw.device" value="Power device"/>
     <param pos="0" name="hw.vendor" value="APC"/>
   </fingerprint>
   <fingerprint pattern="^CN=Temporary CA [a-fA-F0-9]{8}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{12},OU=Temporary CA">

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -71,10 +71,11 @@
     <param pos="2" name="hw.product"/>
     <param pos="1" name="host.mac"/>
   </fingerprint>
-  <fingerprint pattern="^SERIALNUMBER=PID:([^ ]+) SN:([^,]+),CN=(?:[a-zA-Z0-9\-]+)-SEP([a-fA-F0-9]{12}),OU=CTG,O=Cisco Systems Inc\.$">
-    <description>Cisco / Linksys Router with serial number</description>
+  <fingerprint pattern="^SERIALNUMBER=PID:([^ ]+) SN:([^,]+),CN=(?:[a-zA-Z0-9\-]+)-SEP([a-fA-F0-9]{12}),OU=[CV]TG,O=Cisco Systems Inc\.$">
+    <description>Cisco IP phone with serial number</description>
     <example host.mac="B07D47D33A1C" hw.product="CP-8851" cisco.serial_number="FCH1924AHCA">SERIALNUMBER=PID:CP-8851 SN:FCH1924AHCA,CN=CP-8851-SEPB07D47D33A1C,OU=CTG,O=Cisco Systems Inc.</example>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <example host.mac="64D989000000" hw.product="CP-9951" cisco.serial_number="FCH15200000">SERIALNUMBER=PID:CP-9951 SN:FCH15200000,CN=CP-9951-SEP64D989000000,OU=VTG,O=Cisco Systems Inc.</example>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="cisco.serial_number"/>
@@ -805,18 +806,18 @@
     <description>NEC DT Series IP Phone</description>
     <example>CN=DT800 Series,O=NEC Corporation,ST=Tokyo,C=JP</example>
     <param pos="0" name="os.vendor" value="NEC"/>
-    <param pos="0" name="os.device" value="IP Phone"/>
+    <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="NEC"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
   <fingerprint pattern="^CN=([a-fA-F0-9]{12}),O=Polycom Inc\.$">
     <description>Polycom SoundPoint IP Phone</description>
     <example host.mac="64167F169981">CN=64167F169981,O=Polycom Inc.</example>
     <param pos="0" name="os.vendor" value="Polycom"/>
-    <param pos="0" name="os.device" value="IP Phone"/>
+    <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Polycom"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.product" value="SoundPoint"/>
     <param pos="1" name="host.mac"/>
   </fingerprint>
@@ -824,9 +825,9 @@
     <description>Siemens EN Software</description>
     <example>CN=EN Software Production &amp; Release,OU=Enterprise Networks,O=Siemens AG,L=Munich,ST=Germany,C=DE</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
-    <param pos="0" name="os.device" value="IP Phone"/>
+    <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
-    <param pos="0" name="hw.device" value="IP Phone"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
   </fingerprint>
   <fingerprint pattern="^CN=SecureConnect server,O=Quest,ST=CA,C=US$">
     <description>SecureConnect SSL VPN</description>
@@ -927,6 +928,16 @@
     <param pos="0" name="hw.vendor" value="AirDefense"/>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.product" value="Sensor"/>
+  </fingerprint>
+  <fingerprint pattern="^CN=HiveAP,OU=Default,O=Aerohive,ST=California,C=US$">
+    <description>Aerohive Access Point</description>
+    <example>CN=HiveAP,OU=Default,O=Aerohive,ST=California,C=US</example>
+    <param pos="0" name="hw.vendor" value="Aerohive"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="hw.product" value="Access Point"/>
+    <param pos="0" name="os.vendor" value="Aerohive"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
   <fingerprint pattern="^CN=(usg[^_]+)_([a-fA-F0-9]{12})$">
     <description>ZyWall Router</description>


### PR DESCRIPTION
## Description

This PR rolls up a bunch of small changes, including consistency improvements around Terminal Servers (now Device Server) and IP Phones (now VoIP). New fingerprints were added for LANDesk, NetData, and Pulse Secure VPN. Small fixes were made to existing fingerprints (NetScaler). Cisco Tandberg and IP Phone fingerprints needed small tweaks for coverage.

## Motivation and Context

Improve coverage and make existing coverage more consistent

## How Has This Been Tested?

Real-world scans, rspec, and recog_verify

## Types of changes
- Consistency changes across fingerprints
- Small fingerprint updates
- New fingerprints


## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
