### PR TITLE
HTTPS related fingerprints

### DIFF
--- a/identifiers/hw_family.txt
+++ b/identifiers/hw_family.txt
@@ -90,6 +90,7 @@ UniFi
 Unified Security Gateway
 VDX
 VSX
+Vigor
 VoIP
 WD2GO
 WiMax

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -294,6 +294,9 @@ UCM6202
 UCM6204
 UCM6208
 UCS Manager
+USG20-VPN
+USG40
+USG60
 UniFi Cloud Key
 UniFi NVR
 UniFi Security Gateway

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -118,6 +118,7 @@ IPReach
 IPSO
 IRIX
 Integrated Lights Out Manager
+Integrated Lights Out Manager firmware
 Irix
 Isilon OneFS OS
 JetDirect
@@ -259,6 +260,9 @@ UCM6204 Firmware
 UCM6208 Firmware
 UCS Device
 UNIX
+USG20-VPN firmware
+USG40 firmware
+USG60 firmware
 Ubuntu Linux
 Ultrix
 UnixWare
@@ -317,6 +321,7 @@ WorkCentre Pro
 X3e 31C-M
 XCC Linux
 XOS
+XenServer
 Zentyal
 Zone Director
 ZyNOS firmware

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -272,7 +272,6 @@ VIOS
 VMS
 VMware ESX Server
 VMware ESXi Server
-VPN
 VPN 3000 Concentrator
 VRP
 Virtual Library

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -68,8 +68,6 @@ Document Centre
 Dynix
 EDR G902 Firmware
 EDR G903 Firmware
-ESX
-ESXi
 EdgeBlaster
 EdgeOS
 Email Appliance

--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -12,6 +12,7 @@ Application Protection System
 Appweb
 Atlas Anchor
 Aura
+Azure
 BIG-IP
 BIND
 Bftpd

--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -49,7 +49,6 @@ Dynamo
 E-mail Services
 EWS
 Ecelerity Mail Server
-Elastic Load Balancing
 EmWeb
 Email Security
 Embedded SSH Server

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -3,8 +3,10 @@
 11000 Series Content Service Switch
 2wire
 389 Directory Server
+3CX Web Server
 4690 FTP Server
 ADAudit Plus
+AIOHTTP
 AOS
 APIC
 ARRIS
@@ -12,6 +14,7 @@ ASM
 ASP.NET
 Abyss Web Server X1
 Abyss Web Server X2
+Access Manager
 Active Directory Controller
 Active Intelligence Engine
 ActiveMQ
@@ -24,6 +27,7 @@ AnswerX
 Antivirus for Gateways
 Apache Tomcat HTTP Connector
 AppleShare IP Mail Server
+Application Load Balancer
 Application Protection System, Enterprise
 Application Server Portal
 Application Server Web Cache
@@ -35,6 +39,7 @@ Aura Communication Manager
 AuthServ
 Authoritative Server
 Avahi
+Azure App Service on Azure Stack
 BIG-IP LTM
 BIND
 BRCM400
@@ -119,6 +124,7 @@ E-mail Services
 ESMTP
 EWS
 Ecelerity Mail Server
+Elastic Load Balancer
 EmWeb
 Email Appliance
 Email Security
@@ -144,6 +150,7 @@ FastTrack Server
 Fiery Print Server
 FileZilla Server
 Firewall-1
+Fireware XTM
 Fisheye
 Flink
 Flower
@@ -153,6 +160,7 @@ FortiVoice
 FortressSSH Server
 FreSSH
 FreeSWITCH
+Fusion Middleware
 GHost
 GNAT Box
 GStreamer RTSP Server
@@ -415,6 +423,7 @@ Sage X3 Syracuse Web Server
 Samba
 Search
 Secure FTP Server
+Secure Global Desktop
 Secure Tencent Gateway
 SecureTransport
 Security Center
@@ -468,12 +477,14 @@ Tomcat
 Tor
 Tornado
 Traefik Proxy
+Transportation Management
 Twisted FTPD
 Twisted Web
 Twonky Media Server
 UnboundID Directory Proxy Server
 UnboundID Directory Server
 UniFi Video
+Universal Management Appliance
 Urchin Tracking Module
 Usermin
 VM
@@ -731,6 +742,7 @@ ucftpd
 unbound
 uvicorn
 vCenter
+vCenter Converter
 vmauthd
 vsFTPd
 vsFTPd Extended

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -1,3 +1,4 @@
+3CX
 3Com
 8x8 Inc.
 A.K.I Software
@@ -6,6 +7,7 @@ ACT Security
 ADB
 ADC
 ADTRAN
+AIOHTTP Project
 ALCATEL
 ALT
 ALU

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -27,14 +27,32 @@
     <example>403 Forbidden</example>
   </fingerprint>
 
-  <fingerprint pattern="^404 Not Found$">
+  <fingerprint pattern="^(?:404 )?Not Found$">
     <description>404 Not Found - generic -- assert nothing.</description>
     <example>404 Not Found</example>
+    <example>Not Found</example>
   </fingerprint>
 
   <fingerprint pattern="^Invalid URL$">
     <description>Invalid URL - generic -- assert nothing.</description>
     <example>Invalid URL</example>
+  </fingerprint>
+
+  <fingerprint pattern="^ERROR: The request could not be satisfied$">
+    <description>Amazon CloudFront web load balancer endpoint</description>
+    <example>ERROR: The request could not be satisfied</example>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.family" value="CloudFront"/>
+    <param pos="0" name="service.product" value="CloudFront Load Balancer"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Microsoft Azure Web App - Error 404$">
+    <description>Microsoft Azure Web App - Error 404</description>
+    <example>Microsoft Azure Web App - Error 404</example>
+    <param pos="0" name="service.vendor" value="Microsoft"/>
+    <param pos="0" name="service.family" value="Azure"/>
+    <param pos="0" name="service.product" value="Azure App Service on Azure Stack"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:azure_app_service_on_azure_stack:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Index of /">
@@ -342,6 +360,30 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:sonicwall:sonicos:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^SonicWall Universal Management Suite v(\d+\.\d+)$">
+    <description>SonicWall Universal Management Appliance - with version</description>
+    <example service.version="8.7">SonicWall Universal Management Suite v8.7</example>
+    <param pos="0" name="service.vendor" value="SonicWall"/>
+    <param pos="0" name="service.product" value="Universal Management Appliance"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sonicwall:universal_management_appliance:{service.version}"/>
+    <param pos="0" name="os.vendor" value="SonicWall"/>
+    <param pos="0" name="os.family" value="SonicOS"/>
+    <param pos="0" name="os.product" value="SonicOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:sonicwall:sonicos:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Fireware XTM User Authentication$">
+    <description>WatchGuard Fireware XTM login page</description>
+    <example>Fireware XTM User Authentication</example>
+    <param pos="0" name="service.vendor" value="WatchGuard"/>
+    <param pos="0" name="service.product" value="Fireware XTM"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:watchguard:fireware_xtm:-"/>
+    <param pos="0" name="os.vendor" value="WatchGuard"/>
+    <param pos="0" name="os.product" value="Fireware"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:watchguard:fireware:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(.*).nbsp;-.nbsp;Synology.nbsp;DiskStation$">
     <description>Synology DiskStation</description>
     <example host.name="DiskStation">DiskStation&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
@@ -456,6 +498,50 @@
     <param pos="0" name="hw.family" value="UniFi"/>
     <param pos="0" name="hw.product" value="UniFi NVR"/>
     <param pos="0" name="hw.device" value="DVR"/>
+  </fingerprint>
+
+  <!-- Various products by Zyxel -->
+
+  <fingerprint pattern="^USG60$">
+    <description>Zyxel USG60 Unified Security Gateway</description>
+    <example>USG60</example>
+    <param pos="0" name="os.vendor" value="Zyxel"/>
+    <param pos="0" name="os.product" value="USG60 firmware"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:zyxel:usg60_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="Zyxel"/>
+    <param pos="0" name="hw.family" value="Unified Security Gateway"/>
+    <param pos="0" name="hw.product" value="USG60"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:zyxel:usg60:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^USG40$">
+    <description>Zyxel USG40 Unified Security Gateway</description>
+    <example>USG40</example>
+    <param pos="0" name="os.vendor" value="Zyxel"/>
+    <param pos="0" name="os.product" value="USG40 firmware"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:zyxel:usg40_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="Zyxel"/>
+    <param pos="0" name="hw.family" value="Unified Security Gateway"/>
+    <param pos="0" name="hw.product" value="USG40"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:zyxel:usg40:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^USG20-VPN$">
+    <description>Zyxel USG20-VPN Unified Security Gateway</description>
+    <example>USG20-VPN</example>
+    <param pos="0" name="os.vendor" value="Zyxel"/>
+    <param pos="0" name="os.product" value="USG20-VPN firmware"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:zyxel:usg20-vpn_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="Zyxel"/>
+    <param pos="0" name="hw.family" value="Unified Security Gateway"/>
+    <param pos="0" name="hw.product" value="USG20-VPN"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:zyxel:usg20-vpn:-"/>
   </fingerprint>
 
   <fingerprint pattern="^RomPager Embedded Web Server Toolkit$">
@@ -1038,6 +1124,14 @@
     <param pos="0" name="hw.device" value="VoIP"/>
   </fingerprint>
 
+  <fingerprint pattern="^3CX Phone System Management Console$">
+    <description>3CX Phone System Management Console</description>
+    <example>3CX Phone System Management Console</example>
+    <param pos="0" name="service.vendor" value="3CX"/>
+    <param pos="0" name="service.product" value="3CX Web Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:3cx:3cx_web_server:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(SPA\S+) Configuration Utility$">
     <description>Cisco IP Phone - SPA504G Configuration Utility</description>
     <example hw.product="SPA504G">SPA504G Configuration Utility</example>
@@ -1473,7 +1567,26 @@
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.product" value="XenServer"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.device" value="Hypervisor"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:citrix:xenserver:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Citrix"/>
+    <param pos="0" name="os.product" value="XenServer"/>
+    <param pos="0" name="os.device" value="Hypervisor"/>
+    <param pos="0" name="hw.device" value="Hypervisor"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Welcome to Citrix Hypervisor ([0-9\.]+)$">
+    <description>XenServer</description>
+    <example service.version="8.2.0">Welcome to Citrix Hypervisor 8.2.0</example>
+    <param pos="0" name="service.vendor" value="Citrix"/>
+    <param pos="0" name="service.product" value="XenServer"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.device" value="Hypervisor"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:citrix:xenserver:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Citrix"/>
+    <param pos="0" name="os.product" value="XenServer"/>
+    <param pos="0" name="os.device" value="Hypervisor"/>
+    <param pos="0" name="hw.device" value="Hypervisor"/>
   </fingerprint>
 
   <fingerprint pattern="^RabbitMQ Management$">
@@ -1598,6 +1711,25 @@
     <param pos="0" name="service.vendor" value="VMware"/>
     <param pos="0" name="service.product" value="vCenter"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:vmware:vcenter_server:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^&quot; \+ ID_EESX_Welcome \+ &quot;$">
+    <description>VMware ESXi</description>
+    <example>" + ID_EESX_Welcome + "</example>
+    <param pos="0" name="service.vendor" value="VMware"/>
+    <param pos="0" name="os.vendor" value="VMware"/>
+    <param pos="0" name="os.product" value="ESX"/>
+    <param pos="0" name="os.device" value="Hypervisor"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esx:-"/>
+    <param pos="0" name="hw.device" value="Hypervisor"/>
+  </fingerprint>
+
+  <fingerprint pattern="^&quot; \+ ID_Converter_Welcome \+ &quot;$">
+    <description>VMware Converter</description>
+    <example>" + ID_Converter_Welcome + "</example>
+    <param pos="0" name="service.vendor" value="VMware"/>
+    <param pos="0" name="service.product" value="vCenter Converter"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:vmware:vcenter_converter:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Graylog Web Interface$">
@@ -2280,6 +2412,47 @@
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
+  <fingerprint pattern="^Welcome to Oracle Fusion Middleware$">
+    <description>Oracle Fusion Middleware</description>
+    <example>Welcome to Oracle Fusion Middleware</example>
+    <param pos="0" name="service.vendor" value="Oracle"/>
+    <param pos="0" name="service.product" value="Fusion Middleware"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:oracle:fusion_middleware:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Oracle Secure Global Desktop(?: Redirect Page)?$">
+    <description>Oracle Secure Global Desktop</description>
+    <example>Oracle Secure Global Desktop</example>
+    <example>Oracle Secure Global Desktop Redirect Page</example>
+    <param pos="0" name="service.vendor" value="Oracle"/>
+    <param pos="0" name="service.product" value="Secure Global Desktop"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:oracle:secure_global_desktop:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OTM - Oracle Transportation Management$">
+    <description>Oracle Transportation Management</description>
+    <example>OTM - Oracle Transportation Management</example>
+    <param pos="0" name="service.vendor" value="Oracle"/>
+    <param pos="0" name="service.product" value="Transportation Management"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:oracle:transportation_management:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Bad Oracle Access Manager Request$">
+    <description>Oracle Access Manager - Bad Request</description>
+    <example>Bad Oracle Access Manager Request</example>
+    <param pos="0" name="service.vendor" value="Oracle"/>
+    <param pos="0" name="service.product" value="Access Manager"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:oracle:access_manager:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Oracle Access Manager Operation Error$">
+    <description>Oracle Access Manager - Operation Error</description>
+    <example>Oracle Access Manager Operation Error</example>
+    <param pos="0" name="service.vendor" value="Oracle"/>
+    <param pos="0" name="service.product" value="Access Manager"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:oracle:access_manager:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:Oracle\(R\) )?Integrated Lights Out Manager$">
     <description>Oracle iLOM</description>
     <example>Oracle(R) Integrated Lights Out Manager</example>
@@ -2291,7 +2464,8 @@
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="ILOM"/>
-    <param pos="0" name="os.product" value="ILOM"/>
+    <param pos="0" name="os.product" value="Integrated Lights Out Manager firmware"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:oracle:integrated_lights_out_manager_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Genetec - SHARPV\S+$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1576,7 +1576,7 @@
   </fingerprint>
 
   <fingerprint pattern="^Welcome to Citrix Hypervisor ([0-9\.]+)$">
-    <description>XenServer</description>
+    <description>XenServer - Hypervisor variant</description>
     <example service.version="8.2.0">Welcome to Citrix Hypervisor 8.2.0</example>
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.product" value="XenServer"/>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1718,9 +1718,10 @@
     <example>" + ID_EESX_Welcome + "</example>
     <param pos="0" name="service.vendor" value="VMware"/>
     <param pos="0" name="os.vendor" value="VMware"/>
-    <param pos="0" name="os.product" value="ESX"/>
+    <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
+    <param pos="0" name="os.product" value="VMware ESXi Server"/>
     <param pos="0" name="os.device" value="Hypervisor"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esx:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esxi:-"/>
     <param pos="0" name="hw.device" value="Hypervisor"/>
   </fingerprint>
 

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -14,6 +14,27 @@
     <param pos="0" name="service.family" value="CloudFlare"/>
   </fingerprint>
 
+  <fingerprint pattern="^(AWSALB(?:TG)?(?:CORS)?)=.*$">
+    <description>Amazon Application Load Balancer</description>
+    <example cookie="AWSALB">AWSALB=791357231C9C446E295988DA51A2CD313D13788329433D96A05631377389B17BF097D4C8A2D0BE5BC4F3C649AED7DFF939364A5790E2EC67F33C4483E2E9DD17E99814071B;PATH=/;HttpOnly;Secure</example>
+    <example cookie="AWSALBCORS">AWSALBCORS=D5A3BF7B08C8E0626B1C77DAAEAB0A7542DEB35F43097F06FD3833E22A9BA2543B805B7AE1B6E97F2BE3A701A19AF5D2CC898E0DB5E52055B0B983CC64EAD006CF77C1CF72;PATH=/;SECURE;SAMESITE=None</example>
+    <example cookie="AWSALBTGCORS">AWSALBTGCORS=E0+uuQyz1jbU2P5jrIIWTuoK0aAbjfgsuA814N0xT5w9Vu4N61/CZTKT+yxwCfUqIUx/IgZfsDyA24+eSXKFO60aqEbtGPw2Mm4bGNDMVpcZ/yKHzifDPjT7mNQvNVq7xCAed5VgTpMH/nD3D2pLn9+ooJcShVgv+z97rSYAV5C98tecx6Q=; Expires=Mon, 10 May 2021 01:21:27 GMT; Path=/; SameSite=None; Secure</example>
+    <param pos="1" name="cookie"/>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.family" value="Web Services"/>
+    <param pos="0" name="service.product" value="Application Load Balancer"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(AWSELB(?:CORS)?)=.*$">
+    <description>Amazon Elastic Load Balancer</description>
+    <example cookie="AWSELB">AWSELB=791357231C9C446E295988DA51A2CD313D13788329433D96A05631377389B17BF097D4C8A2D0BE5BC4F3C649AED7DFF939364A5790E2EC67F33C4483E2E9DD17E99814071B;PATH=/;HttpOnly;Secure</example>
+    <example cookie="AWSELBCORS">AWSELBCORS=D5A3BF7B08C8E0626B1C77DAAEAB0A7542DEB35F43097F06FD3833E22A9BA2543B805B7AE1B6E97F2BE3A701A19AF5D2CC898E0DB5E52055B0B983CC64EAD006CF77C1CF72;PATH=/;SECURE;SAMESITE=None</example>
+    <param pos="1" name="cookie"/>
+    <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.family" value="Web Services"/>
+    <param pos="0" name="service.product" value="Elastic Load Balancer"/>
+  </fingerprint>
+
   <fingerprint pattern="^(PHPSESSI(?:D|ON))=.*">
     <description>PHP - http://www.php.net/ref.session</description>
     <example cookie="PHPSESSID">PHPSESSID=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2509,6 +2509,17 @@
     <param pos="2" name="python.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^Python/(\d\.[\d.]+) aiohttp/(\d[\w.]+)$">
+    <description>AIOHTTP Project AIOHTTP</description>
+    <example service.version="3.7.4.post0">Python/3.8 aiohttp/3.7.4.post0</example>
+    <example python.version="3.4">Python/3.4 aiohttp/1.0.5</example>
+    <param pos="0" name="service.vendor" value="AIOHTTP Project"/>
+    <param pos="0" name="service.product" value="AIOHTTP"/>
+    <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:aiohttp_project:aiohttp:{service.version}"/>
+    <param pos="1" name="python.version"/>
+  </fingerprint>
+
   <fingerprint pattern="^uvicorn$">
     <description>Encode uvicorn</description>
     <example>uvicorn</example>
@@ -3029,10 +3040,11 @@
   </fingerprint>
 
   <fingerprint pattern="^awselb/([\d.rc]+)$">
-    <description>Amazon Elastic Load Balancing</description>
+    <description>Amazon Elastic Load Balancer</description>
     <example service.version="2.0">awselb/2.0</example>
     <param pos="0" name="service.vendor" value="Amazon"/>
-    <param pos="0" name="service.family" value="Elastic Load Balancing"/>
+    <param pos="0" name="service.family" value="Web Services"/>
+    <param pos="0" name="service.product" value="Elastic Load Balancer"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
 
@@ -4502,6 +4514,17 @@
     <param pos="0" name="service.family" value="UPnP"/>
     <param pos="0" name="hw.vendor" value="Pelco"/>
     <param pos="0" name="hw.device" value="IP Camera"/>
+  </fingerprint>
+
+  <fingerprint pattern="^xxxxxxxx-xxxxx$">
+    <description>Fortinet - device unknown</description>
+    <example>xxxxxxxx-xxxxx</example>
+    <param pos="0" name="os.vendor" value="Fortinet"/>
+    <param pos="0" name="os.family" value="FortiOS"/>
+    <param pos="0" name="os.product" value="FortiOS"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fortinet:fortios:-"/>
+    <param pos="0" name="hw.vendor" value="Fortinet"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -927,6 +927,10 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:hp-ux:{os.version}"/>
   </fingerprint>
 
+  <!--
+    This may need to be split into ESX and ESXi. ESXi started w/ version 4.1 and
+    all versions 5.x were ESXi only.
+    -->
   <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;VMkernel/?([^ ]+)?&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on VMware ESXi</description>
     <example>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -931,6 +931,7 @@
     This may need to be split into ESX and ESXi. ESXi started w/ version 4.1 and
     all versions 5.x were ESXi only.
     -->
+
   <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;VMkernel/?([^ ]+)?&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on VMware ESXi</description>
     <example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -7094,13 +7094,26 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^(VMware ESXi?) (\d\.\d+\.\d+) build-\d+ VMware, Inc\. (\S+)$">
     <description>VMware ESX/ESXi</description>
     <example os.product="VMware ESXi" os.version="5.1.0" os.arch="x86_64">VMware ESXi 5.1.0 build-1157734 VMware, Inc. x86_64</example>
+    <param pos="0" name="os.vendor" value="VMware"/>
+    <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
+    <param pos="0" name="os.product" value="VMware ESXi Server"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.arch"/>
+    <param pos="0" name="os.device" value="Hypervisor"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esxi:{os.version}"/>
+    <param pos="0" name="hw.device" value="Hypervisor"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(VMware ESXi?) (\d\.\d+\.\d+) build-\d+ VMware, Inc\. (\S+)$">
+    <description>VMware ESX/ESXi</description>
     <example os.product="VMware ESX" os.version="5.0.0" os.arch="x86_64">VMware ESX 5.0.0 build-623860 VMware, Inc. x86_64</example>
     <param pos="0" name="os.vendor" value="VMware"/>
     <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
-    <param pos="1" name="os.product"/>
-    <param pos="2" name="os.version"/>
-    <param pos="3" name="os.arch"/>
+    <param pos="0" name="os.product" value="VMware ESX Server"/>
+    <param pos="1" name="os.version"/>
+    <param pos="2" name="os.arch"/>
     <param pos="0" name="os.device" value="Hypervisor"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esx:{os.version}"/>
     <param pos="0" name="hw.device" value="Hypervisor"/>
   </fingerprint>
 

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -7091,9 +7091,9 @@ Copyright (c) 1995-2005 by Cisco Systems
                              VMware
    =======================================================================-->
 
-  <fingerprint pattern="^(VMware ESXi?) (\d\.\d+\.\d+) build-\d+ VMware, Inc\. (\S+)$">
-    <description>VMware ESX/ESXi</description>
-    <example os.product="VMware ESXi" os.version="5.1.0" os.arch="x86_64">VMware ESXi 5.1.0 build-1157734 VMware, Inc. x86_64</example>
+  <fingerprint pattern="^VMware ESXi (\d\.\d+\.\d+) build-\d+ VMware, Inc\. (\S+)$">
+    <description>VMware ESXi</description>
+    <example os.version="5.1.0" os.arch="x86_64">VMware ESXi 5.1.0 build-1157734 VMware, Inc. x86_64</example>
     <param pos="0" name="os.vendor" value="VMware"/>
     <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
     <param pos="0" name="os.product" value="VMware ESXi Server"/>
@@ -7104,9 +7104,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="hw.device" value="Hypervisor"/>
   </fingerprint>
 
-  <fingerprint pattern="^(VMware ESXi?) (\d\.\d+\.\d+) build-\d+ VMware, Inc\. (\S+)$">
-    <description>VMware ESX/ESXi</description>
-    <example os.product="VMware ESX" os.version="5.0.0" os.arch="x86_64">VMware ESX 5.0.0 build-623860 VMware, Inc. x86_64</example>
+  <fingerprint pattern="^VMware ESX (\d\.\d+\.\d+) build-\d+ VMware, Inc\. (\S+)$">
+    <description>VMware ESX</description>
+    <example os.version="5.0.0" os.arch="x86_64">VMware ESX 5.0.0 build-623860 VMware, Inc. x86_64</example>
     <param pos="0" name="os.vendor" value="VMware"/>
     <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
     <param pos="0" name="os.product" value="VMware ESX Server"/>

--- a/xml/tls_jarm.xml
+++ b/xml/tls_jarm.xml
@@ -125,7 +125,7 @@
     <example>21d14d00021d21d21c21d14d21d21d3e9a0dda94718e521eb7d1409c9e3601</example>
     <param pos="0" name="os.vendor" value="VMware"/>
     <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
-    <param pos="0" name="os.product" value="ESXi"/>
+    <param pos="0" name="os.product" value="VMware ESXi Server"/>
     <param pos="0" name="os.device" value="Hypervisor"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esxi:-"/>
     <param pos="0" name="hw.device" value="Hypervisor"/>

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -8,6 +8,61 @@
   a specific order. Please see the comments in x509_subjects.xml for details.
   -->
 
+  <!-- The following group has been included for performance reasons -->
+
+  <fingerprint pattern="^CN=R3,O=Let's Encrypt,C=US$">
+    <description>Lets Encrypt R3 - generic -- assert nothing.</description>
+    <example>CN=R3,O=Let's Encrypt,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US$">
+    <description>Lets Encrypt X3 - generic -- assert nothing.</description>
+    <example>CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=Amazon,OU=Server CA 1B,O=Amazon,C=US$">
+    <description>Amazon AWS Server CA 1B - generic -- assert nothing.</description>
+    <example>CN=Amazon,OU=Server CA 1B,O=Amazon,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US$">
+    <description>DigiCert SHA2 - generic -- assert nothing.</description>
+    <example>CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=DigiCert TLS (?:RSA SHA256|Hybrid ECC SHA384) 2020 CA1,O=DigiCert Inc,C=US$">
+    <description>DigiCert SHA256 2020 CA1 - generic -- assert nothing.</description>
+    <example>CN=DigiCert TLS RSA SHA256 2020 CA1,O=DigiCert Inc,C=US</example>
+    <example>CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1,O=DigiCert Inc,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=DigiCert Secure Site ECC CA-1,OU=www.digicert.com,O=DigiCert Inc,C=US$">
+    <description>DigiCert ECC CA-1 - generic -- assert nothing.</description>
+    <example>CN=DigiCert Secure Site ECC CA-1,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=DigiCert SHA2 (?:Extended Validation|High Assurance) Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US$">
+    <description>DigiCert SHA2 EV - generic -- assert nothing.</description>
+    <example>CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
+    <example>CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=Sectigo RSA (?:Domain|Organization) Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB$">
+    <description>Sectigo RSA - generic -- assert nothing.</description>
+    <example>CN=Sectigo RSA Domain Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB</example>
+    <example>CN=Sectigo RSA Organization Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=GeoTrust RSA CA 2018,OU=www.digicert.com,O=DigiCert Inc,C=US$">
+    <description>GeoTrust RSA CA 2018 - generic -- assert nothing.</description>
+    <example>CN=GeoTrust RSA CA 2018,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs\.godaddy\.com/repository/,O=GoDaddy.com\\, Inc\.,L=Scottsdale,ST=Arizona,C=US$">
+    <description>Go Daddy G2 - generic -- assert nothing.</description>
+    <example>CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\, Inc.,L=Scottsdale,ST=Arizona,C=US</example>
+  </fingerprint>
+
   <!-- Chromecast and various devices that support the Cast protocol -->
 
   <fingerprint pattern="^CN=Eureka Gen1 ICA,OU=Google TV,O=Google Inc,L=Mountain View,ST=California,C=US$">
@@ -123,6 +178,20 @@
     <param pos="0" name="hw.vendor" value="APC"/>
   </fingerprint>
 
+  <fingerprint pattern="^CN=ASA Temporary Self Signed Certificate$">
+    <description>Cisco ASA Temp Cert</description>
+    <example>CN=ASA Temporary Self Signed Certificate</example>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
+    <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance:-"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
+    <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
+    <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^CN=Temporary CA [a-fA-F0-9]{8}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{12},OU=Temporary CA">
     <description>Cisco Video Communication Server</description>
     <example>CN=Temporary CA 218131fe-8af4-11e7-aa6e-9950d6bbaf74,OU=Temporary CA 218131fe-8af4-11e7-aa6e-9950d6bbaf74,O=Temporary CA 218131fe-8af4-11e7-aa6e-9950d6bbaf74</example>
@@ -192,6 +261,68 @@
     <param pos="0" name="hw.family" value="Netscaler"/>
     <param pos="0" name="hw.product" value="Netscaler Gateway"/>
     <param pos="0" name="hw.device" value="Network Management Device"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:citrix:netscaler_gateway:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^O=Technicolor,L=Edegem,ST=Antwerp,C=BE$">
+    <description>Technicolor Router - without model or version</description>
+    <example>O=Technicolor,L=Edegem,ST=Antwerp,C=BE</example>
+    <param pos="0" name="os.vendor" value="Technicolor"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="hw.vendor" value="Technicolor"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.certainty" value="0.5"/>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=Vigor Router,OU=DrayTek Support,O=DrayTek Corp.,L=HuKou,ST=HsinChu,C=TW$">
+    <description>DrayTek Vigor Router - without model or version</description>
+    <example>CN=Vigor Router,OU=DrayTek Support,O=DrayTek Corp.,L=HuKou,ST=HsinChu,C=TW</example>
+    <param pos="0" name="os.vendor" value="DrayTek"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="hw.vendor" value="DrayTek"/>
+    <param pos="0" name="hw.family" value="Vigor"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.certainty" value="0.5"/>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=Kubernetes Ingress Controller Fake Certificate,O=Acme Co$">
+    <description>Kubernetes NGINX Ingress Controller with default cert</description>
+    <example>CN=Kubernetes Ingress Controller Fake Certificate,O=Acme Co</example>
+    <param pos="0" name="service.vendor" value="Kubernetes"/>
+    <param pos="0" name="service.family" value="Kubernetes"/>
+    <param pos="0" name="service.product" value="NGINX Ingress Controller"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:kubernetes:nginx_ingress_controller:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=TRAEFIK DEFAULT CERT$">
+    <description>Traefik Proxy default certificate</description>
+    <example>CN=TRAEFIK DEFAULT CERT</example>
+    <param pos="0" name="service.vendor" value="Traefik Labs"/>
+    <param pos="0" name="service.family" value="Traefik"/>
+    <param pos="0" name="service.product" value="Traefik Proxy"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:containous:traefik:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?i)CN=Fireware web CA,OU=Fireware,O=WatchGuard(?: CA)?$">
+    <description>WatchGuard Fireware</description>
+    <example>CN=Fireware web ca,OU=Fireware,O=WatchGuard</example>
+    <example>CN=Fireware web CA,OU=Fireware,O=Watchguard CA</example>
+    <param pos="0" name="service.vendor" value="WatchGuard"/>
+    <param pos="0" name="service.product" value="Fireware XTM"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:watchguard:fireware_xtm:-"/>
+    <param pos="0" name="os.vendor" value="WatchGuard"/>
+    <param pos="0" name="os.product" value="Fireware"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:watchguard:fireware:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^O=Caddy Self-Signed$">
+    <description>CaddyServer Caddy - golang based httpd</description>
+    <example>O=Caddy Self-Signed</example>
+    <param pos="0" name="service.vendor" value="CaddyServer"/>
+    <param pos="0" name="service.product" value="Caddy"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:caddyserver:caddy:-"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -204,7 +204,8 @@
     <description>VMware ESXi w/Installer</description>
     <example>O=VMware Installer</example>
     <param pos="0" name="os.vendor" value="VMware"/>
-    <param pos="0" name="os.product" value="ESXi"/>
+    <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
+    <param pos="0" name="os.product" value="VMware ESXi Server"/>
     <param pos="0" name="os.device" value="Hypervisor"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esxi:-"/>
     <param pos="0" name="hw.device" value="Hypervisor"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -503,7 +503,7 @@
     <param pos="0" name="service.vendor" value="VMware"/>
     <param pos="0" name="os.vendor" value="VMware"/>
     <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
-    <param pos="0" name="os.product" value="VMware ESXi Server"/>
+    <param pos="0" name="os.product" value="VMware ESX Server"/>
     <param pos="0" name="os.device" value="Hypervisor"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esx:-"/>
     <param pos="1" name="host.name"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -103,6 +103,29 @@
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
+  <fingerprint pattern="^O=Technicolor,L=Edegem,ST=Antwerp,C=BE$">
+    <description>Technicolor Router - without model or version</description>
+    <example>O=Technicolor,L=Edegem,ST=Antwerp,C=BE</example>
+    <param pos="0" name="os.vendor" value="Technicolor"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="hw.vendor" value="Technicolor"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.certainty" value="0.5"/>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=Vigor Router,OU=DrayTek Support,O=DrayTek Corp.,L=HuKou,ST=HsinChu,C=TW$">
+    <description>DrayTek Vigor Router - without model or version</description>
+    <example>CN=Vigor Router,OU=DrayTek Support,O=DrayTek Corp.,L=HuKou,ST=HsinChu,C=TW</example>
+    <param pos="0" name="os.vendor" value="DrayTek"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="hw.vendor" value="DrayTek"/>
+    <param pos="0" name="hw.family" value="Vigor"/>
+    <param pos="0" name="hw.device" value="Router"/>
+    <param pos="0" name="hw.certainty" value="0.5"/>
+  </fingerprint>
+
   <fingerprint pattern="^CN=Nepenthes Development Team,OU=anv,O=dionaea\.carnivore\.it,C=DE$">
     <description>Nepenthes honeypot</description>
     <example>CN=Nepenthes Development Team,OU=anv,O=dionaea.carnivore.it,C=DE</example>
@@ -581,6 +604,7 @@
     <param pos="0" name="hw.family" value="Netscaler"/>
     <param pos="0" name="hw.product" value="Netscaler Gateway"/>
     <param pos="0" name="hw.device" value="Network Management Device"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:citrix:netscaler_gateway:-"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=([a-zA-Z0-9]{5,12}) ([a-zA-Z0-9]{12}),OU=(?:Cast|Google TV),O=Google Inc,L=Mountain View,ST=California,C=US$">
@@ -1172,6 +1196,14 @@
     <param pos="0" name="service.product" value="GHost"/>
     <param pos="0" name="os.vendor" value="Akamai"/>
     <param pos="0" name="os.device" value="Web Proxy"/>
+  </fingerprint>
+
+  <fingerprint pattern="^O=Caddy Self-Signed$">
+    <description>CaddyServer Caddy - golang based httpd</description>
+    <example>O=Caddy Self-Signed</example>
+    <param pos="0" name="service.vendor" value="CaddyServer"/>
+    <param pos="0" name="service.product" value="Caddy"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:caddyserver:caddy:-"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=HP_3PAR_">

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -502,7 +502,8 @@
     <example>CN=server99.,OU=VMware ESX Server Default Certificate,O=VMware\, Inc,L=Palo Alto,ST=California,C=US</example>
     <param pos="0" name="service.vendor" value="VMware"/>
     <param pos="0" name="os.vendor" value="VMware"/>
-    <param pos="0" name="os.product" value="ESX"/>
+    <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
+    <param pos="0" name="os.product" value="VMware ESXi Server"/>
     <param pos="0" name="os.device" value="Hypervisor"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:vmware:esx:-"/>
     <param pos="1" name="host.name"/>


### PR DESCRIPTION
## Description
This PR includes fingerprint updates based on recent data. Most changes revolve around HTML titles or certificates.

*NOTE*: I have attempted to normalize some of the VMware ESX / ESXi values around what already exists in the NTP and SNMP databases.  

- ESXi replaced ESX.  They were released side by side starting with version 4.1. All versions of 5.x (starting in 2010) were ESXi only.
- My preference would be to set the `os.family` to `vSphere` and the `os.product` to either `ESX` or `ESXi` as appropriate but I do not want to break any existing dependencies. 


## Types of changes
- Fingerprints


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
