### PR TITLE
CPE: stop using deprecated CPEs, split the remap YAML into sections

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -1,242 +1,315 @@
 mappings:
-  alpine:
-    vendor: alpinelinux
-    products:
-      linux: alpine_linux
-  amazon:
-    products:
-      s3: web_services_simple_storage_service
-  apache:
-    products:
-      httpd: http_server
-  apple:
-    products:
-      ios: iphone_os
-  aprelium_technologies:
-    vendor: aprelium
-  alt-n:
-    vendor: altn
-  aruba_networks:
-    vendor: arubanetworks
-  bea:
-    products:
-      weblogic: weblogic_server
-  blue_coat:
-    vendor: bluecoat
-  carnegie_mellon_university:
-    vendor: cmu
-    products:
-      cyrus_imap: cyrus_imap_server
-  centos:
-    products:
-      linux: centos
-  centos_webpanel:
-    vendor: centos-webpanel
-  check_point:
-    vendor: checkpoint
-  cherokee_project:
-    vendor: cherokee-project
-  cisco:
-    vendor: cisco
-    products:
-      adaptive_security_appliance: adaptive_security_appliance_software
-      apic: application_policy_infrastructure_controller
-      pix: pix_firewall_software
-      telepresence: telepresence_video_communication_server_software
-  cpanel:
-    products:
-      cpanel_service_daemon: cpanel
-  crushftp:
-    products:
-      crushftp_web_interface: crushftp
-  cumulus:
-    vendor: cumulusnetworks
-  cz.nic:
-    vendor: knot-dns
-  data_domain:
-    vendor: dell
-    products:
-      dd_os: emc_data_domain_os
-  debian:
-    products:
-      linux: debian_linux
-  drupal:
-    products:
-      cms: drupal
-  embedthis:
-    products:
-       goahead_webserver: goahead
-  emc:
-    products:
-      celerra: celerra_network_attached_storage
-  envoy_proxy:
-    vendor: envoyproxy
-  f5:
-    products:
-      big-ip: big-ip_local_traffic_manager
-      big-ip_ltm: big-ip_local_traffic_manager
-  fedora_project:
-    vendor: fedoraproject
-  google:
-    products:
-      google_web_services: web_server
-  hp:
-    products:
-      ilo: integrated_lights_out
-      tru64_unix: tru64
-  ibm:
-    products:
-      lotus_domino: lotus_domino_server
-      ibm_domino: lotus_domino
-      os/400: os_400
-      i5/os: i5os
-  ignite_realtime:
-    vendor: igniterealtime
-  intel:
-    products:
-      intel(r)_active_management_technology: active_management_technology
-      intel(r)_standard_manageability: standard_manageability
-  jamf:
-    products:
-      jamf_pro: jamf
-  juniper:
-    products:
-      junos_os: junos
-  kibana:
-    vendor: elasticsearch
-  kubernetes:
-    products:
-      nginx_ingress_controller: ingress-nginx
-  kodi:
-    products:
-      media_server: kodi
-  kong:
-    vendor: konghq
-    products:
-      gateway: kong_gateway
-  litespeed_technologies:
-    vendor: litespeedtech
-  linux:
-    products:
-      linux: linux_kernel
-  lynx_technology:
-    vendor: lynxtechnology
-    products:
-      twonky_media_server: twonky_server
-  mailenable:
-    products:
-      mail_server: mailenable
-  microsoft:
-    products:
-      active_directory_controller: active_directory
-      exchange_server_5.5: exchange_server
-      exchange_2000_server: exchange_server
-      exchange_2003_server: exchange_server
-      exchange_2007_server: exchange_server
-      lightweight_directory_server: active_directory_lightweight_directory_service
-      windows_server_2003_datacenter_edition: windows_server_2003
-      windows_server_2003_r2: windows_server_2003
-      windows_2008_r2: windows_server_2008
-      windows_server_2008_datacenter_edition: windows_server_2008
-      windows_server_2008_r2: windows_server_2008
-      windows_server_2008_r2_datacenter_edition: windows_server_2008
-      windows_server_2012_r2: windows_server_2012
-      nt: windows_nt
-      windows_nt_desktop: windows_nt
-      windows_nt_server: windows_nt
-      windows_server_2000: windows_2000
-      windows_2000_server: windows_2000
-      windows_2000_datacenter_server: windows_2000
-      pws: personal_web_server
-  mod_ssl:
-    vendor: modssl
-  mod_wsgi:
-    vendor: modwsgi
-  # NIST took the vendor name from the website but apparently missed the `.in`
-  # in moinmo.in was part of the name
-  moinmoin:
-    vendor: moinmo
-  mort_bay:
-    vendor: mortbay
-  munin:
-    vendor: munin-monitoring
-  nlnet_labs:
-    vendor: nlnetlabs
-    products:
-      dnsd: name_server_daemon
-  net-snmp:
-    products:
-      snmp_agent: net-snmp
-  owncloud:
-    products:
-      owncloud_server: owncloud
-  palo_alto_networks:
-    vendor: paloaltonetworks
-  parallels:
-    products:
-      plesk: parallels_plesk_panel
-  plesk:
-    vendor: parallels
-  proftpd_project:
-    vendor: proftpd
-  progress:
-    products:
-      openedge_explorer: openedge
-  pulse_secure:
-    vendor: pulsesecure
-  realvnc_ltd.:
-    vendor: realvnc
-  red_hat:
-    vendor: redhat
-    products:
-      cygwin_x_server_project: cygwin
-      fedora_core_linux: fedora_core
-      jboss_as: jboss_wildfly_application_server
-      jboss_eap: jboss_enterprise_application_platform
-      jbossweb: jboss_web_framework_kit
-      red_hat_directory_server: directory_server
-  squid_cache:
-    vendor: squid-cache
-  sun:
-    vendor: sun
-    products:
-      solaris: sunos
-  swagger:
-    vendor: smartbear
-  synology:
-    products:
-      dsm: diskstation_manager
-  tandberg:
-    vendor: cisco
-  tightvnc:
-    products:
-      desktop: tightvnc
-  tor_project:
-    vendor: torproject
-  traefik_labs:
-    vendor: containous
-    products:
-      traefik_proxy: traefik
-  twistedmatrix:
-    products:
-      twisted_web: twistedweb
-  ubiquiti:
-    vendor: ui
-  ubuntu:
-    vendor: canonical
-    products:
-      linux: ubuntu_linux
-  vandyke_software:
-    vendor: vandyke
-  vmware:
-    products:
-      photon_linux: photon_os
-      zimbra: zimbra_desktop
-      vcenter: vcenter_server
-      vmware_esx_server: esx
-      vmware_esxi_server: esxi
-  wind_river:
-    vendor: windriver
-  x.org:
-    products:
-      x.org_x11: x11
+  # The following section contains CPE application or 'a' remappings. These will
+  # ONLY be used for mapping Recog 'service' attributes.
+  a:
+    akamai:
+      products:
+        ghost: akamaighost
+    amazon:
+      products:
+        s3: amazon_simple_storage_service
+        cloudfront_load_balancer: amazon_cloudfront
+    apache:
+      products:
+        httpd: http_server
+    aprelium_technologies:
+      vendor: aprelium
+    alt-n:
+      vendor: altn
+    aruba_networks:
+      vendor: arubanetworks
+    bea:
+      products:
+        weblogic: weblogic_server
+    blue_coat:
+      vendor: bluecoat
+    carnegie_mellon_university:
+      vendor: cmu
+      products:
+        cyrus_imap: cyrus_imap_server
+    centos_webpanel:
+      vendor: centos-webpanel
+    check_point:
+      vendor: checkpoint
+    cherokee_project:
+      vendor: cherokee-project
+    cisco:
+      products:
+        apic: application_policy_infrastructure_controller
+    cloudflare:
+      products:
+        cloudflare_load_balancer: load_balancing
+    cpanel:
+      products:
+        cpanel_service_daemon: cpanel
+    crushftp:
+      products:
+        crushftp_web_interface: crushftp
+    cz.nic:
+      vendor: knot-dns
+    drupal:
+      products:
+        cms: drupal
+    embedthis:
+      products:
+        goahead_webserver: goahead
+    envoy_proxy:
+      vendor: envoyproxy
+    f5:
+      products:
+        big-ip: big-ip_local_traffic_manager
+        big-ip_ltm: big-ip_local_traffic_manager
+    fedora_project:
+      vendor: fedoraproject
+    google:
+      products:
+        google_web_services: web_server
+    ibm:
+      products:
+        lotus_domino: lotus_domino_server
+        ibm_domino: lotus_domino
+    ignite_realtime:
+      vendor: igniterealtime
+    intel:
+      products:
+        intel(r)_active_management_technology: active_management_technology
+        intel(r)_standard_manageability: standard_manageability
+    jamf:
+      products:
+        jamf_pro: jamf
+    kibana:
+      vendor: elasticsearch
+    kubernetes:
+      products:
+        nginx_ingress_controller: ingress-nginx
+    kodi:
+      products:
+        media_server: kodi
+    kong:
+      vendor: konghq
+      products:
+        gateway: kong_gateway
+    litespeed_technologies:
+      vendor: litespeedtech
+    lotus:
+      vendor: ibm
+    lynx_technology:
+      vendor: lynxtechnology
+      products:
+        twonky_media_server: twonky_server
+    mailenable:
+      products:
+        mail_server: mailenable
+    manageengine:
+      vendor: zohocorp
+      products:
+        adaudit_plus: manageengine_adaudit_plus
+        desktop_central: manageengine_desktop_central
+        opmanager: manageengine_opmanager
+    microsoft:
+      products:
+        active_directory_controller: active_directory
+        exchange_server_5.5: exchange_server
+        exchange_2000_server: exchange_server
+        exchange_2003_server: exchange_server
+        exchange_2007_server: exchange_server
+        lightweight_directory_server: active_directory_lightweight_directory_service
+        pws: personal_web_server
+    mod_ssl:
+      vendor: modssl
+    mod_wsgi:
+      vendor: modwsgi
+    # NIST took the vendor name from the website but apparently missed the `.in`
+    # in moinmo.in was part of the name
+    moinmoin:
+      vendor: moinmo
+    mort_bay:
+      vendor: mortbay
+    munin:
+      vendor: munin-monitoring
+    nlnet_labs:
+      vendor: nlnetlabs
+      products:
+        dnsd: name_server_daemon
+    net-snmp:
+      products:
+        snmp_agent: net-snmp
+    owncloud:
+      products:
+        owncloud_server: owncloud
+    parallels:
+      products:
+        plesk: parallels_plesk_panel
+    plesk:
+      vendor: parallels
+    proftpd_project:
+      vendor: proftpd
+    progress:
+      products:
+        openedge_explorer: openedge
+    pulse_secure:
+      vendor: pulsesecure
+    realvnc_ltd.:
+      vendor: realvnc
+    red_hat:
+      vendor: redhat
+      products:
+        cygwin_x_server_project: cygwin
+        jboss_as: jboss_wildfly_application_server
+        jboss_eap: jboss_enterprise_application_platform
+        jbossweb: jboss_web_framework_kit
+        red_hat_directory_server: directory_server
+    serv-u:
+      vendor: solarwinds
+    squid_cache:
+      vendor: squid-cache
+    ssh_communications_security:
+      vendor: ssh
+      products:
+        ssh_tectia_server: tectia_server
+    standard_networks:
+      vendor: ipswitch
+    swagger:
+      vendor: smartbear
+    synology:
+      products:
+        dsm: diskstation_manager
+    tightvnc:
+      products:
+        desktop: tightvnc
+    tor_project:
+      vendor: torproject
+    traefik_labs:
+      vendor: containous
+      products:
+        traefik_proxy: traefik
+    twistedmatrix:
+      products:
+        twisted_web: twistedweb
+    ubiquiti:
+      vendor: ui
+    vandyke_software:
+      vendor: vandyke
+    vmware:
+      products:
+        zimbra: zimbra_desktop
+        vcenter: vcenter_server
+    x.org:
+      products:
+        x.org_x11: x11
+
+  # The following section contains CPE operating system or 'o' remappings. These will
+  # ONLY be used for mapping Recog 'os' attributes.
+  o:
+    alpine:
+      vendor: alpinelinux
+      products:
+        linux: alpine_linux
+    apple:
+      products:
+        ios: iphone_os
+    centos:
+      products:
+        linux: centos
+    check_point:
+      vendor: checkpoint
+    cisco:
+      products:
+        adaptive_security_appliance: adaptive_security_appliance_software
+        nam: network_analysis_module_software
+        pix: pix_firewall_software
+        telepresence: telepresence_video_communication_server_software
+        vpn_3000_concentrator: vpn_3000_concentrator_series_software
+        wireless_lan_controller: wireless_lan_controller_software
+    citrix:
+      products:
+        netscaler: netscaler_firmware
+        netscaler_gateway: netscaler_gateway_firmware
+    cumulus:
+      vendor: cumulusnetworks
+    data_domain:
+      vendor: dell
+      products:
+        dd_os: emc_data_domain_os
+    debian:
+      products:
+        linux: debian_linux
+    hp:
+      products:
+        ilo: integrated_lights-out_firmware
+        ilo_firmware: integrated_lights-out_firmware
+        ilo_2: integrated_lights-out_2_firmware
+        ilo_3: integrated_lights-out_3_firmware
+        ilo_4: integrated_lights-out_4_firmware
+        ilo_5: integrated_lights-out_5_firmware
+        tru64_unix: tru64
+    ibm:
+      products:
+        os/400: os_400
+        i5/os: i5os
+    juniper:
+      products:
+        junos_os: junos
+    linux:
+      products:
+        linux: linux_kernel
+    microsoft:
+      products:
+        windows_server_2003_datacenter_edition: windows_server_2003
+        windows_server_2003_r2: windows_server_2003
+        windows_2008_r2: windows_server_2008
+        windows_server_2008_datacenter_edition: windows_server_2008
+        windows_server_2008_r2: windows_server_2008
+        windows_server_2008_r2_datacenter_edition: windows_server_2008
+        windows_server_2012_r2: windows_server_2012
+        nt: windows_nt
+        windows_nt_desktop: windows_nt
+        windows_nt_server: windows_nt
+        windows_server_2000: windows_2000
+        windows_2000_server: windows_2000
+        windows_2000_datacenter_server: windows_2000
+    oracle:
+      products:
+        ilom: integrated_lights_out_manager_firmware
+    palo_alto_networks:
+      vendor: paloaltonetworks
+    red_hat:
+      vendor: redhat
+      products:
+        fedora_core_linux: fedora_core
+    sun:
+      products:
+        solaris: sunos
+    ubiquiti:
+      vendor: ui
+    ubuntu:
+      vendor: canonical
+      products:
+        linux: ubuntu_linux
+    vmware:
+      products:
+        photon_linux: photon_os
+        vmware_esx_server: esx
+        vmware_esxi_server: esxi
+    wind_river:
+      vendor: windriver
+
+  # The following section contains CPE hardware or 'h' remappings. These will
+  # ONLY be used for mapping Recog 'hw' attributes.
+  h:
+    cisco:
+      products:
+        nam: network_analysis_module
+    citrix:
+      products:
+        netscaler_sdx_gateway: netscaler_sdx
+    emc:
+      products:
+        celerra: celerra_network_attached_storage
+    hp:
+      products:
+        ilo: integrated_lights-out
+    tandberg:
+      vendor: cisco
+    ubiquiti:
+      vendor: ui

--- a/identifiers/hw_family.txt
+++ b/identifiers/hw_family.txt
@@ -45,6 +45,7 @@ Multifunction
 My Book
 NE
 NPort
+NetScaler
 NetVanta
 Netscaler
 Network Audio

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -204,9 +204,12 @@ Mergepoint
 Miniserver
 My Book Live
 N5172B Signal Generator
+NAM
 NAS4Free
 NFVIS
 NPort
+NetScaler Gateway
+NetScaler SDX Gateway
 NetScreen
 NetVR
 Netbox
@@ -332,6 +335,7 @@ iCOM Control Panel
 iDRAC
 iLO
 iLO 3
+iLO 4
 iMac (20/24-inch, Early 2008)
 iMac (21.5-inch, 2017)
 iMac (21.5-inch, Late 2012)

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -330,6 +330,7 @@ iDRAC Linux
 iLO
 iLO 2
 iLO 3
+iLO 4
 iOS
 iScale
 im

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -125,6 +125,7 @@ ESMTP
 EWS
 Ecelerity Mail Server
 Elastic Load Balancer
+Elastic Load Balancing
 EmWeb
 Email Appliance
 Email Security
@@ -277,7 +278,7 @@ MetaDirectory Server
 Metabase
 Metasploit
 MiniDLNA
-MiniUPnP
+MiniUPnPd
 MobaXterm
 MoinMoin
 Mongoose
@@ -389,6 +390,7 @@ Recursor
 Red Hat Directory Server
 Redmine
 Reflection
+Reflection for Secure IT
 ReflectionX
 RemoteView
 Resin

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -237,6 +237,7 @@
     <param pos="0" name="service.vendor" value="ManageEngine"/>
     <param pos="0" name="service.product" value="ADAudit Plus"/>
     <param pos="0" name="service.certainty" value="0.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_adaudit_plus:-"/>
   </fingerprint>
 
   <fingerprint pattern="^e9d6d23a961ea23a3e961266876e0ffd$">
@@ -1189,7 +1190,7 @@
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.certainty" value="0.5"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -1373,6 +1374,7 @@
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler"/>
     <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:-"/>
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.family" value="NetScaler"/>
     <param pos="0" name="service.device" value="Network Management Device"/>
@@ -1389,6 +1391,7 @@
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler Gateway"/>
     <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_gateway_firmware:-"/>
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.family" value="NetScaler"/>
     <param pos="0" name="service.device" value="Network Management Device"/>
@@ -1581,6 +1584,7 @@
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO 3"/>
     <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_3_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:ad93b3973782b03ea62a43bd6602ba8b|d521487f45fa7657450edfd6c16e4a63)$">
@@ -1591,12 +1595,13 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.product" value="iLO"/>
     <param pos="0" name="hw.certainty" value="0.5"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO"/>
     <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^d11917dc7e651b21f0f75cd0dc309e8a$">

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -404,8 +404,6 @@ more text</example>
     <param pos="0" name="service.cpe23" value="cpe:/a:pureftpd:pure-ftpd:{service.version}"/>
   </fingerprint>
 
-  <!-- CPEs for Serv-U 15.x and above changed to SolarWinds -->
-
   <fingerprint pattern="^Serv-U FTP Server v(15\.\S+) ready\.\.\.$">
     <description>SolarWinds Serv-U with version </description>
     <example service.version="15.1.3.25">Serv-U FTP Server v15.1.3.25 ready...</example>
@@ -421,10 +419,10 @@ more text</example>
     <example service.version="2.5n">Serv-U FTP-Server v2.5n for WinSock ready...</example>
     <example service.version="6.0">Serv-U FTP Server v6.0 for WinSock ready</example>
     <param pos="0" name="service.vendor" value="Serv-U"/>
-    <param pos="0" name="service.product" value="Serv-U"/>
+    <param pos="0" name="service.product" value="Serv-U FTP Server"/>
     <param pos="0" name="service.family" value="Serv-U"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:serv-u:serv-u:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:solarwinds:serv-u_ftp_server:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -436,10 +434,10 @@ more text</example>
     <example service.version="7.2">Serv-U FTP Server v7.2 ready...</example>
     <example service.version="14.0">Serv-U FTP Server v14.0 ready...</example>
     <param pos="0" name="service.vendor" value="Serv-U"/>
-    <param pos="0" name="service.product" value="Serv-U"/>
+    <param pos="0" name="service.product" value="Serv-U FTP Server"/>
     <param pos="0" name="service.family" value="Serv-U"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:serv-u:serv-u:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:solarwinds:serv-u_ftp_server:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Welcom to Serv-U FTP Server$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -44,6 +44,7 @@
     <param pos="0" name="service.vendor" value="Amazon"/>
     <param pos="0" name="service.family" value="CloudFront"/>
     <param pos="0" name="service.product" value="CloudFront Load Balancer"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:amazon:amazon_cloudfront:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Microsoft Azure Web App - Error 404$">
@@ -965,11 +966,12 @@
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.product" value="iLO"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^HP Integrated Lights-Out 2$">
@@ -978,24 +980,38 @@
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.product" value="iLO"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO 2"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_2_firmware:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(iLO \d+)$">
-    <description>HP Integrated Lights-Out 3+</description>
-    <example hw.product="iLO 3" os.product="iLO 3">iLO 3</example>
-    <example hw.product="iLO 4" os.product="iLO 4">iLO 4</example>
+  <fingerprint pattern="^iLO 3$">
+    <description>HP Integrated Lights-Out 3</description>
+    <example>iLO 3</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
-    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.product" value="iLO 3"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.family" value="iLO"/>
-    <param pos="1" name="os.product"/>
+    <param pos="0" name="os.product" value="iLO 3"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_3_firmware:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^iLO 4$">
+    <description>HP Integrated Lights-Out 4</description>
+    <example>iLO 4</example>
+    <param pos="0" name="hw.device" value="Lights Out Management"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="hw.product" value="iLO 4"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.family" value="iLO"/>
+    <param pos="0" name="os.product" value="iLO 4"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_4_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^HPE SimpliVity OmniStack$">
@@ -1223,7 +1239,6 @@
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.product" value="MDS 9000"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:mds_9000:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Stealthwatch Management Console$">
@@ -1277,7 +1292,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Wireless Controller"/>
     <param pos="0" name="os.product" value="Wireless LAN Controller"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.product" value="Wireless LAN Controller"/>
@@ -1695,10 +1710,11 @@
   </fingerprint>
 
   <fingerprint pattern="^Login - OpenStack Dashboard$">
-    <description>OpenStack Dashboard</description>
+    <description>OpenStack Horizon Dashboard</description>
     <example>Login - OpenStack Dashboard</example>
     <param pos="0" name="service.vendor" value="OpenStack"/>
-    <param pos="0" name="service.product" value="Dashboard"/>
+    <param pos="0" name="service.product" value="Horizon"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openstack:horizon:-"/>
   </fingerprint>
 
   <fingerprint pattern="^splunkd$">
@@ -1815,7 +1831,7 @@
     <example>ManageEngine OpManager</example>
     <param pos="0" name="service.vendor" value="ManageEngine"/>
     <param pos="0" name="service.product" value="OpManager"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:manageengine:opmanager:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_opmanager:-"/>
   </fingerprint>
 
   <fingerprint pattern="^ManageEngine Desktop Central 9$">
@@ -1831,6 +1847,7 @@
     <example>ManageEngine ADAudit Plus</example>
     <param pos="0" name="service.vendor" value="ManageEngine"/>
     <param pos="0" name="service.product" value="ADAudit Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_adaudit_plus:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(ScanFront \d.+)Web Menu$">
@@ -1889,11 +1906,17 @@
     <param pos="0" name="os.family" value="NetScaler"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:-"/>
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.family" value="NetScaler"/>
     <param pos="0" name="service.device" value="Network Management Device"/>
     <param pos="0" name="service.product" value="NetScaler"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:citrix:netscaler:-"/>
+    <param pos="0" name="hw.vendor" value="Citrix"/>
+    <param pos="0" name="hw.family" value="NetScaler"/>
+    <param pos="0" name="hw.device" value="Network Management Device"/>
+    <param pos="0" name="hw.product" value="NetScaler Gateway"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:citrix:netscaler_gateway:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Netscaler Gateway$">
@@ -1903,11 +1926,17 @@
     <param pos="0" name="os.family" value="NetScaler"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler Gateway"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_gateway_firmware:-"/>
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.family" value="NetScaler"/>
     <param pos="0" name="service.device" value="Network Management Device"/>
     <param pos="0" name="service.product" value="NetScaler Gateway"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:citrix:netscaler_gateway:-"/>
+    <param pos="0" name="hw.vendor" value="Citrix"/>
+    <param pos="0" name="hw.family" value="NetScaler"/>
+    <param pos="0" name="hw.device" value="Network Management Device"/>
+    <param pos="0" name="hw.product" value="NetScaler Gateway"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:citrix:netscaler_gateway:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Citrix (?:NetScaler SDX|ADC SDX)$">
@@ -1922,6 +1951,11 @@
     <param pos="0" name="service.family" value="NetScaler"/>
     <param pos="0" name="service.device" value="Network Management Device"/>
     <param pos="0" name="service.product" value="NetScaler SDX Gateway"/>
+    <param pos="0" name="hw.vendor" value="Citrix"/>
+    <param pos="0" name="hw.family" value="NetScaler"/>
+    <param pos="0" name="hw.device" value="Network Management Device"/>
+    <param pos="0" name="hw.product" value="NetScaler SDX Gateway"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:citrix:netscaler_sdx:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Citrix NetScaler Insight Center$">
@@ -2492,7 +2526,7 @@
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="Oracle"/>
     <param pos="0" name="os.family" value="ILOM"/>
-    <param pos="0" name="os.product" value="Integrated Lights Out Manager firmware"/>
+    <param pos="0" name="os.product" value="ILOM"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:oracle:integrated_lights_out_manager_firmware:-"/>
   </fingerprint>
 

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -12,6 +12,7 @@
     <param pos="0" name="service.vendor" value="CloudFlare"/>
     <param pos="0" name="service.product" value="CloudFlare Load Balancer"/>
     <param pos="0" name="service.family" value="CloudFlare"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cloudflare:load_balancing:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(AWSALB(?:TG)?(?:CORS)?)=.*$">
@@ -198,7 +199,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -222,6 +223,7 @@
     <param pos="0" name="os.family" value="NetScaler"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:-"/>
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.family" value="NetScaler"/>
     <param pos="0" name="service.device" value="Network Management Device"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1364,13 +1364,13 @@
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="iLO"/>
     <param pos="0" name="service.family" value="iLO"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:hp:integrated_lights_out:-"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.product" value="iLO"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
   </fingerprint>
 
   <!--
@@ -2110,7 +2110,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -2235,6 +2235,7 @@
     <param pos="0" name="os.family" value="NetScaler"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="NetScaler"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:-"/>
     <param pos="0" name="service.vendor" value="Citrix"/>
     <param pos="0" name="service.family" value="NetScaler"/>
     <param pos="0" name="service.device" value="Network Management Device"/>
@@ -2996,6 +2997,7 @@
     <example>GHost</example>
     <param pos="0" name="service.vendor" value="Akamai"/>
     <param pos="0" name="service.product" value="GHost"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:akamai:akamaighost:-"/>
     <param pos="0" name="os.vendor" value="Akamai"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.device" value="Web Proxy"/>
@@ -3026,8 +3028,9 @@
     <description>Amazon CloudFront web load balancer endpoint</description>
     <example>CloudFront</example>
     <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.family" value="Web Services"/>
     <param pos="0" name="service.product" value="CloudFront Load Balancer"/>
-    <param pos="0" name="service.family" value="CloudFront"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:amazon:amazon_cloudfront:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Amazon-Cloud-Drive$">
@@ -3043,13 +3046,14 @@
     <param pos="0" name="service.vendor" value="Amazon"/>
     <param pos="0" name="service.family" value="Web Services"/>
     <param pos="0" name="service.product" value="S3"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:amazon:web_services_simple_storage_service:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:amazon:amazon_simple_storage_service:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Amazon SimpleDB$">
     <description>Amazon SimpleDB / Simple Database Service</description>
     <example>Amazon SimpleDB</example>
     <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.family" value="Web Services"/>
     <param pos="0" name="service.product" value="SimpleDB"/>
   </fingerprint>
 
@@ -3057,16 +3061,18 @@
     <description>Amazon Snowball</description>
     <example>AmazonSnowball</example>
     <param pos="0" name="service.vendor" value="Amazon"/>
+    <param pos="0" name="service.family" value="Web Services"/>
     <param pos="0" name="service.product" value="Snowball"/>
   </fingerprint>
 
   <fingerprint pattern="^awselb/([\d.rc]+)$">
-    <description>Amazon Elastic Load Balancer</description>
+    <description>Amazon Elastic Load Balancing</description>
     <example service.version="2.0">awselb/2.0</example>
     <param pos="0" name="service.vendor" value="Amazon"/>
     <param pos="0" name="service.family" value="Web Services"/>
-    <param pos="0" name="service.product" value="Elastic Load Balancer"/>
+    <param pos="0" name="service.product" value="Elastic Load Balancing"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:amazon:elastic_load_balancing:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^cloudflare(?:-nginx)?$">
@@ -3076,6 +3082,7 @@
     <param pos="0" name="service.vendor" value="CloudFlare"/>
     <param pos="0" name="service.product" value="CloudFlare Load Balancer"/>
     <param pos="0" name="service.family" value="CloudFlare"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cloudflare:load_balancing:-"/>
   </fingerprint>
 
   <fingerprint pattern="^gSOAP/([\d\.]+)$">
@@ -3303,9 +3310,9 @@
     <example>Linux/2.6.29.6-217.2.3.fc11.i686.PAE UPnP/1.0 miniupnpd/1.0</example>
     <example>Linux/2.4.21 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
@@ -3316,18 +3323,18 @@
     <description>Tomato UPnP Server</description>
     <example service.version="1.2">Tomato UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^(RT-\w+) UPnP/\S+ MiniUPnPd/([\d.]+)$">
     <description>Asus WAP UPnP Server</description>
     <example service.version="1.2">RT-G32 UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Asus"/>
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -3337,9 +3344,9 @@
     <description>DrayTek Vigor router UPnP Server</description>
     <example service.version="1.0" hw.model="2130">DrayTek/Vigor2130 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="hw.vendor" value="DrayTek"/>
     <param pos="0" name="hw.product" value="Vigor"/>
     <param pos="1" name="hw.model"/>
@@ -3357,9 +3364,9 @@
     <description>OpenWRT Kamikaze WAP UPnP Server</description>
     <example service.version="1.5">OpenWRT/kamikaze UPnP/1.0 MiniUPnPd/1.5</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Linux"/>
     <param pos="0" name="os.family" value="OpenWRT"/>
     <param pos="0" name="os.product" value="Kamikaze"/>
@@ -3370,9 +3377,9 @@
     <description>Netgear DG834G or WNDR3300 WAP UPnP Server</description>
     <example service.version="1.0">Netgear/1.0 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Netgear"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Netgear"/>
@@ -3397,9 +3404,9 @@
     <example os.version="wheezy/sid" service.version="1.8">Debian/wheezy/sid UPnP/1.1 MiniUPnPd/1.8</example>
     <example os.version="4.0" service.version="1.0">Debian/4.0 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.certainty" value="0.5"/>
@@ -3413,9 +3420,9 @@
     <example os.version="8" service.version="1.0">Fedora/8 UPnP/1.0 miniupnpd/1.0</example>
     <example os.version="6" service.version="1.0">FedoraCore/6 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
     <param pos="0" name="os.product" value="Fedora Core Linux"/>
@@ -3430,9 +3437,9 @@
     <example os.version="7.10" service.version="1.0">Ubuntu/7.10 UPnP/1.0 miniupnpd/1.0</example>
     <example os.version="9.04" service.version="1.0">Ubuntu/9.04 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
@@ -3443,9 +3450,9 @@
     <description>miniupnpd on an Ubuntu bionic/18.04</description>
     <example os.version="18.04" service.version="1.4">Ubuntu/bionic UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="18.04"/>
@@ -3456,9 +3463,9 @@
     <description>miniupnpd on an Ubuntu yakkety/16.10</description>
     <example os.version="16.10" service.version="1.4">Ubuntu/yakkety UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="16.10"/>
@@ -3469,9 +3476,9 @@
     <description>miniupnpd on an Ubuntu xenial/16.04</description>
     <example os.version="16.04" service.version="1.4">Ubuntu/xenial UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="16.04"/>
@@ -3482,9 +3489,9 @@
     <description>miniupnpd on an Ubuntu utopic/14.10</description>
     <example os.version="14.10" service.version="1.4">Ubuntu/utopic UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.10"/>
@@ -3495,9 +3502,9 @@
     <description>miniupnpd on an Ubuntu trusty/14.04</description>
     <example os.version="14.04" service.version="1.4">Ubuntu/trusty UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="14.04"/>
@@ -3508,9 +3515,9 @@
     <description>miniupnpd on an Ubuntu saucy/13.10</description>
     <example os.version="13.10" service.version="1.4">Ubuntu/saucy UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.10"/>
@@ -3521,9 +3528,9 @@
     <description>miniupnpd on an Ubuntu raring/13.04</description>
     <example os.version="13.04" service.version="1.4">Ubuntu/raring UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.04"/>
@@ -3534,9 +3541,9 @@
     <description>miniupnpd on an Ubuntu quantal/12.10</description>
     <example os.version="12.10" service.version="1.4">Ubuntu/quantal UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
@@ -3547,9 +3554,9 @@
     <description>miniupnpd on an Ubuntu precise/12.04</description>
     <example os.version="12.04" service.version="1.4">Ubuntu/precise UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.04"/>
@@ -3560,9 +3567,9 @@
     <description>miniupnpd on an Ubuntu oneiric/11.10</description>
     <example os.version="11.10" service.version="1.4">Ubuntu/oneiric UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="11.10"/>
@@ -3573,9 +3580,9 @@
     <description>miniupnpd on an Ubuntu natty/11.04</description>
     <example os.version="11.04" service.version="1.4">Ubuntu/natty UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="11.04"/>
@@ -3586,9 +3593,9 @@
     <description>miniupnpd on an Ubuntu maverick/10.10</description>
     <example os.version="10.10" service.version="1.4">Ubuntu/maverick UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.10"/>
@@ -3599,9 +3606,9 @@
     <description>miniupnpd on an Ubuntu lucid/10.04</description>
     <example os.version="10.04" service.version="1.4">Ubuntu/lucid UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="10.04"/>
@@ -3612,9 +3619,9 @@
     <description>miniupnpd on an Ubuntu karmic/9.10</description>
     <example os.version="9.10" service.version="1.4">Ubuntu/karmic UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="9.10"/>
@@ -3625,9 +3632,9 @@
     <description>miniupnpd on an Ubuntu jaunty/9.04</description>
     <example os.version="9.04" service.version="1.4">Ubuntu/jaunty UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="9.04"/>
@@ -3638,9 +3645,9 @@
     <description>miniupnpd on an Ubuntu hardy/8.04</description>
     <example os.version="8.04" service.version="1.4">Ubuntu/hardy UPnP/1.0 MiniUPnPd/1.4</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.04"/>
@@ -3651,9 +3658,9 @@
     <description>Linux MIPS UPnP Server</description>
     <example>Linux Mips 2.4.20 UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.vendor" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
@@ -3668,9 +3675,9 @@
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:smoothwall:smoothwall:{os.version}"/>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^(\S+) \d+/Service Pack \d+, UPnP/[\d\.]+, TVersity Media Server$">
@@ -3886,9 +3893,9 @@
     <example service.version="1.2">TBS/R2 UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="hw.vendor" value="D-Link"/>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^alphapd/(\d\.[\d.]+)$">
@@ -4101,9 +4108,9 @@
     <param pos="0" name="hw.product" value="Roku"/>
     <param pos="0" name="hw.device" value="Media Server"/>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnp:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^UPnP/\S+, DLNADOC/\S+, Platinum/(\S+)$">
@@ -4521,7 +4528,7 @@
     <param pos="2" name="service.version"/>
     <param pos="0" name="service.vendor" value="Netgear"/>
     <param pos="0" name="service.family" value="UPnP"/>
-    <param pos="0" name="service.product" value="MiniUPnP"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="0" name="hw.vendor" value="Netgear"/>
     <param pos="0" name="hw.product" value="WNR2000"/>
     <param pos="0" name="hw.device" value="Router"/>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -362,6 +362,7 @@
     <param pos="0" name="os.product" value="NetScaler"/>
     <param pos="3" name="os.arch"/>
     <param pos="4" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^.*version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -837,6 +837,7 @@
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
     <param pos="0" name="service.version" value="4"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:4"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
@@ -888,6 +889,7 @@
     <param pos="0" name="service.vendor" value="Lotus"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:-"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="notes.build.version"/>
     <param pos="3" name="system.time"/>
@@ -899,6 +901,7 @@
     <param pos="0" name="service.vendor" value="Lotus"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:-"/>
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss Z"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="system.time"/>

--- a/xml/smtp_expn.xml
+++ b/xml/smtp_expn.xml
@@ -78,6 +78,7 @@
     <param pos="0" name="service.vendor" value="Lotus"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:-"/>
   </fingerprint>
 
   <fingerprint pattern="^550[ -]Unable to find list '.*'\.$">

--- a/xml/smtp_vrfy.xml
+++ b/xml/smtp_vrfy.xml
@@ -95,6 +95,7 @@
     <param pos="0" name="service.vendor" value="Lotus"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ibm:lotus_domino:-"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1583,7 +1583,7 @@
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance:{os.version}"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:{os.version}"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -1612,7 +1612,7 @@
     <param pos="0" name="os.product" value="VPN 3000 Concentrator"/>
     <param pos="0" name="os.device" value="VPN"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:vpn_3000_concentrator:{os.version}"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:vpn_3000_concentrator_series_software:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-[^\)]+\), Version ([^, ]+)[,\s]?">
@@ -1631,6 +1631,11 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     <param pos="0" name="os.product" value="NAM"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:network_analysis_module_software:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.product" value="NAM"/>
+    <param pos="0" name="hw.device" value="Network Management Device"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:network_analysis_module:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-([^\-]+)-NAM\)$">
@@ -1640,6 +1645,9 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="NAM"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:network_analysis_module_software:-"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="hw.device" value="Network Management Device"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
@@ -3074,6 +3082,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.product" value="iLO"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Integrated Lights-Out (\d) \(iLO \d\) for Integrity$">
@@ -3084,6 +3093,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.product" value="iLO"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:{os.version}"/>
   </fingerprint>
 
   <!--======================================================================
@@ -4912,6 +4922,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.product" value="NetScaler"/>
     <param pos="1" name="os.version"/>
     <param pos="2" name="os.version.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:{os.version}"/>
   </fingerprint>
 
   <!--======================================================================

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -33,12 +33,12 @@
     <param pos="0" name="service.product" value="iLO"/>
     <param pos="0" name="service.family" value="iLO"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:hp:integrated_lights_out:{service.version}"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.product" value="iLO"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Serv-U_([\d\.]+)$">
@@ -1704,7 +1704,7 @@
     <param pos="0" name="service.product" value="SSH"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="Wireless LAN Controller"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller_software:-"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^Cleo (\S+)/(\S+) SSH FTP server$">
@@ -1865,6 +1865,7 @@
     <param pos="0" name="service.vendor" value="Standard Networks"/>
     <param pos="0" name="service.family" value="MOVEit DMZ"/>
     <param pos="0" name="service.product" value="MOVEit DMZ"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ipswitch:moveit_dmz:{service.version}"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -1953,7 +1954,8 @@
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="Attachmate"/>
     <param pos="0" name="service.family" value="Reflection"/>
-    <param pos="0" name="service.product" value="Reflection"/>
+    <param pos="0" name="service.product" value="Reflection for Secure IT"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:attachmate:reflection_for_secure_it:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^([^\s]*)\s*F-Secure SSH\s*(?:.*)$">
@@ -1972,6 +1974,7 @@
     <param pos="0" name="service.vendor" value="SSH Communications Security"/>
     <param pos="0" name="service.family" value="SSH Tectia Server"/>
     <param pos="0" name="service.product" value="SSH Tectia Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ssh:tectia_server:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^([0-9\.]+) SSH Secure Shell(?: \(non-commercial\))?$">
@@ -1983,6 +1986,7 @@
     <param pos="0" name="service.vendor" value="SSH Communications Security"/>
     <param pos="0" name="service.family" value="SSH Tectia Server"/>
     <param pos="0" name="service.product" value="SSH Tectia Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ssh:tectia_server:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^([0-9\.]+) SSH Secure Shell Windows NT Server$">
@@ -1996,6 +2000,7 @@
     <param pos="0" name="service.vendor" value="SSH Communications Security"/>
     <param pos="0" name="service.family" value="SSH Tectia Server"/>
     <param pos="0" name="service.product" value="SSH Tectia Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ssh:tectia_server:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^ARRIS_(.*)$">
@@ -2083,6 +2088,7 @@
     <param pos="0" name="service.vendor" value="Standard Networks"/>
     <param pos="0" name="service.family" value="MOVEit DMZ"/>
     <param pos="0" name="service.product" value="MOVEit DMZ"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:ipswitch:moveit_dmz:-"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -184,7 +184,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -226,11 +226,12 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
     <param pos="0" name="hw.product" value="iLO"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=synology.com,O=Synology Inc.,L=Taipei,C=TW$">

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -221,11 +221,12 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
     <param pos="0" name="hw.product" value="iLO"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
@@ -236,11 +237,12 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
     <param pos="0" name="hw.product" value="iLO"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=OA\-([a-fA-F0-9]+),OU=Onboard Administrator,">
@@ -251,11 +253,12 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
     <param pos="0" name="hw.product" value="iLO"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
     <param pos="1" name="host.mac"/>
   </fingerprint>
 
@@ -266,11 +269,12 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
     <param pos="0" name="hw.product" value="iLO"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights_out:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out:-"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="iLO"/>
     <param pos="0" name="os.product" value="iLO"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_firmware:-"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
@@ -393,7 +397,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -407,7 +411,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Wireless Controller"/>
     <param pos="0" name="os.product" value="Wireless LAN Controller"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller_software:-"/>
     <param pos="1" name="cisco.serial_number"/>
   </fingerprint>
 
@@ -417,7 +421,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Wireless Controller"/>
     <param pos="0" name="os.product" value="Wireless LAN Controller"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.product" value="Wireless LAN Controller"/>
@@ -1195,6 +1199,7 @@
     <example>CN=a248.e.akamai.net,O=Akamai Technologies\, Inc.,L=Cambridge,ST=Massachusetts,C=US</example>
     <param pos="0" name="service.vendor" value="Akamai"/>
     <param pos="0" name="service.product" value="GHost"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:akamai:akamaighost:-"/>
     <param pos="0" name="os.vendor" value="Akamai"/>
     <param pos="0" name="os.device" value="Web Proxy"/>
   </fingerprint>


### PR DESCRIPTION
## Description
This PR addresses an issue brought up by @p0lr in Issue #343. In that issue @p0lr points out that we're using deprecated CPE values and that the NIST database that we're already using indicates that the values are deprecated.

I've adjusted the matching logic in `update_cpes.py` so that these deprecated CPEs aren't added when we build our list of NIST issued CPEs.

I've also restructured `cpe-remap.yaml` so that we remap values are specific to a CPE type (`a`, `o`, `h`). This will allow us to remap certain older records that use the same `.product` value but for which the CPE would be different between `service.product` and `os.product`.

For example in the fingerprint below we couldn't have created a remap for `ILOM` under `oracle` because it would have then generated (or tried to generate) the same CPE for both `hw.product` and `os.product`.

```xml
<fingerprint pattern="^(?:Oracle\(R\) )?Integrated Lights Out Manager$">
    <description>Oracle iLOM</description>
    <example>Oracle(R) Integrated Lights Out Manager</example>
    <example>Integrated Lights Out Manager</example>
    <param pos="0" name="hw.device" value="Lights Out Management"/>
    <param pos="0" name="hw.vendor" value="Oracle"/>
    <param pos="0" name="hw.family" value="ILOM"/>
    <param pos="0" name="hw.product" value="ILOM"/>
    <param pos="0" name="os.device" value="Lights Out Management"/>
    <param pos="0" name="os.vendor" value="Oracle"/>
    <param pos="0" name="os.family" value="ILOM"/>
    <param pos="0" name="os.product" value="ILOM"/>
  </fingerprint>
```

With the new system we can remap them independently which will help us generate CPEs for existing values without having to change them.


## Motivation and Context
Correctness of results.


## How Has This Been Tested?
Execution of `cpe-remap.yaml`, rspec, etc.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
