### PR TITLE
CPE: Correct CPE generating automation

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -48,7 +48,6 @@ mappings:
     products:
       lotus_domino: lotus_domino_server
       os/400: os_400
-      z/os: z\/os
   jamf:
     products:
       jamf_pro: jamf

--- a/update_cpes.py
+++ b/update_cpes.py
@@ -24,6 +24,7 @@ def parse_cpe_vp_map(file):
                 vp_map[cpe_type] = {}
             if not vendor in vp_map[cpe_type]:
                 vp_map[cpe_type][vendor] = set()
+            product = product.replace('%2f', '/')
             vp_map[cpe_type][vendor].add(product)
         else:
             logging.error("Unexpected CPE %s", cpe_name)
@@ -160,6 +161,8 @@ def update_cpes(xml_file, cpe_vp_map, r7_vp_map):
                         continue
 
                 # building the CPE string
+                # Last minute escaping of '/'
+                product = product.replace('/', '\/')
                 cpe_value = 'cpe:/{}:{}:{}'.format(cpe_type, vendor, product)
 
                 if version:

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -362,11 +362,12 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:jetbrains:teamcity:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^e48c482f8f5a8e5a6249b21a39f911e7$"><description>Cockroach DB Console</description>
+  <fingerprint pattern="^e48c482f8f5a8e5a6249b21a39f911e7$">
+    <description>Cockroach DB Console</description>
     <example>e48c482f8f5a8e5a6249b21a39f911e7</example>
     <param pos="0" name="service.vendor" value="Cockroach Labs"/>
     <param pos="0" name="service.product" value="CockroachDB"/>
-	  <param pos="0" name="service.certainty" value="0.5"/>
+    <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:4f21edb50ae95a99bbd4aa0a956a179e|1531801cb9e3047e72034ed34da9d104)$">

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -574,6 +574,7 @@ more text</example>
     <param pos="0" name="os.family" value="z/OS"/>
     <param pos="0" name="os.device" value="Mainframe"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:z\/os:{os.version}"/>
     <param pos="2" name="host.name"/>
   </fingerprint>
 

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2551,6 +2551,7 @@
     <param pos="0" name="service.vendor" value="Treck"/>
     <param pos="0" name="service.product" value="TCP/IP"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:treck:tcp\/ip:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^WEBrick/([\d\.]+) .*$">

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -515,9 +515,9 @@
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;NETGEAR (Orbi(?:-(?:micro|mini))?)&quot;.*$">
     <description>Netgear Orbi</description>
-    <example hw.product="Orbi">Basic realm=&quot;NETGEAR Orbi&quot;</example>
-    <example hw.product="Orbi-micro">Basic realm=&quot;NETGEAR Orbi-micro&quot;</example>
-    <example hw.product="Orbi-mini">Basic realm=&quot;NETGEAR Orbi-mini&quot;</example>
+    <example hw.product="Orbi">Basic realm="NETGEAR Orbi"</example>
+    <example hw.product="Orbi-micro">Basic realm="NETGEAR Orbi-micro"</example>
+    <example hw.product="Orbi-mini">Basic realm="NETGEAR Orbi-mini"</example>
     <param pos="0" name="hw.vendor" value="Netgear"/>
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.family" value="Orbi"/>
@@ -526,9 +526,9 @@
 
   <fingerprint pattern="(?:Basic|Digest) realm=&quot;NETGEAR ([a-zA-Z0-9\-\+]+)\s*&quot;.*$">
     <description>Netgear Routers</description>
-    <example hw.product="DG834">Basic realm=&quot;NETGEAR DG834  &quot;</example>
-    <example hw.product="C7000v2">Basic realm=&quot;NETGEAR C7000v2&quot;</example>
-    <example hw.product="R7000P">Basic realm=&quot;NETGEAR R7000P&quot;</example>
+    <example hw.product="DG834">Basic realm="NETGEAR DG834  "</example>
+    <example hw.product="C7000v2">Basic realm="NETGEAR C7000v2"</example>
+    <example hw.product="R7000P">Basic realm="NETGEAR R7000P"</example>
     <param pos="0" name="hw.vendor" value="Netgear"/>
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="1" name="hw.product"/>
@@ -538,7 +538,7 @@
 
   <fingerprint pattern="(?:Basic|Digest) realm=&quot;Netgear&quot;.*$">
     <description>Netgear Unspecified Router</description>
-    <example>Basic realm=&quot;Netgear&quot;</example>
+    <example>Basic realm="Netgear"</example>
     <param pos="0" name="hw.vendor" value="Netgear"/>
     <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3353,6 +3353,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.family" value="z/OS"/>
     <param pos="0" name="os.product" value="z/OS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:z\/os:-"/>
   </fingerprint>
 
   <fingerprint pattern="^BladeCenter Management Module$">


### PR DESCRIPTION
## Description
PR #272 re-raised an issue where `update_cpes.py` wasn't correctly mapping products which had a `/` in the name. The new PR correctly escapes the forward slash.

This:
```xml
<param pos="0" name="service.product" value="TCP/IP"/>
<param pos="0" name="service.vendor" value="Treck"/>`
```

should result in following.
```xml
<param pos="0" name="service.cpe23" value="cpe:/a:treck:tcp\/ip:{service.version}"/>
```

It was failing because it used `tcp/ip` instead of `tcp\/ip` which isn't a valid NIST issued CPE.  See: https://nvd.nist.gov/products/cpe/search/results?keyword=Treck&status=FINAL&orderBy=CPEURI&namingFormat=2.3

The PR also contains misc formatting fixes that were automatically handled by the scripts.

## Motivation and Context
Correct CPE generating automation, few work arounds in `cpe-mapping.xml`


## How Has This Been Tested?
`rspec`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
