### PR TITLE
Add low certainty to IIS 10 fingerprint to prevent trumping better system fingerprints

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -285,6 +285,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:iis:10.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.certainty" value="0.5"/>
   </fingerprint>
 
   <fingerprint pattern="^Microsoft-IIS/([\d\.]+)$">


### PR DESCRIPTION
## Description
Simply adds a low certainty to the IIS 10 fingerprint as it has a lot of null fields and without the certainty it defaults to 0.8 which actually ends up trumping fingerprints with more information.

## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?
I have ran a scan against an IIS 10 host before and after the change and noted this fingerprint no longer trumps others which have more information.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
