### PR TITLE
Add a vCenter fingerprint based on HTML title

### DIFF
--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1547,6 +1547,14 @@
     <param pos="0" name="service.product" value="Site Recovery Manager"/>
   </fingerprint>
 
+  <fingerprint pattern="^&quot; \+ ID_VC_Welcome \+ &quot;$">
+    <description>VMware vCenter</description>
+    <example>&quot; + ID_VC_Welcome + &quot;</example>
+    <param pos="0" name="service.vendor" value="VMware"/>
+    <param pos="0" name="service.product" value="vCenter"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:vmware:vcenter_server:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^Graylog Web Interface$">
     <description>Graylog Web Interface</description>
     <example>Graylog Web Interface</example>


### PR DESCRIPTION
## Description
Adds a fingerprint for VMware vCenter. 

This is sort of experimental. The VMware vCenter page content looks like this:

```
<script type="text/javascript">document.write("<title>" + ID_VC_Welcome + "</title>");</script>
```

At least Shodan and Censys both grab the page title as `" + ID_VC_Welcome + "`.  However, it's obviously meant to be interpreted, as it's javascript (likely because of internationalization -- if you view what the page title ends up being after this is interpreted, it is "Welcome to VMware vSphere").

If we're OK with HTML title tag matching to be defined as simply "whatever is in the static text representation of two enclosing title tags" I think this fingerprint is valid. If we think it that title tag retrieval is defined by some other means (interpreted, etc.) then we should reject this change.

Thoughts?


## Motivation and Context
A 9.8 unauth remote file write that leads to RCE was announced.


## How Has This Been Tested?
Simply using `bin/recog_verify xml/html_title.xml`


## Types of changes
- New feature: Add fingerprint for generic VMware vCenter detection (versionless)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
