### PR TITLE
CPE: use safe_load, update CPEs

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,7 +4,7 @@ version: v1.14.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-PYTHON-PYYAML-590151:
-    - '*':
+    - pyyaml:
         reason: Project doesn't use vulnerable code path.
         expires: 2021-06-01T00:00:00.000Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+python: 3.6.0
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-PYTHON-PYYAML-590151:
+    - '*':
+        reason: Project doesn't use vulnerable code path.
+        expires: 2021-06-01T00:00:00.000Z
+patch: {}

--- a/update_cpes.py
+++ b/update_cpes.py
@@ -9,7 +9,7 @@ from lxml import etree
 
 def parse_r7_remapping(file):
     with open(file) as remap_file:
-        return yaml.load(remap_file)["mappings"]
+        return yaml.safe_load(remap_file)["mappings"]
 
 def parse_cpe_vp_map(file):
     vp_map = {} # cpe_type -> vendor -> products

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -464,6 +464,7 @@
     <param pos="0" name="service.vendor" value="SABnzbd"/>
     <param pos="0" name="service.product" value="SABnzbd"/>
     <param pos="0" name="service.certainty" value="0.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sabnzbd:sabnzbd:-"/>
   </fingerprint>
 
   <fingerprint pattern="^5c9f3938754b459fb3590a00e5947fed$">
@@ -612,6 +613,7 @@
     <param pos="0" name="service.vendor" value="Elastic"/>
     <param pos="0" name="service.product" value="Kibana"/>
     <param pos="0" name="service.certainty" value="0.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:elastic:kibana:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:ef07026465d7b449a9759132486d1e3b|bcc4933f81eff43e5d9bcc5b2828aa70|b204c198a410e5ee28346c4a2110535e|c00da11c81f9b887eed4123daee89909)$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1551,6 +1551,7 @@
     <example>Elastic Kibana</example>
     <param pos="0" name="service.vendor" value="Elastic"/>
     <param pos="0" name="service.product" value="Kibana"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:elastic:kibana:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Grafana$">
@@ -2274,6 +2275,7 @@
     <example>SABnzbd - Log in</example>
     <param pos="0" name="service.vendor" value="SABnzbd"/>
     <param pos="0" name="service.product" value="SABnzbd"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sabnzbd:sabnzbd:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:Zabbix|.*: Zabbix)$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -440,7 +440,7 @@
     <param pos="0" name="service.component.vendor" value="Red Hat"/>
     <param pos="0" name="service.component.product" value="JBossWeb"/>
     <param pos="2" name="service.component.version"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:redhat:jboss_web_framework_kit:{service.component.version}"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:redhat:jbossweb:{service.component.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Servlet\/[\d\.]+; JBossAS-(.*)$">

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -77,6 +77,7 @@
     <param pos="0" name="service.family" value="Mail Server"/>
     <param pos="0" name="service.product" value="Mail Server"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:argosoft:mail_server:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^^(?:(\S+) +)?ArGoSoft Mail Server Freeware, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
@@ -91,6 +92,7 @@
     <param pos="0" name="service.family" value="Mail Server"/>
     <param pos="0" name="service.product" value="Mail Server"/>
     <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:argosoft:mail_server:{service.version}"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
@@ -108,6 +110,7 @@
     <param pos="0" name="service.product" value="Mail Server"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:argosoft:mail_server:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^([^ ]+) +AppleShare IP Mail Server ([^ ]+\.[\d.]+) SMTP Server Ready *$">

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -15,6 +15,7 @@
     <param pos="0" name="service.family" value="Mail Server"/>
     <param pos="0" name="service.product" value="Mail Server"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:argosoft:mail_server:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^214[ -].*support@argosoft\.com *$">
@@ -23,6 +24,7 @@
     <param pos="0" name="service.vendor" value="ArGoSoft"/>
     <param pos="0" name="service.family" value="Mail Server"/>
     <param pos="0" name="service.product" value="Mail Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:argosoft:mail_server:-"/>
   </fingerprint>
 
   <fingerprint pattern="^500[ -]Syntax error, command &quot;XXXX&quot; unrecognized$">

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6099,7 +6099,6 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:sonicwall:sonicos:{os.version}"/>
   </fingerprint>
 
-
   <fingerprint pattern="^SonicWALL (\S+).*?\(SonicOS \S+ ((?:\d\.)+\d+-\d+[a-zA-Z]).*\)">
     <description>SonicWall - SonicOS Enhanced variant without hardware model</description>
     <example hw.product="SOHO" os.version="5.9.1.4-4o">SonicWALL SOHO (SonicOS Enhanced 5.9.1.4-4o)</example>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1064,6 +1064,7 @@
     <param pos="0" name="hw.family" value="EDR"/>
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="0" name="hw.product" value="EDR-G902"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:moxa:edr-g902:-"/>
     <param pos="0" name="os.vendor" value="Moxa"/>
     <param pos="0" name="os.family" value="EDR"/>
     <param pos="0" name="os.device" value="Router"/>

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -14,7 +14,8 @@
     <description>Google Chromecast Gen 1</description>
     <example>CN=Eureka Gen1 ICA,OU=Google TV,O=Google Inc,L=Mountain View,ST=California,C=US</example>
     <param pos="0" name="os.vendor" value="Google"/>
-    <param pos="0" name="os.product" value="ChromeOS"/>
+    <param pos="0" name="os.product" value="Chrome OS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:google:chrome_os:-"/>
     <param pos="0" name="hw.device" value="Media Server"/>
     <param pos="0" name="hw.vendor" value="Google"/>
     <param pos="0" name="hw.product" value="Chromecast"/>
@@ -32,7 +33,8 @@
     <example chromecast.generation="11" chromecast.capabilities="Video Assist">CN=Chromecast ICA 11 (Video Assist),OU=Cast,O=Google Inc,L=Mountain View,ST=California,C=US</example>
     <example chromecast.generation="12">CN=Chromecast ICA 12,OU=Cast,O=Google Inc,L=Mountain View,ST=California,C=US</example>
     <param pos="0" name="os.vendor" value="Google"/>
-    <param pos="0" name="os.product" value="ChromeOS"/>
+    <param pos="0" name="os.product" value="Chrome OS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:google:chrome_os:-"/>
     <param pos="0" name="hw.device" value="Media Server"/>
     <param pos="0" name="hw.vendor" value="Google"/>
     <param pos="0" name="hw.product" value="Chromecast"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -512,7 +512,8 @@
     <example chromecast.serial_number="LVDZG5" host.mac_local="FA8FCA67413D">CN=LVDZG5 FA8FCA67413D,OU=Cast,O=Google Inc,L=Mountain View,ST=California,C=US</example>
     <example chromecast.serial_number="YRBLE" host.mac_local="FA8FCA7DE87D">CN=YRBLE FA8FCA7DE87D,OU=Google TV,O=Google Inc,L=Mountain View,ST=California,C=US</example>
     <param pos="0" name="os.vendor" value="Google"/>
-    <param pos="0" name="os.product" value="ChromeOS"/>
+    <param pos="0" name="os.product" value="Chrome OS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:google:chrome_os:-"/>
     <param pos="0" name="hw.device" value="Media Server"/>
     <param pos="0" name="hw.vendor" value="Google"/>
     <param pos="0" name="hw.product" value="Chromecast"/>


### PR DESCRIPTION
## Description
This PR changes `update_cpes.py` so that it uses `yaml.safe_load()` instead of `yaml.load()`. This should reduce the risk when loading YAML.  I've also run it against our fingerprint databases using the latest data from NIST.

I've also added a `.snyk` file in order to suppress the Synk warning on PyYAML. We don't currently use a vulnerable code path, Snyk doesn't check to see if you are using the vulnerable code path, and there is no full library level fix for this other than to use `safe_load()` (which this PR does) or the `SafeLoader` loader.

https://app.snyk.io/vuln/SNYK-PYTHON-PYYAML-590151

## Motivation and Context
Risk reduction


## How Has This Been Tested?
`rspec`, Github PR hooks


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
