### PR TITLE
Add the initial "known identifiers" lists.

### DIFF
--- a/bin/recog_standardize
+++ b/bin/recog_standardize
@@ -1,0 +1,118 @@
+#!/usr/bin/env ruby
+
+$:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "lib")))
+require 'optparse'
+require 'ostruct'
+require 'recog'
+
+def load_identifiers(path)
+  res = {}
+  File.readlines(path).map{|line| line.strip}.each do |ident|
+    res[ident] = true
+  end
+  return res
+end
+
+def write_identifiers(vals, path)
+  res = []
+  vals.each_pair do |k,v|
+    res = res.push(k)
+  end
+  res = res.sort.uniq
+  File.write(path, res.join("\n") + "\n")
+end
+
+bdir = File.expand_path(File.join(File.dirname(__FILE__), "..", "identifiers"))
+
+options = OpenStruct.new(write: false)
+option_parser = OptionParser.new do |opts|
+  opts.banner = "Usage: #{$0} [options] XML_FINGERPRINT_FILE1 ..."
+  opts.separator "Verifies that each fingerprint asserts known identifiers."
+  opts.separator ""
+  opts.separator "Options"
+
+  opts.on("-w", "--write") do
+      options.write = true
+  end
+
+  opts.on("-h", "--help", "Show this message.") do
+    puts opts
+    exit
+  end
+end
+option_parser.parse!(ARGV)
+
+if ARGV.empty?
+  $stderr.puts 'Missing XML fingerprint files'
+  puts option_parser
+  exit(1)
+end
+
+# Load the unique identifiers
+vendors = load_identifiers(File.join(bdir, "vendor.txt"))
+os_arch = load_identifiers(File.join(bdir, "os_architecture.txt"))
+os_prod = load_identifiers(File.join(bdir, "os_product.txt"))
+os_family = load_identifiers(File.join(bdir, "os_family.txt"))
+os_device = load_identifiers(File.join(bdir, "os_device.txt"))
+svc_prod = load_identifiers(File.join(bdir, "service_product.txt"))
+svc_family = load_identifiers(File.join(bdir, "service_family.txt"))
+
+ARGV.each do |arg|
+  Dir.glob(arg).each do |file|
+    ndb = Recog::DB.new(file)
+    ndb.fingerprints.each do |f|
+      f.params.each do |k,v|
+        paramIndex, val = v
+        next if paramIndex != 0
+        case k
+        when "os.vendor", "service.vendor", "service.component.vendor", "hw.vendor"
+          if ! vendors[val]
+            puts "VENDOR MISSING: #{val}"
+            vendors[val] = true
+          end
+        when "os.product"
+          if ! os_prod[val]
+            puts "OS PRODUCT MISSING: #{val}"
+            os_prod[val] = true
+          end
+        when "os.arch"
+          if ! os_arch[val]
+            puts "OS ARCH MISSING: #{val}"
+            os_arch[val] = true
+          end
+        when "os.family"
+          if ! os_family[val]
+            puts "OS FAMILY MISSING: #{val}"
+            os_family[val] = true
+          end
+        when "os.device"
+          if ! os_device[val]
+            puts "OS DEVICE MISSING: #{val}"
+            os_device[val] = true
+          end
+        when "service.product"
+          if ! svc_prod[val]
+            puts "SERVICE PRODUCT MISSING: #{val}"
+            svc_prod[val] = true
+          end            
+        when "service.family"
+          if ! svc_family[val]
+            puts "SERVICE FAMILY MISSING: #{val}"
+            svc_family[val] = true
+          end          
+        end
+      end
+    end
+  end
+end
+
+exit if ! options.write
+
+# Write back the unique identifiers
+write_identifiers(vendors, File.join(bdir, "vendor.txt"))
+write_identifiers(os_arch, File.join(bdir, "os_architecture.txt"))
+write_identifiers(os_prod, File.join(bdir, "os_product.txt"))
+write_identifiers(os_family, File.join(bdir, "os_family.txt"))
+write_identifiers(os_device, File.join(bdir, "os_device.txt"))
+write_identifiers(svc_prod, File.join(bdir, "service_product.txt"))
+write_identifiers(svc_family, File.join(bdir, "service_family.txt"))

--- a/identifiers/README.md
+++ b/identifiers/README.md
@@ -1,0 +1,47 @@
+# Recog: Identifiers
+
+This directory contains lists of standard identifiers for mapping Recog matches. The goal is define a standard set of constants to represent known software, hardware, vendors, and categories.
+
+This is currently incomplete and will be updated as standardization work moves forward.
+
+Fingerprints should use these identifiers whenever possible; if a different name or syntax for a given identifier is preferred, this should be implemented in the application through a mapping function.
+
+## Lists
+
+### Vendors
+
+`vendor.txt` defines known vendor names, covering services, operating systems, and hardware.
+
+### Operating Systems
+
+`os_architecture.txt` defines known CPU types.
+
+`os_product.txt` defines known operating system names.
+
+`os_family.txt` defines known operating system families.
+
+`os_device.txt` defines known types of devices by function or purpose.
+
+### Services
+
+`service_product.txt` defines known service product names.
+
+`service_family.txt` defines known service product families.
+
+### Software
+
+`software_product.txt` defines known software product names.
+
+`software_family.txt` defines known software product families.
+
+`software_class.txt` defines known types of software by function or purpose.
+
+## Pending Work
+
+  * All existing fingerprints should be correlated against these lists to identify mismatches and updated accordingly.
+
+  * All net new identifiers from the existing fingerprints should be merged into these lists.
+
+  * All fingerprint assertions should be enumerated, documented, and standardized where possible (`host.mac`, etc).
+
+  * Hardware identifiers should be enumerated, consolidated, and standardized.

--- a/identifiers/os_architecture.txt
+++ b/identifiers/os_architecture.txt
@@ -1,0 +1,17 @@
+Alpha
+ARM
+ia64
+iSeries
+680xx
+880xx
+MIPS
+MPC
+PA
+PowerPC
+pSeries
+Risc
+s390
+s390x
+Sparc
+x86
+x86_64

--- a/identifiers/os_architecture.txt
+++ b/identifiers/os_architecture.txt
@@ -1,9 +1,9 @@
+680xx
+880xx
 Alpha
 ARM
 ia64
 iSeries
-680xx
-880xx
 MIPS
 MPC
 PA

--- a/identifiers/os_device.txt
+++ b/identifiers/os_device.txt
@@ -1,11 +1,9 @@
-Domain controller
-Server
-Workstation
 BBS
 Bridge
 Broadband router
 Console server
 CSU/DSU
+Domain controller
 DSLAM
 Encryption accelerator
 Fax server
@@ -13,12 +11,11 @@ File server
 Firewall
 Game console
 General
-General
 Hub
 IPS
 KVM
-Load balancer
 Lights Out Management
+Load balancer
 Mainframe
 Management
 Monitoring
@@ -28,13 +25,14 @@ NAC
 Network management device
 PBX
 PDA
-Power device
 Point of sale
+Power device
 Print server
 Printer
 Remote access server
 Router
 Scanner
+Server
 Specialized
 Storage
 Switch
@@ -47,7 +45,8 @@ Virtualization host
 VoIP
 VPN
 WAP
+Web cam
 Web proxy
 Web server
-Web cam
+Workstation
 X terminal

--- a/identifiers/os_device.txt
+++ b/identifiers/os_device.txt
@@ -1,0 +1,53 @@
+Domain controller
+Server
+Workstation
+BBS
+Bridge
+Broadband router
+Console server
+CSU/DSU
+DSLAM
+Encryption accelerator
+Fax server
+File server
+Firewall
+Game console
+General
+General
+Hub
+IPS
+KVM
+Load balancer
+Lights Out Management
+Mainframe
+Management
+Monitoring
+Multifunction Device
+Multiplexer
+NAC
+Network management device
+PBX
+PDA
+Power device
+Point of sale
+Print server
+Printer
+Remote access server
+Router
+Scanner
+Specialized
+Storage
+Switch
+Tablet
+Tape library
+Telecom
+Terminal server
+UPS
+Virtualization host
+VoIP
+VPN
+WAP
+Web proxy
+Web server
+Web cam
+X terminal

--- a/identifiers/os_family.txt
+++ b/identifiers/os_family.txt
@@ -1,4 +1,5 @@
 A/UX
+Adaptive Security Appliance
 Aficio
 AirPort
 AIX
@@ -7,13 +8,11 @@ AMOS
 AOS
 AOS/VS
 APC
-Adaptive Security Appliance
 Atari
 AtheOS
 AuspexOS
 BeOS
 BIG-IP
-NetCache
 Brocade
 BSD
 BSDi
@@ -31,15 +30,14 @@ Cyras
 CyROS
 DART
 Data ONTAP
+Dell Remote Access Controller
 DG/UX
 Digital UNIX
 Domain/OS
 DOS
-Dell Remote Access Controller
 Dynix
 Embedded
-Embedded
-Embedded
+ES
 ExtremeWare
 Firewall-1
 Fortinet
@@ -49,12 +47,11 @@ GigaVUE HD
 GigaVUE TA
 HI-UX
 HP-UX
-MT
 Hurd
-Integrated Dell Remote Access Controller
 iLO
 IM Series
 Imagistics
+Integrated Dell Remote Access Controller
 IOS
 IPS
 IPSO
@@ -75,9 +72,11 @@ MAXserver
 MedNet
 Minix
 MPE/iX
+MT
 MVS
 NC Series
 NetBSD
+NetCache
 Netopia
 NetOS
 NetStation
@@ -97,6 +96,7 @@ OS/2
 OS/390
 OS/400
 OS-9
+PacketShaper pSOS
 PalmOS
 Palo Alto
 PAN-OS
@@ -104,14 +104,13 @@ PIX
 Plan9
 ProCurve
 ProLiant
-PacketShaper pSOS
 QNX
 Raptor
 Reliant UNIX
 RISC OS
-ES
-RS
 RouterOS
+RS
+RT
 SAN-OS
 SCO UNIX
 ScreenOS
@@ -128,9 +127,9 @@ SVR4
 Tahoe OS
 Tandem NSK
 Taos
-TiOS
 ThreadX
 TINIOS
+TiOS
 TOPS-20
 Tru64 UNIX
 Ubuntu
@@ -157,6 +156,5 @@ Wide Format Printer
 Windows
 Worldgroup
 xMach
-RT
 z/OS
 ZyNOS

--- a/identifiers/os_family.txt
+++ b/identifiers/os_family.txt
@@ -1,0 +1,162 @@
+A/UX
+Aficio
+AirPort
+AIX
+AmigaOS
+AMOS
+AOS
+AOS/VS
+APC
+Adaptive Security Appliance
+Atari
+AtheOS
+AuspexOS
+BeOS
+BIG-IP
+NetCache
+Brocade
+BSD
+BSDi
+CacheOS
+CatOS
+CBOS
+CentOS
+Check Point
+Clix
+ComOS
+ConnectUPS
+Content Networking System
+ConvexOS
+Cyras
+CyROS
+DART
+Data ONTAP
+DG/UX
+Digital UNIX
+Domain/OS
+DOS
+Dell Remote Access Controller
+Dynix
+Embedded
+Embedded
+Embedded
+ExtremeWare
+Firewall-1
+Fortinet
+FreeBSD
+GAiA
+GigaVUE HD
+GigaVUE TA
+HI-UX
+HP-UX
+MT
+Hurd
+Integrated Dell Remote Access Controller
+iLO
+IM Series
+Imagistics
+IOS
+IPS
+IPSO
+Irix
+Ironware
+JetDirect
+Junos
+KA9Q
+LaserJet
+Linux
+lwIP
+LynxOS
+Mac OS
+Mac OS X
+Mach
+Madge CrossFire
+MAXserver
+MedNet
+Minix
+MPE/iX
+MVS
+NC Series
+NetBSD
+Netopia
+NetOS
+NetStation
+NetVanta
+NetWare
+NewsOS
+Newton OS
+Nexpose
+NEXTSTEP
+NmpSW
+NX-OS
+OpenBSD
+OpenROUTE
+OpenServer
+OpenVMS
+OS/2
+OS/390
+OS/400
+OS-9
+PalmOS
+Palo Alto
+PAN-OS
+PIX
+Plan9
+ProCurve
+ProLiant
+PacketShaper pSOS
+QNX
+Raptor
+Reliant UNIX
+RISC OS
+ES
+RS
+RouterOS
+SAN-OS
+SCO UNIX
+ScreenOS
+SHARP AR Series
+SHARP MX Series
+SINIX
+Solaris
+SpeedTouch
+SPP-UX
+SSL-VPN
+StackTOS
+SunOS
+SVR4
+Tahoe OS
+Tandem NSK
+Taos
+TiOS
+ThreadX
+TINIOS
+TOPS-20
+Tru64 UNIX
+Ubuntu
+UCOS
+UCS
+Ultrasound Device
+Ultrix
+UnicOS
+Unisys
+UnixWare
+UX/4800
+VG200
+VirtuOS
+VM
+VM/CMS
+VM/ESA
+VMS
+VMware ESX/ESXi
+VOS
+VRP
+VxWorks
+WAAS
+Wide Format Printer
+Windows
+Worldgroup
+xMach
+RT
+z/OS
+ZyNOS

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -1,0 +1,199 @@
+AIX
+UPS
+Adaptive Security Appliance
+BIG-IP
+NetCache
+CatOS
+Firewall-1
+NG
+Cobalt RaQ
+ConnectUPS
+Data ONTAP
+OSF/1
+Dell Remote Access Controller
+Vigor
+Eagle Secure Gateway
+Email Appliance
+EulerOS
+ExtendNet DX
+ExtendNet SX
+Fedora Core Linux
+Fibre Channel
+FortiOS
+FreeBSD
+GAiA OS
+GigaVUE HD
+GigaVUE TA1
+HP-UX
+Remote Supervisor Adapter / Remote Management Module
+Integrated Dell Remote Access Controller
+iLO
+cs
+im
+IOS
+IOS-XR
+IOS-XE
+IPSO
+JetDirect
+Junos OS
+LaserJet
+Linux
+Linux AMI
+Linux AMI 2
+Enterprise Linux
+Linux Enterprise Desktop
+Linux Enterprise Server
+LX
+Mac OS X
+Mac OS X Server
+Madge CrossFire
+MedNet Server
+Windows Storage Server 2012 R2
+Windows Storage Server 2012
+NetBSD
+Netopia
+NetScaler
+NetVanta
+NetWare
+BoSS
+Meridian
+Passport
+Nortel
+OpenVMS
+OS/400
+NX-OS
+PalmOS
+PA Firewall
+PA Panorama
+PAN-OS
+PIX
+ProLiant
+PacketShaper pSOS
+Raptor
+Enterprise Linux AS
+Enterprise Linux ES
+Enterprise Linux WS
+RouterOS
+RT
+SAN-OS
+ScreenOS
+Secure Linux
+Solaris
+SonicWALL
+SonicOS
+SpeedTouch
+Tru64 UNIX
+Ubuntu Linux
+UCS Device
+UCS Manager
+UNIX
+UnixWare
+AIX VIOS
+VMware ESX Server
+VMware ESXi Server
+VRP
+WAAS
+Windows Server 2012 R2
+Windows Server 2012 R2 Datacenter Edition
+Windows Server 2012 R2 Essentials Edition
+Windows Server 2012 R2 Foundation Edition
+Windows Server 2012 R2 Standard Edition
+Windows Server 2016
+Windows Server 2016 Datacenter Edition
+Windows Server 2016 Essentials Edition
+Windows Server 2016 Foundation Edition
+Windows Server 2016 Standard Edition
+Windows Storage Server 2016
+Windows 2000
+Windows 2000 Professional
+Windows 2000 Server
+Windows 2000 Advanced Server
+Windows 2000 Datacenter Server
+Windows Server 2012
+Windows Server 2012 Datacenter Edition
+Windows Server 2012 Essentials Edition
+Windows Server 2012 Foundation Edition
+Windows Server 2012 Standard Edition
+Windows Server 2003
+Windows Server 2003, Datacenter Edition
+Windows Server 2003 R2, Datacenter Edition
+Windows Server 2003, Enterprise Edition
+Windows Server 2003 R2, Enterprise Edition
+Windows Server 2003 R2, Express Edition
+Windows Server 2003 R2
+Windows Small Business Server 2003
+Windows Small Business Server 2003 R2
+Windows Server 2003, Standard Edition
+Windows Server 2003 R2, Standard Edition
+Windows Server 2003, Web Edition
+Windows Server 2003 R2, Web Edition
+Windows Server 2003 R2, Workgroup Edition
+Windows Server 2008
+Windows Server 2008 Datacenter Edition
+Windows Server 2008 R2, Datacenter Edition
+Windows Essential Business Server 2008
+Windows Server 2008 Enterprise Edition
+Windows Server 2008 R2, Enterprise Edition
+Windows Server 2008 HPC Edition
+Windows Server 2008 R2
+Windows Small Business Server 2008
+Windows Server 2008 Storage Edition
+Windows Server 2008 Standard Edition
+Windows Server 2008 R2, Standard Edition
+Windows Server 2008 Web Edition
+Windows Server 2008 R2, Web Edition
+Windows 7
+Windows 7 Home, Basic Edition
+Windows 7 Home, Basic N Edition
+Windows 7 Enterprise Edition
+Windows 7 Enterprise N Edition
+Windows 7 Home, Premium Edition
+Windows 7 Home, Premium N Edition
+Windows 7 Professional Edition
+Windows 7 Starter Edition
+Windows 7 Starter N Edition
+Windows 7 Ultimate Edition
+Windows 7 Ultimate N Edition
+Windows 8
+Windows 8 Enterprise Edition
+Windows 8 Professional Edition
+Windows 8.1
+Windows 8.1 Enterprise Edition
+Windows 8.1 Professional Edition
+Windows 10 Enterprise Edition
+Windows 10 Home Edition
+Windows 10 Mobile Enterprise Edition
+Windows 10 Mobile Edition
+Windows 10 Education Edition
+Windows 10 Professional Edition
+Windows 10
+Windows 95
+Windows 98
+Windows 98SE
+Windows CE
+Windows Longhorn Server Beta
+Windows ME
+Windows NT
+Windows NT Server
+Windows NT Advanced Server
+Windows NT Server, Enterprise Edition
+Windows NT Server, Terminal Server Edition
+Windows NT Workstation
+Windows RT
+Windows Vista
+Windows Vista Business Edition
+Windows Vista Home, Basic Edition
+Windows Vista Home, Basic N Edition
+Windows Vista Business N Edition
+Windows Vista Enterprise Edition
+Windows Vista Home, Premium Edition
+Windows Vista Starter Edition
+Windows Vista Ultimate Edition
+Windows XP
+Windows XP Home
+Windows XP Professional
+Windows XP Tablet PC Edition
+Windows
+Wireless LAN Controller
+WRT54G
+z/OS

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -1,38 +1,38 @@
-AIX
-UPS
 Adaptive Security Appliance
+AIX
+AIX VIOS
 BIG-IP
-NetCache
+BoSS
 CatOS
-Firewall-1
-NG
 Cobalt RaQ
 ConnectUPS
+cs
 Data ONTAP
-OSF/1
 Dell Remote Access Controller
-Vigor
 Eagle Secure Gateway
 Email Appliance
+Enterprise Linux
+Enterprise Linux AS
+Enterprise Linux ES
+Enterprise Linux WS
 EulerOS
 ExtendNet DX
 ExtendNet SX
 Fedora Core Linux
 Fibre Channel
+Firewall-1
 FortiOS
 FreeBSD
 GAiA OS
 GigaVUE HD
 GigaVUE TA1
 HP-UX
-Remote Supervisor Adapter / Remote Management Module
-Integrated Dell Remote Access Controller
 iLO
-cs
 im
+Integrated Dell Remote Access Controller
 IOS
-IOS-XR
 IOS-XE
+IOS-XR
 IPSO
 JetDirect
 Junos OS
@@ -40,7 +40,6 @@ LaserJet
 Linux
 Linux AMI
 Linux AMI 2
-Enterprise Linux
 Linux Enterprise Desktop
 Linux Enterprise Server
 LX
@@ -48,39 +47,37 @@ Mac OS X
 Mac OS X Server
 Madge CrossFire
 MedNet Server
-Windows Storage Server 2012 R2
-Windows Storage Server 2012
+Meridian
 NetBSD
+NetCache
 Netopia
 NetScaler
 NetVanta
 NetWare
-BoSS
-Meridian
-Passport
+NG
 Nortel
+NX-OS
 OpenVMS
 OS/400
-NX-OS
-PalmOS
+OSF/1
 PA Firewall
 PA Panorama
+PacketShaper pSOS
+PalmOS
 PAN-OS
+Passport
 PIX
 ProLiant
-PacketShaper pSOS
 Raptor
-Enterprise Linux AS
-Enterprise Linux ES
-Enterprise Linux WS
+Remote Supervisor Adapter / Remote Management Module
 RouterOS
 RT
 SAN-OS
 ScreenOS
 Secure Linux
 Solaris
-SonicWALL
 SonicOS
+SonicWALL
 SpeedTouch
 Tru64 UNIX
 Ubuntu Linux
@@ -88,65 +85,30 @@ UCS Device
 UCS Manager
 UNIX
 UnixWare
-AIX VIOS
+UPS
+Vigor
 VMware ESX Server
 VMware ESXi Server
 VRP
 WAAS
-Windows Server 2012 R2
-Windows Server 2012 R2 Datacenter Edition
-Windows Server 2012 R2 Essentials Edition
-Windows Server 2012 R2 Foundation Edition
-Windows Server 2012 R2 Standard Edition
-Windows Server 2016
-Windows Server 2016 Datacenter Edition
-Windows Server 2016 Essentials Edition
-Windows Server 2016 Foundation Edition
-Windows Server 2016 Standard Edition
-Windows Storage Server 2016
+Windows
+Windows 10
+Windows 10 Education Edition
+Windows 10 Enterprise Edition
+Windows 10 Home Edition
+Windows 10 Mobile Edition
+Windows 10 Mobile Enterprise Edition
+Windows 10 Professional Edition
 Windows 2000
-Windows 2000 Professional
-Windows 2000 Server
 Windows 2000 Advanced Server
 Windows 2000 Datacenter Server
-Windows Server 2012
-Windows Server 2012 Datacenter Edition
-Windows Server 2012 Essentials Edition
-Windows Server 2012 Foundation Edition
-Windows Server 2012 Standard Edition
-Windows Server 2003
-Windows Server 2003, Datacenter Edition
-Windows Server 2003 R2, Datacenter Edition
-Windows Server 2003, Enterprise Edition
-Windows Server 2003 R2, Enterprise Edition
-Windows Server 2003 R2, Express Edition
-Windows Server 2003 R2
-Windows Small Business Server 2003
-Windows Small Business Server 2003 R2
-Windows Server 2003, Standard Edition
-Windows Server 2003 R2, Standard Edition
-Windows Server 2003, Web Edition
-Windows Server 2003 R2, Web Edition
-Windows Server 2003 R2, Workgroup Edition
-Windows Server 2008
-Windows Server 2008 Datacenter Edition
-Windows Server 2008 R2, Datacenter Edition
-Windows Essential Business Server 2008
-Windows Server 2008 Enterprise Edition
-Windows Server 2008 R2, Enterprise Edition
-Windows Server 2008 HPC Edition
-Windows Server 2008 R2
-Windows Small Business Server 2008
-Windows Server 2008 Storage Edition
-Windows Server 2008 Standard Edition
-Windows Server 2008 R2, Standard Edition
-Windows Server 2008 Web Edition
-Windows Server 2008 R2, Web Edition
+Windows 2000 Professional
+Windows 2000 Server
 Windows 7
-Windows 7 Home, Basic Edition
-Windows 7 Home, Basic N Edition
 Windows 7 Enterprise Edition
 Windows 7 Enterprise N Edition
+Windows 7 Home, Basic Edition
+Windows 7 Home, Basic N Edition
 Windows 7 Home, Premium Edition
 Windows 7 Home, Premium N Edition
 Windows 7 Professional Edition
@@ -160,32 +122,71 @@ Windows 8 Professional Edition
 Windows 8.1
 Windows 8.1 Enterprise Edition
 Windows 8.1 Professional Edition
-Windows 10 Enterprise Edition
-Windows 10 Home Edition
-Windows 10 Mobile Enterprise Edition
-Windows 10 Mobile Edition
-Windows 10 Education Edition
-Windows 10 Professional Edition
-Windows 10
 Windows 95
 Windows 98
 Windows 98SE
 Windows CE
+Windows Essential Business Server 2008
 Windows Longhorn Server Beta
 Windows ME
 Windows NT
-Windows NT Server
 Windows NT Advanced Server
+Windows NT Server
 Windows NT Server, Enterprise Edition
 Windows NT Server, Terminal Server Edition
 Windows NT Workstation
 Windows RT
+Windows Server 2003
+Windows Server 2003 R2
+Windows Server 2003 R2, Datacenter Edition
+Windows Server 2003 R2, Enterprise Edition
+Windows Server 2003 R2, Express Edition
+Windows Server 2003 R2, Standard Edition
+Windows Server 2003 R2, Web Edition
+Windows Server 2003 R2, Workgroup Edition
+Windows Server 2003, Datacenter Edition
+Windows Server 2003, Enterprise Edition
+Windows Server 2003, Standard Edition
+Windows Server 2003, Web Edition
+Windows Server 2008
+Windows Server 2008 Datacenter Edition
+Windows Server 2008 Enterprise Edition
+Windows Server 2008 HPC Edition
+Windows Server 2008 R2
+Windows Server 2008 R2, Datacenter Edition
+Windows Server 2008 R2, Enterprise Edition
+Windows Server 2008 R2, Standard Edition
+Windows Server 2008 R2, Web Edition
+Windows Server 2008 Standard Edition
+Windows Server 2008 Storage Edition
+Windows Server 2008 Web Edition
+Windows Server 2012
+Windows Server 2012 Datacenter Edition
+Windows Server 2012 Essentials Edition
+Windows Server 2012 Foundation Edition
+Windows Server 2012 R2
+Windows Server 2012 R2 Datacenter Edition
+Windows Server 2012 R2 Essentials Edition
+Windows Server 2012 R2 Foundation Edition
+Windows Server 2012 R2 Standard Edition
+Windows Server 2012 Standard Edition
+Windows Server 2016
+Windows Server 2016 Datacenter Edition
+Windows Server 2016 Essentials Edition
+Windows Server 2016 Foundation Edition
+Windows Server 2016 Standard Edition
+Windows Small Business Server 2003
+Windows Small Business Server 2003 R2
+Windows Small Business Server 2008
+Windows Storage Server 2012
+Windows Storage Server 2012 R2
+Windows Storage Server 2016
 Windows Vista
 Windows Vista Business Edition
-Windows Vista Home, Basic Edition
-Windows Vista Home, Basic N Edition
 Windows Vista Business N Edition
 Windows Vista Enterprise Edition
+Windows Vista Home, Basic Edition
+Windows Vista Home, Basic N Edition
 Windows Vista Home, Premium Edition
 Windows Vista Starter Edition
 Windows Vista Ultimate Edition
@@ -193,7 +194,6 @@ Windows XP
 Windows XP Home
 Windows XP Professional
 Windows XP Tablet PC Edition
-Windows
 Wireless LAN Controller
 WRT54G
 z/OS

--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -1,0 +1,191 @@
+Apache
+Tomcat
+Apache Tomcat HTTP Connector
+IIS
+SQL Server
+Exchange Server
+.NET
+ASP.NET
+FrontPage
+SharePoint
+Windows Media Services
+Commerce Server
+E-mail Services
+Windows CE Web Server
+PWS
+Oracle
+Oracle Database
+OracleAS
+Postgres
+SQL Server
+Adaptive Server Enterprise
+DB2
+IOS
+PIX
+Content Service Switch
+Palo Alto Networks
+Netscape Enterprise Server
+iPlanet Web Server
+Sun ONE Web Server
+Sun Java System Web Server
+Java System Web Server
+Java System Web Proxy Server
+Java System Application Server
+Internet Mail Server
+Sendmail
+AppleShare IP Mail Server
+IMail Server
+Internet Mail Scanner
+Internet Mail Services
+Internet Mail Server
+MAILsweeper
+Mail Server
+Mail Server
+Mail-Max
+MailSite
+Mercury Mail Transport System
+Messaging Server
+Messaging Server
+VOPMail
+SLMail
+NTMail
+VPOP3
+exim
+ZMailer
+qmail
+VM
+Qpopper
+qpopper-mysql
+Postfix
+Dovecot
+Abyss Web Server
+Compaq HTTP Server
+HTTP Server
+lighttpd
+NetWare Enterprise Web Server
+NetWare HTTP Server
+NetWare HTTP Stack
+RealMedia
+thttpd
+Webserver
+WebServer
+Webserver
+iGateway
+CherryPy
+Web PN Server
+Lotus Expeditor
+sfcb
+Twisted Web
+mini_httpd
+Thin
+DSView
+Google Front End
+Mongrel
+Sentinel
+GoAhead Webserver
+Appweb
+JC-HTTPD
+JC-SHTTPD
+ConnectUPS
+AURA
+emHTTPD
+Proxy
+NetCache
+Squid
+Proxy
+HAProxy
+FileZilla FTP Server
+ProFTPD
+Pure-FTPd
+Secure FTP Server
+vsFTPd
+Serv-U
+Embedded SSH Server
+FortressSSH Server
+FreSSH
+OpenSSH
+SSH
+SSH Tectia Server
+sshlib
+WinSSHD
+Content Server
+EWS
+ASM
+CVS
+Agent
+4th Dimension 2004
+AOS
+Alteon
+Antivirus for Gateways
+Application Protection System
+BIG-IP
+BIND
+CMS
+CMS400.NET
+CRM
+Check Point
+ColdFusion
+Coyote
+Cyrus
+Desktop Authority
+Dropbear
+Dynamo
+ePolicy Orchestrator
+FTGate
+FWTK
+FastTrack Server
+Firewall-1
+GNAT Box
+GroupWise
+iLO
+Integrated Lights Out Manager
+IntraStore
+Helix Server
+HP Data Protector
+JBoss
+JServ
+JetDirect
+Jetty
+Joom!Fish
+Lotus Domino
+MDaemon
+MERCUR
+MOVEit DMZ
+MT
+MultiNet
+MySQL
+Nepenthes
+NetBus
+NetScreen
+NetTracker
+NetVanta
+NetWeaver
+OpenAdStream
+PHP
+Post.Office
+Reflection
+RemoteView
+Resin
+Network Printer Manager
+Snort Console
+SSL-VPN
+SpeedTouch
+Stronghold
+Tivoli
+Urchin
+VMware
+VRP
+VShell
+Vignette
+WebGUI
+WebSTAR
+WebShield
+WebLogic
+WebSphere
+WebTrends
+Webmin
+WinRoute
+RT
+Zincite
+Zope
+NTP

--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -1,191 +1,185 @@
-Apache
-Tomcat
-Apache Tomcat HTTP Connector
-IIS
-SQL Server
-Exchange Server
 .NET
-ASP.NET
-FrontPage
-SharePoint
-Windows Media Services
-Commerce Server
-E-mail Services
-Windows CE Web Server
-PWS
-Oracle
-Oracle Database
-OracleAS
-Postgres
-SQL Server
-Adaptive Server Enterprise
-DB2
-IOS
-PIX
-Content Service Switch
-Palo Alto Networks
-Netscape Enterprise Server
-iPlanet Web Server
-Sun ONE Web Server
-Sun Java System Web Server
-Java System Web Server
-Java System Web Proxy Server
-Java System Application Server
-Internet Mail Server
-Sendmail
-AppleShare IP Mail Server
-IMail Server
-Internet Mail Scanner
-Internet Mail Services
-Internet Mail Server
-MAILsweeper
-Mail Server
-Mail Server
-Mail-Max
-MailSite
-Mercury Mail Transport System
-Messaging Server
-Messaging Server
-VOPMail
-SLMail
-NTMail
-VPOP3
-exim
-ZMailer
-qmail
-VM
-Qpopper
-qpopper-mysql
-Postfix
-Dovecot
-Abyss Web Server
-Compaq HTTP Server
-HTTP Server
-lighttpd
-NetWare Enterprise Web Server
-NetWare HTTP Server
-NetWare HTTP Stack
-RealMedia
-thttpd
-Webserver
-WebServer
-Webserver
-iGateway
-CherryPy
-Web PN Server
-Lotus Expeditor
-sfcb
-Twisted Web
-mini_httpd
-Thin
-DSView
-Google Front End
-Mongrel
-Sentinel
-GoAhead Webserver
-Appweb
-JC-HTTPD
-JC-SHTTPD
-ConnectUPS
-AURA
-emHTTPD
-Proxy
-NetCache
-Squid
-Proxy
-HAProxy
-FileZilla FTP Server
-ProFTPD
-Pure-FTPd
-Secure FTP Server
-vsFTPd
-Serv-U
-Embedded SSH Server
-FortressSSH Server
-FreSSH
-OpenSSH
-SSH
-SSH Tectia Server
-sshlib
-WinSSHD
-Content Server
-EWS
-ASM
-CVS
-Agent
 4th Dimension 2004
-AOS
+Abyss Web Server
+Adaptive Server Enterprise
+Agent
 Alteon
 Antivirus for Gateways
+AOS
+Apache Tomcat HTTP Connector
+Apache
+AppleShare IP Mail Server
 Application Protection System
+Appweb
+ASM
+ASP.NET
+AURA
 BIG-IP
 BIND
+Check Point
+CherryPy
 CMS
 CMS400.NET
-CRM
-Check Point
 ColdFusion
+Commerce Server
+Compaq HTTP Server
+ConnectUPS
+Content Server
+Content Service Switch
 Coyote
+CRM
+CVS
 Cyrus
+DB2
 Desktop Authority
+Dovecot
 Dropbear
+DSView
 Dynamo
+E-mail Services
+Embedded SSH Server
+emHTTPD
 ePolicy Orchestrator
+EWS
+Exchange Server
+exim
+FastTrack Server
+FileZilla FTP Server
+Firewall-1
+FortressSSH Server
+FreSSH
+FrontPage
 FTGate
 FWTK
-FastTrack Server
-Firewall-1
 GNAT Box
+GoAhead Webserver
+Google Front End
 GroupWise
-iLO
-Integrated Lights Out Manager
-IntraStore
+HAProxy
 Helix Server
 HP Data Protector
+HTTP Server
+iGateway
+IIS
+iLO
+IMail Server
+Integrated Lights Out Manager
+Internet Mail Scanner
+Internet Mail Server
+Internet Mail Services
+IntraStore
+IOS
+iPlanet Web Server
+Java System Application Server
+Java System Web Proxy Server
+Java System Web Server
 JBoss
-JServ
+JC-HTTPD
+JC-SHTTPD
 JetDirect
 Jetty
 Joom!Fish
+JServ
+lighttpd
 Lotus Domino
+Lotus Expeditor
+Mail Server
+Mail-Max
+MailSite
+MAILsweeper
 MDaemon
 MERCUR
+Mercury Mail Transport System
+Messaging Server
+mini_httpd
+Mongrel
 MOVEit DMZ
 MT
 MultiNet
 MySQL
 Nepenthes
 NetBus
+NetCache
+Netscape Enterprise Server
 NetScreen
 NetTracker
 NetVanta
+NetWare Enterprise Web Server
+NetWare HTTP Server
+NetWare HTTP Stack
 NetWeaver
+Network Printer Manager
+NTMail
+NTP
 OpenAdStream
+OpenSSH
+Oracle Database
+Oracle
+OracleAS
+Palo Alto Networks
 PHP
+PIX
 Post.Office
+Postfix
+Postgres
+ProFTPD
+Proxy
+Pure-FTPd
+PWS
+qmail
+Qpopper
+qpopper-mysql
+RealMedia
 Reflection
 RemoteView
 Resin
-Network Printer Manager
-Snort Console
-SSL-VPN
-SpeedTouch
-Stronghold
-Tivoli
-Urchin
-VMware
-VRP
-VShell
-Vignette
-WebGUI
-WebSTAR
-WebShield
-WebLogic
-WebSphere
-WebTrends
-Webmin
-WinRoute
 RT
+Secure FTP Server
+Sendmail
+Sentinel
+Serv-U
+sfcb
+SharePoint
+SLMail
+Snort Console
+SpeedTouch
+SQL Server
+Squid
+SSH Tectia Server
+SSH
+sshlib
+SSL-VPN
+Stronghold
+Sun Java System Web Server
+Sun ONE Web Server
+Thin
+thttpd
+Tivoli
+Tomcat
+Twisted Web
+Urchin
+Vignette
+VM
+VMware
+VOPMail
+VPOP3
+VRP
+vsFTPd
+VShell
+Web PN Server
+WebGUI
+WebLogic
+Webmin
+Webserver
+WebServer
+WebShield
+WebSphere
+WebSTAR
+WebTrends
+Windows CE Web Server
+Windows Media Services
+WinRoute
+WinSSHD
 Zincite
+ZMailer
 Zope
-NTP

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -1,51 +1,122 @@
-IIS
-SQL Server
-SQL Server, Standard Edition
-SQL Server, Enterprise Edition
-SQL Server, Desktop Engine
-SQL Server, Developer Edition
-SQL Server 2000
-SQL Server 2000, Standard Edition
-SQL Server 2000, Personal Edition
-SQL Server 2000, Enterprise Edition
-SQL Server 2000, Desktop Engine
-SQL Server 2000, Developer Edition
-SQL Server 2005
-SQL Server 2005, Express Edition
-SQL Server 2005, Enterprise Edition
-SQL Server 2005, Standard Edition
-SQL Server 2005, Developer Edition
-SQL Server 2005, Compact Edition
-SQL Server 2005, Workgroup Edition
-SQL Server 2008
-SQL Server 2012
-SQL Server 2014
-SQL Server 2016
-SQL Server 2017
-Exchange Server
-Exchange Server 4.0
-Exchange Server 5.0
-Exchange Server 5.5
+.NET CLR
+.NET Remoting
+11000 Series Content Service Switch
+4th Dimension 2004
+Abyss Web Server X1
+Adaptive Server Enterprise
+Adaptive Server Enterprise, Backup Server
+Alteon Web Switch
+Antivirus for Gateways
+AOS
+Apache Tomcat HTTP Connector
+Apache
+AppleShare IP Mail Server
+Application Protection System, Enterprise
+Appweb
+ARRIS
+ASM
+ASP.NET
+Aura Communication Manager
+Avahi
+Back Orifice 2000
+Back Orifice
+Ben-SSL
+BIG-IP LTM
+BIG-IP
+BIND
+CakePHP
+Cart32
+CherryPy
+CMS
+CMS400.NET
+ColdFusion
+Commerce Server
+Confluence
+ConnectUPS
+Content Server
+Coyote
+CRM
+CUPS
+CVS
+Cyrus
+DAV
+DB2
+Desktop Authority
+dnsmasq
+Dovecot
+Dropbear
+DSView
+Dynamo
+Email Appliance
+E-mail Services
+Embedded SSH Server
+emHTTPD
+ePolicy Orchestrator
 Exchange 2000 Server
 Exchange 2003 Server
 Exchange 2007 Server
-.NET CLR
-.NET Remoting
-ASP.NET
+Exchange Server 4.0
+Exchange Server 5.0
+Exchange Server 5.5
+Exchange Server
+exim
+FastTrack Server
+FileZilla FTP Server
+Firewall-1
+Fisheye
+Flash
+FortressSSH Server
+FreSSH
 FrontPage
-Commerce Server
-E-mail Services
-Windows CE Web Server
-PWS
-Apache
-Tomcat
-Apache Tomcat HTTP Connector
-Server: Apache
-Ben-SSL
-DAV
-OpenSSL
-PHP
-Python
+FTGate
+FTP
+FWTK
+Generic Printer
+GNAT Box
+GoAhead Webserver
+Google Web Server
+GroupWise
+HAProxy
+HP Data Protector
+HTTP Server
+HTTP
+iGateway
+IIS
+iLO
+IMail Server
+Integrated Lights Out Manager
+Internet Mail Scanner
+Internet Mail Server
+Internet Mail Services
+IntraStore
+IOS
+iPlanet or Sun ONE
+Java System Application Server Platform Edition
+Java System Application Server
+Java System Web Server
+JBoss EAP
+JC-HTTPD
+JC-SHTTPD
+JetDirect
+Jetty
+JIRA
+Joom!Fish
+JServ
+Knot DNS
+lighttpd
+ListManager
+Lotus Domino
+Lotus Expeditor Server
+Mail Server
+Mail-Max
+MailSite
+MAILsweeper
+MDaemon
+MERCUR
+Mercury Mail Transport System
+Messaging Server
+Microsoft DNS
+mini_httpd
 mod_auth_oracle
 mod_auth_pgsql
 mod_frontpage
@@ -53,210 +124,132 @@ mod_gzip
 mod_jk
 mod_python
 mod_ssl
-WebDAV
-WebDAV component (instead of DAV
-DAV
-WebDAV
-Cart32
-Ruby on Rails
-Oracle
-Oracle Database
-OracleAS Portal
-XML DB
-Postgres
-Adaptive Server Enterprise
-Adaptive Server Enterprise, Backup Server
-DB2
-SQL Server
-SQL Server, Backup Server
-IOS
-PIX
-11000 Series Content Service Switch
-PA Firewall
-iPlanet or Sun ONE
-Java System Web Server
-Java System Application Server
-Java System Application Server Platform Edition
-Internet Mail Server
-Sendmail
-AppleShare IP Mail Server
-IMail Server
-Internet Mail Scanner
-Internet Mail Services
-Internet Mail Server
-MAILsweeper
-Mail Server
-Mail-Max
-MailSite
-Mercury Mail Transport System
-Messaging Server
-Messaging Server
-VOPMail
-SLMail
-NTMail
-VPOP3
-exim
-ZMailer
-qmail
-VM
-Qpopper
-qpopper-mysql
-Postfix
-Dovecot
-thttpd
-lighttpd
-Abyss Web Server X1
-NetWare Enterprise Web Server
-NetWare HTTP Server
-NetWare HTTP Stack
-Webserver
-WebServer
-HTTP Server
-Xerox_MicroServer
-HTTP
-iGateway
-CherryPy
-Web PN Server
-Lotus Expeditor Server
-sfcb
-Twisted Web
-mini_httpd
-Thin
-DSView
-Google Web Server
 Mongrel
-Sentinel Protection Server
-Sentinel Keys Server
-GoAhead Webserver
-Appweb
-JC-HTTPD
-JC-SHTTPD
-ConnectUPS
-Aura Communication Manager
-Rapid Logic
-Email Appliance
-emHTTPD
-CUPS
-Proxy
-NetCache
-Squid
-Proxy
-HAProxy
-FileZilla FTP Server
-ProFTPD
-Pure-FTPd
-Secure FTP Server
-vsFTPd
-Serv-U
-z/OS FTP Server
-NcFTPd Server
-FTP
-Embedded SSH Server
-FortressSSH Server
-FreSSH
-OpenSSH
-SSH Tectia Server
-sshlib
-WinSSHD
-SSH
-Content Server
-Back Orifice
-Back Orifice 2000
-VMware
-VMware Authentication Daemon
-ASM
-CVS
-ListManager
-4th Dimension 2004
-AOS
-ARRIS
-Alteon Web Switch
-Antivirus for Gateways
-Application Protection System, Enterprise
-BIG-IP
-BIG-IP LTM
-CMS
-CMS400.NET
-CRM
-CakePHP
-ColdFusion
-Coyote
-Cyrus
-Desktop Authority
-Dropbear
-Dynamo
-ePolicy Orchestrator
-FTGate
-FWTK
-FastTrack Server
-Firewall-1
-GNAT Box
-GroupWise
-BIND
-dnsmasq
-Knot DNS
-Microsoft DNS
-NSD
-PowerDNS
-Unbound
-Avahi
-HP Data Protector
-iLO
-Integrated Lights Out Manager
-IntraStore
-JServ
-JetDirect
-Jetty
-Joom!Fish
-Lotus Domino
-MDaemon
-MERCUR
 MOVEit DMZ
 MultiNet
 MySQL
+NcFTPd Server
 Nepenthes
 NetBus
+NetCache
 NetScreen
 NetTracker
 NetVanta
+NetWare Enterprise Web Server
+NetWare HTTP Server
+NetWare HTTP Stack
 NetWeaver Web AS
+Network Printer Manager
+NSD
+NTMail
+NTP
 OpenAdStream
+OpenSSH
+OpenSSL
+Oracle Database
+Oracle
+OracleAS Portal
+PA Firewall
 PHP
+PIX
 Post.Office
+Postfix
+Postgres
+PowerDNS
+ProFTPD
+Proxy
+Pure-FTPd
+PWS
+Python
+qmail
+Qpopper
+qpopper-mysql
+Rapid Logic
+Rapid7 Agent
+Raptor
 Reflection
 RemoteView
 Resin
-Network Printer Manager
+RT
+Ruby on Rails
+Secure FTP Server
+Sendmail
+Sentinel Keys Server
+Sentinel Protection Server
+Server: Apache
+Serv-U
+sfcb
+SLMail
 Snort Console
-SSL-VPN
 SpeedTouch
+SQL Server 2000
+SQL Server 2000, Desktop Engine
+SQL Server 2000, Developer Edition
+SQL Server 2000, Enterprise Edition
+SQL Server 2000, Personal Edition
+SQL Server 2000, Standard Edition
+SQL Server 2005
+SQL Server 2005, Compact Edition
+SQL Server 2005, Developer Edition
+SQL Server 2005, Enterprise Edition
+SQL Server 2005, Express Edition
+SQL Server 2005, Standard Edition
+SQL Server 2005, Workgroup Edition
+SQL Server 2008
+SQL Server 2012
+SQL Server 2014
+SQL Server 2016
+SQL Server 2017
+SQL Server
+SQL Server, Backup Server
+SQL Server, Desktop Engine
+SQL Server, Developer Edition
+SQL Server, Enterprise Edition
+SQL Server, Standard Edition
+Squid
+SSH Tectia Server
+SSH
+sshlib
+SSL-VPN
 Stronghold
 Symantec Mail Security for SMTP
+Thin
+thttpd
 Tivoli Access Manager for e-business WebSEAL
 Tivoli Storage Manager
+Tomcat
+Twisted Web
+Unbound
 Urchin Tracking Module
-VRP
-VShell
 Vignette
+VM
+VMware Authentication Daemon
+VMware
+VOPMail
+VPOP3
+VRP
+vsFTPd
+VShell
+Web PN Server
+WebDAV component (instead of DAV
+WebDAV
 WebGUI
-WebSTAR
-WebShield
-WebLogic
 WebLogic Server Plugin
-WebSphere
-WebSphere Load Balancer
-WebTrends
+WebLogic
 Webmin
+Webserver
+WebServer
+WebShield
+WebSphere Load Balancer
+WebSphere
+WebSTAR
+WebTrends
+Windows CE Web Server
 WinRoute
-RT
+WinSSHD
+Xerox_MicroServer
+XML DB
+z/OS FTP Server
 Zincite
+ZMailer
 Zope
-Raptor
-Flash
-NTP
-Confluence
-Fisheye
-JIRA
-Rapid7 Agent
-Generic Printer
-JBoss EAP

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -1,0 +1,262 @@
+IIS
+SQL Server
+SQL Server, Standard Edition
+SQL Server, Enterprise Edition
+SQL Server, Desktop Engine
+SQL Server, Developer Edition
+SQL Server 2000
+SQL Server 2000, Standard Edition
+SQL Server 2000, Personal Edition
+SQL Server 2000, Enterprise Edition
+SQL Server 2000, Desktop Engine
+SQL Server 2000, Developer Edition
+SQL Server 2005
+SQL Server 2005, Express Edition
+SQL Server 2005, Enterprise Edition
+SQL Server 2005, Standard Edition
+SQL Server 2005, Developer Edition
+SQL Server 2005, Compact Edition
+SQL Server 2005, Workgroup Edition
+SQL Server 2008
+SQL Server 2012
+SQL Server 2014
+SQL Server 2016
+SQL Server 2017
+Exchange Server
+Exchange Server 4.0
+Exchange Server 5.0
+Exchange Server 5.5
+Exchange 2000 Server
+Exchange 2003 Server
+Exchange 2007 Server
+.NET CLR
+.NET Remoting
+ASP.NET
+FrontPage
+Commerce Server
+E-mail Services
+Windows CE Web Server
+PWS
+Apache
+Tomcat
+Apache Tomcat HTTP Connector
+Server: Apache
+Ben-SSL
+DAV
+OpenSSL
+PHP
+Python
+mod_auth_oracle
+mod_auth_pgsql
+mod_frontpage
+mod_gzip
+mod_jk
+mod_python
+mod_ssl
+WebDAV
+WebDAV component (instead of DAV
+DAV
+WebDAV
+Cart32
+Ruby on Rails
+Oracle
+Oracle Database
+OracleAS Portal
+XML DB
+Postgres
+Adaptive Server Enterprise
+Adaptive Server Enterprise, Backup Server
+DB2
+SQL Server
+SQL Server, Backup Server
+IOS
+PIX
+11000 Series Content Service Switch
+PA Firewall
+iPlanet or Sun ONE
+Java System Web Server
+Java System Application Server
+Java System Application Server Platform Edition
+Internet Mail Server
+Sendmail
+AppleShare IP Mail Server
+IMail Server
+Internet Mail Scanner
+Internet Mail Services
+Internet Mail Server
+MAILsweeper
+Mail Server
+Mail-Max
+MailSite
+Mercury Mail Transport System
+Messaging Server
+Messaging Server
+VOPMail
+SLMail
+NTMail
+VPOP3
+exim
+ZMailer
+qmail
+VM
+Qpopper
+qpopper-mysql
+Postfix
+Dovecot
+thttpd
+lighttpd
+Abyss Web Server X1
+NetWare Enterprise Web Server
+NetWare HTTP Server
+NetWare HTTP Stack
+Webserver
+WebServer
+HTTP Server
+Xerox_MicroServer
+HTTP
+iGateway
+CherryPy
+Web PN Server
+Lotus Expeditor Server
+sfcb
+Twisted Web
+mini_httpd
+Thin
+DSView
+Google Web Server
+Mongrel
+Sentinel Protection Server
+Sentinel Keys Server
+GoAhead Webserver
+Appweb
+JC-HTTPD
+JC-SHTTPD
+ConnectUPS
+Aura Communication Manager
+Rapid Logic
+Email Appliance
+emHTTPD
+CUPS
+Proxy
+NetCache
+Squid
+Proxy
+HAProxy
+FileZilla FTP Server
+ProFTPD
+Pure-FTPd
+Secure FTP Server
+vsFTPd
+Serv-U
+z/OS FTP Server
+NcFTPd Server
+FTP
+Embedded SSH Server
+FortressSSH Server
+FreSSH
+OpenSSH
+SSH Tectia Server
+sshlib
+WinSSHD
+SSH
+Content Server
+Back Orifice
+Back Orifice 2000
+VMware
+VMware Authentication Daemon
+ASM
+CVS
+ListManager
+4th Dimension 2004
+AOS
+ARRIS
+Alteon Web Switch
+Antivirus for Gateways
+Application Protection System, Enterprise
+BIG-IP
+BIG-IP LTM
+CMS
+CMS400.NET
+CRM
+CakePHP
+ColdFusion
+Coyote
+Cyrus
+Desktop Authority
+Dropbear
+Dynamo
+ePolicy Orchestrator
+FTGate
+FWTK
+FastTrack Server
+Firewall-1
+GNAT Box
+GroupWise
+BIND
+dnsmasq
+Knot DNS
+Microsoft DNS
+NSD
+PowerDNS
+Unbound
+Avahi
+HP Data Protector
+iLO
+Integrated Lights Out Manager
+IntraStore
+JServ
+JetDirect
+Jetty
+Joom!Fish
+Lotus Domino
+MDaemon
+MERCUR
+MOVEit DMZ
+MultiNet
+MySQL
+Nepenthes
+NetBus
+NetScreen
+NetTracker
+NetVanta
+NetWeaver Web AS
+OpenAdStream
+PHP
+Post.Office
+Reflection
+RemoteView
+Resin
+Network Printer Manager
+Snort Console
+SSL-VPN
+SpeedTouch
+Stronghold
+Symantec Mail Security for SMTP
+Tivoli Access Manager for e-business WebSEAL
+Tivoli Storage Manager
+Urchin Tracking Module
+VRP
+VShell
+Vignette
+WebGUI
+WebSTAR
+WebShield
+WebLogic
+WebLogic Server Plugin
+WebSphere
+WebSphere Load Balancer
+WebTrends
+Webmin
+WinRoute
+RT
+Zincite
+Zope
+Raptor
+Flash
+NTP
+Confluence
+Fisheye
+JIRA
+Rapid7 Agent
+Generic Printer
+JBoss EAP

--- a/identifiers/software_class.txt
+++ b/identifiers/software_class.txt
@@ -1,26 +1,26 @@
+Backup
+Blog
+Browser Add-On
+Container Orchestrator
+Database Client
+Database Server
+Gateway
 General
-Utility
-Security
-Productivity
-Peer-Peer
+IM Client
+IM Server
+Internet Client
+Internet Server
+Mail Client
+Mail Server
 Media Client
 Media Server
 Medical Device
-Internet Client
-Browser Add-On
-Internet Server
-Database Client
-Database Server
-Mail Client
-Mail Server
 Middleware
-IM Client
-IM Server
-Blog
-Backup
-Gateway
-SCADA
-Systems Management
-Virtualization
 OS Level Virtualization
-Container Orchestrator
+Peer-Peer
+Productivity
+SCADA
+Security
+Systems Management
+Utility
+Virtualization

--- a/identifiers/software_class.txt
+++ b/identifiers/software_class.txt
@@ -1,0 +1,26 @@
+General
+Utility
+Security
+Productivity
+Peer-Peer
+Media Client
+Media Server
+Medical Device
+Internet Client
+Browser Add-On
+Internet Server
+Database Client
+Database Server
+Mail Client
+Mail Server
+Middleware
+IM Client
+IM Server
+Blog
+Backup
+Gateway
+SCADA
+Systems Management
+Virtualization
+OS Level Virtualization
+Container Orchestrator

--- a/identifiers/software_family.txt
+++ b/identifiers/software_family.txt
@@ -1,91 +1,91 @@
+.NET Framework
 Acrobat
+ASP.NET MVC
 Chrome
+Cisco WebEx
 ColdFusion
+Commerce Server
 CyberArk
 DB2
 Docker Platform
-Fusion
-Flash
-Ghostscript
-HP System Management Homepage
-HP Systems Insight Manager
-iTunes
-Java
-JBoss
-LastPass
-Moodle
-Mozilla
-ASP.NET MVC
-Microsoft Biztalk Server
-Commerce Server
-.NET Framework
-Microsoft Dynamics AX
 Edge
 Enhanced Mitigation Experience Toolkit
 Essentials
 Exchange Server
 Expression Suite
-Forefront
+Flash
 Forefront Endpoint Protection
-Visual FoxPro
-Host Integration Server
+Forefront
+Fusion
+Ghostscript
 Host Integration Server 2004
 Host Integration Server 2006
 Host Integration Server 2009
 Host Integration Server 2010
+Host Integration Server
+HP System Management Homepage
+HP Systems Insight Manager
 Internet Explorer
 Internet Information Services
+iTunes
+Java
+JBoss
+LastPass
 Lync 2010
 Lync 2013
 MDAC
+Microsoft Biztalk Server
+Microsoft Dynamics AX
+Moodle
+Mozilla
 MSXML
-Office Communicator
-Office Communicator 2005
-Office Communicator 2007
-Office Communicator 2007 R2
-Office
+Norton
 Office 2000
 Office 2003
 Office 2007
 Office 2010
 Office 2013
 Office 2016
-Office XP
-Outlook
+Office Communicator 2005
+Office Communicator 2007 R2
+Office Communicator 2007
+Office Communicator
 Office Web Apps
-System Center Operations Manager
-SharePoint
-Silverlight
-Skype for Business 2015
-Skype for Business 2016
-Systems Management Server
-SQL Server
-Visual Basic for Applications
-Visual Studio
-Visual Studio Foundation Server
-Windows Media Player
-Works
-Norton
-OpenView
+Office XP
+Office
+OfficeScan
 OpenShift
-QuickTime
+OpenView
+Outlook
 ownCloud
+QuickTime
 Rapid7 Agent
 Safari
 Scada
+SharePoint
 Shockwave
+Silverlight
+Skype for Business 2015
+Skype for Business 2016
 Sophos
+SQL Server
 Struts
 Symantec Endpoint Protection Manager
+System Center Operations Manager
+Systems Management Server
 Tomcat
 TOR
-OfficeScan
-VirusScan
-VLC
-Workstation
 vCenter Server
-Cisco WebEx
+VirusScan
+Visual Basic for Applications
+Visual FoxPro
+Visual Studio Foundation Server
+Visual Studio
+VLC
 WebLogic Server
 WebSphere
+Windows Media Player
 Wordpress
+Works
+Workstation
 Worry-Free Business Security

--- a/identifiers/software_family.txt
+++ b/identifiers/software_family.txt
@@ -1,0 +1,91 @@
+Acrobat
+Chrome
+ColdFusion
+CyberArk
+DB2
+Docker Platform
+Fusion
+Flash
+Ghostscript
+HP System Management Homepage
+HP Systems Insight Manager
+iTunes
+Java
+JBoss
+LastPass
+Moodle
+Mozilla
+ASP.NET MVC
+Microsoft Biztalk Server
+Commerce Server
+.NET Framework
+Microsoft Dynamics AX
+Edge
+Enhanced Mitigation Experience Toolkit
+Essentials
+Exchange Server
+Expression Suite
+Forefront
+Forefront Endpoint Protection
+Visual FoxPro
+Host Integration Server
+Host Integration Server 2004
+Host Integration Server 2006
+Host Integration Server 2009
+Host Integration Server 2010
+Internet Explorer
+Internet Information Services
+Lync 2010
+Lync 2013
+MDAC
+MSXML
+Office Communicator
+Office Communicator 2005
+Office Communicator 2007
+Office Communicator 2007 R2
+Office
+Office 2000
+Office 2003
+Office 2007
+Office 2010
+Office 2013
+Office 2016
+Office XP
+Outlook
+Office Web Apps
+System Center Operations Manager
+SharePoint
+Silverlight
+Skype for Business 2015
+Skype for Business 2016
+Systems Management Server
+SQL Server
+Visual Basic for Applications
+Visual Studio
+Visual Studio Foundation Server
+Windows Media Player
+Works
+Norton
+OpenView
+OpenShift
+QuickTime
+ownCloud
+Rapid7 Agent
+Safari
+Scada
+Shockwave
+Sophos
+Struts
+Symantec Endpoint Protection Manager
+Tomcat
+TOR
+OfficeScan
+VirusScan
+VLC
+Workstation
+vCenter Server
+Cisco WebEx
+WebLogic Server
+WebSphere
+Wordpress
+Worry-Free Business Security

--- a/identifiers/software_product.txt
+++ b/identifiers/software_product.txt
@@ -1,160 +1,142 @@
-Acrobat Pro
-Acrobat Standard
-Acrobat DC
-AIR
-ColdFusion
-Digital Editions
-Reader
-Reader MUI
-Acrobat Reader DC
-Bash
-Chrome
-Password Vault Web Access
-DB2
-Docker
-Docker CE
-Docker EE
-OpenShift
-OpenShift Container Platform
-OpenShift Origin
-Firefox
-Firefox ESR
-Flash
-Foxit Reader
-Foxit PhantomPDF
-Ghostscript
-Identity Manager
-Tuxedo
-HP System Management Homepage
-HP Systems Insight Manager
-HTTP Server
-IntelliVue
-iScale
-iTunes
-JRE
-JBoss AS
-JBoss EAP
-Joomla!
-jQuery
-Endpoint Security
-Security for Exchange
-Security for SharePoint
-LastPass for Chrome
-Local Administrator Password Solution
-Logentries Monitoring Agent
-Lotus Notes
-Endpoint Protection
-MicTray
-MongoDB
-Moodle
-Mozilla
-Access
+.NET Framework
+7-Zip
 Access Viewer
+Access
+Acrobat DC
+Acrobat Pro
+Acrobat Reader DC
+Acrobat Standard
 Active Directory
+AIR
+AntiXSS
+Bash
 BizTalk Server 2000
 BizTalk Server 2002
 BizTalk Server 2004
 BizTalk Server 2006
 BizTalk Server 2009
 BizTalk Server 2010
+Chrome
+Citect SCADA
+Citrix XenDesktop
+ColdFusion
 Commerce Server
-.NET Framework
-Dynamics AX 4.0
+DB2
+Digital Editions
+Docker CE
+Docker EE
+Docker
 Dynamics AX 2009
-Dynamics AX 2012
 Dynamics AX 2012 R2
+Dynamics AX 2012
+Dynamics AX 4.0
 Edge
+Endpoint Protection
+Endpoint Security
 Enhanced Mitigation Experience Toolkit
-Essentials
 Essentials 2011
 Essentials 2012
-Excel
+Essentials
 Excel Viewer
-Exchange Server
+Excel
+Exchange 2000 Server
+Exchange Server 2003
+Exchange Server 2007
 Exchange Server 2010
 Exchange Server 2013
 Exchange Server 2016
 Exchange Server 2019
-Exchange 2000 Server
-Exchange Server 2003
-Exchange Server 2007
-Expression Blend
+Exchange Server
 Expression Blend 1
 Expression Blend 2
 Expression Blend 3
 Expression Blend 4
-Expression Design
+Expression Blend
 Expression Design 1
 Expression Design 2
 Expression Design 3
 Expression Design 4
-Expression Encoder
+Expression Design
 Expression Encoder 1
 Expression Encoder 2
 Expression Encoder 3
 Expression Encoder 4
-Expression Web
+Expression Encoder
 Expression Web 1
 Expression Web 2
 Expression Web 3
 Expression Web 4
-FAST Search Server for SharePoint
+Expression Web
 FAST Search Server 2010 for SharePoint
+FAST Search Server for SharePoint
+Firefox ESR
+Firefox
+Flash
+Forefront Protection for Exchange Server
 Forefront TMG
 Forefront UAG
-Forefront Protection for Exchange Server
-Visual FoxPro
+Foxit PhantomPDF
+Foxit Reader
 FrontPage
-Groove Client
+Fusion
+Ghostscript
 Groove Client 2007
 Groove Client 2010
-Groove Server
+Groove Client
 Groove Server 2007
 Groove Server 2010
-Host Integration Server
-Host Integration Server 2004
+Groove Server
 Host Integration Server 2004 Client
+Host Integration Server 2004
 Host Integration Server 2006
 Host Integration Server 2009
 Host Integration Server 2010
-Internet Explorer
-Internet Information Services
+Host Integration Server
+HP System Management Homepage
+HP Systems Insight Manager
+HTTP Server
+Identity Manager
 IME 2010
 InfoPath
-Lync 2010
+IntelliVue
+Internet Explorer
+Internet Information Services
+iScale
+iTunes
+Java Web Console
+JBoss AS
+JBoss EAP
+Joomla!
+jQuery
+JRE
+LastPass for Chrome
+Local Administrator Password Solution
+Logentries Monitoring Agent
+Lotus Notes
 Lync 2010 Attendant
 Lync 2010 Attendee
+Lync 2010
+Lync 2013
+Lync Basic 2013
 Lync Server 2010
 Lync Server 2010, Core Components
 Lync Server 2010, Response Group Service
 Lync Server 2010, Web Components Server
-Lync 2013
-Lync Basic 2013
 Lync Server 2013
 Lync Server 2013, Core Components
 Lync Server 2013, Response Group Service
 Lync Server 2013, Web Components Server
 MDAC
+MicTray
+MongoDB
+Moodle
+Mozilla
 MSXML
-Office Communicator 2005
-Office Communicator 2005 Attendant
-Office Communicator 2005 Attendee
-Office Communicator 2005 Group Chat Admin
-Office Communicator 2005 Group Chat Client
-Office Communicator 2005 Server
-Office Communicator 2007
-Office Communicator 2007 Attendant
-Office Communicator 2007 Attendee
-Office Communicator 2007 Group Chat Admin
-Office Communicator 2007 Group Chat Client
-Office Communicator 2007 Server
-Office Communicator 2007 R2
-Office Communicator 2007 R2 Attendant
-Office Communicator 2007 R2 Attendee
-Office Communicator 2007 R2 Group Chat Admin
-Office Communicator 2007 R2 Group Chat Client
-Office Communicator 2007 R2 Server
-Office
+Music Jukebox
+Native Client plugin for Chrome
+Norton 360
+Norton AntiVirus
+Norton Internet Security
 Office 2000
 Office 2003
 Office 2007
@@ -162,117 +144,36 @@ Office 2010
 Office 2013
 Office 2016
 Office 2019
+Office Communicator 2005 Attendant
+Office Communicator 2005 Attendee
+Office Communicator 2005 Group Chat Admin
+Office Communicator 2005 Group Chat Client
+Office Communicator 2005 Server
+Office Communicator 2005
+Office Communicator 2007 Attendant
+Office Communicator 2007 Attendee
+Office Communicator 2007 Group Chat Admin
+Office Communicator 2007 Group Chat Client
+Office Communicator 2007 R2 Attendant
+Office Communicator 2007 R2 Attendee
+Office Communicator 2007 R2 Group Chat Admin
+Office Communicator 2007 R2 Group Chat Client
+Office Communicator 2007 R2 Server
+Office Communicator 2007 R2
+Office Communicator 2007 Server
+Office Communicator 2007
 Office Compatibility Pack
-Office XP
-OneNote
-Outlook
-Office Web Apps Application Server
 Office Web Apps Application Server 2010
 Office Web Apps Application Server 2013
-PowerPoint
-PowerPoint Viewer
-Project
-Publisher
-System Center Configuration Manager
-System Center Configuration Manager 2007
-System Center Configuration Manager 2007 Admin Console
-System Center Configuration Manager 2012
-System Center Configuration Manager 2012 Admin Console
-System Center Configuration Manager Admin Console
-System Center Operations Manager 2007
-System Center Operations Manager 2007 R2
-System Center Operations Manager 2012
-SharePoint
-SharePoint 2003
-SharePoint 2007
-SharePoint 2010
-SharePoint 2013
-SharePoint 2016
-SharePoint 2019
-SharePoint Foundation
-SharePoint Foundation 2010
-SharePoint Foundation 2013
-Silverlight
-Skype for Business 2015
-Skype for Business Basic 2015
-Skype for Business Server 2015
-Skype for Business Server 2019
-Skype for Business Server 2015, Core Components
-Skype for Business Server 2019, Core Components
-Skype for Business Server 2015, Response Group Service
-Skype for Business Server 2019, Response Group Service
-Skype for Business Server 2015, Web Components Server
-Skype for Business Server 2019, Web Components Server
-Skype for Business 2016
-Skype for Business Basic 2016
-Skype for Business Basic 2019
-Systems Management Server
-Systems Management Server 2003
-Systems Management Server 2003 Administrator Console
-Systems Management Server Administrator Console
-SQL Server
-SQL Server 2005, Compact Edition
-SQL Server, Desktop Engine
-SQL Server 2000, Desktop Engine
-SQL Server, Developer Edition
-SQL Server 2000, Developer Edition
-SQL Server 2005, Developer Edition
-SQL Server, Enterprise Edition
-SQL Server 2000, Enterprise Edition
-SQL Server 2005, Enterprise Edition
-SQL Server 2005, Express Edition
-SQL Server 2000, Personal Edition
-SQL Server, Standard Edition
-SQL Server 2000, Standard Edition
-SQL Server 2005, Standard Edition
-SQL Server 2005, Workgroup Edition
-SQL Server 2000
-SQL Server 2005
-SQL Server 2008
-SQL Server 2008 R2
-SQL Server 2012
-SQL Server 2014
-SQL Server 2016
-SQL Server 2017
-Visual Basic for Applications Core
-Visual Basic for Applications SDK
-Visio
-Visio Viewer
-Visio Viewer 2002
-Visio Viewer 2003
-Visio Viewer 2007
-Visio Viewer 2010
-Visio Viewer 2013
-Visual Studio
-Visual Studio 2010
-Visual Studio 2003
-Visual Studio 2005
-Visual Studio 2008
-Visual Studio 2010
-Visual Studio 2012
-Visual Studio 2013
-Visual Studio 2015
-Visual Studio 2017
-Visual Studio Team Foundation Server
-Visual Studio Team Foundation Server 2010
-Visual Studio Team Foundation Server 2012
-Visual Studio Team Foundation Server 2013
-Visual Studio Team Foundation Server 2015
-Visual Studio Team Foundation Server 2017
-Visual Studio Team Foundation Server 2018
-Windows Media Player
-Word
-Word Viewer
-Works
-Works 6-9 Converter
-Windows SharePoint Services 2.0
-Windows SharePoint Services 3.0
-AntiXSS
-Music Jukebox
-Native Client plugin for Chrome
-Norton 360
-Norton AntiVirus
-Norton Internet Security
+Office Web Apps Application Server
+Office XP
+Office
+OfficeScan Client
+OfficeScan Server
+OneNote
+OpenShift Container Platform
+OpenShift Origin
+OpenShift
 OpenSSH
 OpenView
 Opera
@@ -281,54 +182,152 @@ Outlook 2002
 Outlook 2003
 Outlook 97
 Outlook 98
+Outlook
 ownCloud Server
-User-ID Agent
+Password Vault Web Access
 phpMyAdmin
+Player
+PowerPoint Viewer
+PowerPoint
+Project
+Publisher
 Python
 QuickTime
 Rapid7 Insight Agent
+Reader MUI
+Reader
 Safari
-Citect SCADA
-SeaMonkey
 SeaMonkey ESR
+SeaMonkey
+Security for Exchange
+Security for SharePoint
 Sendmail
-7-Zip
+SharePoint 2003
+SharePoint 2007
+SharePoint 2010
+SharePoint 2013
+SharePoint 2016
+SharePoint 2019
+SharePoint Foundation 2010
+SharePoint Foundation 2013
+SharePoint Foundation
+SharePoint
 Shockwave
+Silverlight
+Skype for Business 2015
+Skype for Business 2016
+Skype for Business Basic 2015
+Skype for Business Basic 2016
+Skype for Business Basic 2019
+Skype for Business Server 2015
+Skype for Business Server 2015, Core Components
+Skype for Business Server 2015, Response Group Service
+Skype for Business Server 2015, Web Components Server
+Skype for Business Server 2019
+Skype for Business Server 2019, Core Components
+Skype for Business Server 2019, Response Group Service
+Skype for Business Server 2019, Web Components Server
 Sophos AntiVirus
 SoundPoint
+SQL Server 2000
+SQL Server 2000, Desktop Engine
+SQL Server 2000, Developer Edition
+SQL Server 2000, Enterprise Edition
+SQL Server 2000, Personal Edition
+SQL Server 2000, Standard Edition
+SQL Server 2005
+SQL Server 2005, Compact Edition
+SQL Server 2005, Developer Edition
+SQL Server 2005, Enterprise Edition
+SQL Server 2005, Express Edition
+SQL Server 2005, Standard Edition
+SQL Server 2005, Workgroup Edition
+SQL Server 2008 R2
+SQL Server 2008
+SQL Server 2012
+SQL Server 2014
+SQL Server 2016
+SQL Server 2017
+SQL Server
+SQL Server, Desktop Engine
+SQL Server, Developer Edition
+SQL Server, Enterprise Edition
+SQL Server, Standard Edition
 Struts
 Struts1 Plugin for Struts2
-Symantec Endpoint Protection
 Symantec Endpoint Protection Manager
+Symantec Endpoint Protection
+System Center Configuration Manager 2007 Admin Console
+System Center Configuration Manager 2007
+System Center Configuration Manager 2012 Admin Console
+System Center Configuration Manager 2012
+System Center Configuration Manager Admin Console
+System Center Configuration Manager
+System Center Operations Manager 2007 R2
+System Center Operations Manager 2007
+System Center Operations Manager 2012
+Systems Management Server 2003 Administrator Console
+Systems Management Server 2003
+Systems Management Server Administrator Console
+Systems Management Server
 Telerik UI for ASP.NET AJAX
-Thunderbird
 Thunderbird ESR
+Thunderbird
 Tomcat
 Tor Browser
-OfficeScan Client
-OfficeScan Server
-VLC
-Virtual Desktop Agent - x86
+Tuxedo
+User-ID Agent
+vCenter Server
+Virtual Delivery Agent - x64
 Virtual Delivery Agent - x86
 Virtual Desktop Agent - x64
-Virtual Delivery Agent - x64
-Fusion
-Player
-Workstation
-vCenter Server
-Java Web Console
+Virtual Desktop Agent - x86
+Visio Viewer 2002
+Visio Viewer 2003
+Visio Viewer 2007
+Visio Viewer 2010
+Visio Viewer 2013
+Visio Viewer
+Visio
+Visual Basic for Applications Core
+Visual Basic for Applications SDK
+Visual FoxPro
+Visual Studio 2003
+Visual Studio 2005
+Visual Studio 2008
+Visual Studio 2010
+Visual Studio 2012
+Visual Studio 2013
+Visual Studio 2015
+Visual Studio 2017
+Visual Studio Team Foundation Server 2010
+Visual Studio Team Foundation Server 2012
+Visual Studio Team Foundation Server 2013
+Visual Studio Team Foundation Server 2015
+Visual Studio Team Foundation Server 2017
+Visual Studio Team Foundation Server 2018
+Visual Studio Team Foundation Server
+Visual Studio
+VLC
 WebEx Browser Extension for Chrome
-WebEx Browser Plugin for Firefox
 WebEx Browser Extension for Firefox
 WebEx Browser Extension for Internet Explorer
-WebSphere Application Server
+WebEx Browser Plugin for Firefox
+WebLogic
 WebSphere Application Server Liberty
+WebSphere Application Server
 Widevine Content Decryption Module for Chrome
+Windows Media Player
+Windows SharePoint Services 2.0
+Windows SharePoint Services 3.0
 WinRAR
 Wireshark
-WebLogic
+Word Viewer
+Word
 Wordpress
+Works 6-9 Converter
+Works
+Workstation
 Worry-Free Business Security Agent
-Citrix XenDesktop
 XnView
 Zoom

--- a/identifiers/software_product.txt
+++ b/identifiers/software_product.txt
@@ -1,0 +1,334 @@
+Acrobat Pro
+Acrobat Standard
+Acrobat DC
+AIR
+ColdFusion
+Digital Editions
+Reader
+Reader MUI
+Acrobat Reader DC
+Bash
+Chrome
+Password Vault Web Access
+DB2
+Docker
+Docker CE
+Docker EE
+OpenShift
+OpenShift Container Platform
+OpenShift Origin
+Firefox
+Firefox ESR
+Flash
+Foxit Reader
+Foxit PhantomPDF
+Ghostscript
+Identity Manager
+Tuxedo
+HP System Management Homepage
+HP Systems Insight Manager
+HTTP Server
+IntelliVue
+iScale
+iTunes
+JRE
+JBoss AS
+JBoss EAP
+Joomla!
+jQuery
+Endpoint Security
+Security for Exchange
+Security for SharePoint
+LastPass for Chrome
+Local Administrator Password Solution
+Logentries Monitoring Agent
+Lotus Notes
+Endpoint Protection
+MicTray
+MongoDB
+Moodle
+Mozilla
+Access
+Access Viewer
+Active Directory
+BizTalk Server 2000
+BizTalk Server 2002
+BizTalk Server 2004
+BizTalk Server 2006
+BizTalk Server 2009
+BizTalk Server 2010
+Commerce Server
+.NET Framework
+Dynamics AX 4.0
+Dynamics AX 2009
+Dynamics AX 2012
+Dynamics AX 2012 R2
+Edge
+Enhanced Mitigation Experience Toolkit
+Essentials
+Essentials 2011
+Essentials 2012
+Excel
+Excel Viewer
+Exchange Server
+Exchange Server 2010
+Exchange Server 2013
+Exchange Server 2016
+Exchange Server 2019
+Exchange 2000 Server
+Exchange Server 2003
+Exchange Server 2007
+Expression Blend
+Expression Blend 1
+Expression Blend 2
+Expression Blend 3
+Expression Blend 4
+Expression Design
+Expression Design 1
+Expression Design 2
+Expression Design 3
+Expression Design 4
+Expression Encoder
+Expression Encoder 1
+Expression Encoder 2
+Expression Encoder 3
+Expression Encoder 4
+Expression Web
+Expression Web 1
+Expression Web 2
+Expression Web 3
+Expression Web 4
+FAST Search Server for SharePoint
+FAST Search Server 2010 for SharePoint
+Forefront TMG
+Forefront UAG
+Forefront Protection for Exchange Server
+Visual FoxPro
+FrontPage
+Groove Client
+Groove Client 2007
+Groove Client 2010
+Groove Server
+Groove Server 2007
+Groove Server 2010
+Host Integration Server
+Host Integration Server 2004
+Host Integration Server 2004 Client
+Host Integration Server 2006
+Host Integration Server 2009
+Host Integration Server 2010
+Internet Explorer
+Internet Information Services
+IME 2010
+InfoPath
+Lync 2010
+Lync 2010 Attendant
+Lync 2010 Attendee
+Lync Server 2010
+Lync Server 2010, Core Components
+Lync Server 2010, Response Group Service
+Lync Server 2010, Web Components Server
+Lync 2013
+Lync Basic 2013
+Lync Server 2013
+Lync Server 2013, Core Components
+Lync Server 2013, Response Group Service
+Lync Server 2013, Web Components Server
+MDAC
+MSXML
+Office Communicator 2005
+Office Communicator 2005 Attendant
+Office Communicator 2005 Attendee
+Office Communicator 2005 Group Chat Admin
+Office Communicator 2005 Group Chat Client
+Office Communicator 2005 Server
+Office Communicator 2007
+Office Communicator 2007 Attendant
+Office Communicator 2007 Attendee
+Office Communicator 2007 Group Chat Admin
+Office Communicator 2007 Group Chat Client
+Office Communicator 2007 Server
+Office Communicator 2007 R2
+Office Communicator 2007 R2 Attendant
+Office Communicator 2007 R2 Attendee
+Office Communicator 2007 R2 Group Chat Admin
+Office Communicator 2007 R2 Group Chat Client
+Office Communicator 2007 R2 Server
+Office
+Office 2000
+Office 2003
+Office 2007
+Office 2010
+Office 2013
+Office 2016
+Office 2019
+Office Compatibility Pack
+Office XP
+OneNote
+Outlook
+Office Web Apps Application Server
+Office Web Apps Application Server 2010
+Office Web Apps Application Server 2013
+PowerPoint
+PowerPoint Viewer
+Project
+Publisher
+System Center Configuration Manager
+System Center Configuration Manager 2007
+System Center Configuration Manager 2007 Admin Console
+System Center Configuration Manager 2012
+System Center Configuration Manager 2012 Admin Console
+System Center Configuration Manager Admin Console
+System Center Operations Manager 2007
+System Center Operations Manager 2007 R2
+System Center Operations Manager 2012
+SharePoint
+SharePoint 2003
+SharePoint 2007
+SharePoint 2010
+SharePoint 2013
+SharePoint 2016
+SharePoint 2019
+SharePoint Foundation
+SharePoint Foundation 2010
+SharePoint Foundation 2013
+Silverlight
+Skype for Business 2015
+Skype for Business Basic 2015
+Skype for Business Server 2015
+Skype for Business Server 2019
+Skype for Business Server 2015, Core Components
+Skype for Business Server 2019, Core Components
+Skype for Business Server 2015, Response Group Service
+Skype for Business Server 2019, Response Group Service
+Skype for Business Server 2015, Web Components Server
+Skype for Business Server 2019, Web Components Server
+Skype for Business 2016
+Skype for Business Basic 2016
+Skype for Business Basic 2019
+Systems Management Server
+Systems Management Server 2003
+Systems Management Server 2003 Administrator Console
+Systems Management Server Administrator Console
+SQL Server
+SQL Server 2005, Compact Edition
+SQL Server, Desktop Engine
+SQL Server 2000, Desktop Engine
+SQL Server, Developer Edition
+SQL Server 2000, Developer Edition
+SQL Server 2005, Developer Edition
+SQL Server, Enterprise Edition
+SQL Server 2000, Enterprise Edition
+SQL Server 2005, Enterprise Edition
+SQL Server 2005, Express Edition
+SQL Server 2000, Personal Edition
+SQL Server, Standard Edition
+SQL Server 2000, Standard Edition
+SQL Server 2005, Standard Edition
+SQL Server 2005, Workgroup Edition
+SQL Server 2000
+SQL Server 2005
+SQL Server 2008
+SQL Server 2008 R2
+SQL Server 2012
+SQL Server 2014
+SQL Server 2016
+SQL Server 2017
+Visual Basic for Applications Core
+Visual Basic for Applications SDK
+Visio
+Visio Viewer
+Visio Viewer 2002
+Visio Viewer 2003
+Visio Viewer 2007
+Visio Viewer 2010
+Visio Viewer 2013
+Visual Studio
+Visual Studio 2010
+Visual Studio 2003
+Visual Studio 2005
+Visual Studio 2008
+Visual Studio 2010
+Visual Studio 2012
+Visual Studio 2013
+Visual Studio 2015
+Visual Studio 2017
+Visual Studio Team Foundation Server
+Visual Studio Team Foundation Server 2010
+Visual Studio Team Foundation Server 2012
+Visual Studio Team Foundation Server 2013
+Visual Studio Team Foundation Server 2015
+Visual Studio Team Foundation Server 2017
+Visual Studio Team Foundation Server 2018
+Windows Media Player
+Word
+Word Viewer
+Works
+Works 6-9 Converter
+Windows SharePoint Services 2.0
+Windows SharePoint Services 3.0
+AntiXSS
+Music Jukebox
+Native Client plugin for Chrome
+Norton 360
+Norton AntiVirus
+Norton Internet Security
+OpenSSH
+OpenView
+Opera
+Outlook 2000
+Outlook 2002
+Outlook 2003
+Outlook 97
+Outlook 98
+ownCloud Server
+User-ID Agent
+phpMyAdmin
+Python
+QuickTime
+Rapid7 Insight Agent
+Safari
+Citect SCADA
+SeaMonkey
+SeaMonkey ESR
+Sendmail
+7-Zip
+Shockwave
+Sophos AntiVirus
+SoundPoint
+Struts
+Struts1 Plugin for Struts2
+Symantec Endpoint Protection
+Symantec Endpoint Protection Manager
+Telerik UI for ASP.NET AJAX
+Thunderbird
+Thunderbird ESR
+Tomcat
+Tor Browser
+OfficeScan Client
+OfficeScan Server
+VLC
+Virtual Desktop Agent - x86
+Virtual Delivery Agent - x86
+Virtual Desktop Agent - x64
+Virtual Delivery Agent - x64
+Fusion
+Player
+Workstation
+vCenter Server
+Java Web Console
+WebEx Browser Extension for Chrome
+WebEx Browser Plugin for Firefox
+WebEx Browser Extension for Firefox
+WebEx Browser Extension for Internet Explorer
+WebSphere Application Server
+WebSphere Application Server Liberty
+Widevine Content Decryption Module for Chrome
+WinRAR
+Wireshark
+WebLogic
+Wordpress
+Worry-Free Business Security Agent
+Citrix XenDesktop
+XnView
+Zoom

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -13,12 +13,12 @@ Adtran
 AIM
 Aironet
 Alcatel
-Allied Telesyn
 Allegro Software
+Allied Telesyn
 Alpha Micro
 Alpine
-Alt-N
 Alteon
+Alt-N
 Amazon
 AMD
 Amiga
@@ -63,7 +63,6 @@ BSDi
 BT
 Buffalo
 Business Objects
-Computer Associates
 Cabletron
 Cacheflow
 Canon
@@ -87,6 +86,7 @@ Cobalt
 Commodore
 Compaq
 Compatible Systems
+Computer Associates
 Computone
 Conectiva
 Conexant
@@ -99,7 +99,6 @@ CSM
 CyberArk
 CyberGuard
 Cyclades
-D-Link
 Data General
 Datamax
 DataVoice
@@ -109,6 +108,7 @@ Dell
 Digital Link
 Digital Networks
 DigiTel
+D-Link
 Docker Inc.
 DrayTek
 EasyTel
@@ -289,15 +289,16 @@ Racal
 Radionics
 Rapid7
 Raptor
+Rarlab
 RCA
 RealMedia
-Redback
 Red Hat
+Redback
 Rhino Software
 Ricoh
 Ringdale
-Riverstone Networks
 Riverbed Technology
+Riverstone Networks
 RoadLanner
 Rockliffe
 Rockwell
@@ -384,7 +385,6 @@ Webmin
 WebTrends
 White Box
 Wind River
-Rarlab
 Wireshark
 Wordpress
 WTI

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -1,0 +1,405 @@
+2Wire
+3Com
+4D
+ACC
+ACME Laboratories
+Acorn
+Actiontec
+ActiveState
+Adaptec
+ADC
+Adobe
+Adtran
+AIM
+Aironet
+Alcatel
+Allied Telesyn
+Allegro Software
+Alpha Micro
+Alpine
+Alt-N
+Alteon
+Amazon
+AMD
+Amiga
+AnalogX
+Apache
+APC
+Apollo
+Apple
+Aprelium Technologies
+Arescom
+ArGoSoft
+Arlan
+ARM
+ARRIS
+Artifex Software Inc.
+Asante
+Ascend
+Ascom
+Asianux
+Atari
+ATG
+AtheOS
+Atrium Software
+Attachmate
+Auspex
+Avaya
+Avocent
+Axent
+Axis
+Bay Networks
+Be
+BEA
+Bell Labs
+Bintec
+Bitvise
+Blue Coat
+Borderware
+Brix Networks
+Brocade
+Brother
+BSDi
+BT
+Buffalo
+Business Objects
+Computer Associates
+Cabletron
+Cacheflow
+Canon
+Canonical
+Cantillion
+Capellix
+Castelle
+CastleNet
+Caucho
+Cayman
+CentOS
+Chase
+Check Point
+CherryPy
+Cisco
+Citrix
+Clearswift
+CNET
+CNT
+Cobalt
+Commodore
+Compaq
+Compatible Systems
+Computone
+Conectiva
+Conexant
+Convex
+Copper Mountain
+Corega
+Cray
+Critical Path
+CSM
+CyberArk
+CyberGuard
+Cyclades
+D-Link
+Data General
+Datamax
+DataVoice
+Debian
+DEC
+Dell
+Digital Link
+Digital Networks
+DigiTel
+Docker Inc.
+DrayTek
+EasyTel
+Eaton
+Edimax
+Eicon
+Ektron
+ELSA
+Embedthis
+EMC
+EMWAC
+Enterasys
+Epson
+EqualLogic
+Ericsson
+Eudora
+EUSSO
+Exabyte
+exim
+ExtendNet
+Extreme Networks
+F5
+FastComm
+FatWire
+FiberLine
+Floosietek
+FlowPoint
+Fore
+FortiNet
+Foundry
+Foxit Software Inc.
+FreeBSD
+FreeScale
+FreeSCO
+Fujitsu Siemens
+GalactiComm
+Gandalf
+Gauntlet
+Genius
+Gentoo
+Gigamon
+Global Technology Associates
+GlobalScape
+GNet
+GNU
+Google
+Gordano
+Hawking
+Hitachi
+Hospira
+HP
+Huawei
+Hydra
+IBM
+Imagistics
+Innovaphone
+Intel
+Intergraph
+IPCop
+Ipswitch
+Isolation
+IXIA
+Juniper
+KA9Q
+Kaspersky Lab
+Kentrox
+Kerio
+Konica
+Kronos
+Kyocera
+Labtam
+LANCOM Systems
+Lantronix
+Leunig
+Lexmark
+LG Goldstream
+Linksys
+Linux
+Linux Foundation
+Livingston
+LogMeIn
+Lotus
+Lucent
+LWIP
+Lyris
+Macromedia
+Madge
+Magna
+Mail-Max
+Mandrake
+Mandriva
+Maxim IC
+McAfee
+Megabit
+Merak
+Meridian
+MetaInfo
+Microbase
+Microplex
+Microsoft
+MikroTik
+Minix
+Minolta
+Mirapoint
+Mocana
+Moodle
+Mort Bay
+Motorola
+Mozilla
+MRV Communications
+MultiTech
+MySQL
+NAT
+NCD
+NcFTP Software
+NCR
+NEC
+Neoware
+NetApp
+NetBSD
+Netgear
+NetJet
+NetMatrix
+Netopia
+Netscape
+NetScreen
+NetSilicon
+Network Systems
+Nexland
+NeXT
+Nokia
+Nortel
+Norton
+Novell
+NSG
+NTT
+Oce
+Okidata
+Omron
+OpenBSD
+OpenJDK
+OpenSUSE
+Opera Software
+Oracle
+Overland
+Oversee
+ownCloud
+Packet Engines
+Packeteer
+Palm
+Palo Alto Networks
+Panasonic
+Paul Smith Computer Services
+Philips
+PHP
+phpMyAdmin
+Pigtail
+Piriform
+Pitney Bowes
+Plain Black
+Planet
+PLD
+Polycom
+Postgres
+PowerWare
+Pragma Systems
+PreEmptive Solutions
+Process Software
+Proteon
+Proxim
+qmail
+QMS
+QNX
+Qualcomm
+Quanterra
+Quantum
+Racal
+Radionics
+Rapid7
+Raptor
+RCA
+RealMedia
+Redback
+Red Hat
+Rhino Software
+Ricoh
+Ringdale
+Riverstone Networks
+Riverbed Technology
+RoadLanner
+Rockliffe
+Rockwell
+Roxen
+rPath
+SafeNet
+SAP
+SAR
+Savin
+SBLIM
+Schneider Electric
+SCO
+Seattle Labs
+Secure Computing
+Sega
+Sendmail
+Sequent
+SGI
+Sharp
+Shiva
+Siebel
+Siemens
+Simon Tatham
+Slackware
+SMC
+SmoothWall
+SonicWALL
+SonoSite
+Sony
+Sophos
+Source Technologies
+Sourcefire
+SpeedStream
+Sphera
+SSH Communications Security
+StackTools
+Standard Networks
+StartCom
+Stratus
+Sun
+SUSE
+Sybase
+Symantec
+Symbol
+SysTech
+Tahoe
+Tally
+Tandberg
+Tandem
+Tasman Networks
+Tekelec
+Tektonix
+Telebit
+Telindus
+Telocity
+Teltrend
+Thomson
+TIS
+TOR
+Toshiba
+Trancell
+Trend Micro
+Truetime
+Trustix
+Turbolinux
+Turtle Beach
+Twisted Matrix Labs
+TYPO3
+Ubuntu
+Unica
+UnitedLinux
+US Robotics
+VanDyke Software
+Vanguard
+VersaNet
+VideoLAN
+Vignette
+Vine
+Vircom
+Virtual Access
+VMware
+WatchGuard
+Webmin
+WebTrends
+White Box
+Wind River
+Rarlab
+Wireshark
+Wordpress
+WTI
+XCD
+Xerox
+Xitami
+XMach
+XnSoft
+Xylan
+Xylogics
+Xyplex
+Yahoo
+Yamaha
+Zero One
+ZMailer
+Zoom
+ZoomAir
+Zyxel


### PR DESCRIPTION
The goal is to drive standardization of the hw, os, product, service, and vendor fields across Recog.

## Description

This adds a new directory full of text files. These lists were contributed by Rapid7 with sign-off from Brent Cook and converted from CSV to per-column text files. This is the initial work needed to begin standardization around known identifiers across the platform. 

## Motivation and Context

Having known identifiers formalized will make it easier to keep new fingerprints aligned with expected values and prevent changes to existing fingerprints from breaking products that depend on these identifiers.

## How Has This Been Tested?

It's a list of lists =D

## Types of changes
 - Documentation and known identifier lists
 - Adds bin/recog_standardize to compare against identifiers

## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
