### PR TITLE
Added SonicOS FP

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6099,6 +6099,19 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:sonicwall:sonicos:{os.version}"/>
   </fingerprint>
 
+
+  <fingerprint pattern="^SonicWALL (\S+).*?\(SonicOS \S+ ((?:\d\.)+\d+-\d+[a-zA-Z]).*\)">
+    <description>SonicWall - SonicOS Enhanced variant without hardware model</description>
+    <example hw.product="SOHO" os.version="5.9.1.4-4o">SonicWALL SOHO (SonicOS Enhanced 5.9.1.4-4o)</example>
+    <example hw.product="SOHO" os.version="6.2.5.1-26n">SonicWALL SOHO wireless-N (SonicOS Enhanced 6.2.5.1-26n--HF175723-2n)</example>
+    <param pos="0" name="os.vendor" value="SonicWall"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.product" value="SonicOS"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:sonicwall:sonicos:{os.version}"/>
+  </fingerprint>
+
   <fingerprint pattern="^SonicWALL (.*?)\s+\(([^\)]+)\)\s*$">
     <description>SonicWall</description>
     <example>SonicWALL StrongARM / 233 Mhz (PRO 200)</example>


### PR DESCRIPTION
## Description
Added a SNMP fingerprint for SonicOS SonicWALL devices that do not include a hardware model in the snmp.banner.
The target that was being tested returnes the following snmp.banner:
```
SonicWALL SOHO (SonicOS Enhanced 5.9.1.4-4o)
```
Currently the fingerprinter that almost matches the above expects at least one digit after the hardware product, SOHO, and that digit or set of digits gets asserted as the hw.model.  

Because there's no hw.model in the fingerprint seen above, instead of making the hw.model optional (which would mean asserting a null hw.model for the above FP) we've added a second FP that doesn't expect a hw.model.

## How Has This Been Tested?
A clear and concise description of your changes were tested.
Rake tests run successfully. Deploying to nexpose now
```
9 scenarios (9 passed)
20 steps (20 passed)
0m1.917s
```

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
