### PR TITLE
Palo Alto Tweaks

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -160,8 +160,6 @@ mappings:
       owncloud_server: owncloud
   palo_alto_networks:
     vendor: paloaltonetworks
-    products:
-      panos: pan-os
   parallels:
     products:
       plesk: parallels_plesk_panel

--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -161,7 +161,7 @@ mappings:
   palo_alto_networks:
     vendor: paloaltonetworks
     products:
-      pa_firewall: pan-os
+      panos: pan-os
   parallels:
     products:
       plesk: parallels_plesk_panel

--- a/identifiers/os_device.txt
+++ b/identifiers/os_device.txt
@@ -14,7 +14,6 @@ DSU/CSU
 DVR
 Device Server
 Fax Server
-File Server
 Firewall
 Frame Relay
 HMI Controller

--- a/identifiers/os_family.txt
+++ b/identifiers/os_family.txt
@@ -132,6 +132,7 @@ OpenServer
 OpenVMS
 OpenWRT
 Optra
+PAN-OS
 PIX
 PLC
 Packet-Optical

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -173,7 +173,7 @@ OpenServer
 OpenTV
 OpenVMS
 OpenWall
-PANOS
+PAN-OS
 PIX
 PLC-5
 PRO/100

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -78,7 +78,6 @@ Enterprise Linux
 Enterprise WAP
 EqualLogic
 Excella
-FRITZ!BOX
 FRITZ!OS
 Fabric OS
 Fastmark M5
@@ -174,14 +173,12 @@ OpenServer
 OpenTV
 OpenVMS
 OpenWall
-PA Firewall
 PANOS
 PIX
 PLC-5
 PRO/100
 PacketShaper
 PalmOS
-Panorama Server
 Photon Linux
 PocketPro
 Polycom
@@ -194,7 +191,6 @@ Prestige 660HW-D1
 Prestige 660ME-61
 Prime Collaboration Manager
 Print Server
-Print server
 PrintServer
 Printer
 Printer Board

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -346,6 +346,7 @@ PHP
 PMS
 PMail Server
 PWS
+Panorama Server
 Paramiko
 Percona Server
 Perl

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -363,7 +363,6 @@ PowerMTA
 ProFTPD
 ProRat
 Prometheus
-Proxmox
 Proxy
 Proxygen
 Pulse Connect Secure
@@ -393,7 +392,6 @@ S7/S5 OPC Server
 SABnzbd
 SAP Message Server
 SCO X server
-SIP Server
 SIP Stack
 SIPPS IP Phone
 SLMail

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -790,7 +790,6 @@ noVNC
 ownCloud
 pfSense
 port25
-proxmox
 qmail
 rPath
 vsFTPd Project

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1473,7 +1473,8 @@
     <param pos="0" name="hw.device" value="Firewall"/>
     <param pos="0" name="hw.certainty" value="0.5"/>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
-    <param pos="0" name="os.product" value="PANOS"/>
+    <param pos="0" name="os.product" value="PAN-OS"/>
+    <param pos="0" name="os.family" value="PAN-OS"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.certainty" value="0.5"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1476,6 +1476,7 @@
     <param pos="0" name="os.product" value="PANOS"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
   </fingerprint>
 
   <fingerprint pattern="^efe29d50711d9b093d8187e97cc0e593$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2816,11 +2816,13 @@
   <fingerprint pattern="^PanWeb Server/ -">
     <description>HTTP and HTTPS server found on Palo Alto Networks devices</description>
     <example>PanWeb Server/ -</example>
+    <param pos="0" name="hw.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="service.product" value="PA Firewall"/>
     <param pos="0" name="service.device" value="Firewall"/>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
-    <param pos="0" name="os.product" value="PANOS"/>
+    <param pos="0" name="os.product" value="PAN-OS"/>
+    <param pos="0" name="os.family" value="PAN-OS"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
   </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2818,8 +2818,9 @@
     <example>PanWeb Server/ -</example>
     <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="service.product" value="PA Firewall"/>
+    <param pos="0" name="service.device" value="Firewall"/>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
-    <param pos="0" name="os.product" value="PA Firewall"/>
+    <param pos="0" name="os.product" value="PANOS"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
   </fingerprint>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5555,14 +5555,26 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Palo Alto Networks PA-4000 series firewall</example>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="os.device" value="Firewall"/>
-    <param pos="1" name="os.product"/>
+    <param pos="0" name="os.product" value="PANOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
+    <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
+    <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="hw.vendor" value="Palo Alto Networks"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="1" name="hw.product"/>
   </fingerprint>
 
   <fingerprint pattern="^Palo Alto Networks Panorama server$">
     <description>Palo Alto Panorama</description>
     <example>Palo Alto Networks Panorama server</example>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
-    <param pos="0" name="os.product" value="Panorama Server"/>
+    <param pos="0" name="os.product" value="PANOS"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
+    <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
+    <param pos="0" name="service.product" value="Panorama Server"/>
+    <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="hw.vendor" value="Palo Alto Networks"/>
   </fingerprint>
 
   <!--======================================================================

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -5555,7 +5555,8 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example>Palo Alto Networks PA-4000 series firewall</example>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="os.device" value="Firewall"/>
-    <param pos="0" name="os.product" value="PANOS"/>
+    <param pos="0" name="os.product" value="PAN-OS"/>
+    <param pos="0" name="os.family" value="PAN-OS"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
     <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="service.device" value="Firewall"/>
@@ -5568,7 +5569,8 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>Palo Alto Panorama</description>
     <example>Palo Alto Networks Panorama server</example>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
-    <param pos="0" name="os.product" value="PANOS"/>
+    <param pos="0" name="os.product" value="PAN-OS"/>
+    <param pos="0" name="os.family" value="PAN-OS"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
     <param pos="0" name="service.vendor" value="Palo Alto Networks"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -1236,6 +1236,9 @@
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="os.product" value="PANOS"/>
     <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
+    <param pos="0" name="service.vendor" value="Palo Alto Networks"/>
+    <param pos="0" name="service.device" value="Firewall"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=VMware default certificate,OU=vCenterServer.*,O=VMware\\, Inc\.$">

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -1234,7 +1234,8 @@
     <param pos="0" name="hw.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="hw.device" value="Firewall"/>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
-    <param pos="0" name="os.product" value="PANOS"/>
+    <param pos="0" name="os.product" value="PAN-OS"/>
+    <param pos="0" name="os.family" value="PAN-OS"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:paloaltonetworks:pan-os:-"/>
     <param pos="0" name="service.vendor" value="Palo Alto Networks"/>


### PR DESCRIPTION
## Description
This PR tweaks the fields for Palo Alto so as to return better data and/or improve the ability to generate CPEs.

I would have preferred to change `PANOS` to `PAN-OS` for the `os.product` but I wasn't sure what this would break downstream.

I also reset and regenerated the contents of the `identifiers/` directory.

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
