### PR TITLE
Regex cross-language compatibility

### DIFF
--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -353,7 +353,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Default (?:Parallels )?Plesk (?:Panel )?Page$">
+  <fingerprint pattern="(?i)^Default (?:Parallels )?Plesk (?:Panel )?Page$">
     <description>Plesk web hosting platform with no version</description>
     <example>Default Parallels Plesk Panel Page</example>
     <example>Default Parallels Plesk Page</example>
@@ -378,7 +378,7 @@
     <param pos="0" name="hw.device" value="DVR"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)(?:Dell )?Sonicwall - Authentication$">
+  <fingerprint pattern="(?i)^(?:Dell )?Sonicwall - Authentication$">
     <description>Sonicwall firewalls</description>
     <example>SonicWall - Authentication</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -945,7 +945,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:wftpserver:wing_ftp_server:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Linux UPnP/1.0 Sonos/([\d\.\-a-z]+) \((BR\d+)\)$">
+  <fingerprint pattern="(?i)^Linux UPnP/1.0 Sonos/([\d\.\-a-z]+) \((BR\d+)\)$">
     <description>Sonos Bridge/ZoneBridge</description>
     <example hw.model="BR100" hw.version="47.2-59120">Linux UPnP/1.0 Sonos/47.2-59120 (BR100)</example>
     <param pos="0" name="hw.vendor" value="Sonos"/>
@@ -956,7 +956,7 @@
     <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Linux UPnP/1.0 Sonos/([\d\.\-a-z]+) \(ANVIL\)$">
+  <fingerprint pattern="(?i)^Linux UPnP/1.0 Sonos/([\d\.\-a-z]+) \(ANVIL\)$">
     <description>Sonos Subwoofer Speaker</description>
     <example>Linux UPnP/1.0 Sonos/31.3-22220 (ANVIL)</example>
     <param pos="0" name="hw.vendor" value="Sonos"/>
@@ -1423,7 +1423,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:eclipse:jetty:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)squid/(\d+\.[\w.\-\+]+)$">
+  <fingerprint pattern="(?i)^squid/(\d+\.[\w.\-\+]+)$">
     <description>Squid Web Proxy with a version</description>
     <example service.version="2.3.STABLE1">Squid/2.3.STABLE1</example>
     <example service.version="4.4">squid/4.4</example>
@@ -1435,7 +1435,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:squid-cache:squid:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)squid$">
+  <fingerprint pattern="(?i)^squid$">
     <description>Squid Web Proxy without a version</description>
     <example>Squid</example>
     <example>squid</example>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -575,7 +575,7 @@
     <param pos="0" name="os.arch" value="ARM"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)OpenSER \(([\d.]+)(?:-tls|-notls)? \(sh4/linux\)\)$">
+  <fingerprint pattern="(?i)^OpenSER \(([\d.]+)(?:-tls|-notls)? \(sh4/linux\)\)$">
     <description>OpenSER OpenSER - Linux on Renesas SH4</description>
     <example service.version="1.3.2">OpenSER (1.3.2-notls (sh4/linux))</example>
     <param pos="0" name="service.vendor" value="OpenSER"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -1047,7 +1047,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)([^ ]+) +E?SMTP.* Postfix *$">
+  <fingerprint pattern="(?i)^([^ ]+) +E?SMTP.* Postfix *$">
     <description>Postfix - generic banner</description>
     <example>foo.bar ESMTP Postfix</example>
     <example>foo.bar SMTP Postfix</example>
@@ -1067,7 +1067,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:postfix:postfix:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)([^ ]+) POSTFIX$">
+  <fingerprint pattern="(?i)^([^ ]+) POSTFIX$">
     <description>Postfix - generic w/o ESMTP</description>
     <example host.name="foo.bar">foo.bar Postfix</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
@@ -1578,7 +1578,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)([^ ]+) +(?:ESMTP +)?Sendmail *(?: Ready.? ?)?(?:;|at)? ?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)(?: \(.+\))?$">
+  <fingerprint pattern="(?i)^([^ ]+) +(?:ESMTP +)?Sendmail *(?: Ready.? ?)?(?:;|at)? ?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)(?: \(.+\))?$">
     <description>Sendmail - with date, w/o version or platform, optional status string.</description>
     <example host.name="foo.bar">foo.bar ESMTP Sendmail ; Thu, 30 Nov 2017 17:50:14 +0900</example>
     <example host.name="foo.bar">foo.bar ESMTP Sendmail; Thu, 30 Nov 2017 17:50:14 +0900</example>
@@ -1680,7 +1680,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)([^ ]+) SMTP Server SLMail v?(\d\.[\d.]+) Ready ESMTP spoken here *$">
+  <fingerprint pattern="(?i)^([^ ]+) SMTP Server SLMail v?(\d\.[\d.]+) Ready ESMTP spoken here *$">
     <description>Seattle Labs SLMail server for Windows NT/2k (v2.7 runs on Win9x)</description>
     <example service.version="2.7">foo.bar Smtp Server SLMail v2.7 Ready ESMTP spoken here</example>
     <example service.version="3.2.3113">foo.bar SMTP Server SLmail 3.2.3113 Ready ESMTP spoken here</example>
@@ -1712,7 +1712,7 @@
 
   <!-- SonicWall makes hardware, virtual appliances, and Windows software. The banner doesn't indicate which. -->
 
-  <fingerprint pattern="^(?i)([^ ]+) ESMTP SonicWALL \(([\d.]+)\)$">
+  <fingerprint pattern="(?i)^([^ ]+) ESMTP SonicWALL \(([\d.]+)\)$">
     <description>SonicWall Email Security</description>
     <example host.name="foo.bar" service.version="9.0.5.2077">foo.bar ESMTP SonicWALL (9.0.5.2077)</example>
     <example host.name="foo.bar" service.version="9.1.1.3113">foo.bar ESMTP SonicWall (9.1.1.3113)</example>
@@ -1919,14 +1919,14 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)(\S+) E?SMTP Perl">
+  <fingerprint pattern="(?i)^(\S+) E?SMTP Perl">
     <description>Some simple PERL SMTP server</description>
     <example host.name="foo.bar">foo.bar ESMTP Perl</example>
     <param pos="0" name="service.product" value="Perl"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)(?:([^ ]+) )?E?SMTP(?: (?:Service )?Ready\.?)?$">
+  <fingerprint pattern="(?i)^(?:([^ ]+) )?E?SMTP(?: (?:Service )?Ready\.?)?$">
     <description>Non-specific banner with optional hostname</description>
     <example host.name="foo.bar">foo.bar ESMTP</example>
     <example host.name="foo.bar">foo.bar ESMTP Ready</example>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -17,28 +17,28 @@
   Ruby, Python, Java, and Golang.
   -->
 
-  <fingerprint pattern="\A(?i)(?:\r|\n)*login:\s*$">
+  <fingerprint pattern="(?i)\A(?:\r|\n)*login:\s*$">
     <description>bare 'login:' -- assert nothing.</description>
     <example>login:</example>
   </fingerprint>
 
-  <fingerprint pattern="\A(?i)(?:\r|\n)*User(?:name)?\s*:\s*$">
+  <fingerprint pattern="(?i)\A(?:\r|\n)*User(?:name)?\s*:\s*$">
     <description>bare 'Username:' -- assert nothing.</description>
     <example>Username:</example>
     <example>User:</example>
   </fingerprint>
 
-  <fingerprint pattern="\A(?i)(?:\r|\n)*Password:\s*$">
+  <fingerprint pattern="(?i)\A(?:\r|\n)*Password:\s*$">
     <description>bare 'Password:' -- assert nothing.</description>
     <example>Password:</example>
   </fingerprint>
 
-  <fingerprint pattern="\A(?i)(?:\r|\n)*Account:\s*$">
+  <fingerprint pattern="(?i)\A(?:\r|\n)*Account:\s*$">
     <description>bare 'Account:' -- assert nothing.</description>
     <example>Account:</example>
   </fingerprint>
 
-  <fingerprint pattern="\A(?i)Connection refused(?:\r|\n)*$">
+  <fingerprint pattern="(?i)\AConnection refused(?:\r|\n)*$">
     <description>bare 'Connection refused' -- assert nothing.</description>
     <example>Connection refused</example>
   </fingerprint>
@@ -424,7 +424,7 @@
     <param pos="4" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)TiMOS-[CB]-([\S]+) (?:both|cpm)/([\w]+) ALCATEL (SR [\S]+) Copyright.*Login:\s*$" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^TiMOS-[CB]-([\S]+) (?:both|cpm)/([\w]+) ALCATEL (SR [\S]+) Copyright.*Login:\s*$" flags="REG_MULTILINE">
     <description>ALCATEL Service Router running TiMOS</description>
     <!-- TiMOS-C-12.0.R12 cpm/hops64 ALCATEL SR 7750 Copyright (c) 2000-2015 Alcatel-Lucent.\r\r\nBanner Shortened For \r\r\nBrevity\r\nLogin: -->
 
@@ -446,7 +446,7 @@
 
   <!-- Nokia purchased Alcatel Lucent, finalized in Nov 2016 -->
 
-  <fingerprint pattern="^(?m)TiMOS-[CB]-([\S]+) (?:both|cpm)\/([\w]+) Nokia ([\S]+ [SRX]+) Copyright.*Login:\s*$" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^TiMOS-[CB]-([\S]+) (?:both|cpm)\/([\w]+) Nokia ([\S]+ [SRX]+) Copyright.*Login:\s*$" flags="REG_MULTILINE">
     <description>Nokia Service Router running TiMOS</description>
     <!-- TiMOS-C-14.0.R5 cpm/hops64 Nokia 7750 SR Copyright (c) 2000-2016 Nokia.\r\r\nBanner Shortened For \r\r\nBrevity\r\nLogin: -->
 
@@ -473,7 +473,7 @@
     <param pos="3" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)TiMOS-[CB]-([\S]+) (?:both|cpm)\/([\w]+) Nokia (SAS[+\w\s-]+) Copyright.*Login:\s*$" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^TiMOS-[CB]-([\S]+) (?:both|cpm)\/([\w]+) Nokia (SAS[+\w\s-]+) Copyright.*Login:\s*$" flags="REG_MULTILINE">
     <description>Nokia Service Access Switch running TiMOS</description>
     <!-- TiMOS-B-8.0.R12 both/hops Nokia SAS-Mxp 22F2C 4SFP+ 7210 Copyright (c) 2000-2017 Nokia.\r\r\nBanner Shortened For \r\r\nBrevity\r\nLogin: -->
 
@@ -721,7 +721,7 @@
     <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)(?:\r|\n)*Catalyst 1900 Management Console(?:\r|\n)+.*Ethernet Address:\s+([\w-]+)(?:\r|\n)+.*Model Number:\s+([\w-]+)(?:\r|\n)+System Serial Number:\s+(\w+)(?:\r|\n)+Power Supply" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^(?:\r|\n)*Catalyst 1900 Management Console(?:\r|\n)+.*Ethernet Address:\s+([\w-]+)(?:\r|\n)+.*Model Number:\s+([\w-]+)(?:\r|\n)+System Serial Number:\s+(\w+)(?:\r|\n)+Power Supply" flags="REG_MULTILINE">
     <description>Cisco Catalyst 1900</description>
     <!-- Catalyst 1900, unlike other Catalyst models, didn't run CatOS or IOS -->
 
@@ -855,7 +855,7 @@
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)(BCM\d+) Broadband Router\r\n.*Please input the verification code:$" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^(BCM\d+) Broadband Router\r\n.*Please input the verification code:$" flags="REG_MULTILINE">
     <description>OEM'd Broadcom Router - input validation code</description>
     <!-- BCM96318 Broadband Router\r\n====================================================\r\n    * *         * * * *      * * * *      * * * *   \r\n      *         *                  *      *     *   \r\n      *         * * * *      * * * *      * * * *   \r\n      *         *     *            *            *   \r\n      *         *     *            *            *   \r\n   * * * *      * * * *      * * * *      * * * *   \r\n====================================================\r\nPlease input the verification code: -->
 
@@ -1084,7 +1084,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
     <description>RedHat Enterprise Linux ES</description>
     <!-- Red Hat Enterprise Linux ES release 3 (Taroon Update 9\nKernel 2.4.21-47.EL on an x86_64\nlogin: -->
 
@@ -1101,7 +1101,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:redhat:linux:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)Red Hat Enterprise Linux AS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^Red Hat Enterprise Linux AS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">
     <description>RedHat Enterprise Linux AS</description>
     <!-- Red Hat Enterprise Linux AS release 5.8 (Tikanga)\nKernel 2.6.18-308.11.1.el5 on an x86_64\nlogin: -->
 
@@ -1117,7 +1117,7 @@
     <param pos="3" name="os.arch"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)Red Hat Enterprise Linux WS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^Red Hat Enterprise Linux WS release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*)" flags="REG_MULTILINE">
     <description>RedHat Enterprise Linux WS</description>
     <!--Red Hat Enterprise Linux WS release 2.1 (Tampa) \nKernel 2.4.9-e.40smp on an i686 \nlogin:  -->
 
@@ -1133,7 +1133,7 @@
     <param pos="3" name="os.arch"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)Fedora Core.release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d).*$" flags="REG_MULTILINE">
+  <fingerprint pattern="(?m)^Fedora Core.release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d).*$" flags="REG_MULTILINE">
     <description>Fedora Core Release</description>
     <!-- Fedora Core release 1 (Yarrow)\nKernel 2.4.20-13.9ensim-3.5.0-13 on an i686\nlogin:-->
 
@@ -1149,7 +1149,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)Welcome to SuSE Linux (.*) \(([^\)]+)\) - Kernel (.*) .*">
+  <fingerprint pattern="(?m)^Welcome to SuSE Linux (.*) \(([^\)]+)\) - Kernel (.*) .*">
     <description>SuSE Linux</description>
     <!-- Welcome to SuSE Linux 7.0 (i386) - Kernel 2.2.16-RAID (0). 2VG029037\n\nlogin: -->
 
@@ -1454,7 +1454,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*">
+  <fingerprint pattern="(?m)^Compaq Tru64 UNIX V(.*) \(Rev. (.*\d)\) .*">
     <description>Compaq Tru64 UNIX V</description>
     <!-- Compaq Tru64 UNIX V5.1B (Rev. 2650) (docalpha) (pts/11)\n\n\n\n\nlogin: -->
 
@@ -1517,7 +1517,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)SCO OpenServer\(TM\) Release ([^ ]+).*$">
+  <fingerprint pattern="(?m)^SCO OpenServer\(TM\) Release ([^ ]+).*$">
     <description>SCO OpenServer</description>
     <!-- SCO OpenServer(TM) Release 5 (bomdia.co.za) (ttyp6)\nlogin: -->
 
@@ -1723,7 +1723,7 @@
     <param pos="1" name="os.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m).*ConnectUPS">
+  <fingerprint pattern="(?m)^.*ConnectUPS">
     <description>PowerWare ConnectUPS</description>
     <!-- +============================================================================+\n|            [ ConnectUPS Web/SNMP
      Card Configuration Utility ]              |\n+============================================================================+\n
@@ -1800,7 +1800,7 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m).*Welcome to MELCO Print Server.*Server Name *: *([^ ]*)\W.*Server Model *: *([^ ]*).*F \/ W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. .. ..).*$">
+  <fingerprint pattern="(?m)^.*Welcome to MELCO Print Server.*Server Name *: *([^ ]*)\W.*Server Model *: *([^ ]*).*F \/ W Version *: *([^ ]*).*MAC Address *: *(.. .. .. .. .. ..).*$">
     <description>System is a Buffalo/MELCO Embedded Print Server</description>
     <!-- ***********************************\n* Welcome to MELCO Print Server *\n* Telnet Console *\n***********************************
     \n \nServer Name: PS-B04E8E\nServer Model: LPV 2 - TX 1\nF / W Version: 2.00 J \nMAC Address: AE 32 EA 21 BB E3\n
@@ -1825,7 +1825,7 @@
     <param pos="4" name="host.mac"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)AIX Version\W(\d).*">
+  <fingerprint pattern="(?m)^AIX Version\W(\d).*">
     <description>System is IBM AIX v</description>
     <!-- AIX Version 6\nCopyright IBM Corporation, 1982, 2007.\nlogin: -->
 
@@ -1839,7 +1839,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)CIMC Debug Firmware Utility Shell\W([^\s]+).*">
+  <fingerprint pattern="(?m)^CIMC Debug Firmware Utility Shell\W([^\s]+).*">
     <description>System is Cisco UCS Device</description>
     <!-- CIMC Debug Firmware Utility Shell\nfake-ucs-device-3-1-p login: -->
 
@@ -1853,7 +1853,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?m)HP ProLiant.*v(\d+.\d+)">
+  <fingerprint pattern="(?m)^HP ProLiant.*v(\d+.\d+)">
     <description>Sytem is HP ProLiant server</description>
     <!-- HP ProLiant BL e-Class Integrated Administrator v2.00
          Copyright 2005 Hewlett-Packard Development Group, L.P.
@@ -1880,7 +1880,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^Power Measurement Ltd. Meter ION ([[:alnum:]]+)">
+  <fingerprint pattern="^Power Measurement Ltd. Meter ION ([a-zA-Z0-9]+)">
     <!-- Power Measurement Ltd. Meter ION 7330V271 ETH ETH7330V272
          Serial#: PB-0204A058-11
          login: -->
@@ -1895,7 +1895,7 @@
     <param pos="1" name="hw.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^GW25 v([[:digit:]\.]+) - Intelligent Power Meters GPRS Gateway[[:space:]]+Developed by Satelitech">
+  <fingerprint pattern="^GW25 v([\d.]+) - Intelligent Power Meters GPRS Gateway\s+Developed by Satelitech">
     <!-- GW25 v1.2.1 - Intelligent Power Meters GPRS Gateway
          Developed by Satelitech S.A for ESG Dilec
          Enter password: -->

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -307,7 +307,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:containous:traefik:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)CN=Fireware web CA,OU=Fireware,O=WatchGuard(?: CA)?$">
+  <fingerprint pattern="(?i)^CN=Fireware web CA,OU=Fireware,O=WatchGuard(?: CA)?$">
     <description>WatchGuard Fireware</description>
     <example>CN=Fireware web ca,OU=Fireware,O=WatchGuard</example>
     <example>CN=Fireware web CA,OU=Fireware,O=Watchguard CA</example>


### PR DESCRIPTION
## Description
The intent of this PR is to improve cross language compatibility for the regex patterns used. 

The changes:

- Moves inline flags such as `(?i)` and `(?m)` to the beginning of the regex.  In Python these flags have global meaning and use of them anywhere other than the start of the pattern is deprecated. This does not change the function of these flags in current patterns for other languages.

- Replaces the use of POSIX character class indicators (`[[:alnum:]]`, `[[:digit:]`, and `[[:space:]`) with either the short backslash version (`\d`, `\s`) or a character range (`a-zA-Z0-9`).  The reason for this is that certain languages (Java, Python, Javascript) don't support the use of POSIX character classes.




## How Has This Been Tested?
`rspec`, 3rd party regex testors.


## Types of changes
Fingerprint construction


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
