### PR TITLE
MDNS: Add AppleTV 4K second gen

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -297,6 +297,26 @@ mappings:
   # The following section contains CPE hardware or 'h' remappings. These will
   # ONLY be used for mapping Recog 'hw' attributes.
   h:
+    apple:
+      products:
+        imac_(retina_4k_21.5-inch_2019): imac
+        imac_(retina_5k_27-inch_2017): imac
+        imac_(retina_5k_27-inch_2019): imac
+        imac_(retina_5k_27-inch_2020): imac
+        macbook_air_(13-inch_2017): macbook_air
+        macbook_air_(m1_2020): macbook_air
+        macbook_air_(retina_13-inch_2018): macbook_air
+        macbook_air_(retina_13-inch_2019): macbook_air
+        macbook_air_(retina_13-inch_2020): macbook_air
+        macbook_pro_(13-inch_2018_four_thunderbolt_3_ports): macbook_pro
+        macbook_pro_(13-inch_2019_two_thunderbolt_3_ports): macbook_pro
+        macbook_pro_(13-inch_2020): macbook_pro
+        macbook_pro_(13-inch_m1_2020): macbook_pro
+        macbook_pro_(15-inch_2018): macbook_pro
+        macbook_pro_(15-inch_2019): macbook_pro
+        macbook_pro_(16-inch_2019): macbook_pro
+        macbook_pro_(retina_13-inch_early_2015): macbook_pro
+        macbook_pro_(retina_15-inch_mid_2015): macbook_pro
     cisco:
       products:
         nam: network_analysis_module

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -20,6 +20,7 @@ Apple TV (2nd generation)
 Apple TV (3rd generation)
 Apple TV (4th generation)
 Apple TV 4K
+Apple TV 4K (2nd generation)
 Appliance
 ArchiveTeam Warrior
 Asset Management

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -1817,6 +1817,20 @@
 
   <!-- Apple TV -->
 
+  <fingerprint pattern="^model=(?:J305AP|AppleTV11,1)$">
+    <description>Apple TV 4K (2nd generation)</description>
+    <example>model=J305AP</example>
+    <example>model=AppleTV11,1</example>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="tvOS"/>
+    <param pos="0" name="os.product" value="tvOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:tvos:-"/>
+    <param pos="0" name="hw.vendor" value="Apple"/>
+    <param pos="0" name="hw.family" value="Apple TV"/>
+    <param pos="0" name="hw.product" value="Apple TV 4K (2nd generation)"/>
+    <param pos="0" name="hw.device" value="Media Server"/>
+  </fingerprint>
+
   <fingerprint pattern="^model=(?:J105aAP|AppleTV6,2)$">
     <description>Apple TV 4K</description>
     <example>model=J105aAP</example>

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -259,6 +259,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, M1, 2020)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro16,1$">
@@ -272,6 +273,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (16-inch, 2019)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro16,[23]$">
@@ -286,6 +288,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2020)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro15,4$">
@@ -299,6 +302,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro15,3$">
@@ -312,6 +316,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (15-inch, 2019)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro15,2$">
@@ -325,6 +330,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2018, Four Thunderbolt 3 ports)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro15,1$">
@@ -338,6 +344,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (15-inch, 2018)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro14,3$">
@@ -429,6 +436,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (Retina, 13-inch, Early 2015)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro11,[45]$">
@@ -443,6 +451,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (Retina, 15-inch, Mid 2015)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro11,3$">
@@ -746,6 +755,7 @@
     <param pos="0" name="hw.family" value="MacBook"/>
     <param pos="0" name="hw.product" value="MacBook Air (M1, 2020)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_air:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookAir9,1$">
@@ -759,6 +769,7 @@
     <param pos="0" name="hw.family" value="MacBook"/>
     <param pos="0" name="hw.product" value="MacBook Air (Retina, 13-inch, 2020)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_air:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookAir8,2$">
@@ -772,6 +783,7 @@
     <param pos="0" name="hw.family" value="MacBook"/>
     <param pos="0" name="hw.product" value="MacBook Air (Retina, 13-inch, 2019)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_air:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookAir8,1$">
@@ -785,6 +797,7 @@
     <param pos="0" name="hw.family" value="MacBook"/>
     <param pos="0" name="hw.product" value="MacBook Air (Retina, 13-inch, 2018)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_air:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookAir7,2$">
@@ -798,6 +811,7 @@
     <param pos="0" name="hw.family" value="MacBook"/>
     <param pos="0" name="hw.product" value="MacBook Air (13-inch, 2017)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_air:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookAir7,1$">
@@ -1236,6 +1250,7 @@
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="iMac (Retina 5K, 27-inch, 2020)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:imac:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=iMac19,1$">
@@ -1249,6 +1264,7 @@
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="iMac (Retina 5K, 27-inch, 2019)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:imac:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=iMac19,2$">
@@ -1262,6 +1278,7 @@
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="iMac (Retina 4K, 21.5-inch, 2019)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:imac:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=iMacPro1,1$">
@@ -1288,6 +1305,7 @@
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="iMac (Retina 5K, 27-inch, 2017)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:imac:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=iMac18,2$">


### PR DESCRIPTION
## Description
Add AppleTV 4K second generation to `xml/mdns_device-info_txt.xml`. Values observed in PCAPs.


Reference: https://www.theiphonewiki.com/wiki/J305AP

I've also added some CPE remaps for recent Apple hardware.

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
