### PR TITLE
Include Red Hat Enterprise Linux HTTP Banner Fingerprint

### DIFF
--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -149,11 +149,12 @@ against the following patterns to extract OS information.
     <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
   <fingerprint pattern=".*\(Red Hat Enterprise (?:Linux)?\).*">
-    <description>Red Hat Enterprise Linux</description>
+    <description>Apache OS: Red Hat Enterprise Linux</description>
     <example os.vendor="Red Hat">Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips</example>
     <param pos="0" name="os.vendor" value="Red Hat"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.product" value="Enterprise"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:enterprise_linux:-"/>
   </fingerprint>
   <fingerprint pattern=".*Debian(?:[/ ]GNU)?(?:/Linux)?.*">
     <description>Debian Linux</description>

--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -153,7 +153,7 @@ against the following patterns to extract OS information.
     <example os.vendor="Red Hat">Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips</example>
     <param pos="0" name="os.vendor" value="Red Hat"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Enterprise"/>
+    <param pos="0" name="os.product" value="Enterprise Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:redhat:enterprise_linux:-"/>
   </fingerprint>
   <fingerprint pattern=".*Debian(?:[/ ]GNU)?(?:/Linux)?.*">

--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -148,6 +148,13 @@ against the following patterns to extract OS information.
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
+  <fingerprint pattern=".*\(Red Hat Enterprise (?:Linux)?\).*">
+    <description>Red Hat Enterprise Linux</description>
+    <example os.vendor="Red Hat">Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips</example>
+    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+  </fingerprint>
   <fingerprint pattern=".*Debian(?:[/ ]GNU)?(?:/Linux)?.*">
     <description>Debian Linux</description>
     <param pos="0" name="os.vendor" value="Debian"/>


### PR DESCRIPTION
## Description
This request includes an Apache HTTP banner fingerprint for newer versions of Red Hat Enterprise Linux.


## Motivation and Context
Current Apache OS fingerprints do not adequately recognize the presented OS Vendor as Red Hat.


## How Has This Been Tested?
`echo 'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips' | ./bin/recog_verify xml/apache_os.xml` has been used against the included example within the fingerprint.
The fingerprint has also been tested successfully as a custom Nexpose fingerprint within a relatively large production environment.  


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)
Additional Signature


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [X] I have updated the documentation accordingly (or changes are not required).
- [X] I have added tests to cover my changes (or new tests are not required).
- [X] All new and existing tests passed.
