### PR TITLE
DNS: Avoid spoofed Microsoft DNS Server, add Debian Buster

### DIFF
--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -197,6 +197,21 @@
     <param pos="0" name="os.product" value="Zentyal"/>
   </fingerprint>
 
+  <fingerprint pattern="^(9.[^-]+(?:-[SP]\d)?)(?:-[\d\.]+)?\+deb10[\w~\.]+-Debian$">
+    <description>ISC BIND: Debian 10.0 (buster)</description>
+    <example service.version="9.11.5-P4">9.11.5-P4-5.1+deb10u1-Debian</example>
+    <param pos="0" name="service.vendor" value="ISC"/>
+    <param pos="0" name="service.family" value="BIND"/>
+    <param pos="0" name="service.product" value="BIND"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:isc:bind:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="10.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.0"/>
+  </fingerprint>
+
   <fingerprint pattern="^(9.[^-]+(?:-[SP]\d)?)-9\+deb8u[\w~\.]+-Debian$">
     <description>ISC BIND: Debian 8.0 (jessie)</description>
     <example service.version="9.9.5">9.9.5-9+deb8u11-Debian</example>
@@ -520,6 +535,20 @@
     <param pos="0" name="service.product" value="unbound"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:BIND )?(9.[^-]+(?:-[SP]\d)?)(?:-[\d\.]+)?\+deb10u\d+-Raspbian$">
+    <description>ISC BIND: Raspbian based on Debian Buster</description>
+    <example service.version="9.11.5-P4">9.11.5-P4-5.1+deb10u1-Raspbian</example>
+    <param pos="0" name="service.vendor" value="ISC"/>
+    <param pos="0" name="service.family" value="BIND"/>
+    <param pos="0" name="service.product" value="BIND"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:isc:bind:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Raspbian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="10.0"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:BIND )?(9.[^-]+(?:-[SP]\d)?)-9\+deb8u\d+-Raspbian$">
     <description>ISC BIND: Raspbian based on Debian Jessie</description>
     <example service.version="9.9.5">9.9.5-9+deb8u7-Raspbian</example>
@@ -660,6 +689,19 @@
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
     <param pos="0" name="os.build" value="6.1.7600"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
+  </fingerprint>
+
+  <!-- This value is a spoofed value. There isn't a publicly available version
+       of Windows with build 6.0.6100 and this explicit string is used in an
+       example of how to change your version on BIND. We tested servers reporting
+       this string and NONE of them were Windows DNS.
+       This fingerprint serves to prevent someone who doesn't know from creating
+       one and stops further pattern matching efforts.
+  -->
+
+  <fingerprint pattern="^Microsoft DNS 6.0.6100 \(2AEF76E\)$">
+    <description>SPOOFED - Microsoft DNS on Windows 2008 SP something</description>
+    <example>Microsoft DNS 6.0.6100 (2AEF76E)</example>
   </fingerprint>
 
   <fingerprint pattern="^Microsoft DNS 6.0.6003(?: \(\w+\))?$">


### PR DESCRIPTION
## Description
This PR handles a spoofed DNS version bind response as well as adds coverage for Debian Buster.

The PR adds a fingerprint to assert nothing for a particular DNS `version.bind` response that claims to be Microsoft DNS server but isn't. The comment should explain the details. I tested using a quirk in how Microsoft handles `version.bind` queries.  They respond to lowercase version.bind queries but not uppercase queries. Pretty much everyone else handles the query in a case insensitive way. I sampled the servers reporting `Microsoft DNS 6.0.6100 (2AEF76E)` and was unable to find one that was actually a Microsoft DNS server.

Actual Microsoft DNS server response:

```shell
$ dig chaos txt VERSION.BIND  @96.94.199.217

; <<>> DiG 9.10.6 <<>> chaos txt VERSION.BIND @96.94.199.217
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOTIMP, id: 34973
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;VERSION.BIND.			CH	TXT

;; Query time: 46 msec
;; SERVER: 96.94.199.217#53(96.94.199.217)
;; WHEN: Wed Jul 15 07:48:32 CDT 2020
;; MSG SIZE  rcvd: 41
```

Spoofed response
```shell
$ dig chaos txt VERSION.BIND  @72.232.237.212

; <<>> DiG 9.10.6 <<>> chaos txt VERSION.BIND @72.232.237.212
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 43076
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;VERSION.BIND.			CH	TXT

;; ANSWER SECTION:
VERSION.BIND.		0	CH	TXT	"Microsoft DNS 6.0.6100 (2AEF76E)"

;; AUTHORITY SECTION:
VERSION.BIND.		0	CH	NS	VERSION.BIND.

;; Query time: 46 msec
;; SERVER: 72.232.237.212#53(72.232.237.212)
;; WHEN: Wed Jul 15 07:07:19 CDT 2020
;; MSG SIZE  rcvd: 100
```

![image](https://user-images.githubusercontent.com/20306699/87546847-d5de3300-c66f-11ea-90d7-55e1c95c23c7.png)

Here's an article where that version string shows up: https://raymii.org/s/tutorials/Get_DNS_server_version_and_hide_it_in_BIND.html

## Motivation and Context
Improved accuracy and coverage.


## How Has This Been Tested?
`rspec`, local tests.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
