### PR TITLE
DNS fingerprint for Windows 2003

### DIFF
--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -763,7 +763,7 @@
 
   <fingerprint pattern="^Microsoft DNS (\d+\.\d+\.\d+) \(([^)]+)\)$">
     <description>Microsoft DNS generic version banner</description>
-    <example service.version.version="17714726">Microsoft DNS 5.2.3790 (ECE135D)</example>
+    <example service.version.version="ECE135D">Microsoft DNS 5.2.3790 (ECE135D)</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="DNS"/>
     <param pos="0" name="service.product" value="DNS"/>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -761,9 +761,24 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:Service Pack 1"/>
   </fingerprint>
 
-  <fingerprint pattern="^Microsoft DNS (\d+\.\d+\.\d+)(?: \(([^)]+)\))?$">
-    <description>Microsoft DNS generic version banner</description>
-    <example service.version.version="ECE135D" service.version="5.2.3790">Microsoft DNS 5.2.3790 (ECE135D)</example>
+  <fingerprint pattern="^Microsoft DNS 5.2.3790(?: \(([^)]+)\))?$">
+    <description>Microsoft DNS on Windows 2003</description>
+    <example service.version.version="ECE135D">Microsoft DNS 5.2.3790 (ECE135D)</example>
+    <param pos="0" name="service.vendor" value="Microsoft"/>
+    <param pos="0" name="service.family" value="DNS"/>
+    <param pos="0" name="service.product" value="DNS"/>
+    <param pos="0" name="service.version" value="5.2.3790"/>
+    <param pos="1" name="service.version.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows Server 2003"/>
+    <param pos="0" name="os.build" value="5.2.3790"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2003:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Microsoft DNS (5.0.\d+)(?: \(([^)]+)\))?$">
+    <description>Microsoft DNS on Windows 2000</description>
+    <example service.version="5.0.14393" os.build="5.0.14393" service.version.version="383900CE">Microsoft DNS 5.0.14393 (383900CE)</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="DNS"/>
     <param pos="0" name="service.product" value="DNS"/>
@@ -771,6 +786,9 @@
     <param pos="2" name="service.version.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows Server 2000"/>
+    <param pos="1" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2000:-"/>
   </fingerprint>
 
   <fingerprint pattern="^DNSServer$">

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -761,7 +761,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:Service Pack 1"/>
   </fingerprint>
 
-  <fingerprint pattern="^Microsoft DNS (\d\.\d+\.\d+) \(([^)]+)\)$">
+  <fingerprint pattern="^Microsoft DNS (\d+\.\d+\.\d+) \(([^)]+)\)$">
     <description>Microsoft DNS generic version banner</description>
     <example service.version.version="17714726">Microsoft DNS 5.2.3790 (ECE135D)</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -776,21 +776,6 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2003:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Microsoft DNS (5.0.\d+)(?: \(([^)]+)\))?$">
-    <description>Microsoft DNS on Windows 2000</description>
-    <example service.version="5.0.14393" os.build="5.0.14393" service.version.version="383900CE">Microsoft DNS 5.0.14393 (383900CE)</example>
-    <param pos="0" name="service.vendor" value="Microsoft"/>
-    <param pos="0" name="service.family" value="DNS"/>
-    <param pos="0" name="service.product" value="DNS"/>
-    <param pos="1" name="service.version"/>
-    <param pos="2" name="service.version.version"/>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.product" value="Windows Server 2000"/>
-    <param pos="1" name="os.build"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2000:-"/>
-  </fingerprint>
-
   <fingerprint pattern="^DNSServer$">
     <description>Synology DNS service</description>
     <example>DNSServer</example>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -761,6 +761,18 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:Service Pack 1"/>
   </fingerprint>
 
+  <fingerprint pattern="^Microsoft DNS (\d\.\d+\.\d+) \(([^)]+)\)$">
+    <description>Microsoft DNS generic version banner</description>
+    <example service.version.version="17714726">Microsoft DNS 5.2.3790 (ECE135D)</example>
+    <param pos="0" name="service.vendor" value="Microsoft"/>
+    <param pos="0" name="service.family" value="DNS"/>
+    <param pos="0" name="service.product" value="DNS"/>
+    <param pos="1" name="service.version"/>
+    <param pos="1" name="service.version.version"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+  </fingerprint>
+
   <fingerprint pattern="^DNSServer$">
     <description>Synology DNS service</description>
     <example>DNSServer</example>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -763,7 +763,7 @@
 
   <fingerprint pattern="^Microsoft DNS (\d+\.\d+\.\d+)(?: \(([^)]+)\))?$">
     <description>Microsoft DNS generic version banner</description>
-    <example service.version.version="ECE135D">Microsoft DNS 5.2.3790 (ECE135D)</example>
+    <example service.version.version="ECE135D" service.version="5.2.3790">Microsoft DNS 5.2.3790 (ECE135D)</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="DNS"/>
     <param pos="0" name="service.product" value="DNS"/>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -761,7 +761,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:Service Pack 1"/>
   </fingerprint>
 
-  <fingerprint pattern="^Microsoft DNS (\d+\.\d+\.\d+) \(([^)]+)\)$">
+  <fingerprint pattern="^Microsoft DNS (\d+\.\d+\.\d+)(?: \(([^)]+)\))?$">
     <description>Microsoft DNS generic version banner</description>
     <example service.version.version="ECE135D">Microsoft DNS 5.2.3790 (ECE135D)</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -768,7 +768,7 @@
     <param pos="0" name="service.family" value="DNS"/>
     <param pos="0" name="service.product" value="DNS"/>
     <param pos="1" name="service.version"/>
-    <param pos="1" name="service.version.version"/>
+    <param pos="2" name="service.version.version"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
   </fingerprint>


### PR DESCRIPTION
## Description
A fingerprint pattern has been added for Microsoft DNS versions on Windows 2003. We have added Windows 2003 as one fingerprint as Windows 2003 and Windows 2003 R2 use the same kernel version.

## Motivation and Context
This change is being made to allow recog to support Microsoft DNS versions in the format of "5.2.3790.x" for Windows 2003.

## How Has This Been Tested?
The changes were tested by running `bin/recog_verify xml/dns_versionbind.xml`.

**Test result:**  
`14:22 $ bin/recog_verify xml/dns_versionbind.xml`
`SUMMARY: Test completed with 145 successful, 0 warnings, and 0 failures`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
