### PR TITLE
Move patch strings in version to update field

### DIFF
--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -118,15 +118,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.4p1) (FreeBSD 20020702)$">
+  <fingerprint pattern="^OpenSSH_(3\.4)(p1) (FreeBSD 20020702)$">
     <description>OpenSSH running on FreeBSD 4.6.2</description>
-    <example service.version="3.4p1" openssh.comment="FreeBSD 20020702">OpenSSH_3.4p1 FreeBSD 20020702</example>
+    <example service.version="3.4" service.update="p1" openssh.comment="FreeBSD 20020702">OpenSSH_3.4p1 FreeBSD 20020702</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -150,15 +151,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.6"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.4p1) (FreeBSD-20020702)$">
+  <fingerprint pattern="^OpenSSH_(3\.4)(p1) (FreeBSD-20020702)$">
     <description>OpenSSH running on FreeBSD 4.7</description>
-    <example service.version="3.4p1" openssh.comment="FreeBSD-20020702">OpenSSH_3.4p1 FreeBSD-20020702</example>
+    <example service.version="3.4" service.update="p1" openssh.comment="FreeBSD-20020702">OpenSSH_3.4p1 FreeBSD-20020702</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -166,15 +168,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.7"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20030201)$">
+  <fingerprint pattern="^OpenSSH_(3\.5)(p1) (FreeBSD-20030201)$">
     <description>OpenSSH running on FreeBSD 4.8</description>
-    <example service.version="3.5p1" openssh.comment="FreeBSD-20030201">OpenSSH_3.5p1 FreeBSD-20030201</example>
+    <example service.version="3.5" service.update="p1" openssh.comment="FreeBSD-20030201">OpenSSH_3.5p1 FreeBSD-20030201</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -184,15 +187,16 @@
 
   <!-- Multiple minor version match, assert the oldest version -->
 
-  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20030924)$">
+  <fingerprint pattern="^OpenSSH_(3\.5)(p1) (FreeBSD-20030924)$">
     <description>OpenSSH running on FreeBSD 4.9/4.10 (sometimes 4.11)</description>
-    <example service.version="3.5p1" openssh.comment="FreeBSD-20030924">OpenSSH_3.5p1 FreeBSD-20030924</example>
+    <example service.version="3.5" service.update="p1" openssh.comment="FreeBSD-20030924">OpenSSH_3.5p1 FreeBSD-20030924</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -200,15 +204,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.9"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20060930)$">
+  <fingerprint pattern="^OpenSSH_(3\.5)(p1) (FreeBSD-20060930)$">
     <description>OpenSSH running on FreeBSD 4.11</description>
-    <example service.version="3.5p1" openssh.comment="FreeBSD-20060930">OpenSSH_3.5p1 FreeBSD-20060930</example>
+    <example service.version="3.5" service.update="p1" openssh.comment="FreeBSD-20060930">OpenSSH_3.5p1 FreeBSD-20060930</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -216,15 +221,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:4.11"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.5p1) (FreeBSD-20021029)$">
+  <fingerprint pattern="^OpenSSH_(3\.5)(p1) (FreeBSD-20021029)$">
     <description>OpenSSH running on FreeBSD 5.0</description>
-    <example service.version="3.5p1" openssh.comment="FreeBSD-20021029">OpenSSH_3.5p1 FreeBSD-20021029</example>
+    <example service.version="3.5" service.update="p1" openssh.comment="FreeBSD-20021029">OpenSSH_3.5p1 FreeBSD-20021029</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -232,15 +238,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.6\.1p1) (FreeBSD-20030423)$">
+  <fingerprint pattern="^OpenSSH_(3\.6\.1)(p1) (FreeBSD-20030423)$">
     <description>OpenSSH running on FreeBSD 5.1</description>
-    <example service.version="3.6.1p1" openssh.comment="FreeBSD-20030423">OpenSSH_3.6.1p1 FreeBSD-20030423</example>
+    <example service.version="3.6.1" service.update="p1" openssh.comment="FreeBSD-20030423">OpenSSH_3.6.1p1 FreeBSD-20030423</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -248,15 +255,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.6\.1p1) (FreeBSD-20030924)$">
+  <fingerprint pattern="^OpenSSH_(3\.6\.1)(p1) (FreeBSD-20030924)$">
     <description>OpenSSH running on FreeBSD 5.2</description>
-    <example service.version="3.6.1p1" openssh.comment="FreeBSD-20030924">OpenSSH_3.6.1p1 FreeBSD-20030924</example>
+    <example service.version="3.6.1" service.update="p1" openssh.comment="FreeBSD-20030924">OpenSSH_3.6.1p1 FreeBSD-20030924</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -266,15 +274,16 @@
 
   <!-- Multiple minor version match, assert the oldest version -->
 
-  <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (FreeBSD-20040419)$">
+  <fingerprint pattern="^OpenSSH_(3\.8\.1)(p1) (FreeBSD-20040419)$">
     <description>OpenSSH running on FreeBSD 5.3/5.4</description>
-    <example service.version="3.8.1p1" openssh.comment="FreeBSD-20040419">OpenSSH_3.8.1p1 FreeBSD-20040419</example>
+    <example service.version="3.8.1" service.update="p1" openssh.comment="FreeBSD-20040419">OpenSSH_3.8.1p1 FreeBSD-20040419</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -282,15 +291,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:5.3"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (FreeBSD-20060123)$">
+  <fingerprint pattern="^OpenSSH_(3\.8\.1)(p1) (FreeBSD-20060123)$">
     <description>OpenSSH running on FreeBSD 5.5</description>
-    <example service.version="3.8.1p1" openssh.comment="FreeBSD-20060123">OpenSSH_3.8.1p1 FreeBSD-20060123</example>
+    <example service.version="3.8.1" service.update="p1" openssh.comment="FreeBSD-20060123">OpenSSH_3.8.1p1 FreeBSD-20060123</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -300,15 +310,16 @@
 
   <!-- Multiple minor version match, assert the oldest version -->
 
-  <fingerprint pattern="^OpenSSH_(4\.2p1) (FreeBSD-20050903)$">
+  <fingerprint pattern="^OpenSSH_(4\.2)(p1) (FreeBSD-20050903)$">
     <description>OpenSSH running on FreeBSD 6.0/6.1</description>
-    <example service.version="4.2p1" openssh.comment="FreeBSD-20050903">OpenSSH_4.2p1 FreeBSD-20050903</example>
+    <example service.version="4.2" service.update="p1" openssh.comment="FreeBSD-20050903">OpenSSH_4.2p1 FreeBSD-20050903</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -318,15 +329,16 @@
 
   <!-- Spans major versions, do not assert a version number -->
 
-  <fingerprint pattern="^OpenSSH_(4\.5p1) (FreeBSD-20061110)$">
+  <fingerprint pattern="^OpenSSH_(4\.5)(p1) (FreeBSD-20061110)$">
     <description>OpenSSH running on FreeBSD 6.2/6.3/6.4/7.0</description>
-    <example service.version="4.5p1" openssh.comment="FreeBSD-20061110">OpenSSH_4.5p1 FreeBSD-20061110</example>
+    <example service.version="4.5" service.update="p1" openssh.comment="FreeBSD-20061110">OpenSSH_4.5p1 FreeBSD-20061110</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -335,15 +347,16 @@
 
   <!-- Multiple minor version match, assert the oldest version -->
 
-  <fingerprint pattern="^OpenSSH_(5\.1p1) (FreeBSD-20080901)$">
+  <fingerprint pattern="^OpenSSH_(5\.1)(p1) (FreeBSD-20080901)$">
     <description>OpenSSH running on FreeBSD 7.1/7.2/7.3/7.4</description>
-    <example service.version="5.1p1" openssh.comment="FreeBSD-20080901">OpenSSH_5.1p1 FreeBSD-20080901</example>
+    <example service.version="5.1" service.update="p1" openssh.comment="FreeBSD-20080901">OpenSSH_5.1p1 FreeBSD-20080901</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -351,15 +364,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:7.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.2p1) (FreeBSD-20090522)$">
+  <fingerprint pattern="^OpenSSH_(5\.2)(p1) (FreeBSD-20090522)$">
     <description>OpenSSH running on FreeBSD 8.0</description>
-    <example service.version="5.2p1" openssh.comment="FreeBSD-20090522">OpenSSH_5.2p1 FreeBSD-20090522</example>
+    <example service.version="5.2" service.update="p1" openssh.comment="FreeBSD-20090522">OpenSSH_5.2p1 FreeBSD-20090522</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -369,15 +383,16 @@
 
   <!-- Multiple minor version match, assert the oldest version -->
 
-  <fingerprint pattern="^OpenSSH_(5\.4p1) (FreeBSD-20100308)$">
+  <fingerprint pattern="^OpenSSH_(5\.4)(p1) (FreeBSD-20100308)$">
     <description>OpenSSH running on FreeBSD 8.1/8.2</description>
-    <example service.version="5.4p1" openssh.comment="FreeBSD-20100308">OpenSSH_5.4p1 FreeBSD-20100308</example>
+    <example service.version="5.4" service.update="p1" openssh.comment="FreeBSD-20100308">OpenSSH_5.4p1 FreeBSD-20100308</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="FreeBSD"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
@@ -602,15 +617,16 @@
 
   <!-- Ubuntu -->
 
-  <fingerprint pattern="^OpenSSH_(3\.8\.1p1) (Debian-11ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(3\.8\.1)(p1) (Debian-11ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 4.10</description>
-    <example service.version="3.8.1p1" openssh.comment="Debian-11ubuntu3">OpenSSH_3.8.1p1 Debian-11ubuntu3</example>
+    <example service.version="3.8.1" service.update="p1" openssh.comment="Debian-11ubuntu3">OpenSSH_3.8.1p1 Debian-11ubuntu3</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -618,15 +634,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:4.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(3\.9p1) (Debian-1ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(3\.9)(p1) (Debian-1ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 5.04</description>
-    <example service.version="3.9p1" openssh.comment="Debian-1ubuntu2">OpenSSH_3.9p1 Debian-1ubuntu2</example>
+    <example service.version="3.9" service.update="p1" openssh.comment="Debian-1ubuntu2">OpenSSH_3.9p1 Debian-1ubuntu2</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -634,15 +651,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:5.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(4\.1p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(4\.1)(p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 5.10</description>
-    <example service.version="4.1p1" openssh.comment="Debian-7ubuntu4">OpenSSH_4.1p1 Debian-7ubuntu4</example>
+    <example service.version="4.1" service.update="p1" openssh.comment="Debian-7ubuntu4">OpenSSH_4.1p1 Debian-7ubuntu4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -650,16 +668,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:5.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(4\.2p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(4\.2)(p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 6.04</description>
-    <example service.version="4.2p1" openssh.comment="Debian-7ubuntu3.1">OpenSSH_4.2p1 Debian-7ubuntu3.1</example>
+    <example service.version="4.2" service.update="p1" openssh.comment="Debian-7ubuntu3.1">OpenSSH_4.2p1 Debian-7ubuntu3.1</example>
     <example>OpenSSH_4.2p1 Debian-7ubuntu3.2</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -667,15 +686,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:6.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(4\.3p2) (Debian-8ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(4\.3)(p2) (Debian-8ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 7.04</description>
-    <example service.version="4.3p2" openssh.comment="Debian-8ubuntu1.4">OpenSSH_4.3p2 Debian-8ubuntu1.4</example>
+    <example service.version="4.3" service.update="p2" openssh.comment="Debian-8ubuntu1.4">OpenSSH_4.3p2 Debian-8ubuntu1.4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -683,18 +703,19 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:7.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(4\.6p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(4\.6)(p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 7.10</description>
-    <example service.version="4.6p1" openssh.comment="Debian-5ubuntu0.2">OpenSSH_4.6p1 Debian-5ubuntu0.2</example>
+    <example service.version="4.6" service.update="p1" openssh.comment="Debian-5ubuntu0.2">OpenSSH_4.6p1 Debian-5ubuntu0.2</example>
     <example>OpenSSH_4.6p1 Debian-5ubuntu0.5</example>
     <example>OpenSSH_4.6p1 Debian-5ubuntu0.6</example>
     <example>OpenSSH_4.6p1 Debian-5ubuntu0</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -702,16 +723,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:7.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(4\.7p1) (Debian-8ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(4\.7)(p1) (Debian-8ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 8.04</description>
-    <example service.version="4.7p1" openssh.comment="Debian-8ubuntu1.2">OpenSSH_4.7p1 Debian-8ubuntu1.2</example>
-    <example service.version="4.7p1" openssh.comment="Debian-8ubuntu3">OpenSSH_4.7p1 Debian-8ubuntu3</example>
+    <example service.version="4.7" service.update="p1" openssh.comment="Debian-8ubuntu1.2">OpenSSH_4.7p1 Debian-8ubuntu1.2</example>
+    <example service.version="4.7" service.update="p1" openssh.comment="Debian-8ubuntu3">OpenSSH_4.7p1 Debian-8ubuntu3</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -719,15 +741,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:8.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.1)(p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 8.10</description>
-    <example service.version="5.1p1" openssh.comment="Debian-3ubuntu1">OpenSSH_5.1p1 Debian-3ubuntu1</example>
+    <example service.version="5.1" service.update="p1" openssh.comment="Debian-3ubuntu1">OpenSSH_5.1p1 Debian-3ubuntu1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -735,15 +758,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:8.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.1)(p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 9.04</description>
-    <example service.version="5.1p1" openssh.comment="Debian-5ubuntu1">OpenSSH_5.1p1 Debian-5ubuntu1</example>
+    <example service.version="5.1" service.update="p1" openssh.comment="Debian-5ubuntu1">OpenSSH_5.1p1 Debian-5ubuntu1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -751,15 +775,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:9.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-6ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.1)(p1) (Debian-6ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 9.10</description>
-    <example service.version="5.1p1" openssh.comment="Debian-6ubuntu2">OpenSSH_5.1p1 Debian-6ubuntu2</example>
+    <example service.version="5.1" service.update="p1" openssh.comment="Debian-6ubuntu2">OpenSSH_5.1p1 Debian-6ubuntu2</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -767,20 +792,21 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:9.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.3p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.3)(p1) (Debian-3ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 10.04 (lucid)</description>
-    <example service.version="5.3p1" openssh.comment="Debian-3ubuntu3">OpenSSH_5.3p1 Debian-3ubuntu3</example>
-    <example service.version="5.3p1" openssh.comment="Debian-3ubuntu4">OpenSSH_5.3p1 Debian-3ubuntu4</example>
-    <example service.version="5.3p1" openssh.comment="Debian-3ubuntu5">OpenSSH_5.3p1 Debian-3ubuntu5</example>
-    <example service.version="5.3p1" openssh.comment="Debian-3ubuntu6">OpenSSH_5.3p1 Debian-3ubuntu6</example>
-    <example service.version="5.3p1" openssh.comment="Debian-3ubuntu7">OpenSSH_5.3p1 Debian-3ubuntu7</example>
-    <example service.version="5.3p1" openssh.comment="Debian-3ubuntu7.1">OpenSSH_5.3p1 Debian-3ubuntu7.1</example>
+    <example service.version="5.3" service.update="p1" openssh.comment="Debian-3ubuntu3">OpenSSH_5.3p1 Debian-3ubuntu3</example>
+    <example service.version="5.3" service.update="p1" openssh.comment="Debian-3ubuntu4">OpenSSH_5.3p1 Debian-3ubuntu4</example>
+    <example service.version="5.3" service.update="p1" openssh.comment="Debian-3ubuntu5">OpenSSH_5.3p1 Debian-3ubuntu5</example>
+    <example service.version="5.3" service.update="p1" openssh.comment="Debian-3ubuntu6">OpenSSH_5.3p1 Debian-3ubuntu6</example>
+    <example service.version="5.3" service.update="p1" openssh.comment="Debian-3ubuntu7">OpenSSH_5.3p1 Debian-3ubuntu7</example>
+    <example service.version="5.3" service.update="p1" openssh.comment="Debian-3ubuntu7.1">OpenSSH_5.3p1 Debian-3ubuntu7.1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -788,17 +814,18 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:10.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.5p1) (Debian-4ubuntu\d+(?:\.\d+)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.5)(p1) (Debian-4ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 10.10</description>
-    <example service.version="5.5p1" openssh.comment="Debian-4ubuntu4">OpenSSH_5.5p1 Debian-4ubuntu4</example>
-    <example service.version="5.5p1" openssh.comment="Debian-4ubuntu5">OpenSSH_5.5p1 Debian-4ubuntu5</example>
-    <example service.version="5.5p1" openssh.comment="Debian-4ubuntu6">OpenSSH_5.5p1 Debian-4ubuntu6</example>
+    <example service.version="5.5" service.update="p1" openssh.comment="Debian-4ubuntu4">OpenSSH_5.5p1 Debian-4ubuntu4</example>
+    <example service.version="5.5" service.update="p1" openssh.comment="Debian-4ubuntu5">OpenSSH_5.5p1 Debian-4ubuntu5</example>
+    <example service.version="5.5" service.update="p1" openssh.comment="Debian-4ubuntu6">OpenSSH_5.5p1 Debian-4ubuntu6</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -806,15 +833,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:10.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-1ubuntu\d(?:\.\d)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.8)(p1) (Debian-1ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 11.04</description>
-    <example service.version="5.8p1" openssh.comment="Debian-1ubuntu3">OpenSSH_5.8p1 Debian-1ubuntu3</example>
+    <example service.version="5.8" service.update="p1" openssh.comment="Debian-1ubuntu3">OpenSSH_5.8p1 Debian-1ubuntu3</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -822,15 +850,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:11.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.8p1) (Debian-7ubuntu\d(?:\.\d)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.8)(p1) (Debian-7ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 11.10</description>
-    <example service.version="5.8p1" openssh.comment="Debian-7ubuntu1">OpenSSH_5.8p1 Debian-7ubuntu1</example>
+    <example service.version="5.8" service.update="p1" openssh.comment="Debian-7ubuntu1">OpenSSH_5.8p1 Debian-7ubuntu1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -838,16 +867,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:11.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.9p1) (Debian-5ubuntu\d(?:\.\d)?)$">
+  <fingerprint pattern="^OpenSSH_(5\.9)(p1) (Debian-5ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 12.04</description>
-    <example service.version="5.9p1" openssh.comment="Debian-5ubuntu1">OpenSSH_5.9p1 Debian-5ubuntu1</example>
-    <example service.version="5.9p1" openssh.comment="Debian-5ubuntu1.4">OpenSSH_5.9p1 Debian-5ubuntu1.4</example>
+    <example service.version="5.9" service.update="p1" openssh.comment="Debian-5ubuntu1">OpenSSH_5.9p1 Debian-5ubuntu1</example>
+    <example service.version="5.9" service.update="p1" openssh.comment="Debian-5ubuntu1.4">OpenSSH_5.9p1 Debian-5ubuntu1.4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -855,16 +885,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:12.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(6\.0p1) (Debian-3ubuntu\d(?:\.\d)?)$">
+  <fingerprint pattern="^OpenSSH_(6\.0)(p1) (Debian-3ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 12.10</description>
-    <example service.version="6.0p1" openssh.comment="Debian-3ubuntu1">OpenSSH_6.0p1 Debian-3ubuntu1</example>
+    <example service.version="6.0" service.update="p1" openssh.comment="Debian-3ubuntu1">OpenSSH_6.0p1 Debian-3ubuntu1</example>
     <example>OpenSSH_6.0p1 Debian-3ubuntu1.2</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -872,15 +903,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:12.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(6\.1p1) (Debian-4)$">
+  <fingerprint pattern="^OpenSSH_(6\.1)(p1) (Debian-4)$">
     <description>OpenSSH running on Ubuntu 13.04</description>
-    <example service.version="6.1p1" openssh.comment="Debian-4">OpenSSH_6.1p1 Debian-4</example>
+    <example service.version="6.1" service.update="p1" openssh.comment="Debian-4">OpenSSH_6.1p1 Debian-4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -888,16 +920,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:13.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(6\.2p2) (Ubuntu-6\S*)$">
+  <fingerprint pattern="^OpenSSH_(6\.2)(p2) (Ubuntu-6\S*)$">
     <description>OpenSSH running on Ubuntu 13.10</description>
-    <example service.version="6.2p2" openssh.comment="Ubuntu-6unbuntu0.4">OpenSSH_6.2p2 Ubuntu-6unbuntu0.4</example>
-    <example service.version="6.2p2" openssh.comment="Ubuntu-6">OpenSSH_6.2p2 Ubuntu-6</example>
+    <example service.version="6.2" service.update="p2" openssh.comment="Ubuntu-6unbuntu0.4">OpenSSH_6.2p2 Ubuntu-6unbuntu0.4</example>
+    <example service.version="6.2" service.update="p2" openssh.comment="Ubuntu-6">OpenSSH_6.2p2 Ubuntu-6</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -936,15 +969,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(6\.6\.1p1) (Ubuntu-8)$">
+  <fingerprint pattern="^OpenSSH_(6\.6\.1)(p1) (Ubuntu-8)$">
     <description>OpenSSH running on Ubuntu 14.10</description>
-    <example service.version="6.6.1p1" openssh.comment="Ubuntu-8">OpenSSH_6.6.1p1 Ubuntu-8</example>
+    <example service.version="6.6.1" service.update="p1" openssh.comment="Ubuntu-8">OpenSSH_6.6.1p1 Ubuntu-8</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -952,16 +986,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:14.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(6\.7p1) (Ubuntu-5\S*)$">
+  <fingerprint pattern="^OpenSSH_(6\.7)(p1) (Ubuntu-5\S*)$">
     <description>OpenSSH running on Ubuntu 15.04 (vivid)</description>
-    <example service.version="6.7p1" openssh.comment="Ubuntu-5ubuntu1">OpenSSH_6.7p1 Ubuntu-5ubuntu1</example>
-    <example service.version="6.7p1" openssh.comment="Ubuntu-5ubuntu1.4">OpenSSH_6.7p1 Ubuntu-5ubuntu1.4</example>
+    <example service.version="6.7" service.update="p1" openssh.comment="Ubuntu-5ubuntu1">OpenSSH_6.7p1 Ubuntu-5ubuntu1</example>
+    <example service.version="6.7" service.update="p1" openssh.comment="Ubuntu-5ubuntu1.4">OpenSSH_6.7p1 Ubuntu-5ubuntu1.4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -969,16 +1004,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:15.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(6\.9p1) (Ubuntu-2\S*)$">
+  <fingerprint pattern="^OpenSSH_(6\.9)(p1) (Ubuntu-2\S*)$">
     <description>OpenSSH running on Ubuntu 15.10</description>
-    <example service.version="6.9p1" openssh.comment="Ubuntu-2">OpenSSH_6.9p1 Ubuntu-2</example>
-    <example service.version="6.9p1" openssh.comment="Ubuntu-2ubuntu0.2">OpenSSH_6.9p1 Ubuntu-2ubuntu0.2</example>
+    <example service.version="6.9" service.update="p1" openssh.comment="Ubuntu-2">OpenSSH_6.9p1 Ubuntu-2</example>
+    <example service.version="6.9" service.update="p1" openssh.comment="Ubuntu-2ubuntu0.2">OpenSSH_6.9p1 Ubuntu-2ubuntu0.2</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -986,17 +1022,18 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:15.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.2p2) (Ubuntu-4\S*)$">
+  <fingerprint pattern="^OpenSSH_(7\.2)(p2) (Ubuntu-4\S*)$">
     <description>OpenSSH running on Ubuntu 16.04 (vivid)</description>
-    <example service.version="7.2p2" openssh.comment="Ubuntu-4ubuntu2.7">OpenSSH_7.2p2 Ubuntu-4ubuntu2.7</example>
-    <example service.version="7.2p2" openssh.comment="Ubuntu-4ubuntu1">OpenSSH_7.2p2 Ubuntu-4ubuntu1</example>
-    <example service.version="7.2p2" openssh.comment="Ubuntu-4">OpenSSH_7.2p2 Ubuntu-4</example>
+    <example service.version="7.2" service.update="p2" openssh.comment="Ubuntu-4ubuntu2.7">OpenSSH_7.2p2 Ubuntu-4ubuntu2.7</example>
+    <example service.version="7.2" service.update="p2" openssh.comment="Ubuntu-4ubuntu1">OpenSSH_7.2p2 Ubuntu-4ubuntu1</example>
+    <example service.version="7.2" service.update="p2" openssh.comment="Ubuntu-4">OpenSSH_7.2p2 Ubuntu-4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1004,15 +1041,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.3p1) (Ubuntu-1)$">
+  <fingerprint pattern="^OpenSSH_(7\.3)(p1) (Ubuntu-1)$">
     <description>OpenSSH running on Ubuntu 16.10</description>
-    <example service.version="7.3p1" openssh.comment="Ubuntu-1">OpenSSH_7.3p1 Ubuntu-1</example>
+    <example service.version="7.3" service.update="p1" openssh.comment="Ubuntu-1">OpenSSH_7.3p1 Ubuntu-1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1020,15 +1058,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:16.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.4p1) (Ubuntu-10)$">
+  <fingerprint pattern="^OpenSSH_(7\.4)(p1) (Ubuntu-10)$">
     <description>OpenSSH running on Ubuntu 17.04</description>
-    <example service.version="7.4p1" openssh.comment="Ubuntu-10">OpenSSH_7.4p1 Ubuntu-10</example>
+    <example service.version="7.4" service.update="p1" openssh.comment="Ubuntu-10">OpenSSH_7.4p1 Ubuntu-10</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1036,16 +1075,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:17.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.5p1) (Ubuntu-10\S*)$">
+  <fingerprint pattern="^OpenSSH_(7\.5)(p1) (Ubuntu-10\S*)$">
     <description>OpenSSH running on Ubuntu 17.10</description>
-    <example service.version="7.5p1" openssh.comment="Ubuntu-10ubuntu0.1">OpenSSH_7.5p1 Ubuntu-10ubuntu0.1</example>
-    <example service.version="7.5p1" openssh.comment="Ubuntu-10">OpenSSH_7.5p1 Ubuntu-10</example>
+    <example service.version="7.5" service.update="p1" openssh.comment="Ubuntu-10ubuntu0.1">OpenSSH_7.5p1 Ubuntu-10ubuntu0.1</example>
+    <example service.version="7.5" service.update="p1" openssh.comment="Ubuntu-10">OpenSSH_7.5p1 Ubuntu-10</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1053,16 +1093,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:17.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.6p1) (Ubuntu-4\S*)$">
+  <fingerprint pattern="^OpenSSH_(7\.6)(p1) (Ubuntu-4\S*)$">
     <description>OpenSSH running on Ubuntu 18.04</description>
-    <example service.version="7.6p1" openssh.comment="Ubuntu-4ubuntu0.3">OpenSSH_7.6p1 Ubuntu-4ubuntu0.3</example>
-    <example service.version="7.6p1" openssh.comment="Ubuntu-4">OpenSSH_7.6p1 Ubuntu-4</example>
+    <example service.version="7.6" service.update="p1" openssh.comment="Ubuntu-4ubuntu0.3">OpenSSH_7.6p1 Ubuntu-4ubuntu0.3</example>
+    <example service.version="7.6" service.update="p1" openssh.comment="Ubuntu-4">OpenSSH_7.6p1 Ubuntu-4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1070,16 +1111,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:18.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.7p1) (Ubuntu-4\S*)$">
+  <fingerprint pattern="^OpenSSH_(7\.7)(p1) (Ubuntu-4\S*)$">
     <description>OpenSSH running on Ubuntu 18.10</description>
-    <example service.version="7.7p1" openssh.comment="Ubuntu-4">OpenSSH_7.7p1 Ubuntu-4</example>
-    <example service.version="7.7p1" openssh.comment="Ubuntu-4ubuntu0.3">OpenSSH_7.7p1 Ubuntu-4ubuntu0.3</example>
+    <example service.version="7.7" service.update="p1" openssh.comment="Ubuntu-4">OpenSSH_7.7p1 Ubuntu-4</example>
+    <example service.version="7.7" service.update="p1" openssh.comment="Ubuntu-4ubuntu0.3">OpenSSH_7.7p1 Ubuntu-4ubuntu0.3</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1087,15 +1129,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:18.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.9p1) (Ubuntu-10)$">
+  <fingerprint pattern="^OpenSSH_(7\.9)(p1) (Ubuntu-10)$">
     <description>OpenSSH running on Ubuntu 19.04</description>
-    <example service.version="7.9p1" openssh.comment="Ubuntu-10">OpenSSH_7.9p1 Ubuntu-10</example>
+    <example service.version="7.9" service.update="p1" openssh.comment="Ubuntu-10">OpenSSH_7.9p1 Ubuntu-10</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1103,15 +1146,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:19.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(8\.0p1) (Ubuntu-6build1)$">
+  <fingerprint pattern="^OpenSSH_(8\.0)(p1) (Ubuntu-6build1)$">
     <description>OpenSSH running on Ubuntu 19.10</description>
-    <example service.version="8.0p1" openssh.comment="Ubuntu-6build1">OpenSSH_8.0p1 Ubuntu-6build1</example>
+    <example service.version="8.0" service.update="p1" openssh.comment="Ubuntu-6build1">OpenSSH_8.0p1 Ubuntu-6build1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1119,16 +1163,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:19.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(8\.2p1) (Ubuntu-4\S*)$">
+  <fingerprint pattern="^OpenSSH_(8\.2)(p1) (Ubuntu-4\S*)$">
     <description>OpenSSH running on Ubuntu 20.04</description>
-    <example service.version="8.2p1" openssh.comment="Ubuntu-4ubuntu0.1">OpenSSH_8.2p1 Ubuntu-4ubuntu0.1</example>
-    <example service.version="8.2p1" openssh.comment="Ubuntu-4">OpenSSH_8.2p1 Ubuntu-4</example>
+    <example service.version="8.2" service.update="p1" openssh.comment="Ubuntu-4ubuntu0.1">OpenSSH_8.2p1 Ubuntu-4ubuntu0.1</example>
+    <example service.version="8.2" service.update="p1" openssh.comment="Ubuntu-4">OpenSSH_8.2p1 Ubuntu-4</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1136,15 +1181,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:20.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(8\.3p1) (Ubuntu-1\S*)$">
+  <fingerprint pattern="^OpenSSH_(8\.3)(p1) (Ubuntu-1\S*)$">
     <description>OpenSSH running on Ubuntu 20.10</description>
-    <example service.version="8.3p1" openssh.comment="Ubuntu-1">OpenSSH_8.3p1 Ubuntu-1</example>
+    <example service.version="8.3" service.update="p1" openssh.comment="Ubuntu-1">OpenSSH_8.3p1 Ubuntu-1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1217,16 +1263,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:3.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(4\.3p2) (Debian-9.*)$">
+  <fingerprint pattern="^OpenSSH_(4\.3)(p2) (Debian-9.*)$">
     <description>OpenSSH running on Debian 4.0 (etch)</description>
-    <example service.version="4.3p2" openssh.comment="Debian-9">OpenSSH_4.3p2 Debian-9</example>
-    <example service.version="4.3p2" openssh.comment="Debian-9etch3">OpenSSH_4.3p2 Debian-9etch3</example>
+    <example service.version="4.3" service.update="p2" openssh.comment="Debian-9">OpenSSH_4.3p2 Debian-9</example>
+    <example service.version="4.3" service.update="p2" openssh.comment="Debian-9etch3">OpenSSH_4.3p2 Debian-9etch3</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1234,15 +1281,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:4.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.1p1) (Debian-5)$">
+  <fingerprint pattern="^OpenSSH_(5\.1)(p1) (Debian-5)$">
     <description>OpenSSH running on Debian 5.0 (also 5.10)</description>
-    <example service.version="5.1p1" openssh.comment="Debian-5">OpenSSH_5.1p1 Debian-5</example>
+    <example service.version="5.1" service.update="p1" openssh.comment="Debian-5">OpenSSH_5.1p1 Debian-5</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1268,15 +1316,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:6.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(5\.5p1) (Debian-6)$">
+  <fingerprint pattern="^OpenSSH_(5\.5)(p1) (Debian-6)$">
     <description>OpenSSH running on Debian 6.0 (w/o squeeze in banner)</description>
-    <example service.version="5.5p1" openssh.comment="Debian-6">OpenSSH_5.5p1 Debian-6</example>
+    <example service.version="5.5" service.update="p1" openssh.comment="Debian-6">OpenSSH_5.5p1 Debian-6</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1371,15 +1420,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:9.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10)$">
+  <fingerprint pattern="^OpenSSH_(7\.9)(p1) (Debian-10)$">
     <description>OpenSSH running on Debian 10.0 (buster)</description>
-    <example service.version="7.9p1" openssh.comment="Debian-10">OpenSSH_7.9p1 Debian-10</example>
+    <example service.version="7.9" service.update="p1" openssh.comment="Debian-10">OpenSSH_7.9p1 Debian-10</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1387,15 +1437,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10\+deb10u1)$">
+  <fingerprint pattern="^OpenSSH_(7\.9)(p1) (Debian-10\+deb10u1)$">
     <description>OpenSSH running on Debian 10.1 (buster)</description>
-    <example service.version="7.9p1" openssh.comment="Debian-10+deb10u1">OpenSSH_7.9p1 Debian-10+deb10u1</example>
+    <example service.version="7.9" service.update="p1" openssh.comment="Debian-10+deb10u1">OpenSSH_7.9p1 Debian-10+deb10u1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1403,15 +1454,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10\+deb10u2)$">
+  <fingerprint pattern="^OpenSSH_(7\.9)(p1) (Debian-10\+deb10u2)$">
     <description>OpenSSH running on Debian 10.2 (buster)</description>
-    <example service.version="7.9p1" openssh.comment="Debian-10+deb10u2">OpenSSH_7.9p1 Debian-10+deb10u2</example>
+    <example service.version="7.9" service.update="p1" openssh.comment="Debian-10+deb10u2">OpenSSH_7.9p1 Debian-10+deb10u2</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1419,15 +1471,16 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.2"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.9p1) (Debian-10\S+)$">
+  <fingerprint pattern="^OpenSSH_(7\.9)(p1) (Debian-10\S+)$">
     <description>OpenSSH running on Debian 10.x (buster catchall)</description>
-    <example service.version="7.9p1" openssh.comment="Debian-10+deb10u6">OpenSSH_7.9p1 Debian-10+deb10u6</example>
+    <example service.version="7.9" service.update="p1" openssh.comment="Debian-10+deb10u6">OpenSSH_7.9p1 Debian-10+deb10u6</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1435,16 +1488,17 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:10.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(8\.1p1) (Debian-1|Debian-\d\d?\+deb11u\d+)$">
+  <fingerprint pattern="^OpenSSH_(8\.1)(p1) (Debian-1|Debian-\d\d?\+deb11u\d+)$">
     <description>OpenSSH running on Debian 11.x (bullseye)</description>
-    <example service.version="8.1p1" openssh.comment="Debian-1">OpenSSH_8.1p1 Debian-1</example>
-    <example service.version="8.1p1" openssh.comment="Debian-1+deb11u1">OpenSSH_8.1p1 Debian-1+deb11u1</example>
+    <example service.version="8.1" service.update="p1" openssh.comment="Debian-1">OpenSSH_8.1p1 Debian-1</example>
+    <example service.version="8.1" service.update="p1" openssh.comment="Debian-1+deb11u1">OpenSSH_8.1p1 Debian-1+deb11u1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1505,16 +1559,17 @@
     <param pos="0" name="hw.product" value="Raspberry Pi"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(7\.9p1)\s+(Raspbian-(?:10|\d\d?\+deb10u\d+))$">
+  <fingerprint pattern="^OpenSSH_(7\.9)(p1)\s+(Raspbian-(?:10|\d\d?\+deb10u\d+))$">
     <description>OpenSSH running on Raspbian (Debian 10 "Buster" based)</description>
-    <example service.version="7.9p1" openssh.comment="Raspbian-10">OpenSSH_7.9p1 Raspbian-10</example>
-    <example service.version="7.9p1" openssh.comment="Raspbian-10+deb10u1">OpenSSH_7.9p1 Raspbian-10+deb10u1</example>
+    <example service.version="7.9" service.update="p1" openssh.comment="Raspbian-10">OpenSSH_7.9p1 Raspbian-10</example>
+    <example service.version="7.9" service.update="p1" openssh.comment="Raspbian-10+deb10u1">OpenSSH_7.9p1 Raspbian-10+deb10u1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Raspbian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -1522,16 +1577,17 @@
     <param pos="0" name="hw.product" value="Raspberry Pi"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_(8\.1p1)\s+(Raspbian-(?:1|\d\d?\+deb11u\d+))$">
+  <fingerprint pattern="^OpenSSH_(8\.1)(p1)\s+(Raspbian-(?:1|\d\d?\+deb11u\d+))$">
     <description>OpenSSH running on Raspbian (Debian 11 "Bullseye" based)</description>
-    <example service.version="8.1p1" openssh.comment="Raspbian-1">OpenSSH_8.1p1 Raspbian-1</example>
-    <example service.version="8.1p1" openssh.comment="Raspbian-1+deb11u1">OpenSSH_8.1p1 Raspbian-1+deb11u1</example>
+    <example service.version="8.1" service.update="p1" openssh.comment="Raspbian-1">OpenSSH_8.1p1 Raspbian-1</example>
+    <example service.version="8.1" service.update="p1" openssh.comment="Raspbian-1+deb11u1">OpenSSH_8.1p1 Raspbian-1+deb11u1</example>
     <param pos="1" name="service.version"/>
-    <param pos="2" name="openssh.comment"/>
+    <param pos="2" name="service.update"/>
+    <param pos="3" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}:{service.update}"/>
     <param pos="0" name="os.vendor" value="Raspbian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>


### PR DESCRIPTION
## Description

Move the dangling `p` information for OpenSSH servers into the "update" field.


## Motivation and Context

This is how things are reported at the NVD. Here are CPE searches [before](https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Aopenbsd%3Aopenssh%3A7.9p1%3A*%3A*%3A*%3A*%3A*%3A*%3A*) and [after](https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Aopenbsd%3Aopenssh%3A7.9%3Ap1%3A*%3A*%3A*%3A*%3A*%3A*)


## How Has This Been Tested?

```
% bundle exec rspec spec/lib/fingerprint_self_test_spec.rb -E '.*OpenSSH'

...

Finished in 0.94386 seconds (files took 13.74 seconds to load)
7378 examples, 0 failures
```


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
