### PR TITLE
Add Github Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
-      run: bundle exec rspec
+      run: |
+        bundle exec rake --version
+        bundle exec rake tests
       env:
         JRUBY_OPTS: --server -J-Xms512m -J-Xmx2G

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: 'Ruby: ${{ matrix.ruby-version }}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', 'jruby-9.1.17.0', 'jruby']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rspec
+      env:
+        JRUBY_OPTS: --server -J-Xms512m -J-Xmx2G

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -300,7 +300,7 @@
 
   <fingerprint pattern="^Hyper-V Server 7601 Service Pack 1$">
     <description>Windows Server 2008 R2 Hyper-V</description>
-    <example os.build="17763">Hyper-V Server 7601 Service Pack 1</example>
+    <example>Hyper-V Server 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>


### PR DESCRIPTION
## Description
This PR adds a Github Actions CI workflow configuration to run tests automatically. I have configured the same Ruby versions used in the existing travis-ci config and added newer ones as well. Note: the jruby version used on travis-ci is not available for this GHA workflow, so a newer version was selected along with latest released jruby.

Additionally an invalid example was fixed to get tests to pass.

Note that the new workflow will begin running immediately when this PR is merged.

## Motivation and Context
travis-ci has migrated open source repos from their .org platform to their .com platform, which now includes a limited number of worker credits. Currently, the R7 org has exhausted available worker credits and the UI doesn't indicate when they will be replenished. As such, tests on this repo are not currently being run for pull requests! This PR allows Github Actions to run the same tests in the interim or even long-term.

## How Has This Been Tested?
Using my fork I tested that the workflow behaves as expected. You can see results here:

Top-level Actions results: https://github.com/gschneider-r7/recog/actions
The passing workflow: https://github.com/gschneider-r7/recog/actions/runs/483919285
Example pull request: https://github.com/gschneider-r7/recog/pull/1

Note that for the PR example, it ran tests twice for push (commit) and pull request because I did not limit branches for testing. For fork-based PRs, only the pull request triggered events will appear (so half of the checks you see in that PR).


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
