### PR TITLE
Added Sage X3 Syracuse fingerprints

### DIFF
--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -302,6 +302,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:parallels:parallels_plesk_panel:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^Sage X3$">
+    <description>Sage X3 Syracuse Web Server</description>
+    <example>Sage X3</example>
+    <param pos="0" name="service.vendor" value="Sage"/>
+    <param pos="0" name="service.family" value="Sage X3 Syracuse Web Server"/>
+    <param pos="0" name="service.product" value="Sage X3 Syracuse Web Server"/>
+  </fingerprint>
+
   <fingerprint pattern="^Web Viewer for Samsung DVR$">
     <description>Samsung DVRs</description>
     <example>Web Viewer for Samsung DVR</example>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -407,7 +407,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:redmine:redmine:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^syracuse.sid.\d+=.*">
+  <fingerprint pattern="^(syracuse.sid.\d+)=.*">
     <description>Sage X3 Syracuse Web Server</description>
     <example>syracuse.sid.8124=8b102bf7-327c-4962-9279-550e72afcaa9; path=/; HttpOnly</example>
     <param pos="1" name="cookie"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -407,7 +407,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:redmine:redmine:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(syracuse.sid.\d+)=">
+  <fingerprint pattern="^(syracuse\.sid\.\d+)=">
     <description>Sage X3 Syracuse Web Server</description>
     <example>syracuse.sid.8124=8b102bf7-327c-4962-9279-550e72afcaa9; path=/; HttpOnly</example>
     <param pos="1" name="cookie"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -407,7 +407,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:redmine:redmine:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(syracuse.sid.\d+)=.*">
+  <fingerprint pattern="^(syracuse.sid.\d+)=">
     <description>Sage X3 Syracuse Web Server</description>
     <example>syracuse.sid.8124=8b102bf7-327c-4962-9279-550e72afcaa9; path=/; HttpOnly</example>
     <param pos="1" name="cookie"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -407,6 +407,15 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:redmine:redmine:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^syracuse.sid.\d+=.*">
+    <description>Sage X3 Syracuse Web Server</description>
+    <example>syracuse.sid.8124=8b102bf7-327c-4962-9279-550e72afcaa9; path=/; HttpOnly</example>
+    <param pos="1" name="cookie"/>
+    <param pos="0" name="service.vendor" value="Sage"/>
+    <param pos="0" name="service.family" value="Sage X3 Syracuse Web Server"/>
+    <param pos="0" name="service.product" value="Sage X3 Syracuse Web Server"/>
+  </fingerprint>
+
   <fingerprint pattern="^(gx_session_id|JROUTE)=.*">
     <description>Sun Java System Application Server (formerly iPlanet Application Server, Sun ONE Application Server)</description>
     <param pos="1" name="cookie"/>


### PR DESCRIPTION
## Description
The Sage X3 web application server (Syracuse) can be identified by a cookie in the format of "syracuse.sid.<digits>", making it a pretty simple signature.


## Motivation and Context
The Sage X3 web interface uses a predictable cookie to identify it. This is a heavily deployed ERP product. Some product info:
* https://www.sage.com/en-us/
* https://en.wikipedia.org/wiki/Sage_X3


## How Has This Been Tested?
Match test:

```
~/src/recog $ printf 'syracuse.sid.8124=8b102bf7-327c-4962-9279-550e72afcaa9; path=/; HttpOnly\n' | ./bin/recog_match xml/http_cookies.xml -
MATCH: {"matched"=>"Sage X3 Syracuse Web Server", "cookie"=>nil, "service.vendor"=>"Sage", "service.family"=>"Sage X3 Syracuse Web Server", "service.product"=>"Sage X3 Syracuse Web Server", "service.protocol"=>"http", "fingerprint_db"=>"http_header.cookie", "data"=>"syracuse.sid.8124=8b102bf7-327c-4962-9279-550e72afcaa9; path=/; HttpOnly"}
```

Happy to run more tests or spin up my test instance again if requested.


## Types of changes
- New cookie signature for Sage X3


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
