### PR TITLE
Field migration: host.id -> hw.serial_number

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -309,6 +309,10 @@ mappings:
     hp:
       products:
         ilo: integrated_lights-out
+    kace:
+      vendor: dell
+      products:
+        k1000: kace_k1000_systems_management_appliance
     tandberg:
       vendor: cisco
     ubiquiti:

--- a/identifiers/fields.txt
+++ b/identifiers/fields.txt
@@ -12,7 +12,6 @@ dell.service_tag
 extron.model
 fortinet.serial_number
 host.domain
-host.id
 host.ip
 host.mac
 host.mac_eui64
@@ -25,6 +24,7 @@ hw.device
 hw.family
 hw.model
 hw.product
+hw.serial_number
 hw.series
 hw.vendor
 hw.version

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -116,7 +116,6 @@ IPReach
 IPSO
 IRIX
 Integrated Lights Out Manager
-Integrated Lights Out Manager firmware
 Irix
 Isilon OneFS OS
 JetDirect

--- a/lib/recog/nizer.rb
+++ b/lib/recog/nizer.rb
@@ -8,13 +8,13 @@ class Nizer
   # Non-weighted host attributes that can be extracted from fingerprint matches
   HOST_ATTRIBUTES = %W{
     host.domain
-    host.id
     host.ip
     host.mac
     host.name
     host.time
     hw.device
     hw.family
+    hw.serial_number
     hw.product
     hw.vendor
   }
@@ -264,84 +264,3 @@ class Nizer
 
 end
 end
-
-=begin
-
-Current key names:
-
-  apache.info
-  apache.variant
-  apache.variant.version
-  cookie
-  host.domain
-  host.id
-  host.ip
-  host.mac
-  host.name
-  host.time
-  hw.device
-  hw.family
-  hw.product
-  hw.vendor
-  imail.eval
-  jetty.info
-  junction.cookie
-  junction.name
-  linux.kernel.version
-  loadbalancer.poolname
-  mdaemon.unregistered
-  mercur.os.info
-  metainfo.version
-  metainfo.version.version
-  ms.nttp.version
-  notes.build.version
-  notes.intl
-  ntmail.id
-  openssh.comment
-  openssh.cvepatch
-  os.arch
-  os.build
-  os.certainty
-  os.device
-  os.edition
-  os.family
-  os.product
-  os.vendor
-  os.version
-  os.version.version
-  os.version.version.version
-  postfix.os.info
-  postoffice.build
-  postoffice.id
-  proftpd.server.name
-  pureftpd.config
-  qpopper.version
-  sendmail.config.version
-  sendmail.hpux.phne.version
-  sendmail.vendor.version
-  service.certainty
-  service.component.family
-  service.component.product
-  service.component.vendor
-  service.component.version
-  service.family
-  service.product
-  service.vendor
-  service.version
-  service.version.version
-  service.version.version.version
-  service.version.version.version.version
-  service.version.version.version.version.version
-  siemens.model
-  snmp.fpmib.oid.1
-  snmp.fpmib.oid.2
-  system.time
-  system.time.format
-  system.time.micros
-  system.time.millis
-  thttpd.mx-patch
-  timeout
-  tomcat.info
-  zmailer.ident
-
-=end

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1624,11 +1624,11 @@ more text</example>
 
   <fingerprint pattern="^Sofrel (S5[\w]+) SN ([\d-]+)  ready. Time is (\d{2}:\d{2}:\d{2} \d{2}\/\d{2}\/\d{2})\.$">
     <description>Sofrel Remote Terminal Unit</description>
-    <example hw.product="S500" host.id="01-499-00427" system.time="00:11:39 01/11/16">Sofrel S500 SN 01-499-00427  ready. Time is 00:11:39 01/11/16.</example>
+    <example hw.product="S500" hw.serial_number="01-499-00427" system.time="00:11:39 01/11/16">Sofrel S500 SN 01-499-00427  ready. Time is 00:11:39 01/11/16.</example>
     <param pos="0" name="hw.vendor" value="Sofrel"/>
     <param pos="0" name="hw.family" value="S500 Range"/>
     <param pos="1" name="hw.product"/>
-    <param pos="2" name="host.id"/>
+    <param pos="2" name="hw.serial_number"/>
     <param pos="0" name="system.time.format" value="HH:mm:ss dd/MM/yy"/>
     <param pos="3" name="system.time"/>
   </fingerprint>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1134,20 +1134,22 @@
 
   <fingerprint pattern="^Agilent 33220A \((.*)\)$">
     <description>Agilent 33220A</description>
-    <example agilent.serial="MY44041111">Agilent 33220A (MY44041111)</example>
+    <example agilent.serial="MY44041111" hw.serial="MY44041111">Agilent 33220A (MY44041111)</example>
     <param pos="0" name="hw.vendor" value="Agilent"/>
     <param pos="0" name="hw.device" value="Test Instrument"/>
     <param pos="0" name="hw.product" value="33220A Waveform Generator"/>
     <param pos="1" name="agilent.serial"/>
+    <param pos="1" name="hw.serial_number"/>
   </fingerprint>
 
   <fingerprint pattern="^Agilent N5172B (?:EXG )?(MY\S+)$">
     <description>Agilent N5172B</description>
-    <example agilent.serial="MY44041111">Agilent N5172B EXG MY44041111</example>
+    <example agilent.serial="MY44041111" hw.serial="MY44041111">Agilent N5172B EXG MY44041111</example>
     <param pos="0" name="hw.vendor" value="Agilent"/>
     <param pos="0" name="hw.device" value="Test Instrument"/>
     <param pos="0" name="hw.product" value="N5172B Signal Generator"/>
     <param pos="1" name="agilent.serial"/>
+    <param pos="1" name="hw.serial_number"/>
   </fingerprint>
 
   <fingerprint pattern="^Polycom - Configuration Utility$">
@@ -1397,6 +1399,7 @@
     <param pos="0" name="hw.vendor" value="KACE"/>
     <param pos="0" name="hw.device" value="Support Appliance"/>
     <param pos="0" name="hw.product" value="K1000"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:dell:kace_k1000_systems_management_appliance:-"/>
     <param pos="0" name="os.vendor" value="KACE"/>
     <param pos="0" name="os.family" value="FreeBSD"/>
   </fingerprint>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1134,7 +1134,7 @@
 
   <fingerprint pattern="^Agilent 33220A \((.*)\)$">
     <description>Agilent 33220A</description>
-    <example agilent.serial="MY44041111" hw.serial="MY44041111">Agilent 33220A (MY44041111)</example>
+    <example agilent.serial="MY44041111" hw.serial_number="MY44041111">Agilent 33220A (MY44041111)</example>
     <param pos="0" name="hw.vendor" value="Agilent"/>
     <param pos="0" name="hw.device" value="Test Instrument"/>
     <param pos="0" name="hw.product" value="33220A Waveform Generator"/>
@@ -1144,7 +1144,7 @@
 
   <fingerprint pattern="^Agilent N5172B (?:EXG )?(MY\S+)$">
     <description>Agilent N5172B</description>
-    <example agilent.serial="MY44041111" hw.serial="MY44041111">Agilent N5172B EXG MY44041111</example>
+    <example agilent.serial="MY44041111" hw.serial_number="MY44041111">Agilent N5172B EXG MY44041111</example>
     <param pos="0" name="hw.vendor" value="Agilent"/>
     <param pos="0" name="hw.device" value="Test Instrument"/>
     <param pos="0" name="hw.product" value="N5172B Signal Generator"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -163,14 +163,13 @@
       The cookie value breaks down to [box-id][service-id][timeout-value]
       unfortunately, there's no separator so it's hard to tell what the
       actual break is between the pieces of data.
-      http://www.cisco.com/warp/public/117/AP_cookies.html
   -->
 
   <fingerprint pattern="^ARPT=([A-Z]+)([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})[A-Z]+.*">
     <description>Cisco 11000 Series Content Service Switch (CSS)</description>
-    <example host.id="FOOOB" host.ip="192.168.15.52">ARPT=FOOOB192.168.15.52CKOKM; path=/</example>
+    <example host.name="FOOOB" host.ip="192.168.15.52">ARPT=FOOOB192.168.15.52CKOKM; path=/</example>
     <param pos="0" name="cookie" value="ARPT"/>
-    <param pos="1" name="host.id"/>
+    <param pos="1" name="host.name"/>
     <param pos="2" name="host.ip"/>
     <param pos="0" name="service.vendor" value="Cisco"/>
     <param pos="0" name="service.family" value="Content Service Switch"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1993,11 +1993,11 @@
        this information useful and mappable to CPE
   -->
 
-  <fingerprint pattern="^HP HTTP Server; (?:Hewlett-Packard )?HP ((\S+) \S+)">
+  <fingerprint pattern="^HP HTTP Server; (?:Hewlett-Packard )?HP ((\S+) \S+)[^;]+; Serial Number: ([^;]+);">
     <description>HP Printer</description>
-    <example os.product="Photosmart C309a" os.family="Photosmart">HP HTTP Server; HP Photosmart C309a series - CC335A; Serial Number: abc123; Vader Built:Wed Apr 15, 2009 11:40:58AM {abc123, ASIC id 0x00280004}</example>
-    <example os.product="Officejet 6500" os.family="Officejet">HP HTTP Server; HP Officejet 6500 E709n - CB057A; Serial Number: abc123; Rainbow Built:Sat Dec 13, 2008 10:58:21AM {abc123, ASIC id 0x00ffc2105}</example>
-    <example os.product="Designjet T520" os.family="Designjet">HP HTTP Server; Hewlett-Packard HP Designjet T520 36in - ABC123; Serial Number: 0123456789; Built:Tue Sep 09, 2014 08:32:54AM {012345678901}</example>
+    <example os.product="Photosmart C309a" os.family="Photosmart" hw.serial_number="abc123">HP HTTP Server; HP Photosmart C309a series - CC335A; Serial Number: abc123; Vader Built:Wed Apr 15, 2009 11:40:58AM {abc123, ASIC id 0x00280004}</example>
+    <example os.product="Officejet 6500" os.family="Officejet" hw.serial_number="abc123">HP HTTP Server; HP Officejet 6500 E709n - CB057A; Serial Number: abc123; Rainbow Built:Sat Dec 13, 2008 10:58:21AM {abc123, ASIC id 0x00ffc2105}</example>
+    <example os.product="Designjet T520" os.family="Designjet" hw.serial_number="0123456789">HP HTTP Server; Hewlett-Packard HP Designjet T520 36in - ABC123; Serial Number: 0123456789; Built:Tue Sep 09, 2014 08:32:54AM {012345678901}</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="JetDirect"/>
     <param pos="0" name="service.family" value="JetDirect"/>
@@ -2009,6 +2009,7 @@
     <param pos="0" name="hw.family" value="JetDirect"/>
     <param pos="0" name="hw.product" value="JetDirect"/>
     <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="3" name="hw.serial_number"/>
   </fingerprint>
 
   <fingerprint pattern="^HTTP/1\.0$">

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -578,7 +578,7 @@
     <description>Polycom Video Conferencing - VSX Family</description>
     <!-- Hi, my name is :     Something Pity\r\nHere is what I know about myself:\r\nModel:               VSX 6000A\r\nSerial Number:       00070906FC34F6\r\nSoftware Version:    Release 9.0.6.2-103 - 04Sep2011 21:27\r\nBuild Information:   ecomman -->
 
-    <example _encoding="base64" hw.product="6000A" host.id="00070906FC34F6" os.version="9.0.6.2-103">
+    <example _encoding="base64" hw.product="6000A" hw.serial_number="00070906FC34F6" os.version="9.0.6.2-103">
       SGksIG15IG5hbWUgaXMgOiAgICAgU29tZXRoaW5nIFBpdHkNCkhlcmUgaXMgd2hhdCBJIGtub
       3cgYWJvdXQgbXlzZWxmOg0KTW9kZWw6ICAgICAgICAgICAgICAgVlNYIDYwMDBBDQpTZXJpYW
       wgTnVtYmVyOiAgICAgICAwMDA3MDkwNkZDMzRGNg0KU29mdHdhcmUgVmVyc2lvbjogICAgUmV
@@ -589,7 +589,7 @@
     <param pos="0" name="hw.family" value="VSX"/>
     <param pos="0" name="hw.device" value="Video Conferencing"/>
     <param pos="1" name="hw.product"/>
-    <param pos="2" name="host.id"/>
+    <param pos="2" name="hw.serial_number"/>
     <param pos="3" name="os.version"/>
   </fingerprint>
 
@@ -727,7 +727,7 @@
 
     <!-- Catalyst 1900 Management Console\r\nCopyright (c) Cisco Systems, Inc.  1993-1998\r\nAll rights reserved.\r\nEnterprise Edition Software\r\nEthernet Address:      00-AA-19-38-AA-00\r\n\r\nPCA Number:            73-31AA-AA\r\nPCA Serial Number:     FAB033AAAAA\r\nModel Number:          WS-C1924-EN\r\nSystem Serial Number:  FAB0341AAAA\r\nPower Supply S/N:    -->
 
-    <example _encoding="base64" host.mac="00-AA-19-38-AA-00" hw.model="WS-C1924-EN" host.id="FAB0341AAAA">
+    <example _encoding="base64" host.mac="00-AA-19-38-AA-00" hw.model="WS-C1924-EN" hw.serial_number="FAB0341AAAA">
       Q2F0YWx5c3QgMTkwMCBNYW5hZ2VtZW50IENvbnNvbGUNCkNvcHlyaWdodCAoYykgQ2lzY28gU
       3lzdGVtcywgSW5jLiAgMTk5My0xOTk4DQpBbGwgcmlnaHRzIHJlc2VydmVkLg0KRW50ZXJwcm
       lzZSBFZGl0aW9uIFNvZnR3YXJlDQpFdGhlcm5ldCBBZGRyZXNzOiAgICAgIDAwLUFBLTE5LTM
@@ -744,7 +744,7 @@
     <param pos="0" name="hw.device" value="Switch"/>
     <param pos="1" name="host.mac"/>
     <param pos="2" name="hw.model"/>
-    <param pos="3" name="host.id"/>
+    <param pos="3" name="hw.serial_number"/>
   </fingerprint>
 
   <fingerprint pattern="^192.0.0.64 login:\s*$">
@@ -919,7 +919,7 @@
     <description>Moxa NPort Device Server - IA Series</description>
     <!-- Model name       : NPort IA-5250\r\u0000\nMAC address      : 00:90:E8:AA:AA:AA\r\u0000\nSerial No.       : 281\r\u0000\nFirmware version : 1.6 Build 17060616\r\u0000\nSystem uptime    : 31 days, 06h:03m:45s\r\u0000\n\r\u0000\nPlease keyin your password: -->
 
-    <example _encoding="base64" hw.product="IA-5250" host.mac="00:90:E8:AA:AA:AA" host.id="281" os.version="1.6" os.version.version="17060616">
+    <example _encoding="base64" hw.product="IA-5250" host.mac="00:90:E8:AA:AA:AA" hw.serial_number="281" os.version="1.6" os.version.version="17060616">
       TW9kZWwgbmFtZSAgICAgICA6IE5Qb3J0IElBLTUyNTANAApNQUMgYWRkcmVzcyAgICAgIDogM
       DA6OTA6RTg6QUE6QUE6QUENAApTZXJpYWwgTm8uICAgICAgIDogMjgxDQAKRmlybXdhcmUgdm
       Vyc2lvbiA6IDEuNiBCdWlsZCAxNzA2MDYxNg0AClN5c3RlbSB1cHRpbWUgICAgOiAzMSBkYXl
@@ -930,7 +930,7 @@
     <param pos="0" name="hw.device" value="Device Server"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="host.mac"/>
-    <param pos="3" name="host.id"/>
+    <param pos="3" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Moxa"/>
     <param pos="4" name="os.version"/>
     <param pos="5" name="os.version.version"/>
@@ -942,7 +942,7 @@
 
     <!-- Model name       : NPort 5610-8-DT\r\u0000\nMAC address      : 00:90:E8:AA:AA:AA\r\u0000\nSerial No.       : 9522\r\u0000\nFirmware version : 2.2 Build 11090613\r\u0000\nSystem uptime    : 8 days, 02h:11m:44s\r\u0000\n\r\u0000\nPlease keyin your password: -->
 
-    <example _encoding="base64" hw.product="5610-8-DT" host.mac="00:90:E8:AA:AA:AA" host.id="9522" os.version="2.2" os.version.version="11090613">
+    <example _encoding="base64" hw.product="5610-8-DT" host.mac="00:90:E8:AA:AA:AA" hw.serial_number="9522" os.version="2.2" os.version.version="11090613">
       TW9kZWwgbmFtZSAgICAgICA6IE5Qb3J0IDU2MTAtOC1EVA0ACk1BQyBhZGRyZXNzICAgICAgO
       iAwMDo5MDpFODpBQTpBQTpBQQ0AClNlcmlhbCBOby4gICAgICAgOiA5NTIyDQAKRmlybXdhcm
       UgdmVyc2lvbiA6IDIuMiBCdWlsZCAxMTA5MDYxMw0AClN5c3RlbSB1cHRpbWUgICAgOiA4IGR
@@ -953,7 +953,7 @@
     <param pos="0" name="hw.device" value="Device Server"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="host.mac"/>
-    <param pos="3" name="host.id"/>
+    <param pos="3" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Moxa"/>
     <param pos="4" name="os.version"/>
     <param pos="5" name="os.version.version"/>
@@ -976,7 +976,7 @@
     <description>Moxa MGate Modbus Gateway</description>
     <!-- Model name       : MGate MB3180\r\u0000\nMAC address      : 00:90:E8:AA:AA:AA\r\u0000\nSerial No.       : 9474\r\u0000\nFirmware version : 1.2 Build 09101913\r\u0000\nSystem uptime    : 15 days, 16h:37m:48s\r\u0000\n\r\u0000\nPlease keyin your password: -->
 
-    <example _encoding="base64" hw.product="MB3180" host.mac="00:90:E8:AA:AA:AA" host.id="9474" os.version="1.2" os.version.version="09101913">
+    <example _encoding="base64" hw.product="MB3180" host.mac="00:90:E8:AA:AA:AA" hw.serial_number="9474" os.version="1.2" os.version.version="09101913">
       TW9kZWwgbmFtZSAgICAgICA6IE1HYXRlIE1CMzE4MA0ACk1BQyBhZGRyZXNzICAgICAgOiAwM
       Do5MDpFODpBQTpBQTpBQQ0AClNlcmlhbCBOby4gICAgICAgOiA5NDc0DQAKRmlybXdhcmUgdm
       Vyc2lvbiA6IDEuMiBCdWlsZCAwOTEwMTkxMw0AClN5c3RlbSB1cHRpbWUgICAgOiAxNSBkYXl
@@ -987,7 +987,7 @@
     <param pos="0" name="hw.device" value="Industrial Control"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="host.mac"/>
-    <param pos="3" name="host.id"/>
+    <param pos="3" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Moxa"/>
     <param pos="4" name="os.version"/>
     <param pos="5" name="os.version.version"/>
@@ -997,14 +997,14 @@
     <description>Moxa NE Series Embedded device server</description>
     <!-- Model name       : NE-4110S\r\u0000\nMAC address      : 00:90:E8:AA:AA:AA\r\u0000\nSerial No        : 3616\r\u0000\nFirmware version : 4.1 Build 07061517\r\u0000\n\r\u0000\nPlease keyin your password: -->
 
-    <example _encoding="base64" hw.product="NE-4110S" host.mac="00:90:E8:AA:AA:AA" host.id="3616" os.version="4.1" os.version.version="07061517">
+    <example _encoding="base64" hw.product="NE-4110S" host.mac="00:90:E8:AA:AA:AA" hw.serial_number="3616" os.version="4.1" os.version.version="07061517">
       TW9kZWwgbmFtZSAgICAgICA6IE5FLTQxMTBTDQAKTUFDIGFkZHJlc3MgICAgICA6IDAwOjkwO
       kU4OkFBOkFBOkFBDQAKU2VyaWFsIE5vICAgICAgICA6IDM2MTYNAApGaXJtd2FyZSB2ZXJzaW
       9uIDogNC4xIEJ1aWxkIDA3MDYxNTE3DQAKDQAKUGxlYXNlIGtleWluIHlvdXIgcGFzc3dvcmQ6
     </example>
     <!-- Model name       : NE-4110S\r\nMAC address      : 00:90:E8:AA:AA:AA\r\nSerial No        : 000\r\nFirmware version : 1.5.2\r\n\r\nPlease keyin your password: -->
 
-    <example _encoding="base64" hw.product="NE-4110S" host.mac="00:90:E8:AA:AA:AA" host.id="000" os.version="1.5.2">
+    <example _encoding="base64" hw.product="NE-4110S" host.mac="00:90:E8:AA:AA:AA" hw.serial_number="000" os.version="1.5.2">
       TW9kZWwgbmFtZSAgICAgICA6IE5FLTQxMTBTDQpNQUMgYWRkcmVzcyAgICAgIDogMDA6OTA6RTg6QUE6QUE6QUENClNlcmlhbCBObyAgICAgICAgOiAwMDANCkZpcm13YXJlIHZlcnNpb24gOiAxLjUuMg0KDQpQbGVhc2Uga2V5aW4geW91ciBwYXNzd29yZDoK
       </example>
     <param pos="0" name="hw.vendor" value="Moxa"/>
@@ -1012,7 +1012,7 @@
     <param pos="0" name="hw.device" value="Device Server"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="host.mac"/>
-    <param pos="3" name="host.id"/>
+    <param pos="3" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Moxa"/>
     <param pos="4" name="os.version"/>
     <param pos="5" name="os.version.version"/>
@@ -1022,7 +1022,7 @@
     <description>Moxa MiiNePort Series Embedded device server</description>
     <!-- Model name          : MiiNePort E2\r\nSerial No.          : 9999\r\nDevice name         : MiiNePort_E2_4064\r\nFirmware version    : 1.3.36 Build 15031615\r\nEthernet MAC address: 00:90:E8:5A:92:FF\r\n\r\nPlease keyin your password: -->
 
-    <example _encoding="base64" hw.product="MiiNePort E2" host.mac="00:90:E8:5A:92:FF" host.id="9999" os.version="1.3.36" os.version.version="15031615">
+    <example _encoding="base64" hw.product="MiiNePort E2" host.mac="00:90:E8:5A:92:FF" hw.serial_number="9999" os.version="1.3.36" os.version.version="15031615">
       TW9kZWwgbmFtZSAgICAgICAgICA6IE1paU5lUG9ydCBFMg0KU2VyaWFsIE5vLiAgICAgICAgI
       CA6IDk5OTkNCkRldmljZSBuYW1lICAgICAgICAgOiBNaWlOZVBvcnRfRTJfNDA2NA0KRmlybX
       dhcmUgdmVyc2lvbiAgICA6IDEuMy4zNiBCdWlsZCAxNTAzMTYxNQ0KRXRoZXJuZXQgTUFDIGF
@@ -1033,7 +1033,7 @@
     <param pos="0" name="hw.family" value="MiiNePort"/>
     <param pos="0" name="hw.device" value="Device Server"/>
     <param pos="1" name="hw.product"/>
-    <param pos="2" name="host.id"/>
+    <param pos="2" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Moxa"/>
     <param pos="3" name="os.version"/>
     <param pos="4" name="os.version.version"/>
@@ -1806,7 +1806,7 @@
     \n \nServer Name: PS-B04E8E\nServer Model: LPV 2 - TX 1\nF / W Version: 2.00 J \nMAC Address: AE 32 EA 21 BB E3\n
     Uptime: 0 days, 00: 00: 12\n \nPlease Enter Password:"-->
 
-    <example _encoding="base64" os.version="2.00" host.id="PS-B04E8E" hw.model="LPV" host.mac="AE 32 EA 21 BB E3">
+    <example _encoding="base64" os.version="2.00" host.name="PS-B04E8E" hw.model="LPV" host.mac="AE 32 EA 21 BB E3">
       KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiogV2VsY29tZSB0byBNRUxDTyBQc
       mludCBTZXJ2ZXIgKlxuKiBUZWxuZXQgQ29uc29sZSAqXG4qKioqKioqKioqKioqKioqKioqKioqKi
       oqKioqKioqKioqKlxuIFxuU2VydmVyIE5hbWU6IFBTLUIwNEU4RVxuU2VydmVyIE1vZGVsOiBMUFY
@@ -1817,7 +1817,7 @@
     <param pos="0" name="os.vendor" value="Buffalo"/>
     <param pos="0" name="os.family" value="PrintServer"/>
     <param pos="0" name="os.device" value="Print Server"/>
-    <param pos="1" name="host.id"/>
+    <param pos="1" name="host.name"/>
     <param pos="0" name="hw.vendor" value="Buffalo"/>
     <param pos="0" name="hw.device" value="Print Server"/>
     <param pos="2" name="hw.model"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -69,11 +69,12 @@
 
   <fingerprint pattern="^SERIALNUMBER=PID:([^ ]+) SN:([^,]+),CN=(?:[a-zA-Z0-9\-]+)-SEP([a-fA-F0-9]{12}),OU=[CV]TG,O=Cisco Systems Inc\.$">
     <description>Cisco IP phone with serial number</description>
-    <example host.mac="B07D47D33A1C" hw.product="CP-8851" cisco.serial_number="FCH1924AHCA">SERIALNUMBER=PID:CP-8851 SN:FCH1924AHCA,CN=CP-8851-SEPB07D47D33A1C,OU=CTG,O=Cisco Systems Inc.</example>
-    <example host.mac="64D989000000" hw.product="CP-9951" cisco.serial_number="FCH15200000">SERIALNUMBER=PID:CP-9951 SN:FCH15200000,CN=CP-9951-SEP64D989000000,OU=VTG,O=Cisco Systems Inc.</example>
+    <example host.mac="B07D47D33A1C" hw.product="CP-8851" cisco.serial_number="FCH1924AHCA" hw.serial_number="FCH1924AHCA">SERIALNUMBER=PID:CP-8851 SN:FCH1924AHCA,CN=CP-8851-SEPB07D47D33A1C,OU=CTG,O=Cisco Systems Inc.</example>
+    <example host.mac="64D989000000" hw.product="CP-9951" cisco.serial_number="FCH15200000" hw.serial_number="FCH15200000">SERIALNUMBER=PID:CP-9951 SN:FCH15200000,CN=CP-9951-SEP64D989000000,OU=VTG,O=Cisco Systems Inc.</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.product"/>
+    <param pos="2" name="hw.serial_number"/>
     <param pos="2" name="cisco.serial_number"/>
     <param pos="3" name="host.mac"/>
   </fingerprint>
@@ -307,10 +308,11 @@
 
   <fingerprint pattern="^CN=C-series CIMC,OU=PID:([^ ]+) SERIAL:([^,]+),O=Cisco">
     <description>Cisco Integrated Management Controller</description>
-    <example cisco.serial_number="FCH18999AAA" cisco.imc_model="UCSC-C220-M3S">CN=C-series CIMC,OU=PID:UCSC-C220-M3S SERIAL:FCH18999AAA,O=Cisco Self Signed,L=San Jose,ST=California,C=US</example>
+    <example cisco.serial_number="FCH18999AAA" hw.serial_number="FCH18999AAA" cisco.imc_model="UCSC-C220-M3S">CN=C-series CIMC,OU=PID:UCSC-C220-M3S SERIAL:FCH18999AAA,O=Cisco Self Signed,L=San Jose,ST=California,C=US</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.product" value="IMC"/>
+    <param pos="2" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="IMC"/>
@@ -320,10 +322,11 @@
 
   <fingerprint pattern="^CN=C220-(FCH[^,]+),OU=null,O=Cisco Systems Inc">
     <description>Cisco Integrated Management Controller C220</description>
-    <example cisco.serial_number="FCH17999AAA">CN=C220-FCH17999AAA,OU=null,O=Cisco Systems Inc.,L=San Jose,ST=California,C=US</example>
+    <example cisco.serial_number="FCH17999AAA" hw.serial_number="FCH17999AAA">CN=C220-FCH17999AAA,OU=null,O=Cisco Systems Inc.,L=San Jose,ST=California,C=US</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.product" value="IMC"/>
+    <param pos="1" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="IMC"/>
@@ -407,12 +410,13 @@
 
   <fingerprint pattern="^SERIALNUMBER=([a-zA-Z0-9]+),CN=DEVICE-vWLC,O=Cisco Virtual WLC$">
     <description>Cisco vWLC</description>
-    <example cisco.serial_number="9C89M2088D1">SERIALNUMBER=9C89M2088D1,CN=DEVICE-vWLC,O=Cisco Virtual WLC</example>
+    <example cisco.serial_number="9C89M2088D1" hw.serial_number="9C89M2088D1">SERIALNUMBER=9C89M2088D1,CN=DEVICE-vWLC,O=Cisco Virtual WLC</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Wireless Controller"/>
     <param pos="0" name="os.product" value="Wireless LAN Controller"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:wireless_lan_controller_software:-"/>
     <param pos="1" name="cisco.serial_number"/>
+    <param pos="1" name="hw.serial_number"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=[a-zA-Z0-9\.\-\_]+,OU=DeviceSSL \(WebAdmin\),O=Cisco Systems Inc\.,C=US$">
@@ -614,8 +618,8 @@
 
   <fingerprint pattern="^CN=([a-zA-Z0-9]{5,12}) ([a-zA-Z0-9]{12}),OU=(?:Cast|Google TV),O=Google Inc,L=Mountain View,ST=California,C=US$">
     <description>Google Chromecast</description>
-    <example chromecast.serial_number="LVDZG5" host.mac_local="FA8FCA67413D">CN=LVDZG5 FA8FCA67413D,OU=Cast,O=Google Inc,L=Mountain View,ST=California,C=US</example>
-    <example chromecast.serial_number="YRBLE" host.mac_local="FA8FCA7DE87D">CN=YRBLE FA8FCA7DE87D,OU=Google TV,O=Google Inc,L=Mountain View,ST=California,C=US</example>
+    <example chromecast.serial_number="LVDZG5" host.mac_local="FA8FCA67413D" hw.serial_number="LVDZG5">CN=LVDZG5 FA8FCA67413D,OU=Cast,O=Google Inc,L=Mountain View,ST=California,C=US</example>
+    <example chromecast.serial_number="YRBLE"  host.mac_local="FA8FCA7DE87D" hw.serial_number="YRBLE">CN=YRBLE FA8FCA7DE87D,OU=Google TV,O=Google Inc,L=Mountain View,ST=California,C=US</example>
     <param pos="0" name="os.vendor" value="Google"/>
     <param pos="0" name="os.product" value="Chrome OS"/>
     <param pos="0" name="os.certainty" value="0.5"/>
@@ -623,6 +627,7 @@
     <param pos="0" name="hw.device" value="Media Server"/>
     <param pos="0" name="hw.vendor" value="Google"/>
     <param pos="0" name="hw.product" value="Chromecast"/>
+    <param pos="1" name="hw.serial_number"/>
     <param pos="0" name="hw.certainty" value="0.5"/>
     <param pos="1" name="chromecast.serial_number"/>
     <!-- This is the hotspot-mode MAC address (clear bit 2) -->
@@ -632,13 +637,14 @@
 
   <fingerprint pattern="^CN=([a-zA-Z0-9]{5,12}) ([a-zA-Z0-9]{12}),OU=Cast TV \(Vizio\),O=Google Inc,L=Mountain View,ST=California,C=US$">
     <description>Vizio SmartTV (Android) with Google Cast</description>
-    <example chromecast.serial_number="9V039WC9" host.mac_local="FA8FCA697898">CN=9V039WC9 FA8FCA697898,OU=Cast TV (Vizio),O=Google Inc,L=Mountain View,ST=California,C=US</example>
+    <example chromecast.serial_number="9V039WC9" hw.serial_number="9V039WC9" host.mac_local="FA8FCA697898">CN=9V039WC9 FA8FCA697898,OU=Cast TV (Vizio),O=Google Inc,L=Mountain View,ST=California,C=US</example>
     <param pos="0" name="os.vendor" value="Google"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Android"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:google:android:-"/>
     <param pos="0" name="hw.device" value="Smart TV"/>
     <param pos="0" name="hw.vendor" value="Vizio"/>
+    <param pos="1" name="hw.serial_number"/>
     <param pos="1" name="chromecast.serial_number"/>
     <!-- This is the hotspot-mode MAC address (clear bit 2) -->
 
@@ -878,10 +884,11 @@
 
   <fingerprint pattern="^CN=([A-Za-z0-9]+),OU=FortiGate,O=Fortinet,L=Sunnyvale,ST=California,C=US$">
     <description>Fortinet Gateway</description>
-    <example fortinet.serial_number="FG100ETK1800118">CN=FG100ETK1800118,OU=FortiGate,O=Fortinet,L=Sunnyvale,ST=California,C=US</example>
-    <example fortinet.serial_number="FGT30D3X15038375">CN=FGT30D3X15038375,OU=FortiGate,O=Fortinet,L=Sunnyvale,ST=California,C=US</example>
+    <example fortinet.serial_number="FG100ETK1800118" hw.serial_number="FG100ETK1800118">CN=FG100ETK1800118,OU=FortiGate,O=Fortinet,L=Sunnyvale,ST=California,C=US</example>
+    <example fortinet.serial_number="FGT30D3X15038375" hw.serial_number="FGT30D3X15038375">CN=FGT30D3X15038375,OU=FortiGate,O=Fortinet,L=Sunnyvale,ST=California,C=US</example>
     <param pos="0" name="hw.vendor" value="Fortinet"/>
     <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="1" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Fortinet"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.device" value="Firewall"/>
@@ -892,9 +899,10 @@
 
   <fingerprint pattern="^CN=([A-Za-z0-9]+),O=Fortinet Ltd\.$">
     <description>Fortinet Gateway (Older)</description>
-    <example fortinet.serial_number="FG100D3G13803999">CN=FG100D3G13803999,O=Fortinet Ltd.</example>
+    <example fortinet.serial_number="FG100D3G13803999" hw.serial_number="FG100D3G13803999">CN=FG100D3G13803999,O=Fortinet Ltd.</example>
     <param pos="0" name="hw.vendor" value="Fortinet"/>
     <param pos="0" name="hw.device" value="Firewall"/>
+    <param pos="1" name="hw.serial_number"/>
     <param pos="0" name="os.vendor" value="Fortinet"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.device" value="Firewall"/>
@@ -1298,10 +1306,11 @@
 
   <fingerprint pattern="^CN=Ruckus Wireless ZoneDirector SN-(\d+),O=Ruckus Wireless\\, Inc\.,ST=CA,C=US$">
     <description>Ruckus Zone Director</description>
-    <example ruckus.serial_number="221301007591">CN=Ruckus Wireless ZoneDirector SN-221301007591,O=Ruckus Wireless\, Inc.,ST=CA,C=US</example>
+    <example ruckus.serial_number="221301007591" hw.serial_number="221301007591">CN=Ruckus Wireless ZoneDirector SN-221301007591,O=Ruckus Wireless\, Inc.,ST=CA,C=US</example>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.vendor" value="Ruckus"/>
     <param pos="0" name="hw.product" value="Zone Director"/>
+    <param pos="1" name="hw.serial_number"/>
     <param pos="0" name="os.device" value="Wireless Controller"/>
     <param pos="0" name="os.vendor" value="Ruckus"/>
     <param pos="0" name="os.product" value="Zone Director"/>


### PR DESCRIPTION
## Description
This PR implements the change discussed in Issue #364. 

The changes:
- changes `host.id` to `hw.serial_number` where the value is a hardware serial number
- changes `host.id` to `host.name` where the value references a host name
- in each case where there is a vendor specific serial number field such as `cisco.serial_number` that value is duplicated in `hw.serial_number` and a test added for it.


## Motivation and Context
The intent is to add clarity to the data that is captured. The field `host.id` was unclear and was being used to capture hostnames as well as serial numbers.


## How Has This Been Tested?
`rspec`, fingerprint example captures.


## Types of changes
- Field rename


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
