### PR TITLE
SMB fingerprint improvements

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -70,6 +70,7 @@ mappings:
       lotus_domino: lotus_domino_server
       ibm_domino: lotus_domino
       os/400: os_400
+      i5/os: i5os
   intel:
     products:
       intel(r)_active_management_technology: active_management_technology

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -40,7 +40,7 @@
   <fingerprint pattern="^Samba (\d\.\d+.\d+\w*)">
     <description>Samba</description>
     <example>Samba 3.0.24</example>
-    <example>Samba 3.0.28a</example>
+    <example service.version="3.0.28a">Samba 3.0.28a</example>
     <example>Samba 3.0.32-0.2-2210-SUSE-SL10.3</example>
     <example>Samba 3.6.3</example>
     <example>Samba 3.6.6</example>
@@ -49,6 +49,20 @@
     <param pos="0" name="service.product" value="Samba"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:samba:samba:{service.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Samba (?:Samba )?for GuardianOS v\.?(\d\.[\d.]+)$">
+    <description>Samba on a SnapServer appliance</description>
+    <example os.version="4.3.007.200609131215">Samba Samba for GuardianOS v4.3.007.200609131215</example>
+    <example os.version="5.0.133.200807301131">Samba Samba for GuardianOS v5.0.133.200807301131</example>
+    <example os.version="7.7.220">Samba for GuardianOS v.7.7.220</example>
+    <param pos="0" name="service.vendor" value="Samba"/>
+    <param pos="0" name="service.product" value="Samba"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:samba:samba:-"/>
+    <param pos="0" name="os.vendor" value="SnapServer"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="GuardianOS"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
 
   <fingerprint pattern="^Netreon LANMAN 1.0$">
@@ -65,6 +79,23 @@
     <param pos="0" name="os.family" value="RouterOS"/>
     <param pos="0" name="os.product" value="RouterOS"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:mikrotik:routeros:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^NQ (\d\.\d+)$">
+    <description>Visuality Systems NQ Enterprise Storage SMB stack</description>
+    <example service.version="7.3">NQ 7.3</example>
+    <example service.version="4.32">NQ 4.32</example>
+    <param pos="0" name="service.vendor" value="Visuality Systems"/>
+    <param pos="0" name="service.product" value="NQ"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^YNQ (\d\.[\d.]+)$">
+    <description>Visuality Systems YNQ Storage SMB stack</description>
+    <example service.version="1.2.1">YNQ 1.2.1</example>
+    <param pos="0" name="service.vendor" value="Visuality Systems"/>
+    <param pos="0" name="service.product" value="YNQ"/>
+    <param pos="1" name="service.version"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -2,6 +2,9 @@
 <fingerprints matches="smb.native_os" protocol="smb" database_type="util.os">
   <!--
     SMB fingerprints obtained from the Native OS field of SMB negotations
+    NOTE: os.version is used to capture Service Pack for Microsoft Windows.
+          This is inconsistent with other OSs and CPE generation and should
+          be reviewed for correction.
   -->
 
   <fingerprint pattern="^(Windows NT \d\.\d+)$">
@@ -37,6 +40,11 @@
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows XP"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_xp:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Windows 6.1$">
+    <description>Spoofed value often used by Samba -- assert nothing.</description>
+    <example>Windows 6.1</example>
   </fingerprint>
 
   <fingerprint pattern="^Windows XP (\d+) (Service Pack \d+)$">
@@ -195,7 +203,7 @@
   <!-- TODO: Need an example string -->
 
   <fingerprint pattern="^Windows \(R\) Storage Server 2008 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
-    <description>Windows Web Server 2008 Storage</description>
+    <description>Windows Server 2008 Storage</description>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -215,8 +223,6 @@
     <param pos="2" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:{os.version}"/>
   </fingerprint>
-
-  <!-- TODO: Need an example string -->
 
   <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+)$">
     <description>Windows Web Server 2008 HPC</description>
@@ -255,6 +261,20 @@
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Windows Server 2019 (\w+|\w+ \w+|\w+ \w+ \w+)(?: Evaluation)? (\d+)$">
+    <description>Windows Server 2019 with a build, without service pack</description>
+    <example os.build="17763" os.edition="Standard">Windows Server 2019 Standard 17763</example>
+    <example os.build="17763" os.edition="Standard">Windows Server 2019 Standard Evaluation 17763</example>
+    <example os.build="17763" os.edition="Datacenter">Windows Server 2019 Datacenter 17763</example>
+    <example os.build="17763" os.edition="Essentials">Windows Server 2019 Essentials 17763</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2019"/>
+    <param pos="1" name="os.edition"/>
+    <param pos="2" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2019:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Windows Server 2016(?: Technical Preview \d+)? (\w+|\w+ \w+|\w+ \w+ \w+)(?: Evaluation)? (\d+)$">
@@ -385,10 +405,9 @@
 
   <!-- Windows 2012 R2 matches go first to simplify the regular expressions -->
 
-  <!-- TODO: Need an example string -->
-
   <fingerprint pattern="^Windows Server 2012 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2012 R2 (SP)</description>
+    <example os.build="9600" os.edition="Standard" os.version="Service Pack 1">Windows Server 2012 R2 Standard 9600 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
@@ -400,7 +419,7 @@
 
   <fingerprint pattern="^Windows Server 2012 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2012 R2</description>
-    <example os.edition="Standard">Windows Server 2012 R2 Standard 9600</example>
+    <example os.build="9600" os.edition="Standard">Windows Server 2012 R2 Standard 9600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
@@ -409,10 +428,24 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
   </fingerprint>
 
-  <!-- TODO: Need an example string -->
+  <fingerprint pattern="^Windows Storage Server 2012 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+    <description>Windows Server 2012 R2 Storage</description>
+    <example os.build="9600" os.edition="Standard">Windows Storage Server 2012 R2 Standard 9600</example>
+    <example os.build="9600" os.edition="Workgroup">Windows Storage Server 2012 R2 Workgroup 9600</example>
+    <example os.build="9600" os.edition="Essentials">Windows Storage Server 2012 R2 Essentials 9600</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
+    <param pos="1" name="os.edition"/>
+    <param pos="2" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
+  </fingerprint>
+
+  <!-- Windows 2012 -->
 
   <fingerprint pattern="^Windows Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Server 2012 (SP)</description>
+    <example os.build="9200" os.edition="Standard" os.version="Service Pack 1">Windows Server 2012 Standard 9200 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
@@ -487,7 +520,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_10:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^VxWorks">
+  <fingerprint pattern="^VxWorks$">
     <description>VxWorks</description>
     <example>VxWorks</example>
     <param pos="0" name="os.certainty" value="0.5"/>
@@ -498,9 +531,21 @@
     <param pos="0" name="service.product" value="VxWorks CIFS"/>
   </fingerprint>
 
-  <fingerprint pattern="^OS/400 \D(\d+)\D(\d+)\D(\d+)">
+  <fingerprint pattern="^OS/?400 \D(\d+)\D(\d+)\D(\d+)$">
     <description>OS/400</description>
     <example os.version="4" os.version.version="5" os.version.version.version="0">OS/400 V4R5M0</example>
+    <example os.version="5" os.version.version="4" os.version.version.version="5">OS400 V5R4M5</example>
+    <param pos="0" name="os.vendor" value="IBM"/>
+    <param pos="0" name="os.product" value="OS/400"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.version.version"/>
+    <param pos="3" name="os.version.version.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:os_400:{os.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^I5OS \D(\d+)\D(\d+)\D(\d+)$">
+    <description>IBM i5/OS</description>
+    <example os.version="6" os.version.version="1" os.version.version.version="1">I5OS V6R1M1</example>
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.product" value="OS/400"/>
     <param pos="1" name="os.version"/>
@@ -536,6 +581,14 @@
     <description>Netreon SAN software</description>
     <example>Netreon OS 1.0</example>
     <param pos="0" name="service.vendor" value="Netreon"/>
+  </fingerprint>
+
+  <fingerprint pattern="^QTS$">
+    <description>QNAP QTS</description>
+    <example>QTS</example>
+    <param pos="0" name="os.vendor" value="QNAP"/>
+    <param pos="0" name="os.product" value="QTS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:qnap:qts:-"/>
   </fingerprint>
 
   <!-- VisionFS -->

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -263,44 +263,6 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Windows Server 2019 (\w+|\w+ \w+|\w+ \w+ \w+)(?: Evaluation)? (\d+)$">
-    <description>Windows Server 2019 with a build, without service pack</description>
-    <example os.build="17763" os.edition="Standard">Windows Server 2019 Standard 17763</example>
-    <example os.build="17763" os.edition="Standard">Windows Server 2019 Standard Evaluation 17763</example>
-    <example os.build="17763" os.edition="Datacenter">Windows Server 2019 Datacenter 17763</example>
-    <example os.build="17763" os.edition="Essentials">Windows Server 2019 Essentials 17763</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.product" value="Windows Server 2019"/>
-    <param pos="1" name="os.edition"/>
-    <param pos="2" name="os.build"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2019:-"/>
-  </fingerprint>
-
-  <fingerprint pattern="^Windows Server 2016(?: Technical Preview \d+)? (\w+|\w+ \w+|\w+ \w+ \w+)(?: Evaluation)? (\d+)$">
-    <description>Windows Server 2016 with a build, without service pack</description>
-    <example os.edition="Datacenter" os.build="14393">Windows Server 2016 Datacenter 14393</example>
-    <example os.edition="Standard" os.build="14393">Windows Server 2016 Standard Evaluation 14393</example>
-    <example os.edition="Essentials" os.build="10586">Windows Server 2016 Technical Preview 4 Essentials 10586</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.product" value="Windows Server 2016"/>
-    <param pos="1" name="os.edition"/>
-    <param pos="2" name="os.build"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2016:-"/>
-  </fingerprint>
-
-  <fingerprint pattern="^Windows Storage Server 2016 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
-    <description>Windows Server 2016 Storage</description>
-    <example os.build="14393">Windows Storage Server 2016 Standard 14393</example>
-    <param pos="0" name="os.certainty" value="1.0"/>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.product" value="Windows Server 2016"/>
-    <param pos="0" name="os.edition" value="Storage"/>
-    <param pos="1" name="os.build"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2016:-"/>
-  </fingerprint>
-
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 R2 Web</description>
     <example os.version="Service Pack 1">Windows Web Server 2008 R2 7601 Service Pack 1</example>
@@ -334,6 +296,81 @@
     <param pos="1" name="os.build"/>
     <param pos="2" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:{os.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Hyper-V Server 7601 Service Pack 1$">
+    <description>Windows Server 2008 R2 Hyper-V</description>
+    <example os.build="17763">Hyper-V Server 7601 Service Pack 1</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
+    <param pos="0" name="os.edition" value="Hyper-V"/>
+    <param pos="0" name="os.build" value="7601"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2008:-"/>
+  </fingerprint>
+
+  <!-- Windows 2019 -->
+
+  <fingerprint pattern="^Windows Server 2019 (\w+|\w+ \w+|\w+ \w+ \w+)(?: Evaluation)? (\d+)$">
+    <description>Windows Server 2019 with a build, without service pack</description>
+    <example os.build="17763" os.edition="Standard">Windows Server 2019 Standard 17763</example>
+    <example os.build="17763" os.edition="Standard">Windows Server 2019 Standard Evaluation 17763</example>
+    <example os.build="17763" os.edition="Datacenter">Windows Server 2019 Datacenter 17763</example>
+    <example os.build="17763" os.edition="Essentials">Windows Server 2019 Essentials 17763</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2019"/>
+    <param pos="1" name="os.edition"/>
+    <param pos="2" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2019:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Hyper-V Server 2019  (\d+)$">
+    <description>Windows Server 2019 Hyper-V</description>
+    <example os.build="17763">Hyper-V Server 2019  17763</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2019"/>
+    <param pos="0" name="os.edition" value="Hyper-V"/>
+    <param pos="1" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2019:-"/>
+  </fingerprint>
+
+  <!-- Windows 2016 -->
+
+  <fingerprint pattern="^Windows Server 2016(?: Technical Preview \d+)? (\w+|\w+ \w+|\w+ \w+ \w+)(?: Evaluation)? (\d+)$">
+    <description>Windows Server 2016 with a build, without service pack</description>
+    <example os.edition="Datacenter" os.build="14393">Windows Server 2016 Datacenter 14393</example>
+    <example os.edition="Standard" os.build="14393">Windows Server 2016 Standard Evaluation 14393</example>
+    <example os.edition="Essentials" os.build="10586">Windows Server 2016 Technical Preview 4 Essentials 10586</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2016"/>
+    <param pos="1" name="os.edition"/>
+    <param pos="2" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2016:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Windows Storage Server 2016 (?:\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+    <description>Windows Server 2016 Storage</description>
+    <example os.build="14393">Windows Storage Server 2016 Standard 14393</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2016"/>
+    <param pos="0" name="os.edition" value="Storage"/>
+    <param pos="1" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2016:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Hyper-V Server 2016 (\d+)$">
+    <description>Windows Server 2016 Hyper-V</description>
+    <example os.build="14393">Hyper-V Server 2016 14393</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2016"/>
+    <param pos="0" name="os.edition" value="Hyper-V"/>
+    <param pos="1" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2016:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
@@ -441,6 +478,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^Hyper-V Server 2012 R2 (\d+)$">
+    <description>Windows Server 2012 R2 Hyper-V</description>
+    <example os.build="9600">Hyper-V Server 2012 R2 9600</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2012 R2"/>
+    <param pos="0" name="os.edition" value="Hyper-V"/>
+    <param pos="1" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
+  </fingerprint>
+
   <!-- Windows 2012 -->
 
   <fingerprint pattern="^Windows Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
@@ -463,6 +511,29 @@
     <param pos="0" name="os.product" value="Windows Server 2012"/>
     <param pos="1" name="os.edition"/>
     <param pos="2" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Windows Storage Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
+    <description>Windows Server 2012 Storage</description>
+    <example os.build="9200" os.edition="Standard">Windows Storage Server 2012 Standard 9200</example>
+    <example os.build="9200" os.edition="Workgroup">Windows Storage Server 2012 Workgroup 9200</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2012"/>
+    <param pos="1" name="os.edition"/>
+    <param pos="2" name="os.build"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Hyper-V Server 2012 (\d+)$">
+    <description>Windows Server 2012 Hyper-V</description>
+    <example os.build="9200">Hyper-V Server 2012 9200</example>
+    <param pos="0" name="os.certainty" value="1.0"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.product" value="Windows Server 2012"/>
+    <param pos="0" name="os.edition" value="Hyper-V"/>
+    <param pos="1" name="os.build"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2012:-"/>
   </fingerprint>
 

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -618,11 +618,11 @@
     <description>IBM i5/OS</description>
     <example os.version="6" os.version.version="1" os.version.version.version="1">I5OS V6R1M1</example>
     <param pos="0" name="os.vendor" value="IBM"/>
-    <param pos="0" name="os.product" value="OS/400"/>
+    <param pos="0" name="os.product" value="i5/OS"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.version.version"/>
     <param pos="3" name="os.version.version.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:os_400:{os.version}"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:i5os:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Apple Base Station$">


### PR DESCRIPTION
## Description
The PR adds fingerprints to `smb_native_os` and `smb_native_lm` based on data from Project Sonar scans.

Highlights:
- Add Hyper-V coverage for Windows 2019, 2016, 2012 R2, 2012, and 2008 R2
- Improved Windows Storage Server coverage
- Assert nothing for `Windows 6.1` as this has typically only been seen with Samba
- Multiple fingerprints for IBM midrange devices
- Misc other changes



## Motivation and Context
Improved coverage


## How Has This Been Tested?
`rspec`


## Types of changes
Fingerprint improvements


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
