### PR TITLE
http_servers: fix incorrect IP regex

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2938,7 +2938,7 @@
 
    -->
 
-  <fingerprint pattern="^(?:(?:\d+.){3}\d+):\d{1,4}$">
+  <fingerprint pattern="^(?:(?:\d+\.){3}\d{1,3}):\d{1,4}$">
     <description>A banner consisting of an IP address and port -- assert nothing.</description>
     <example>192.168.0.4:9999</example>
   </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2938,8 +2938,8 @@
 
    -->
 
-  <fingerprint pattern="^(?:(?:\d+\.){3}\d{1,3}):\d{1,4}$">
-    <description>A banner consisting of an IP address and port -- assert nothing.</description>
+  <fingerprint pattern="^(?:(?:\d{1,3}\.){3}\d{1,3}):\d{1,4}$">
+    <description>A banner consisting of an IPv4 address and port -- assert nothing.</description>
     <example>192.168.0.4:9999</example>
   </fingerprint>
 


### PR DESCRIPTION
## Description
This PR corrects a regex used for IPv4 addresses used in `http_servers.xml`.  The regex failed to escape a `.` and could DoS the parser when processing very long numeric sequences.

The PR correctly escapes the period and limits the number of repeating digits allowed before the match fails.

This issue was highlighted in a PR to `recog-java` here: https://github.com/rapid7/recog-java/pull/7

## Motivation and Context
Bug fix, performance improvement


## How Has This Been Tested?
`rspec` with built in `example` tests.  I have also tested the regex with Go and Rust online regex testers. Both of these languages use the RE2 engine by default.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
