### PR TITLE
DoS fix / regex performance tuning

### DIFF
--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -82,7 +82,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
   </fingerprint>
 
-  <fingerprint pattern=".{0,1024}(?:Sun )?Cobalt \(Unix\)?.*">
+  <fingerprint pattern=".{0,512}(?:Sun )?Cobalt \(Unix\)?.*">
     <description>Sun Cobalt RaQ (Red Hat based Linux)</description>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Linux"/>

--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -82,7 +82,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
   </fingerprint>
 
-  <fingerprint pattern=".*(?:Sun )?Cobalt \(Unix\)?.*">
+  <fingerprint pattern=".{0,1024}(?:Sun )?Cobalt \(Unix\)?.*">
     <description>Sun Cobalt RaQ (Red Hat based Linux)</description>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Linux"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1044,7 +1044,7 @@ more text</example>
     <param pos="2" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^ET(\S+) Source Technologies (ST-96\S+) FTP Server (\S+) ready\.?$">
+  <fingerprint pattern="^ET(\S{1,12}) Source Technologies (ST-96\S+) FTP Server (\S+) ready\.?$">
     <description>Source Technologies ST9600 Series Secure Printer</description>
     <example>ET0021B730F70E Source Technologies ST-9620 FTP Server NJ.APS.N254e ready.</example>
     <example>ET0021B7549AF2 Source Technologies ST-9620 FTP Server NR.APS.N447b2 ready.</example>
@@ -1057,7 +1057,7 @@ more text</example>
     <param pos="3" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^ET(\S+) (Pro\d+) Series FTP Server ready\.$" certainty="1.0">
+  <fingerprint pattern="^ET(\S{1,12}) (Pro\d+) Series FTP Server ready\.$" certainty="1.0">
     <description>Lexmark ProXXX Series of Printers</description>
     <example host.mac="0020007E4D2A" hw.product="Pro700">ET0020007E4D2A Pro700 Series FTP Server ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
@@ -1070,7 +1070,7 @@ more text</example>
     <param pos="2" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^ET(\S+) Lexmark Forms Printer (\d+) Ethernet FTP Server (\S+) ready\.$" certainty="1.0">
+  <fingerprint pattern="^ET(\S{1,12}) Lexmark Forms Printer (\d+) Ethernet FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Lexmark Forms Printer</description>
     <example os.product="2590">ET0020004F54EE Lexmark Forms Printer 2590 Ethernet FTP Server LCL.CU.P012c ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
@@ -1085,7 +1085,7 @@ more text</example>
     <param pos="2" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^ET(\S+) TOSHIBA e-STUDIO500S FTP Server (\S+) ready\.$" certainty="1.0">
+  <fingerprint pattern="^ET(\S{1,12}) TOSHIBA e-STUDIO500S FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Toshiba e-STUDIO Printer with MAC address</description>
     <example os.version="NC2.NPS.N221">ET0004001E9C00 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N221 ready.</example>
     <example host.mac="00040089BE42">ET00040089BE42 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N211 ready.</example>
@@ -1099,7 +1099,7 @@ more text</example>
     <param pos="0" name="hw.product" value="e-STUDIO"/>
   </fingerprint>
 
-  <fingerprint pattern="^\S+ TOSHIBA e-STUDIO500S FTP Server (\S+) ready\.$" certainty="1.0">
+  <fingerprint pattern="^\S{1,16} TOSHIBA e-STUDIO500S FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Toshiba e-STUDIO Printer</description>
     <example os.version="NC2.NPS.N211">JHBPRN13 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N211 ready.</example>
     <param pos="0" name="os.vendor" value="Toshiba"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -89,7 +89,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S{1,512}) +FTP +Server \(Revision \S+ Version wuftpd-([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
+  <fingerprint pattern="^([^ ]{1,512}) +FTP +Server \(Revision \S+ Version wuftpd-([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
     <description>WU-FTPD on HPUX with a PHNE (HP Networking patch) installed</description>
     <example>example.com FTP server (Revision 1.1 Version wuftpd-2.6.1(PHNE_38578) Fri Sep 5 12:10:54 GMT 2008) ready.</example>
     <param pos="0" name="service.vendor" value="Washington University"/>
@@ -888,7 +888,7 @@ more text</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:windriver:vxworks:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^[\w\-\.]* FTP server \((?:VxWorks\s?)+([\d\.]+)\) ready.$" flags="REG_ICASE">
+  <fingerprint pattern="^[\w\-\.]{0,128} FTP server \((?:VxWorks\s?)+([\d\.]+)\) ready.$" flags="REG_ICASE">
     <description>VxWorks 6 with version information</description>
     <example os.version="6.6">NanoDAC FTP server (VxWorks VxWorks 6.6) ready.</example>
     <example os.version="6.4">BVS-MR-BSC2 FTP server (VxWorks 6.4) ready.</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -5,9 +5,9 @@
   against these patterns to fingerprint FTP servers.
   -->
 
-  <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version ([1234]\.\d+)\)\.$">
+  <fingerprint pattern="^([^ ]{1,512}) Microsoft FTP Service \(Version ([1234]\.\d+)\)\.$">
     <description>Microsoft FTP Server on Windows NT</description>
-    <example>xx Microsoft FTP Service (Version 3.0).</example>
+    <example host.name="foo.bar" service.version="3.0">foo.bar Microsoft FTP Service (Version 3.0).</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
@@ -20,9 +20,9 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version 5.0\)\.$">
+  <fingerprint pattern="^([^ ]{1,512}) Microsoft FTP Service \(Version 5.0\)\.$">
     <description>Microsoft FTP Server on Windows 2000</description>
-    <example>xxx Microsoft FTP Service (Version 5.0).</example>
+    <example host.name="foo.bar">foo.bar Microsoft FTP Service (Version 5.0).</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
@@ -35,9 +35,9 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Microsoft FTP Service \(Version 5.1\)\.$">
+  <fingerprint pattern="^([^ ]{1,512}) Microsoft FTP Service \(Version 5.1\)\.$">
     <description>Microsoft FTP Server on Windows XP, 2003 or later versions of 2000</description>
-    <example>xxx Microsoft FTP Service (Version 5.1).</example>
+    <example host.name="foo.bar">foo.bar Microsoft FTP Service (Version 5.1).</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
@@ -49,9 +49,9 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Microsoft FTP Service$">
+  <fingerprint pattern="^([^ ]{1,512}) Microsoft FTP Service$">
     <description>Microsoft FTP Server on Windows XP, 2003 or later without version</description>
-    <example>hostname Microsoft FTP Service</example>
+    <example host.name="foo.bar">foo.bar Microsoft FTP Service</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
@@ -76,7 +76,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +FTP +Server \(Version ([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
+  <fingerprint pattern="^([^ ]{1,512}) +FTP +Server \(Version ([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
     <description>FTP on HPUX with a PHNE (HP Networking patch) installed</description>
     <example>example.com FTP server (Version 1.1.214.4(PHNE_38458) Mon Feb 15 06:03:12 GMT 2010) ready.</example>
     <param pos="0" name="service.vendor" value="HP"/>
@@ -89,7 +89,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +FTP +Server \(Revision \S+ Version wuftpd-([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512}) +FTP +Server \(Revision \S+ Version wuftpd-([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
     <description>WU-FTPD on HPUX with a PHNE (HP Networking patch) installed</description>
     <example>example.com FTP server (Revision 1.1 Version wuftpd-2.6.1(PHNE_38578) Fri Sep 5 12:10:54 GMT 2008) ready.</example>
     <param pos="0" name="service.vendor" value="Washington University"/>
@@ -102,7 +102,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+)(?: \S+)? FTP Server \((?:Revision [\d\.]+ )?Version wu(?:ftpd)?-([\d\.]+).*\) ready.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512})(?: \S{1,512})? FTP Server \((?:Revision [\d\.]+ )?Version wu(?:ftpd)?-([\d\.]+).*\) ready.?$" flags="REG_ICASE">
     <description>WU-FTPD on various OS</description>
     <example host.name="example.com" service.version="2.6.2">example.com FTP server (Version wu-2.6.2(1) Sat Jul 19 16:21:30 UTC 2008) ready.</example>
     <example host.name="example.com" service.version="2.6.2">example.com 192.168.0.1 FTP server (Version wu-2.6.2(1) Wed Sep 21 11:16:21 MEST 2005) ready.</example>
@@ -114,7 +114,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+)\s+FTP Server \(Version:\s+Mac OS X Server\s+([\d\.]+).*\) ready\.?" flags="REG_ICASE,REG_MULTILINE">
+  <fingerprint pattern="^(\S{1,512})\s{1,8}FTP Server \(Version:\s+Mac OS X Server\s+([\d\.]+).*\) ready\.?" flags="REG_ICASE,REG_MULTILINE">
     <description>FTPD on Mac OS X Server with a version</description>
     <example host.name="example.com" os.version="10.3">example.com FTP server (Version:  Mac OS X Server 10.3 - +GSSAPI) ready.</example>
     <example host.name="example.com" os.version="10.3">this is a banner.  change it.&#13;
@@ -129,7 +129,7 @@ example.com FTP server (Version:  Mac OS X Server 10.3 - +GSSAPI) ready.</exampl
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x_server:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+)\s+FTP Server \(Version:\s+Mac OS X Server\) ready\.?" flags="REG_ICASE,REG_MULTILINE">
+  <fingerprint pattern="^(\S{1,512})\s{1,8}FTP Server \(Version:\s+Mac OS X Server\) ready\.?" flags="REG_ICASE,REG_MULTILINE">
     <description>FTPD on Mac OS X Server without a version</description>
     <example host.name="example.com">example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <example host.name="example.com">this is a banner.  change it.&#13;
@@ -143,7 +143,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+)\s+FTP Server \(tnftpd (.*)\) ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512})\s{1,8}FTP Server \(tnftpd (.*)\) ready\.?$" flags="REG_ICASE">
     <description>Simple tnftpd banner with a version</description>
     <example host.name="example.com" service.version="20061217">example.com FTP server (tnftpd 20061217) ready.</example>
     <param pos="0" name="service.product" value="tnftpd"/>
@@ -151,7 +151,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.(1[1-9])\) ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512}) FTP Server \(SunOS 5.(1[1-9])\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris</description>
     <example host.name="example.com" os.version="11">example.com FTP server (SunOS 5.11) ready.</example>
     <param pos="0" name="os.vendor" value="Oracle"/>
@@ -162,7 +162,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:oracle:solaris:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.([789]|10)\) ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512}) FTP Server \(SunOS 5.([789]|10)\) ready\.?$" flags="REG_ICASE">
     <description>SunOS/Solaris 5.7-5.10</description>
     <example host.name="example.com" os.version="7">example.com FTP server (SunOS 5.7) ready.</example>
     <example host.name="example.com" os.version="10">example.com FTP server (SunOS 5.10) ready.</example>
@@ -174,7 +174,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:sun:solaris:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP Server \(SunOS 5.6\) ready\." flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512}) FTP Server \(SunOS 5.6\) ready\." flags="REG_ICASE">
     <description>SunOS 5.6 (Solaris 2.6)</description>
     <example host.name="example.com">example.com FTP Server (SunOS 5.6) ready.</example>
     <param pos="0" name="os.vendor" value="Sun"/>
@@ -320,7 +320,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\d{4}\-\d\d\-\d\d \d\d:\d\d:\d\d,\d\d\d )?(\S+) proftpd\[\d+\]: error: no valid servers configured">
+  <fingerprint pattern="^(?:\d{4}\-\d\d\-\d\d \d\d:\d\d:\d\d,\d\d\d )?(\S{1,512}) proftpd\[\d+\]: error: no valid servers configured">
     <description>ProFTPD no valid servers configured</description>
     <example host.name="ftp.host.com">ftp.host.com proftpd[40312]: error: no valid servers configured\n</example>
     <example host.name="hostname.com">2016-10-31 12:14:35,524 hostname.com proftpd[26992]: error: no valid servers configured\n</example>
@@ -515,7 +515,7 @@ more text</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^\s*APC FTP server ready\.$">
+  <fingerprint pattern="^\s{0,1024}APC FTP server ready\.$">
     <description>APC device</description>
     <example>APC FTP server ready.</example>
     <param pos="0" name="service.vendor" value="APC"/>
@@ -526,7 +526,7 @@ more text</example>
     <param pos="0" name="hw.device" value="Power Device"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) Network Management Card AOS v(\d+\..+) FTP server ready\.$">
+  <fingerprint pattern="^(\S{1,64}) Network Management Card AOS v(\d+\..+) FTP server ready\.$">
     <description>APC power/cooling device</description>
     <example service.version="3.3.4">AP7932 Network Management Card AOS v3.3.4 FTP server ready.</example>
     <example os.version="3.6.1">ACRC103 Network Management Card AOS v3.6.1 FTP server ready.</example>
@@ -543,7 +543,7 @@ more text</example>
     <param pos="0" name="hw.device" value="Power Device"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP server \(EMC-SNAS: ([^\)]+)\)(?: \S+)?$">
+  <fingerprint pattern="^(\S{1,512}) FTP server \(EMC-SNAS: ([^\)]+)\)(?: \S+)?$">
     <description>EMC Celerra</description>
     <example service.version="5.6.47.11">foo2 FTP server (EMC-SNAS: 5.6.47.11)</example>
     <example service.version="5.6.50.203">foo2 FTP server (EMC-SNAS: 5.6.50.203) ready.</example>
@@ -612,7 +612,7 @@ more text</example>
     <param pos="0" name="service.product" value="Nepenthes"/>
   </fingerprint>
 
-  <fingerprint pattern="^[^ ]+ IBM FTP CS (V1R\d+) at ([^,]*),.*">
+  <fingerprint pattern="^[^ ]{1,512} IBM FTP CS (V1R\d+) at ([^,]*),.*">
     <description>IBM z/OS FTP Service</description>
     <example>SFTPD1 IBM FTP CS V1R4 at x.y.z, 21:02:19 on 2007-12-15.</example>
     <param pos="0" name="service.vendor" value="IBM"/>
@@ -637,7 +637,7 @@ more text</example>
     <param pos="0" name="os.device" value="Point of Sale"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) NcFTPd Server \(licensed copy\) ready\.$">
+  <fingerprint pattern="^([^ ]{1,512}) NcFTPd Server \(licensed copy\) ready\.$">
     <description>NcFTPd Server
       http://www.ncftp.com/ncftpd/</description>
     <example>ftp.example.com NcFTPd Server (licensed copy) ready.</example>
@@ -646,7 +646,7 @@ more text</example>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) DCS-2100 FTP server ready\.$">
+  <fingerprint pattern="^(\S{1,512}) DCS-2100 FTP server ready\.$">
     <description>D-Link DCS-2100 wireless internet camera</description>
     <example>hostname DCS-2100 FTP server ready.</example>
     <param pos="0" name="os.vendor" value="D-Link"/>
@@ -898,7 +898,7 @@ more text</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:windriver:vxworks:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^[\w&lt;&gt;]+\s*Tenor Multipath Switch FTP server \(Version VxWorks([\d\.]+)\) ready\.$" flags="REG_ICASE">
+  <fingerprint pattern="^[\w&lt;&gt;]{1,32}\s{1,8}Tenor Multipath Switch FTP server \(Version VxWorks([\d\.]+)\) ready\.$" flags="REG_ICASE">
     <description>VxWorks on Tenor MultiPath with version information</description>
     <example os.version="5.4.2">&lt;38785ca0&gt;  Tenor Multipath Switch FTP server (Version VxWorks5.4.2) ready.</example>
     <param pos="0" name="os.vendor" value="Wind River"/>
@@ -1297,7 +1297,7 @@ more text</example>
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(ET(\S+)) Dell (\S+ Laser Printer) FTP Server">
+  <fingerprint pattern="^(ET(\S{1,32})) Dell (\S+ Laser Printer) FTP Server">
     <description>Dell Laser Printer</description>
     <example host.name="ET0021B71A1111" host.mac="0021B71A1111" hw.product="2350dn Laser Printer">ET0021B71A1111 Dell 2350dn Laser Printer FTP Server NR.APS.N449 ready.</example>
     <param pos="0" name="os.vendor" value="Dell"/>
@@ -1309,7 +1309,7 @@ more text</example>
     <param pos="3" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP server \(Version \S+ \w+ \w+ \d{1,2} \d{1,2}:\d{1,2}:\d{1,2} [A-Z]+ (?:1|2)\d{3}\) ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) FTP server \(Version \S+ \w+ \w+ \d{1,2} \d{1,2}:\d{1,2}:\d{1,2} [A-Z]+ (?:1|2)\d{3}\) ready\.?$">
     <description>Generic/unknown FTP Server found on HP-UX and AIX systems</description>
     <example host.name="host.example.com">host.example.com FTP server (Version 4.1 Sat Sep 7 14:31:53 CDT 2002) ready.</example>
     <example host.name="host.example.com">host.example.com FTP server (Version 5.3 Sat Jan 10 14:01:03 CDT 2012) ready</example>
@@ -1332,7 +1332,7 @@ more text</example>
     <param pos="3" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP server \((?:HP|Compaq) Tru64 UNIX Version (\S+)\) ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) FTP server \((?:HP|Compaq) Tru64 UNIX Version (\S+)\) ready\.?$">
     <description>Digital/Compaq/HP Tru64 Unix</description>
     <example host.name="example.com" os.version="5.60">example.com FTP server (Compaq Tru64 UNIX Version 5.60) ready.</example>
     <param pos="0" name="os.vendor" value="HP"/>
@@ -1343,7 +1343,7 @@ more text</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:tru64_unix:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP server \(Digital UNIX Version (\S+)\) ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) FTP server \(Digital UNIX Version (\S+)\) ready\.?$">
     <description>Digital/Compaq/HP Tru64 Unix w/o branding</description>
     <example host.name="example.com" os.version="5.60">example.com FTP server (Digital UNIX Version 5.60) ready.</example>
     <param pos="0" name="os.vendor" value="HP"/>
@@ -1353,7 +1353,7 @@ more text</example>
     <param pos="2" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP server \(MikroTik ([\d\.]+)\) ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) FTP server \(MikroTik ([\d\.]+)\) ready\.?$">
     <description>MikroTik</description>
     <example host.name="example.com" os.version="6.18">example.com FTP server (MikroTik 6.18) ready</example>
     <param pos="0" name="os.vendor" value="MikroTik"/>
@@ -1363,7 +1363,7 @@ more text</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:mikrotik:routeros:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^.* FTP server \(MikroTik (\d\.[\w\.]+)\) ready\.?$">
+  <fingerprint pattern="^.{0,1024} FTP server \(MikroTik (\d\.[\w\.]+)\) ready\.?$">
     <description>MikroTik with description</description>
     <example os.version="6.43.16">Super Thing_Place-  FTP server (MikroTik 6.43.16) ready</example>
     <example os.version="6.43.16beta2">Super Thing_Place-  FTP server (MikroTik 6.43.16beta2) ready</example>
@@ -1541,7 +1541,7 @@ more text</example>
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([\w.-]+) X2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
+  <fingerprint pattern="^([\w.-]{1,512}) X2 WS_FTP Server ([\d.]{3,6}\s?\(\d+\))$">
     <description>WS_FTP FTP Server on Windows - X2 variant</description>
     <example service.version="7.7(50012467)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 7.7(50012467)</example>
     <example service.version="5.0.5 (1989540204)" host.name="a.host.name.tld">a.host.name.tld X2 WS_FTP Server 5.0.5 (1989540204)</example>
@@ -1644,13 +1644,13 @@ more text</example>
     <param pos="2" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP server ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512}) FTP server ready\.?$" flags="REG_ICASE">
     <description>Generic FTP fingerprint with a hostname</description>
     <example host.name="example.com">example.com FTP server ready.</example>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) FTP server \(Version (\d.*)\) ready\.?$" flags="REG_ICASE">
+  <fingerprint pattern="^(\S{1,512}) FTP server \(Version (\d.*)\) ready\.?$" flags="REG_ICASE">
     <description>Generic FTP fingerprint with a hostname and a version for a generic FTP implementation</description>
     <example host.name="example.com" service.version="6.00LS">example.com FTP server (Version 6.00LS) ready.</example>
     <example host.name="example.com" service.version="1.2">example.com FTP server (Version 1.2) ready.</example>
@@ -1675,7 +1675,7 @@ more text</example>
     <param pos="0" name="service.product" value="ProRat"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:(\S+) )?FTP Server \(vftpd ([\d.]+)\) ready\.?$">
+  <fingerprint pattern="^(?:(\S{1,512}) )?FTP Server \(vftpd ([\d.]+)\) ready\.?$">
     <description>Vermillion FTP Daemon</description>
     <example host.name="srv.name" service.version="1.23">srv.name FTP Server (vftpd 1.23) ready.</example>
     <example service.version="1.31">FTP Server (vftpd 1.31) ready.</example>
@@ -1689,7 +1689,7 @@ more text</example>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:(\S+) )?FTP server \(QVT\/Net ([\d.]+)\) ready\.?$">
+  <fingerprint pattern="^(?:(\S{1,512}) )?FTP server \(QVT\/Net ([\d.]+)\) ready\.?$">
     <description>QVT/Net FTP Server</description>
     <example host.name="siren" service.version="5.1">siren FTP server (QVT/Net 5.1) ready.</example>
     <example host.name="qpc-qvtnet" service.version="4.1">qpc-qvtnet FTP server (QVT/Net 4.1) ready.</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -412,7 +412,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:watchguard:fireware:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(.*).nbsp;-.nbsp;Synology.nbsp;DiskStation$">
+  <fingerprint pattern="^(.{0,512}).nbsp;-.nbsp;Synology.nbsp;DiskStation$">
     <description>Synology DiskStation</description>
     <example host.name="DiskStation">DiskStation&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
     <example host.name="DS218">DS218&amp;nbsp;-&amp;nbsp;Synology&amp;nbsp;DiskStation</example>
@@ -699,7 +699,7 @@
     <param pos="0" name="hw.product" value="Prosafe Plus"/>
   </fingerprint>
 
-  <fingerprint pattern="^(.*).nbsp;Configuration and Management$">
+  <fingerprint pattern="^(.{0,256}).nbsp;Configuration and Management$">
     <description>Digi Terminal Servers</description>
     <example hw.product="Digi One SP">Digi One SP&amp;nbsp;Configuration and Management</example>
     <example hw.product="PortServer TS 4">PortServer TS 4&amp;nbsp;Configuration and Management</example>
@@ -820,7 +820,7 @@
     <param pos="0" name="hw.product" value="Rack PDU Card"/>
   </fingerprint>
 
-  <fingerprint pattern="^(.*) IntelliSlot Web(?:/\d+)? Card?$">
+  <fingerprint pattern="^(.{0,256}) IntelliSlot Web(?:/\d+)? Card?$">
     <description>Emerson Network Power IntelliSlot Web Card and rebrands</description>
     <example hw.vendor="Emerson Network Power">Emerson Network Power IntelliSlot Web Card</example>
     <example hw.vendor="Emerson Network Power">Emerson Network Power IntelliSlot Web/485 Card</example>
@@ -1038,7 +1038,7 @@
     <param pos="0" name="hw.product" value="OpenManage Switch"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+)\s+-\s+ProCurve Switch (\S+) \((.*)\)$">
+  <fingerprint pattern="^(\S{1,512})\s{1,8}-\s{1,8}ProCurve Switch (\S+) \((.*)\)$">
     <description>HPE ProCurve Switch w/Hostname</description>
     <example host.name="SW1" hw.product="4204vl" procurve.model="J8770A">SW1 - ProCurve Switch 4204vl (J8770A)</example>
     <param pos="0" name="hw.vendor" value="HPE"/>
@@ -1681,7 +1681,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:realvnc:realvnc:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^.* \[Jenkins\]$">
+  <fingerprint pattern="^.{0,1024} \[Jenkins\]$">
     <description>Jenkins Customized Dashboard</description>
     <example>Continuous Integrations [Jenkins]</example>
     <example>Dashboard [Jenkins]</example>
@@ -2344,7 +2344,7 @@
     <param pos="0" name="service.product" value="SonarQube"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) - Opengear Management Console$">
+  <fingerprint pattern="^(\S{1,512}) - Opengear Management Console$">
     <description>Opengear Management Console</description>
     <example host.name="server01">server01 - Opengear Management Console</example>
     <param pos="0" name="service.vendor" value="Opengear"/>
@@ -2610,7 +2610,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zabbix:zabbix:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) \(build (\S+)\) - Info$">
+  <fingerprint pattern="^(\S{1,512}) \(build (\S+)\) - Info$">
     <description>DD-WRT</description>
     <example host.name="SubTerraVia-NUC" os.version="36104" os.build="36104">SubTerraVia-NUC (build 36104) - Info</example>
     <example host.name="DD-WRT" os.version="35030M" os.build="35030M">DD-WRT (build 35030M) - Info</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -878,10 +878,10 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:acme:mini_httpd:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^LiteSpeed\/?(:?[\d.]+)?(?: \S+)?">
+  <fingerprint pattern="^LiteSpeed\/?([\d.]+)?(?: \S+)?">
     <description>LiteSpeed</description>
     <example>LiteSpeed</example>
-    <example>LiteSpeed/5.2.8 Enterprise</example>
+    <example service.version="5.2.8">LiteSpeed/5.2.8 Enterprise</example>
     <param pos="0" name="service.vendor" value="LiteSpeed Technologies"/>
     <param pos="0" name="service.product" value="LiteSpeed Web Server"/>
     <param pos="1" name="service.version"/>
@@ -897,7 +897,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^openresty\/?(:?[\d.]+)?$">
+  <fingerprint pattern="^openresty\/?([\d.]+)?$">
     <description>OpenResty OpenResty</description>
     <example>openresty</example>
     <example service.version="1.13.6.2">openresty/1.13.6.2</example>
@@ -1000,7 +1000,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:varnish-cache:varnish:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Tengine\/?(:?[\d.]+)?$">
+  <fingerprint pattern="^Tengine\/?([\d.]+)?$">
     <description>Tengine</description>
     <example>Tengine</example>
     <example service.version="2.0.0">Tengine/2.0.0</example>
@@ -1492,7 +1492,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^nginx\/?(:?[\d.]+)?">
+  <fingerprint pattern="^nginx\/?([\d.]+)?">
     <description>nginx with version info and/or mods</description>
     <example service.version="0.8.53">nginx/0.8.53 + Phusion Passenger 3.0.0 (mod_rails/mod_rack)</example>
     <example>nginx/0.8.53</example>
@@ -2651,7 +2651,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^Embedthis-(?:Appweb|http)\/?(:?[\d.]+)?$">
+  <fingerprint pattern="^Embedthis-(?:Appweb|http)\/?([\d.]+)?$">
     <description>Embedthis AppWeb</description>
     <example service.version="3.2.3">Embedthis-Appweb/3.2.3</example>
     <example>Embedthis-http</example>
@@ -3284,7 +3284,7 @@
     <param pos="0" name="service.product" value="Node"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^(.*) UPnP/[\d\.]+\s+AVM FRITZ!(.*) ([\d\.]+)$">
+  <fingerprint pattern="(?i)^(.{0,256}) UPnP/[\d\.]+\s+AVM FRITZ!(.*) ([\d\.]+)$">
     <description>AVM FRITZ! devices of various types</description>
     <example host.name="some thing" os.product="WLAN Repeater 1750E" os.version="134.07.01">some thing UPnP/1.0 AVM FRITZ!WLAN Repeater 1750E 134.07.01</example>
     <param pos="0" name="os.vendor" value="AVM"/>
@@ -3681,7 +3681,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) \d+/Service Pack \d+, UPnP/[\d\.]+, TVersity Media Server$">
+  <fingerprint pattern="^(\S{1,16}) \d+/Service Pack \d+, UPnP/[\d\.]+, TVersity Media Server$">
     <description>TVersity Media Server UPnP Server with Service Pack</description>
     <example>5.2.3790 2/Service Pack 1, UPnP/1.0, TVersity Media Server</example>
     <example>5.1.2600 2/Service Pack 3, UPnP/1.0, TVersity Media Server</example>
@@ -3690,7 +3690,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) 2/, UPnP/\S+, TVersity Media Server$">
+  <fingerprint pattern="^(\S{1,16}) 2/, UPnP/\S+, TVersity Media Server$">
     <description>TVersity Media Server UPnP Server</description>
     <example>6.2.8400 2/, UPnP/1.0, TVersity Media Server</example>
     <example>6.2.9200 2/, UPnP/1.0, TVersity Media Server</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -840,7 +840,7 @@
   </fingerprint>
 
   <fingerprint pattern="^UOS$">
-    <description>HTTP Server that appears unique to Managment Console on HP TippingPoint IPS Devices</description>
+    <description>HTTP Server that appears unique to Management Console on HP TippingPoint IPS Devices</description>
     <example>UOS</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="HTTP"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -419,7 +419,7 @@
     <param pos="0" name="service.product" value="SWAT"/>
   </fingerprint>
 
-  <fingerprint pattern="^.*(?:Basic|Digest) realm=&quot;SPIP Configuration&quot;.*$">
+  <fingerprint pattern="^.{0,1024}(?:Basic|Digest) realm=&quot;SPIP Configuration&quot;.*$">
     <description>SPIP publishing system (www.spip.net)</description>
     <example>Basic realm="SPIP Configuration", Digest realm="SPIP Configuration", nonce="116761147", algorithm="MD5"</example>
     <param pos="0" name="service.vendor" value="SPIP"/>
@@ -427,7 +427,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:spip:spip:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^.*(?:Basic|Digest) .*realm=&quot;HP ISEE @ ([^&quot;]+)&quot;.*$">
+  <fingerprint pattern="^.{0,1024}(?:Basic|Digest) .*realm=&quot;HP ISEE @ ([^&quot;]+)&quot;.*$">
     <description>HP Instant Support Enterprise Edition with a hostname</description>
     <example host.name="blah">Basic realm="HP ISEE @ blah"</example>
     <param pos="0" name="service.vendor" value="HP"/>
@@ -435,7 +435,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^.*(?:Basic|Digest) .*realm=&quot;BIG-IP&quot;.*$">
+  <fingerprint pattern="^.{0,1024}(?:Basic|Digest) .*realm=&quot;BIG-IP&quot;.*$">
     <description>Generic F5 Big-IP</description>
     <example>Basic realm="BIG-IP"</example>
     <param pos="0" name="service.vendor" value="F5"/>

--- a/xml/imap_banners.xml
+++ b/xml/imap_banners.xml
@@ -166,7 +166,7 @@
     <param pos="0" name="service.product" value="Courier IMAP"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) CallPilot IMAP4rev1 v(\S+) server ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) CallPilot IMAP4rev1 v(\S+) server ready\.?$">
     <description>Nortel CallPilot</description>
     <example>nottest.localdomain CallPilot IMAP4rev1 v42.02.05.22 server ready.</example>
     <example>test.localdomain CallPilot IMAP4rev1 v43.03.19.22 server ready.</example>
@@ -177,7 +177,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) Zimbra IMAP4rev1 server ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) Zimbra IMAP4rev1 server ready\.?$">
     <description>VMware Zimbra IMAP</description>
     <example host.name="foo.bar">foo.bar Zimbra IMAP4rev1 server ready</example>
     <param pos="0" name="service.vendor" value="VMware"/>
@@ -186,7 +186,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) Zimbra (\S+) IMAP4rev1 server ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) Zimbra (\S+) IMAP4rev1 server ready\.?$">
     <description>VMware Zimbra IMAP with service version</description>
     <example host.name="foo.bar" service.version="7.0.0_GA_3079">foo.bar Zimbra 7.0.0_GA_3079 IMAP4rev1 server ready</example>
     <param pos="0" name="service.vendor" value="VMware"/>
@@ -196,7 +196,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(.+) Cyrus IMAP4 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready$">
+  <fingerprint pattern="^(\S{1,512}) Cyrus IMAP4 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready$">
     <description>CMU Cyrus IMAP on Mac OS X</description>
     <example host.name="example.com" service.version="2.2.12" os.version="10.4.0">example.com Cyrus IMAP4 v2.2.12-OS X 10.4.0 server ready</example>
     <example host.name="example.com" service.version="2.3.8" os.version="10.5">example.com Cyrus IMAP4 v2.3.8-OS X Server 10.5: 9A562 server ready</example>
@@ -213,7 +213,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(.+) Cyrus IMAP4? (?:\S+ )?v(\d+\.\d+.*) server ready$">
+  <fingerprint pattern="^(\S{1,512}) Cyrus IMAP4? (?:\S+ )?v(\d+\.\d+.*) server ready$">
     <description>CMU Cyrus IMAP</description>
     <example host.name="example.com" service.version="2.3.7">example.com Cyrus IMAP4 v2.3.7 server ready</example>
     <example host.name="example.com" service.version="2.4.8-Invoca-RPM-2.4.8-1">example.com Cyrus IMAP Murder v2.4.8-Invoca-RPM-2.4.8-1 server ready</example>

--- a/xml/nntp_banners.xml
+++ b/xml/nntp_banners.xml
@@ -13,7 +13,7 @@
     <param pos="0" name="service.product" value="CCProxy"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) Lyris ListManager NNTP Service ready">
+  <fingerprint pattern="^(\S{1,512}) Lyris ListManager NNTP Service ready">
     <description>Lyris Listmanager</description>
     <example host.name="blah">blah Lyris ListManager NNTP Service ready (posting ok).</example>
     <param pos="0" name="service.vendor" value="Lyris"/>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -341,7 +341,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:10.10"/>
   </fingerprint>
 
-  <fingerprint pattern="^.*version=&quot;ntpd ([^ p]+)(:?p[^ &quot;]+)?[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?(?:[^ ]+-NETSCALER-([^ ]+))&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="^.*version=&quot;ntpd ([^ p]+)(p[^ &quot;]+)?[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?(?:[^ ]+-NETSCALER-([^ ]+))&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Citrix Netscaler, which is based on FreeBSD</description>
     <example service.version="4.2.6" service.version.version="p2@1.2194" os.arch="i386" os.version="9.3">
       version="ntpd 4.2.6p2@1.2194 Wed Nov 24 15:54:11 UTC 2010 (1)",

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -397,7 +397,7 @@
 
   <!-- Vendor-based distribution catch-call -->
 
-  <fingerprint pattern="^(?i:(.*)\sLinux?\s(.*))$">
+  <fingerprint pattern="(?i)^(\S{0,256})\s{1,8}Linux\s+([\w.-]*)$">
     <description>Vendor-based Linux catch-all</description>
     <example os.vendor="Aurox" os.version="10.2">Aurox Linux 10.2</example>
     <param pos="0" name="os.family" value="Linux"/>
@@ -409,7 +409,7 @@
 
   <!-- Linux catch-all goes at the bottom-->
 
-  <fingerprint pattern="^(?i:.*Linux?\s?(\d+?(?:\.\d+?)*?)?)$">
+  <fingerprint pattern="(?i)^.{0,1024}Linux?\s?(\d+?(?:\.\d+?)*?)?$">
     <description>Linux catch-all</description>
     <example os.version="2.42.6">Linux 2.42.6</example>
     <param pos="0" name="os.vendor" value="Linux"/>
@@ -588,7 +588,7 @@
 
   <!-- BSD begin -->
 
-  <fingerprint pattern="^(?i:(.*?BSD)\s?(\d+?(?:\.\d+?)*?(?:[\-\/_ ]?\w+?)?(?:-[a-z]\d+?)?)?)$">
+  <fingerprint pattern="(?i)^(.{0,256}?BSD)\s?(\d+?(?:\.\d+?)*?(?:[\-\/_ ]?\w+?)?(?:-[a-z]\d+?)?)?$">
     <description>Many BSD family OSes</description>
     <example os.version="10.3-RELEASE" os.product="FreeBSD">FreeBSD 10.3-RELEASE</example>
     <example os.version="10.3-RELEASE-p4" os.product="FreeBSD">FreeBSD 10.3-RELEASE-p4</example>
@@ -605,7 +605,7 @@
 
   <!-- Other Unix-likes begin -->
 
-  <fingerprint pattern="^(?i:(?:Oracle|Sun)?\s?OpenSolaris\s?(\d+?(?:\.\d+?)*?)?)$">
+  <fingerprint pattern="(?i)^(?:Oracle|Sun)?\s?OpenSolaris\s?(\d+?(?:\.\d+?)*?)?$">
     <description>OpenSolaris</description>
     <example os.version="2009.06">OpenSolaris 2009.06</example>
     <param pos="0" name="os.vendor" value="Sun"/>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -5,7 +5,7 @@
   matched against these patterns to fingerprint POP3 servers.
   -->
 
-  <fingerprint pattern="^([^ ]+) +Cyrus POP3 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready">
+  <fingerprint pattern="^([^ ]{1,512}) +Cyrus POP3 v(\d+\.\d+.*)-OS X(?: Server)? ([\d\.]+).* server ready">
     <description>OSX Cyrus POP</description>
     <example host.domain="8.8.8.8" service.version="2.3.8" os.version="10.5">8.8.8.8 Cyrus POP3 v2.3.8-OS X Server 10.5: 9A562 server ready &lt;1999107648.1324502155@8.8.8.8&gt;</example>
     <param pos="0" name="service.vendor" value="Carnegie Mellon University"/>
@@ -20,7 +20,7 @@
     <param pos="1" name="host.domain"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +Cyrus POP3 v([\d\.]+)">
+  <fingerprint pattern="^([^ ]{1,512}) +Cyrus POP3 v([\d\.]+)">
     <description>CMU Cyrus POP</description>
     <example host.domain="foo" service.version="2.3">foo Cyrus POP3 v2.3</example>
     <example host.domain="foo" service.version="2.3.14">foo Cyrus POP3 v2.3.14 server ready &lt;13087751828270990591.1301068892@foo&gt;</example>
@@ -229,7 +229,7 @@
     <param pos="0" name="hw.product" value="Raspberry Pi"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) Zimbra POP3 server ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) Zimbra POP3 server ready\.?$">
     <description>VMware Zimbra POP</description>
     <example host.name="foo.bar">foo.bar Zimbra POP3 server ready</example>
     <param pos="0" name="service.vendor" value="VMware"/>
@@ -238,7 +238,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) Zimbra (\S+) POP3 server ready\.?$">
+  <fingerprint pattern="^(\S{1,512}) Zimbra (\S+) POP3 server ready\.?$">
     <description>VMware Zimbra POP with version</description>
     <example host.name="foo.bar">foo.bar Zimbra 7.0.0_GA_3079 POP3 server ready</example>
     <param pos="0" name="service.vendor" value="VMware"/>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -62,7 +62,7 @@
 
   <!-- The next few Linksys fingerprints could be merged but are split to enable CPEs -->
 
-  <fingerprint pattern="^(?:[\dA-F]+ )?Linksys/RT31P2-([\d.]+)\(\w+\)$">
+  <fingerprint pattern="^(?:[\dA-F]{1,64} )?Linksys/RT31P2-([\d.]+)\(\w+\)$">
     <description>Linksys RT31P2</description>
     <example os.version="3.1.9">Linksys/RT31P2-3.1.9(LId)</example>
     <example os.version="3.1.6">Linksys/RT31P2-3.1.6(LI)</example>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -418,7 +418,7 @@
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:Audiocodes-Sip-Gateway-)?(\S+) FX[A-Z_]+/v.(\S+)$">
+  <fingerprint pattern="^(?:Audiocodes-Sip-Gateway-)?(\S{1,64}) FX[A-Z_]+/v.(\S+)$">
     <description>Audiocodes-Sip-Gateway</description>
     <example hw.product="MP-124" os.version="6.00A.034.003">Audiocodes-Sip-Gateway-MP-124 FXS/v.6.00A.034.003</example>
     <example hw.product="MP-124" os.version="6.60A.342.003">MP-124 FXS/v.6.60A.342.003</example>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -576,7 +576,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) \(Mail-Max Version (\d+\.[\d\.]+), (.+, .+)\) ESMTP Mail Server Ready. *$">
+  <fingerprint pattern="^([^ ]{1,512}) \(Mail-Max Version (\d+\.[\d\.]+), (.+, .+)\) ESMTP Mail Server Ready. *$">
     <description>Mail Max</description>
     <example host.name="foo.bar" service.version="4.2.4.7">foo.bar (Mail-Max Version 4.2.4.7, Wed, 31 Jan 2001 03:44:35 +0100 WST) ESMTP Mail Server Ready.</example>
     <example host.name="foo.bar" service.version="3.073">foo.bar (Mail-Max Version 3.073, Thu, 30 Nov 2017 17:24:59 +0800 ) ESMTP Mail Server Ready.</example>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -202,7 +202,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) running Eudora Internet Mail Server (\d\.[\d.]+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) running Eudora Internet Mail Server (\d\.[\d.]+) *$">
     <description>Eudora Internet Mail Server</description>
     <example service.version="3.0.2" host.name="foo.bar">foo.bar running Eudora Internet Mail Server 3.0.2</example>
     <example service.version="2.2" host.name="foo.bar">foo.bar running Eudora Internet Mail Server 2.2</example>
@@ -217,7 +217,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP Server \(Microsoft Exchange Internet Mail Service (\d+\.\d+\.\d+\.\d+)\) ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP Server \(Microsoft Exchange Internet Mail Service (\d+\.\d+\.\d+\.\d+)\) ready *$">
     <description>Microsoft Exchange Server 5.5 and above (for sure, can't be confused with the IIS builtin SMTP service)</description>
     <example host.name="foo.bar" service.version="5.5.2653.13">foo.bar ESMTP Server (Microsoft Exchange Internet Mail Service 5.5.2653.13) ready</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
@@ -232,7 +232,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Microsoft Exchange Internet Mail Service (\d+\.\d+\.\d+\.\d+) ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) Microsoft Exchange Internet Mail Service (\d+\.\d+\.\d+\.\d+) ready *$">
     <description>Microsoft Exchange Server 5.0 (for sure, can't be confused with the IIS builtin SMTP service)</description>
     <example host.name="foo.bar" service.version="5.0.1460.8">foo.bar Microsoft Exchange Internet Mail Service 5.0.1460.8 ready</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
@@ -247,7 +247,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Microsoft ESMTP MAIL Service ready at .*$">
+  <fingerprint pattern="^([^ ]{1,512}) Microsoft ESMTP MAIL Service ready at .*$">
     <description>Microsoft Exchange 2007/2010 (for sure, can't be confused with the IIS builtin SMTP service)</description>
     <example>foo.bar Microsoft ESMTP MAIL Service ready at Wed, 21 Jul 2010 19:04:24 -0700</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
@@ -740,7 +740,7 @@
 
   <!-- example: 220 mail.db-list.com ESMTP MERAK 3.00.140; Tue, 24 Jul 2001 21:30:47 -0700 -->
 
-  <fingerprint pattern="^([^ ]+) +E?SMTP (?i:MERAK) ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) +E?SMTP (?i:MERAK) ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
     <description>Merak mail server - http://www.icewarp.com/merakmail/ (runs on 2000/NT/9x)</description>
     <example host.name="foo.bar" service.version="8.0.3">foo.bar SMTP Merak 8.0.3; Thu, 30 Nov 2017 20:01:41 +1000</example>
     <example host.name="foo.bar" service.version="8.0.3">foo.bar ESMTP Merak 8.0.3; Thu, 30 Nov 2017 12:08:09 +0200</example>
@@ -770,7 +770,7 @@
 
   <fingerprint pattern="^([^ ]+) Mercury ([^ ]+\.[^ ]+) ESMTP server ready.$">
     <description>Mercury NLM for Netware ( http://www.pmail.com/index.cfm )</description>
-    <example service.version="1.43">foo.bar Mercury 1.43 ESMTP server ready.</example>
+    <example host.name="foo.bar" service.version="1.43">foo.bar Mercury 1.43 ESMTP server ready.</example>
     <param pos="0" name="service.family" value="Mercury Mail Transport System"/>
     <param pos="0" name="service.product" value="Mercury Mail Transport System"/>
     <param pos="0" name="os.vendor" value="Novell"/>
@@ -781,7 +781,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^^([^ ]+) Mercury\/32 v([^ ]+\.[^ ]+) (?:SMTP\/)?ESMTP server ready.?$">
+  <fingerprint pattern="^^([^ ]{1,512}) Mercury\/32 v([^ ]+\.[^ ]+) (?:SMTP\/)?ESMTP server ready.?$">
     <description>Mercury/32 for Win9x/NT/2000 ( http://www.pmail.com/index.cfm )</description>
     <example service.version="3.01a">foo.bar Mercury/32 v3.01a SMTP/ESMTP server ready.</example>
     <example service.version="3.30">foo.bar Mercury/32 v3.30 ESMTP server ready.</example>
@@ -795,7 +795,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) SMTP NAVIEG ([^ ]+\.[^ ]+\.[^ ]+); (.+)* http.*$">
+  <fingerprint pattern="^([^ ]{1,512}) SMTP NAVIEG ([^ ]+\.[^ ]+\.[^ ]+); (.+)* http.*$">
     <description>Norton Antivirus for Internet Email Gateways (becomes NAVGW in 2.1)</description>
     <example host.name="foo.bar" service.version="2.0.1">foo.bar SMTP NAVIEG 2.0.1; Sun, 29 Jul 2001 22:02:16 -0500 http://www.symantec.com</example>
     <param pos="0" name="service.vendor" value="Norton"/>
@@ -807,7 +807,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP service \(Netscape Messaging Server ([^ ]+\.[^ ]+) Patch ([^ ]+).*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP service \(Netscape Messaging Server ([^ ]+\.[^ ]+) Patch ([^ ]+).*$">
     <description>Netscape Messaging Server - with patch number</description>
     <example host.name="foo.bar" service.version="4.15" service.version.version="7">foo.bar ESMTP service (Netscape Messaging Server 4.15 Patch 7 (built Sep 12 2001))</example>
     <param pos="0" name="service.vendor" value="Netscape"/>
@@ -819,7 +819,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:netscape:messaging_server:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP server \(Netscape Messaging Server - Version ([\d.]+)\) ready (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP server \(Netscape Messaging Server - Version ([\d.]+)\) ready (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) *$">
     <description>Netscape Messaging Server - w/o patch number</description>
     <example host.name="foo.bar" service.version="3.6" system.time="Thu, 30 Nov 2017 04:19:10 -0500">foo.bar ESMTP server (Netscape Messaging Server - Version 3.6) ready Thu, 30 Nov 2017 04:19:10 -0500</example>
     <param pos="0" name="service.vendor" value="Netscape"/>
@@ -832,7 +832,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Lotus SMTP MTA Service Ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) Lotus SMTP MTA Service Ready *$">
     <description>Lotus Notes 4 SMTP MTA</description>
     <example host.name="foo.bar">foo.bar Lotus SMTP MTA Service Ready</example>
     <param pos="0" name="service.vendor" value="Lotus"/>
@@ -1025,7 +1025,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +E?SMTP Postfix \(Debian/GNU\)$">
+  <fingerprint pattern="^([^ ]{1,512}) +E?SMTP Postfix \(Debian/GNU\)$">
     <description>Postfix - Debian</description>
     <example>foo.bar ESMTP Postfix (Debian/GNU)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
@@ -1079,7 +1079,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP server \((?i:P)ost\.(?i:O)ffice v([^ ]+\.[^ ]+)(?: release)? (.+) ID# ([^ ]+)\) ready (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP server \((?i:P)ost\.(?i:O)ffice v([^ ]+\.[^ ]+)(?: release)? (.+) ID# ([^ ]+)\) ready (.+) *$">
     <description>Post.Office</description>
     <example host.name="foo.bar" service.version="3.8.4" postoffice.build="116" postoffice.id="1001-65749U100L10S0V38" system.time="Thu, 30 Nov 2017 18:46:24 +0900">foo.bar ESMTP server (post.office v3.8.4 release 116 ID# 1001-65749U100L10S0V38) ready Thu, 30 Nov 2017 18:46:24 +0900</example>
     <example host.name="foo.bar" service.version="3.1" postoffice.build="PO205e" postoffice.id="0-42000U100L2S100" system.time="Tue, 6 Feb 2001 19:38:32 +0100">foo.bar ESMTP server (Post.Office v3.1 release PO205e ID# 0-42000U100L2S100) ready Tue, 6 Feb 2001 19:38:32 +0100</example>
@@ -1093,7 +1093,7 @@
     <param pos="5" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Generic SMTP handler *$">
+  <fingerprint pattern="^([^ ]{1,512}) Generic SMTP handler *$">
     <description>Raptor Firewall (low confidence)</description>
     <example host.name="foo.bar">foo.bar Generic SMTP handler</example>
     <param pos="0" name="service.product" value="raptor"/>
@@ -1209,7 +1209,7 @@
     <param pos="5" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail AIX([^/]+)/([^/]+)/([^;]+); (.+)(?: \(.+\))?$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail AIX([^/]+)/([^/]+)/([^;]+); (.+)(?: \(.+\))?$">
     <description>Sendmail - AIX</description>
     <example host.name="foo.bar" os.version="4.2" service.version="8.7" sendmail.config.version="8.8">foo.bar ESMTP Sendmail AIX4.2/8.7/8.8; Sun, 29 Jul 2001 22:34:37 -0400 (EDT)</example>
     <example host.name="foo.bar" os.version="5.1" service.version="8.11.6p2" sendmail.config.version="8.11.0">foo.bar ESMTP Sendmail AIX5.1/8.11.6p2/8.11.0; Fri, 28 Aug 1970 19:42:05 -0800</example>
@@ -1229,7 +1229,7 @@
     <param pos="5" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/SuSE Linux ([^;]+); (.+)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/SuSE Linux ([^;]+); (.+)$">
     <description>Sendmail - SuSE Linux</description>
     <example>foo.bar ESMTP Sendmail 8.9.3/8.9.3/SuSE Linux 8.9.3-0.1; Mon, 30 Jul 2001 04:48:54 +0200</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1248,7 +1248,7 @@
     <param pos="5" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^ ]+)\+Sun/([^ ]+); (.+)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^ ]+)\+Sun/([^ ]+); (.+)$">
     <description>Sendmail - Solaris with date (no time offeset variant)</description>
     <example>foo.bar ESMTP Sendmail 8.9.3+Sun/8.9.1; Mon, 30 Jul 2001 02:50:22 GMT</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1266,7 +1266,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^ ]+)\+Sun/([^ ]+) ready at (.+) \(.+\)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^ ]+)\+Sun/([^ ]+) ready at (.+) \(.+\)$">
     <description>Sendmail - Solaris with date (ready variant)</description>
     <example>foo.bar ESMTP Sendmail 8.8.8+Sun/8.6.4 ready at Thu, 15 Nov 2000 11:40:32 -0800 (PST)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1284,7 +1284,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP (?:Debian )?Sendmail ([^/]+)/([^/]+)/Debian ([^/]+); (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP (?:Debian )?Sendmail ([^/]+)/([^/]+)/Debian ([^/]+); (.+) *$">
     <description>Sendmail - Debian</description>
     <example service.version="8.12.0.Beta7" sendmail.config.version="8.12.0.Beta7" sendmail.vendor.version="8.12.0.Beta7-1">foo.bar ESMTP Debian Sendmail 8.12.0.Beta7/8.12.0.Beta7/Debian 8.12.0.Beta7-1; Sun, 29 Jul 2001 18:52:20 -0800</example>
     <example service.version="8.11.0" sendmail.config.version="8.9.3" sendmail.vendor.version="8.9.3-21">foo.bar ESMTP Sendmail 8.11.0/8.9.3/Debian 8.9.3-21; Sun, 29 Jul 2001 19:51:00 -0700</example>
@@ -1304,9 +1304,9 @@
     <param pos="5" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+(?:wheezy|deb7u)\d; (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+(?:wheezy|deb7u)\d; (.+); .*$">
     <description>Sendmail - Debian 7.x (wheezy)</description>
-    <example service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4+wheezy1; Thu, 30 Nov 2017 10:33:05 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example host.name="foo.bar" service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4+wheezy1; Thu, 30 Nov 2017 10:33:05 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <example service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4+deb7u1; Thu, 30 Nov 2017 11:00:33 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
@@ -1324,7 +1324,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+deb8u\d; (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+deb8u\d; (.+); .*$">
     <description>Sendmail - Debian 8.x (jessie)</description>
     <example service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-8+deb8u2; Thu, 30 Nov 2017 10:25:48 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1343,9 +1343,9 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+deb9u1; (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+deb9u1; (.+); .*$">
     <description>Sendmail - Debian 9.1 (stretch)</description>
-    <example service.version="8.15.2">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-8+deb9u1; Thu, 29 Apr 2021 06:45:02 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example host.name="foo.bar" service.version="8.15.2">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-8+deb9u1; Thu, 29 Apr 2021 06:45:02 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1362,7 +1362,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+lenny\d; (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+lenny\d; (.+); .*$">
     <description>Sendmail - Debian 5.x (lenny)</description>
     <example service.version="8.14.3">foo.bar ESMTP Sendmail 8.14.3/8.14.3/Debian-5+lenny1; Thu, 30 Nov 2017 12:29:40 +0300; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1381,7 +1381,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+etch\d; (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+etch\d; (.+); .*$">
     <description>Sendmail - Debian 4.x (etch)</description>
     <example service.version="8.13.8" sendmail.config.version="8.13.8">foo.bar ESMTP Sendmail 8.13.8/8.13.8/Debian-3+etch1; Thu, 30 Nov 2017 10:28:23 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1400,7 +1400,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\dsarge\d; (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\dsarge\d; (.+); .*$">
     <description>Sendmail - Debian 3.1 (sarge)</description>
     <example service.version="8.13.4">foo.bar ESMTP Sendmail 8.13.4/8.13.4/Debian-3sarge1; Thu, 30 Nov 2017 10:55:47 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1419,7 +1419,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d(?:\.\d)?(?:build\d)?;+ (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d(?:\.\d)?(?:build\d)?;+ (.+); .*$">
     <description>Sendmail - Debian patch only</description>
     <example service.version="8.15.2">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-3; Thu, 30 Nov 2017 10:55:50 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <example service.version="8.14.3">foo.bar ESMTP Sendmail 8.14.3/8.14.3/Debian-9.4; Thu, 30 Nov 2017 10:11:54 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
@@ -1439,7 +1439,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^/]+)/[^/]+/Debian-[\d.]+ubuntu[^ ]*; (.+); .*$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/[^/]+/Debian-[\d.]+ubuntu[^ ]*; (.+); .*$">
     <description>Sendmail - Ubuntu</description>
     <example service.version="8.13.5.20060308">foo.bar ESMTP Sendmail 8.13.5.20060308/8.13.5/Debian-3ubuntu1.1; Fri, 24 Jul 2009 01:41:21 -0700; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <example service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4.1ubuntu1; Thu, 30 Nov 2017 11:00:30 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
@@ -1457,7 +1457,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) (?:E?SMTP )?Sendmail SMI-([^/]+)/(SMI-SVR4) ready at (.+)$">
+  <fingerprint pattern="^([^ ]{1,512}) (?:E?SMTP )?Sendmail SMI-([^/]+)/(SMI-SVR4) ready at (.+)$">
     <description>Sendmail - Solaris (SMI variant)</description>
     <example>foo.bar Sendmail SMI-8.6/SMI-SVR4 ready at Sun, 29 Jul 2001 22:58:46 -0400</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1475,7 +1475,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail ([^ ]+)/(linuxconf); (.+)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^ ]+)/(linuxconf); (.+)$">
     <description>Sendmail - unknown platform (linuxconf variant)</description>
     <example>foo.bar ESMTP Sendmail 8.9.3/linuxconf; Sun, 29 Jul 2001 22:48:28 -0400</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1491,7 +1491,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP MetaInfo Sendmail ([^ ]+) Build ([^ ]+) \(Berkeley ([^ ]+)\)/([^;]+); (.+)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP MetaInfo Sendmail ([^ ]+) Build ([^ ]+) \(Berkeley ([^ ]+)\)/([^;]+); (.+)$">
     <description>Sendmail - MetaInfo</description>
     <example host.name="foo.bar" service.version="8.8.6">foo.bar ESMTP MetaInfo Sendmail 2.5 Build 2630 (Berkeley 8.8.6)/8.8.4; Mon, 30 Jul</example>
     <param pos="0" name="service.vendor" value="MetaInfo"/>
@@ -1629,7 +1629,7 @@
 
   <!-- *Sendmail* fingerprints after this line had NO matches in 2017.11.30 Project Sonar data set-->
 
-  <fingerprint pattern="^([^ ]+) Sendmail ([^;]+); ([^;\.]+)$">
+  <fingerprint pattern="^([^ ]{1,512}) Sendmail ([^;]+); ([^;\.]+)$">
     <description>Sendmail - unknown platform, variant 1</description>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
@@ -1652,7 +1652,7 @@
     <param pos="3" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) -- Server ESMTP \(Sun Internet Mail Server sims\.(\d\.[\w.]+)\)$">
+  <fingerprint pattern="^([^ ]{1,512}) -- Server ESMTP \(Sun Internet Mail Server sims\.(\d\.[\w.]+)\)$">
     <description>Sun Internet Mail Server</description>
     <example host.name="foo.bar" service.version="4.0.2000.10.12.16.25.p8">foo.bar -- Server ESMTP (Sun Internet Mail Server sims.4.0.2000.10.12.16.25.p8)</example>
     <param pos="0" name="service.vendor" value="Sun"/>
@@ -1666,7 +1666,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:2.0.0 )?([^ ]+) ESMTP ecelerity (\d\.[\d.]+) r\(([^)]+)\) (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) *$">
+  <fingerprint pattern="^(?:2.0.0 )?([^ ]{1,512}) ESMTP ecelerity (\d\.[\d.]+) r\(([^)]+)\) (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) *$">
     <description>Ecelerity</description>
     <example host.name="foo.bar" system.time="Thu, 30 Nov 2017 05:11:00 -0500">2.0.0 foo.bar ESMTP ecelerity 4.0.0.43760 r(Platform:4.0.0.1) Thu, 30 Nov 2017 05:11:00 -0500</example>
     <example>foo.bar ESMTP ecelerity 3.3.1.44388 r(44388) Thu, 30 Nov 2017 03:10:11 -0700</example>
@@ -1803,7 +1803,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Lyris ListManager service ready$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Lyris ListManager service ready$">
     <description>Lyris ListManager</description>
     <example host.name="foo.bar">foo.bar ESMTP Lyris ListManager service ready</example>
     <param pos="0" name="service.vendor" value="Lyris"/>
@@ -1812,7 +1812,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP - WinRoute Pro ([^ ]+\.[^ ]+)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP - WinRoute Pro ([^ ]+\.[^ ]+)$">
     <description>WinRoute Pro, runs on 9x/NT/2k http://www.tinysoftware.com/winpro.php</description>
     <example host.name="foo.bar" service.version="4.2.4">foo.bar ESMTP - WinRoute Pro 4.2.4</example>
     <param pos="0" name="service.family" value="WinRoute"/>
@@ -1831,7 +1831,7 @@
     <param pos="2" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ZMailer Server (\d\.[\d.]+) #([^ ]+) ESMTP ready at (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ZMailer Server (\d\.[\d.]+) #([^ ]+) ESMTP ready at (.+) *$">
     <description>ZMailer http://www.zmailer.org/technical.html</description>
     <example service.version="2.99.57" service.version.version="1">foo.bar ZMailer Server 2.99.57 #1 ESMTP ready at Thu, 16 Nov 2017 12:00:12 +0300</example>
     <param pos="0" name="service.vendor" value="ZMailer"/>
@@ -1844,7 +1844,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ZMailer Server (\d\.[\d.]+) #([^ ]+) ESMTP\+IDENT ready at (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ZMailer Server (\d\.[\d.]+) #([^ ]+) ESMTP\+IDENT ready at (.+) *$">
     <description>ZMailer server that supports IDENT</description>
     <example service.version="2.99.55" service.version.version="16">foo.bar ZMailer Server 2.99.55 #16 ESMTP+IDENT ready at Thu, 16 Nov 2017 06:51:42 -0300</example>
     <param pos="0" name="service.vendor" value="ZMailer"/>
@@ -1858,7 +1858,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Kerio Connect (\d\.[\d.]+) (?:patch (\d) )?ESMTP ready$">
+  <fingerprint pattern="^([^ ]{1,512}) Kerio Connect (\d\.[\d.]+) (?:patch (\d) )?ESMTP ready$">
     <description>Kerio Connect ESMTP</description>
     <example host.name="foo.bar" service.version="8.0.2">foo.bar Kerio Connect 8.0.2 ESMTP ready</example>
     <example service.version="9.2.5" service.version.version="3">foo.bar Kerio Connect 9.2.5 patch 3 ESMTP ready</example>
@@ -1911,7 +1911,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Service ready by David.fx \((\d+)\) ESMTP Server \(Tobit.Software, Germany\)$">
+  <fingerprint pattern="^([^ ]{1,512}) Service ready by David.fx \((\d+)\) ESMTP Server \(Tobit.Software, Germany\)$">
     <description>Tobit Software David</description>
     <example service.version="0486">foo.bar Service ready by David.fx (0486) ESMTP Server (Tobit.Software, Germany)</example>
     <param pos="0" name="service.vendor" value="Tobit Software"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -80,7 +80,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:argosoft:mail_server:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^^(?:(\S+) +)?ArGoSoft Mail Server Freeware, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
+  <fingerprint pattern="^(?:(\S{1,512}) {1,8})?ArGoSoft Mail Server Freeware, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
     <description>ArGoSoft Mail Server - freeware version</description>
     <example host.name="foo.bar" service.version="1.8.8.8">foo.bar ArGoSoft Mail Server Freeware, Version 1.8 (1.8.8.8)</example>
     <example service.version="1.8.8.8">ArGoSoft Mail Server Freeware, Version 1.8 (1.8.8.8)</example>
@@ -96,7 +96,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:(\S+) +)?ArGoSoft Mail Server Pro for WinNT\/2000(?:\/XP)?, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
+  <fingerprint pattern="^(?:(\S{1,512}) {1,8})?ArGoSoft Mail Server Pro for WinNT\/2000(?:\/XP)?, Version [^ ]+ \(([^ ]+\.[^ ]+\.[^ ]+\.[^ ]+)\) *$">
     <description>ArGoSoft Mail Server - Pro version</description>
     <example service.version="1.6.1.8">ArGoSoft Mail Server Pro for WinNT/2000, Version 1.61 (1.6.1.8)</example>
     <example service.version="1.8.9.5">ArGoSoft Mail Server Pro for WinNT/2000/XP, Version 1.8 (1.8.9.5)</example>
@@ -113,7 +113,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:argosoft:mail_server:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +AppleShare IP Mail Server ([^ ]+\.[\d.]+) SMTP Server Ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) +AppleShare IP Mail Server ([^ ]+\.[\d.]+) SMTP Server Ready *$">
     <description>AppleShare IP Mail Server</description>
     <example service.version="6.2.1">foo.bar AppleShare IP Mail Server 6.2.1 SMTP Server Ready</example>
     <example service.version="6.2">foo.bar AppleShare IP Mail Server 6.2 SMTP Server Ready</example>
@@ -162,7 +162,7 @@
     Search Cisco's documentation for "fixup protocol SMTP" for more information.
   -->
 
-  <fingerprint pattern="^[\*20 ]+$">
+  <fingerprint pattern="^[\*20 ]{1,1024}$">
     <description>Cisco PIX firewall MailGuard banner stripping</description>
     <example os.product="PIX">***************************</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
@@ -171,7 +171,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:pix_firewall_software:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP CPMTA-([^ ]+)_([^ ]+)_([^ ]+)_([^ ]+) - NO UCE *$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP CPMTA-([^ ]+)_([^ ]+)_([^ ]+)_([^ ]+) - NO UCE *$">
     <description>Critical Path (aka InScribe) Messaging Server on Windows NT4/2k, Solaris 2.6/2.7/2.8 Sparc/Intel, SGI IRIX 6.5.3 or later, or AIX </description>
     <param pos="0" name="service.vendor" value="Critical Path"/>
     <param pos="0" name="service.family" value="Messaging Server"/>
@@ -192,7 +192,7 @@
     <param pos="0" name="service.product" value="Internet Mail Scanner"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +IMS SMTP Receiver Version ([^ ]+\.[^ ]+) Ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) +IMS SMTP Receiver Version ([^ ]+\.[^ ]+) Ready *$">
     <description>EMWAC Internet Mail Services (http://emwac.ed.ac.uk/html/internet_toolchest/ims/ims.htm)</description>
     <example service.version="0.83" host.name="foo.bar">foo.bar IMS SMTP Receiver Version 0.83 Ready</example>
     <param pos="0" name="service.vendor" value="EMWAC"/>
@@ -261,9 +261,10 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(:?[^ ]+)? ?Microsoft ESMTP MAIL Service, Version: +(10\.0\.14393\.[\d.]+) +ready +(?:at +)?(.+)$">
+  <fingerprint pattern="^([^ ]{1,512})? ?Microsoft ESMTP MAIL Service, Version: +(10\.0\.14393\.[\d.]+) +ready +(?:at +)?(.+)$">
     <description>Microsoft IIS builtin SMTP service - Windows Server 2016</description>
     <example host.name="foo.bar" service.version="10.0.14393.2608">foo.bar Microsoft ESMTP MAIL Service, Version: 10.0.14393.2608 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
+    <example service.version="10.0.14393.2608"> Microsoft ESMTP MAIL Service, Version: 10.0.14393.2608 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
@@ -278,7 +279,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2016:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(:?[^ ]+)? ?Microsoft ESMTP MAIL Service, Version: +(10\.0\.17763\.[\d.]+) +ready +(?:at +)?(.+)$">
+  <fingerprint pattern="^([^ ]{1,512})? ?Microsoft ESMTP MAIL Service, Version: +(10\.0\.17763\.[\d.]+) +ready +(?:at +)?(.+)$">
     <description>Microsoft IIS builtin SMTP service - Windows Server 2019</description>
     <example host.name="foo.bar" service.version="10.0.17763.1">foo.bar Microsoft ESMTP MAIL Service, Version: 10.0.17763.1 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
@@ -295,7 +296,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2019:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Microsoft SMTP MAIL ready at (.+) Version: +(\d+\.\d+\.\d+\.\d+\.\d+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) Microsoft SMTP MAIL ready at (.+) Version: +(\d+\.\d+\.\d+\.\d+\.\d+) *$">
     <description>Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each other in smtp-iis.clp)  - variant 1</description>
     <example host.name="foo.bar" service.version="5.5.1877.197.19">foo.bar Microsoft SMTP MAIL ready at Wed, 29 Nov 2017 23:48:59 +0000 Version: 5.5.1877.197.19</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
@@ -312,7 +313,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(:?[^ ]+)? ?Microsoft ESMTP MAIL Service, Version: +(\d+\.\d+\.\d+\.\d+)(?: +ready)?(?: +(?:at +)?(\w\w\w, \d.+))?$">
+  <fingerprint pattern="^([^ ]{1,512})? ?Microsoft ESMTP MAIL Service, Version: +(\d+\.\d+\.\d+\.\d+)(?: +ready)?(?: +(?:at +)?(\w\w\w, \d.+))?$">
     <description>Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each other in smtp-iis.clp) - variant 2 </description>
     <example service.version="5.0.2195.5329"> Microsoft ESMTP MAIL Service, Version: 5.0.2195.5329 ready Thu, 30 Nov 2017 11:40:25 +0200</example>
     <example service.version="6.0.3790.4675" host.name="foo.bar">foo.bar Microsoft ESMTP MAIL Service, Version: 6.0.3790.4675 ready at Wed, 21 Jul 2010 19:04:24 -0700</example>
@@ -344,7 +345,7 @@
     <param pos="1" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^ ?([^, ]+)(?:,)? +ESMTP \(?(?i:Exim) +(\d+\.[\d_.bdRC-]+)\)?(?: +#\d+)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d{3,4})?) *(?:We do not authorize the use of this system to transport unsolicited, and\/or bulk e-mail.)?$">
+  <fingerprint pattern="^ ?([^, ]{1,512}),? +ESMTP \(?(?i:Exim) +(\d+\.[\d_.bdRC-]+)\)?(?: +#\d+)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d{3,4})?) *(?:We do not authorize the use of this system to transport unsolicited, and\/or bulk e-mail.)?$">
     <description>Exim - with version string and optional timestamp</description>
     <example service.version="4.91" host.name="foo.bar">foo.bar  ESMTP Exim 4.91 Thu, 29 Apr 2021 05:41:36 +400</example>
     <example service.version="4.89" host.name="foo.bar">foo.bar ESMTP Exim 4.89 "</example>
@@ -367,7 +368,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^, ]+)(?:,)? ESMTP (?i:Exim) +(\d+) ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
+  <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim) +(\d+) ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - with digit only version string and optional timestamp</description>
     <example service.version="125302" host.name="foo.bar">foo.bar ESMTP Exim 125302 Thu, 16 Nov 2017 04:55:11 -0500 </example>
     <param pos="0" name="service.vendor" value="exim"/>
@@ -380,7 +381,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^, ]+)(?:,)? ESMTP (?i:Exim) +(\d+\.[\d_.]+)(?: +#\d)? Ubuntu ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
+  <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim) +(\d+\.[\d_.]+)(?: +#\d)? Ubuntu ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - with version string and optional timestamp (Ubuntu)</description>
     <example service.version="4.82" system.time="Thu, 16 Nov 2017 11:30:44 +0300">foo.bar ESMTP Exim 4.82 Ubuntu Thu, 16 Nov 2017 11:30:44 +0300 </example>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
@@ -397,7 +398,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^, ]+)(?:,)? ESMTP (?i:Exim)(?: +#\d)? *((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
+  <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim)(?: +#\d)? *((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - without version string and with optional timestamp</description>
     <example host.name="foo.bar">foo.bar ESMTP Exim</example>
     <example host.name="foo.bar" system.time="Thu, 16 Nov 2017 01:11:30 -0800">foo.bar ESMTP Exim Thu, 16 Nov 2017 01:11:30 -0800 </example>
@@ -425,7 +426,7 @@
     <param pos="2" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^ ?([^, ]+) Exim ESMTP Service ready$">
+  <fingerprint pattern="^ ?([^, ]{1,512}) Exim ESMTP Service ready$">
     <description>Exim - with hostname </description>
     <example host.name="foo.bar">foo.bar Exim ESMTP Service ready</example>
     <param pos="0" name="service.vendor" value="exim"/>
@@ -435,7 +436,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([\w.-]+) ESMTP \([a-z0-9]{32}\)$">
+  <fingerprint pattern="^([\w.-]{1,512}) ESMTP \([a-z0-9]{32}\)$">
     <description>Barracuda Email Security Gateway - physical or virtual appliance</description>
     <example host.name="barracuda.foo.bar">barracuda.foo.bar ESMTP (0a8d40ef45300cc1bd0f16ced5c9e6f1)</example>
     <param pos="0" name="service.vendor" value="Barracuda"/>
@@ -445,7 +446,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) FTGate server ready .*$">
+  <fingerprint pattern="^([^ ]{1,512}) FTGate server ready .*$">
     <description>FTGate mail server, runs on Windows 9x/NT/2k (http://www.ftgate.com)</description>
     <example host.name="foo.bar">foo.bar FTGate server ready -attitude [C.o.r.E]</example>
     <param pos="0" name="service.vendor" value="Floosietek"/>
@@ -454,7 +455,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +SMTP/smap Ready\.$">
+  <fingerprint pattern="^([^ ]{1,512}) +SMTP/smap Ready\.$">
     <description>TIS FWTK and derivatives (other firewalls, like Gauntlet, are derived from TIS)</description>
     <example host.name="foo.bar">foo.bar SMTP/smap Ready.</example>
     <param pos="0" name="service.vendor" value="TIS"/>
@@ -463,7 +464,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) GroupWise Internet Agent ([^ ]+\.[^ ]+\.[^ ]+) Ready \(C\).* Novell, Inc\. *$">
+  <fingerprint pattern="^([^ ]{1,512}) GroupWise Internet Agent ([^ ]+\.[^ ]+\.[^ ]+) Ready \(C\).* Novell, Inc\. *$">
     <description>Novell GroupWise Internet Agent - versions 5 and higher</description>
     <example service.version="5.5.1">foo.bar GroupWise Internet Agent 5.5.1 Ready (C)1993, 1998 Novell, Inc.</example>
     <param pos="0" name="service.vendor" value="Novell"/>
@@ -498,7 +499,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:novell:groupwise:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) (?:ESMTP )?running IBM VM SMTP (.+)(?:; | on )(.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) (?:ESMTP )?running IBM VM SMTP (.+)(?:; | on )(.+) *$">
     <description>IBM SMTP server for VM/ESA on IBM S/390 and IBM eserver z/Series 900.</description>
     <example service.version="Level 640" system.time="Thu, 30 Nov 2017 01:08:59 PDT">foo.bar running IBM VM SMTP Level 640 on Thu, 30 Nov 2017 01:08:59 PDT</example>
     <example service.version="Level 3A0">foo.bar running IBM VM SMTP Level 3A0 on Mon, 10 Sep 2001 07:21:54 EDT</example>
@@ -512,7 +513,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) \(IntraStore TurboSendmail\) ESMTP Service ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) \(IntraStore TurboSendmail\) ESMTP Service ready *$">
     <description>
          Syntegra/CDC IntraStore TurboSendmail, part of the IntraStore server which runs on
          the following platforms ONLY: Linux, HP-UX, Solaris, AIX, and Windows NT/2000
@@ -525,7 +526,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) E?SMTP Server \(JAMES E?SMTP Server ([\d\.]+)\) ready (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) \(.+\)$">
+  <fingerprint pattern="^(\S{1,512}) E?SMTP Server \(JAMES E?SMTP Server ([\d\.]+)\) ready (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) \(.+\)$">
     <description>JAMES SMTP Server</description>
     <example host.name="foo.bar" service.version="2.3.2">foo.bar SMTP Server (JAMES SMTP Server 2.3.2) ready Tue, 19 May 2015 00:36:13 +0200 (CEST)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
@@ -537,7 +538,7 @@
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss Z"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:(\S+) +)?ESMTP MailEnable Service, Version: ([\d.]+)$">
+  <fingerprint pattern="^(?:(\S{1,512}) {1,8})?ESMTP MailEnable Service, Version: ([\d.]+)$">
     <description>MailEnable - Simple</description>
     <example service.version="9.53">ESMTP MailEnable Service, Version: 9.53</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
@@ -554,10 +555,11 @@
 
   <!-- MailEnable has an odd, three version string. Not sure about the meaning the second and third version #s. -->
 
-  <fingerprint pattern="^(?:(\S+) +)?ESMTP MailEnable Service, Version: (?:([\d.]+))?-[\d.]*-[\d.]* (?:ready|denied access) at (\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2})$">
+  <fingerprint pattern="^(?:(\S{1,512}) {1,8})?ESMTP MailEnable Service, Version: (?:([\d.]+))?-[\d.]*-[\d.]* (?:ready|denied access) at (\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2})$">
     <description>MailEnable - Complex</description>
     <example host.name="foo.bar" service.version="1.8">foo.bar ESMTP MailEnable Service, Version: 1.8-- ready at 05/20/15 08:50:22</example>
-    <example host.name="foo.bar" service.version="9.53">foo.bar ESMTP MailEnable Service, Version: 9.53-9.53- ready at 11/30/17 00:57:37</example>
+    <example host.name="*.foo.bar" service.version="9.53">*.foo.bar ESMTP MailEnable Service, Version: 9.53-9.53- ready at 11/30/17 00:57:37</example>
+    <example host.name="%WPI_HOSTNAME%" service.version="10.27">%WPI_HOSTNAME% ESMTP MailEnable Service, Version: 10.27-- ready at 07/07/21 18:24:47</example>
     <example host.name="foo.bar" service.version="9.00" system.time="11/30/17 09:30:34">foo.bar ESMTP MailEnable Service, Version: 9.00--9.00 ready at 11/30/17 09:30:34</example>
     <example host.name="foo.bar" service.version="1.986" system.time="04/05/18 16:15:25">foo.bar ESMTP MailEnable Service, Version: 1.986-- denied access at 04/05/18 16:15:25</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
@@ -587,7 +589,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +MailSite E?SMTP Receiver Version (\d+\.[\d.]+) Ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}MailSite E?SMTP Receiver Version (\d+\.[\d.]+) Ready *$">
     <description>Rockliffe MailSite - with version (http://www.rockliffe.com)</description>
     <example host.name="foo.bar" service.version="3.4.6.0">foo.bar  MailSite ESMTP Receiver Version 3.4.6.0 Ready</example>
     <example host.name="foo.bar" service.version="2.1.7">foo.bar MailSite SMTP Receiver Version 2.1.7 Ready</example>
@@ -598,7 +600,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +MailSite E?SMTP Receiver Ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}MailSite E?SMTP Receiver Ready *$">
     <description>Rockliffe MailSite - without version (http://www.rockliffe.com)</description>
     <example host.name="foo.bar">foo.bar MailSite SMTP Receiver Ready</example>
     <param pos="0" name="service.vendor" value="Rockliffe"/>
@@ -616,7 +618,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +MAILsweeper ESMTP Receiver Version (\d\.[\d.]+) Ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}MAILsweeper ESMTP Receiver Version (\d\.[\d.]+) Ready *$">
     <description>Content Security MAILsweeper for SMTP (http://www.contenttechnologies.com/products/msw4smtp/default.asp)</description>
     <example service.version="4.2.1.0">foo.bar MAILsweeper ESMTP Receiver Version 4.2.1.0 Ready</example>
     <param pos="0" name="service.vendor" value="Clearswift"/>
@@ -626,7 +628,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) UNREGISTERED; *(.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) UNREGISTERED; *(.+) *$">
     <description>MDaemon mail server - with timestamp, unregistered</description>
     <example service.version="4.0.5">foo.bar ESMTP MDaemon 4.0.5 UNREGISTERED; Sat, 06 Oct 2001 09:10:56 +0400</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -645,7 +647,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
     <description>MDaemon mail server - with timestamp</description>
     <example service.version="4.0.2">foo.bar ESMTP MDaemon 4.0.2; Sat, 06 Oct 2001 01:46:44 -0500</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -663,7 +665,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) ready *$">
     <description>MDaemon mail server - without timestamp</description>
     <example service.version="3.5.7">foo.bar ESMTP MDaemon 3.5.7 ready</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -679,7 +681,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:altn:mdaemon:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] (?:using )?MDaemon v(\d+\.[\d.]+) ([^ ]+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP service ready \[[0-9]+\] (?:using )?MDaemon v(\d+\.[\d.]+) ([^ ]+) *$">
     <description>MDaemon mail server - with version revision</description>
     <example service.version="2.84" service.version.version="R">foo.bar ESMTP service ready [1] MDaemon v2.84 R</example>
     <example service.version="3.0.3" service.version.version="R">foo.bar ESMTP service ready [1] using MDaemon v3.0.3 R</example>
@@ -698,7 +700,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:altn:mdaemon:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] (?:\()?MDaemon v([\d.]+) ([^ ]+) ([^ )]+)(?:\))? *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP service ready \[[0-9]+\] (?:\()?MDaemon v([\d.]+) ([^ ]+) ([^ )]+)(?:\))? *$">
     <description>MDaemon mail server - with service pack</description>
     <example service.version="2.7" service.version.version="SP5" service.version.version.version="R">foo.bar ESMTP service ready [1] MDaemon v2.7 SP5 R</example>
     <example service.version="2.7" service.version.version="SP4" service.version.version.version="R">foo.bar ESMTP service ready [1] (MDaemon v2.7 SP4 R)</example>
@@ -717,7 +719,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:altn:mdaemon:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP service ready \[[0-9]+\] \(MDaemon v([^ ]+\.[^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)\) *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP service ready \[[0-9]+\] \(MDaemon v([^ ]+\.[^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)\) *$">
     <description>MDaemon mail server</description>
     <example service.version="2.5" service.version.version.version="b1">foo.bar ESMTP service ready [1] (MDaemon v2.5 rB b1 32-T)</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
@@ -846,7 +848,7 @@
        called IBM Domino as of v9.0 on product and in banners.
   -->
 
-  <fingerprint pattern="^ ?(?:([^ ]+))? *ESMTP Service \(Lotus Domino Release (\d+\.[\w.]+(?: FP\d+)?(?: HF\d+)?)(?: \(Intl\))?\) ready at (.+) *$">
+  <fingerprint pattern=" ?(?:([^ ]{1,512}))? {0,8}ESMTP Service \(Lotus Domino Release (\d+\.[\w.]+(?: FP\d+)?(?: HF\d+)?)(?: \(Intl\))?\) ready at (.+) *$">
     <description>Lotus Domino SMTP MTA</description>
     <example service.version="8.5">foo.bar  ESMTP Service (Lotus Domino Release 8.5) ready at Thu, 30 Nov 2017 17:01:45 +0800</example>
     <example service.version="8.5.3FP6 HF1944">foo.bar ESMTP Service (Lotus Domino Release 8.5.3FP6 HF1944) ready at Thu, 30 Nov 2017 17:17:43 +0800</example>
@@ -867,7 +869,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^ ?(?:([^ ]+))? *ESMTP Service \(IBM Domino Release (\d+\.[\w.]+(?: HF\d+)?)\) ready at (.+) *$">
+  <fingerprint pattern="^ ?(?:([^ ]{1,512}))? {0,8}ESMTP Service \(IBM Domino Release (\d+\.[\w.]+(?: HF\d+)?)\) ready at (.+) *$">
     <description>IBM Domino SMTP MTA</description>
     <example host.name="foo.bar" service.version="9.0.1FP8 HF475">foo.bar ESMTP Service (IBM Domino Release 9.0.1FP8 HF475) ready at Thu, 30 Nov 2017 17:55:48 +0900</example>
     <example host.name="foo.bar" service.version="9.0.1"> foo.bar ESMTP Service (IBM Domino Release 9.0.1) ready at Thu, 30 Nov 2017 10:12:26 +0100</example>
@@ -918,7 +920,7 @@
     <param pos="3" name="ntmail.id"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) WindowsNT SMTP Server v([^ ]+\.[^ ]+\.[^ ]+)/([^ ]+)/SP ESMTP ready at (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) WindowsNT SMTP Server v([^ ]+\.[^ ]+\.[^ ]+)/([^ ]+)/SP ESMTP ready at (.+) *$">
     <description>NTMail - versions 3.x and earlier (it was called Internet Shopper's something or other)</description>
     <example host.name="foo.bar" service.version="3.03.0018" ntmail.id="7.aavn">foo.bar WindowsNT SMTP Server v3.03.0018/7.aavn/SP ESMTP ready at Thu, 30 Nov 2017 10:15:31 +0100</example>
     <param pos="0" name="service.vendor" value="Gordano"/>
@@ -931,7 +933,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+)(?: UCX)? V\S+, OpenVMS V(\S+) (\S+) ready at .*$">
+  <fingerprint pattern="^([^ ]{1,512})(?: UCX)? V\S+, OpenVMS V(\S+) (\S+) ready at .*$">
     <description>Some unknown mail server on OpenVMS</description>
     <example host.name="foo.bar" os.arch="IA64" os.version="8.4">foo.bar V5.7-ECO4, OpenVMS V8.4 IA64 ready at Wed, 20 May 2015 01:22:32 +0100 (BST)</example>
     <example host.name="foo.bar" os.arch="Alpha" os.version="7.3-2">foo.bar V5.4-15E, OpenVMS V7.3-2 Alpha ready at Wed, 20 May 2015 01:22:18 +0100 (BST)</example>
@@ -946,7 +948,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:openvms:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) E?SMTP PMailServer(?: \[Free Edition\])? ([\d\.]+); (\w\w\w, +\d+ \w\w\w \d\d\d\d [\d:]+)$">
+  <fingerprint pattern="^([^ ]{1,512}) E?SMTP PMailServer(?: \[Free Edition\])? ([\d\.]+); (\w\w\w, +\d+ \w\w\w \d\d\d\d [\d:]+)$">
     <description>A.K.I PMail</description>
     <example host.name="foo.bar" service.version="1.91">foo.bar ESMTP PMailServer [Free Edition] 1.91; Fri, 22 May 2015 02:04:56</example>
     <example host.name="foo.bar" service.version="1.78">foo.bar ESMTP PMailServer 1.78; Fri,  6 Apr 2018 04:34:11</example>
@@ -958,7 +960,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Postfix \(Postfix-([^ ]+)-([^ ]+)\) \(([^ ]+)\) *$">
+  <fingerprint pattern="^([^ ]{1,512}) Postfix \(Postfix-([^ ]+)-([^ ]+)\) \(([^ ]+)\) *$">
     <description>Postfix - version + build, followed by os</description>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
@@ -970,7 +972,7 @@
     <param pos="4" name="postfix.os.info"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Postfix \(?([\d.]+)\)?$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Postfix \(?([\d.]+)\)?$">
     <description>Postfix - Std semantic versioning, w/ optional parens</description>
     <example service.version="3.1.4">foo.bar ESMTP Postfix (3.1.4)</example>
     <example service.version="2.7.1">foo.bar ESMTP Postfix 2.7.1</example>
@@ -982,7 +984,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:postfix:postfix:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Postfix \((?:Postfix-)?([\d.]+)-([^ ]+)\)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Postfix \((?:Postfix-)?([\d.]+)-([^ ]+)\)$">
     <description>Postfix - version + build</description>
     <example service.version="2.8" service.version.version="20100306">foo.bar ESMTP Postfix (2.8-20100306)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
@@ -994,7 +996,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:postfix:postfix:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +E?SMTP Postfix \(Ubuntu\)$">
+  <fingerprint pattern="^([^ ]{1,512}) +E?SMTP Postfix \(Ubuntu\)$">
     <description>Postfix - Ubuntu</description>
     <example>foo.bar ESMTP Postfix (Ubuntu)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
@@ -1008,9 +1010,9 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+)(?: ESMTP)? Hi, I'm a Mail-in-a-Box \(Ubuntu/Postfix; see https://mailinabox.email/\)$">
+  <fingerprint pattern="^([^ ]{1,512})(?: ESMTP)? Hi, I'm a Mail-in-a-Box \(Ubuntu/Postfix; see https://mailinabox.email/\)$">
     <description>Postfix - Ubuntu, Mail-in-a-Box package</description>
-    <example>foo.bar ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)</example>
+    <example host.name="foo.bar">foo.bar ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)</example>
     <example>foo.bar Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
@@ -1037,7 +1039,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP.* Postfix *\(.+\) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP.* Postfix *\(.+\) *$">
     <description>Postfix - generic banner with amusing comments in parentheses</description>
     <example>foo.bar ESMTP Postfix (lol)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
@@ -1047,7 +1049,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^([^ ]+) +E?SMTP.* Postfix *$">
+  <fingerprint pattern="(?i)^([^ ]{1,512}) {1,8}E?SMTP.* Postfix *$">
     <description>Postfix - generic banner</description>
     <example>foo.bar ESMTP Postfix</example>
     <example>foo.bar SMTP Postfix</example>
@@ -1058,7 +1060,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^ *ESMTP Postfix$">
+  <fingerprint pattern="^ {0,512}ESMTP Postfix$">
     <description>Postfix - banner without hostname or version</description>
     <example>ESMTP Postfix</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
@@ -1067,7 +1069,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:postfix:postfix:-"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^([^ ]+) POSTFIX$">
+  <fingerprint pattern="(?i)^([^ ]{1,512}) POSTFIX$">
     <description>Postfix - generic w/o ESMTP</description>
     <example host.name="foo.bar">foo.bar Postfix</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
@@ -1098,7 +1100,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) SAP (\S+) E?SMTP service ready$">
+  <fingerprint pattern="^(\S{1,512}) SAP (\S+) E?SMTP service ready$">
     <description>SAP SMTP Server</description>
     <example host.name="foo.bar" service.version="8.04(53)">foo.bar SAP 8.04(53) ESMTP service ready</example>
     <param pos="0" name="service.vendor" value="SAP"/>
@@ -1116,7 +1118,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:sendmail:sendmail:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP +Sendmail +([^ ]+) \(PHNE_([^ ]+)\) */ *(.+); *(.+) \(.+\)$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail +([^ ]+) \(PHNE_([^ ]+)\) */ *(.+); *(.+) \(.+\)$">
     <description>Sendmail - HP-UX with a PHNE (HP Networking patch) installed</description>
     <example host.name="foo.bar" service.version="8.8.6" sendmail.config.version="8.7.1">foo.bar ESMTP Sendmail 8.8.6 (PHNE_14041)/8.7.1; Tue, 6 Feb 2001 10:04:32 -0300 (SAT)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1135,7 +1137,7 @@
     <param pos="5" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) ESMTP Sendmail \S+ version ([\d\.]+) - Revision \S+ HP-UX([\d\.]+).*(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ \w\w\w)$">
+  <fingerprint pattern="^(\S{1,512}) ESMTP Sendmail \S+ version ([\d\.]+) - Revision \S+ HP-UX([\d\.]+).*(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ \w\w\w)$">
     <description>Sendmail - HP-UX</description>
     <example host.name="foo.bar" os.version="11.31" service.version="8.13.3">foo.bar ESMTP Sendmail @(#)Sendmail version 8.13.3 - Revision 1.004:: HP-UX11.31 - 03rd February,2010/8.11.1; Wed, 20 May 2015 23:35:38 GMT</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1153,7 +1155,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP +Sendmail +([^ ]+)/UW([^ ]+) ready at *(.+) \(.+\) *$">
+  <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP +Sendmail +([^ ]+)/UW([^ ]+) ready at *(.+) \(.+\) *$">
     <description>Sendmail - Unixware</description>
     <example service.version="8.8.7">foo.bar ESMTP Sendmail 8.8.7/UW7.1.0 ready at Tue, 6 Feb 2001 16:39:30 -0300 (GMT-0300)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1170,7 +1172,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Sendmail AIX([^/]+)/UCB ([^;]+); (.+) \(.+\)$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail AIX([^/]+)/UCB ([^;]+); (.+) \(.+\)$">
     <description>Sendmail - AIX (UCB variant)</description>
     <example os.version="4.2" service.version="8.7">foo.bar ESMTP Sendmail AIX4.2/UCB 8.7; Sun, 29 Jul 2001 22:34:37 -0400 (EDT)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1508,7 +1510,7 @@
     <param pos="6" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP .*Sendmail +([^/ ]+) */ *([^/ ]+); *((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)(?: \(.+\))?$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP .*Sendmail +([^/ ]+) */ *([^/ ]+); *((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)(?: \(.+\))?$">
     <description>Sendmail - optional timezone and timestamp, w/o OS</description>
     <example host.name="foo.bar" service.version="8.9.3+3.4W" sendmail.config.version="8.9.3+3.4W" system.time="Tue, 30 Jan 2001 20:40:09 -0500">foo.bar ESMTP Sendmail 8.9.3+3.4W/8.9.3+3.4W; Tue, 30 Jan 2001 20:40:09 -0500 (EST)</example>
     <example host.name="foo.bar" service.version="8.12.10" sendmail.config.version="8.12.10">foo.bar ESMTP Sendmail 8.12.10/8.12.10;</example>
@@ -1526,7 +1528,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP .*Sendmail +([^/ ]+) */ *([^/ ]+); *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ \w+)\.?$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP .*Sendmail +([^/ ]+) */ *([^/ ]+); *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ \w+)\.?$">
     <description>Sendmail - with timezone and timestamp, w/o timezone offset or OS</description>
     <example host.name="foo.bar" service.version="8.14.4" sendmail.config.version="8.14.4" system.time="Thu, 5 Apr 2018 19:30:58 GMT">foo.bar ESMTP Sendmail 8.14.4/8.14.4; Thu, 5 Apr 2018 19:30:58 GMT</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1539,7 +1541,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP +Sendmail ([^ ]+) ready at *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\))$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail ([^ ]+) ready at *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\))$">
     <description>Sendmail - with version and date (optional timezone), w/o config version</description>
     <example host.name="foo.bar" service.version="8.8.8" system.time="Tue, 6 Feb 2001 14:37:14 +0100">foo.bar ESMTP Sendmail 8.8.8 ready at Tue, 6 Feb 2001 14:37:14 +0100 (CET)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1552,7 +1554,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP +Sendmail ([^ /]+) - \([^\)]+\)/[^ ]+;? *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\)) *$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail ([^ /]+) - \([^\)]+\)/[^ ]+;? *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\)) *$">
     <description>Sendmail - revision variant 1</description>
     <example>foo.foo.bar ESMTP Sendmail 8.11.1 - (Revision 1.010)/8.9.3; Sat, 22 Jan 2011 10:08:35 -0500 (EST)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1565,7 +1567,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP +Sendmail +(?:[^ ]+) +version +([^ ]+) +- +(?:[^;]+); *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\)) *$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail +(?:[^ ]+) +version +([^ ]+) +- +(?:[^;]+); *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\)) *$">
     <description>Sendmail - revision variant 2</description>
     <example>foo.foo.bar ESMTP Sendmail @(#)Sendmail version 8.13.3 - Revision 2.007 - 8 December 2008/8.8.6; Wed, 21 Jul 2010 11:17:01 -0400 (EDT)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1578,7 +1580,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^([^ ]+) +(?:ESMTP +)?Sendmail *(?: Ready.? ?)?(?:;|at)? ?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)(?: \(.+\))?$">
+  <fingerprint pattern="(?i)^([^ ]{1,512}) {1,8}(?:ESMTP +)?Sendmail *(?: Ready.? ?)?(?:;|at)? ?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)(?: \(.+\))?$">
     <description>Sendmail - with date, w/o version or platform, optional status string.</description>
     <example host.name="foo.bar">foo.bar ESMTP Sendmail ; Thu, 30 Nov 2017 17:50:14 +0900</example>
     <example host.name="foo.bar">foo.bar ESMTP Sendmail; Thu, 30 Nov 2017 17:50:14 +0900</example>
@@ -1612,7 +1614,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP +Sendmail ([^ /]+) \([^\)]+\) *(.+) \(.+\)$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail ([^ /]+) \([^\)]+\) *(.+) \(.+\)$">
     <description>Sendmail - unknown (date in version string variant)</description>
     <example>mail.foo.bar ESMTP Sendmail 8.11.1 (1.1.2.11/12Jul01-1016AM) Wed, 8 Jan 2003 11:21:22 +0100 (MET)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
@@ -1680,7 +1682,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^([^ ]+) SMTP Server SLMail v?(\d\.[\d.]+) Ready ESMTP spoken here *$">
+  <fingerprint pattern="(?i)^([^ ]{1,512}) SMTP Server SLMail v?(\d\.[\d.]+) Ready ESMTP spoken here *$">
     <description>Seattle Labs SLMail server for Windows NT/2k (v2.7 runs on Win9x)</description>
     <example service.version="2.7">foo.bar Smtp Server SLMail v2.7 Ready ESMTP spoken here</example>
     <example service.version="3.2.3113">foo.bar SMTP Server SLmail 3.2.3113 Ready ESMTP spoken here</example>
@@ -1692,7 +1694,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +ESMTP Symantec Mail Security$">
+  <fingerprint pattern="^([^ ]{1,512}) +ESMTP Symantec Mail Security$">
     <description>Symantec Mail Security for SMTP</description>
     <example host.name="foo.bar">foo.bar ESMTP Symantec Mail Security</example>
     <param pos="0" name="service.vendor" value="Symantec"/>
@@ -1701,7 +1703,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Symantec Messaging Gateway$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Symantec Messaging Gateway$">
     <description>Symantec Mail Gateway</description>
     <example host.name="foo.bar">foo.bar ESMTP Symantec Messaging Gateway</example>
     <param pos="0" name="service.vendor" value="Symantec"/>
@@ -1712,7 +1714,7 @@
 
   <!-- SonicWall makes hardware, virtual appliances, and Windows software. The banner doesn't indicate which. -->
 
-  <fingerprint pattern="(?i)^([^ ]+) ESMTP SonicWALL \(([\d.]+)\)$">
+  <fingerprint pattern="(?i)^([^ ]{1,512}) ESMTP SonicWALL \(([\d.]+)\)$">
     <description>SonicWall Email Security</description>
     <example host.name="foo.bar" service.version="9.0.5.2077">foo.bar ESMTP SonicWALL (9.0.5.2077)</example>
     <example host.name="foo.bar" service.version="9.1.1.3113">foo.bar ESMTP SonicWall (9.1.1.3113)</example>
@@ -1723,7 +1725,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) \(PowerMTA\(TM\) v([\d.r]+)\) ESMTP service ready$">
+  <fingerprint pattern="^([^ ]{1,512}) \(PowerMTA\(TM\) v([\d.r]+)\) ESMTP service ready$">
     <description>PowerMTA</description>
     <example host.name="foo.bar" service.version="3.2r24">foo.bar (PowerMTA(TM) v3.2r24) ESMTP service ready</example>
     <param pos="0" name="service.vendor" value="port25"/>
@@ -1733,7 +1735,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) +VOPmail ESMTP Receiver Version (\d\.[\d.]+) Ready$">
+  <fingerprint pattern="^([^ ]{1,512}) +VOPmail ESMTP Receiver Version (\d\.[\d.]+) Ready$">
     <description>VOPMail http://www.vircom.com/en/products/vopmail/vopmail.shtml</description>
     <example host.name="foo.bar" service.version="4.0.179.0">foo.bar VOPmail ESMTP Receiver Version 4.0.179.0 Ready</example>
     <param pos="0" name="service.vendor" value="Vircom"/>
@@ -1743,7 +1745,7 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) VPOP3 E?SMTP Server (?:Ready|access not allowed!)$">
+  <fingerprint pattern="^([^ ]{1,512}) VPOP3 E?SMTP Server (?:Ready|access not allowed!)$">
     <description>VPOP3 Email server: http://www.pscs.co.uk/products/vpop3/index.html</description>
     <example>foo.bar VPOP3 ESMTP Server Ready</example>
     <example>foo.bar VPOP3 SMTP Server Ready</example>
@@ -1754,7 +1756,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) WebShield SMTP V([^ ]+\.[^ ]+) (:?[^ ]+)? ?Network Associates.*Ready at (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) WebShield SMTP V([^ ]+\.[^ ]+) ([^ ]+)? ?Network Associates.*Ready at (.+) *$">
     <description>McAfee WebShield</description>
     <example host.name="foo.bar" service.version="4.5" service.version.version="MR1a">foo.bar WebShield SMTP V4.5 MR1a Network Associates, Inc. Ready at Thu Nov 30 09:15:32 2017</example>
     <example host.name="foo.bar" service.version="4.5" system.time="Thu Nov 30 09:15:32 2017">foo.bar WebShield SMTP V4.5 Network Associates, Inc. Ready at Thu Nov 30 09:15:32 2017</example>
@@ -1769,7 +1771,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) McAfee WebShield ASaP v([^ ]+\.[^ ]+\.[^ ]+): (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) McAfee WebShield ASaP v([^ ]+\.[^ ]+\.[^ ]+): (.+) *$">
     <description>McAfee Webshield ASaP (bundled hardware / software)</description>
     <example host.name="foo.bar" service.version="1.0.1" system.time="Sun, 29 Jul 2001 22:46:18 -0700">foo.bar McAfee WebShield ASaP v1.0.1: Sun, 29 Jul 2001 22:46:18 -0700</example>
     <param pos="0" name="service.vendor" value="McAfee"/>
@@ -1785,7 +1787,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) McAfee VirusScreen ASaP v([^ ]+\.[^ ]+): (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) McAfee VirusScreen ASaP v([^ ]+\.[^ ]+): (.+) *$">
     <description>McAfee VirusScreen</description>
     <example host.name="foo.bar" service.version="1.1" system.time="Sun, 20 Jul 2003 09:20:52 -0700">foo.bar McAfee VirusScreen ASaP v1.1: Sun, 20 Jul 2003 09:20:52 -0700</example>
     <param pos="0" name="service.vendor" value="McAfee"/>
@@ -1868,7 +1870,7 @@
     <param pos="3" name="service.version.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP CommuniGate Pro (\d\.[\w.]+)(?:. It is you again :-\()?$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP CommuniGate Pro (\d\.[\w.]+)(?:. It is you again :-\()?$">
     <description>Communigate Pro</description>
     <example host.name="foo.bar" service.version="5.3.1">foo.bar ESMTP CommuniGate Pro 5.3.1</example>
     <example host.name="foo.bar" service.version="6.2c3">foo.bar ESMTP CommuniGate Pro 6.2c3</example>
@@ -1881,7 +1883,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:communigate:communigate_pro:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) NO UCE NO UBE NO RELAY PROBES ESMTP">
+  <fingerprint pattern="^(\S{1,512}) NO UCE NO UBE NO RELAY PROBES ESMTP">
     <description>Twisted SMTP server</description>
     <example host.name="foo.bar">foo.bar NO UCE NO UBE NO RELAY PROBES ESMTP</example>
     <param pos="0" name="service.vendor" value="Twisted Matrix Labs"/>
@@ -1919,14 +1921,14 @@
     <param pos="2" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^(\S+) E?SMTP Perl">
+  <fingerprint pattern="(?i)^(\S{1,512}) E?SMTP Perl">
     <description>Some simple PERL SMTP server</description>
     <example host.name="foo.bar">foo.bar ESMTP Perl</example>
     <param pos="0" name="service.product" value="Perl"/>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^(?:([^ ]+) )?E?SMTP(?: (?:Service )?Ready\.?)?$">
+  <fingerprint pattern="(?i)^(?:([^ ]{1,512}) )?E?SMTP(?: (?:Service )?Ready\.?)?$">
     <description>Non-specific banner with optional hostname</description>
     <example host.name="foo.bar">foo.bar ESMTP</example>
     <example host.name="foo.bar">foo.bar ESMTP Ready</example>
@@ -1938,7 +1940,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP OpenSMTPD$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP OpenSMTPD$">
     <description>OpenSMPTD</description>
     <example host.name="foo.bar">foo.bar ESMTP OpenSMTPD</example>
     <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -44,9 +44,9 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) \(IMail (\d+\.[^ ]+) \d+-\d+\) NT-ESMTP Server X1$">
+  <fingerprint pattern="^([^ ]{1,512}) \(IMail (\d+\.[^ ]+) \d+-\d+\) NT-ESMTP Server X1$">
     <description>IMail - non-EVAL version, NT-ESMTP at end</description>
-    <example service.version="12.4.2.27">foo.bar (IMail 12.4.2.27 21349-1) NT-ESMTP Server X1</example>
+    <example host.name="foo.bar" service.version="12.4.2.27">foo.bar (IMail 12.4.2.27 21349-1) NT-ESMTP Server X1</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="0" name="service.family" value="IMail Server"/>
     <param pos="0" name="service.product" value="IMail Server"/>
@@ -55,7 +55,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) SMTP AnalogX Proxy ([^ ]+\.[^ ]+) \(Release\) ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) SMTP AnalogX Proxy ([^ ]+\.[^ ]+) \(Release\) ready *$">
     <description>AnalogX proxy  (http://www.analogx.com/contents/download/network/proxy.htm)</description>
     <example host.name="192.168.1.1" service.version="4.15">192.168.1.1 SMTP AnalogX Proxy 4.15 (Release) ready</example>
     <param pos="0" name="service.vendor" value="AnalogX"/>
@@ -475,7 +475,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:novell:groupwise:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) GroupWise Internet Agent (\d+\.[\d.]+)  Copyright .*\d{4}-\d{4} Novell, Inc..* All rights reserved. Ready *$">
+  <fingerprint pattern="^([^ ]{1,512}) GroupWise Internet Agent (\d+\.[\d.]+)  Copyright .*\d{4}-\d{4} Novell, Inc..* All rights reserved. Ready *$">
     <description>Novell GroupWise Internet Agent - versions 5 and higher, second variant</description>
     <example service.version="8.0.3">foo.bar GroupWise Internet Agent 8.0.3  Copyright (c) 1993-2012 Novell, Inc.  All rights reserved. Ready</example>
     <example service.version="14.2.1">foo.bar GroupWise Internet Agent 14.2.1  Copyright 1993-2016 Novell, Inc., a Micro Focus Company. All rights reserved. Ready</example>
@@ -487,7 +487,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:novell:groupwise:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) GroupWise SMTP/MIME Daemon ([^ ]+\.[^ ]+) v([^ ]+) Ready \(C\).* Novell, Inc\. *$">
+  <fingerprint pattern="^([^ ]{1,512}) GroupWise SMTP/MIME Daemon ([^ ]+\.[^ ]+) v([^ ]+) Ready \(C\).* Novell, Inc\. *$">
     <description>Novell GroupWise - versions below 5</description>
     <example host.name="foo.bar" service.version="4.1" service.version.version="3">foo.bar GroupWise SMTP/MIME Daemon 4.1 v3 Ready (C)1993, 1996 Novell, Inc.</example>
     <param pos="0" name="service.vendor" value="Novell"/>
@@ -768,7 +768,7 @@
     <param pos="5" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Mercury ([^ ]+\.[^ ]+) ESMTP server ready.$">
+  <fingerprint pattern="^([^ ]{1,512}) Mercury ([^ ]+\.[^ ]+) ESMTP server ready.$">
     <description>Mercury NLM for Netware ( http://www.pmail.com/index.cfm )</description>
     <example host.name="foo.bar" service.version="1.43">foo.bar Mercury 1.43 ESMTP server ready.</example>
     <param pos="0" name="service.family" value="Mercury Mail Transport System"/>
@@ -884,7 +884,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) ESMTP Service \(Lotus Domino Build (V?[\w.]+)\) ready at (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP Service \(Lotus Domino Build (V?[\w.]+)\) ready at (.+) *$">
     <description>Lotus Domino (some early build)</description>
     <example notes.build.version="166.1">foo.bar ESMTP Service (Lotus Domino Build 166.1) ready at Thu, 16 Nov 2017 10:39:22 +0200</example>
     <example notes.build.version="V85_M2_08202008">foo.bar ESMTP Service (Lotus Domino Build V85_M2_08202008) ready at Thu, 16 Nov 2017 03:57:40 -0500</example>
@@ -909,7 +909,7 @@
     <param pos="2" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) NTMail \(v(\d+\.\d+\.\d+)/([^ ]+)\) ready for ESMTP transfer *$">
+  <fingerprint pattern="^([^ ]{1,512}) NTMail \(v(\d+\.\d+\.\d+)/([^ ]+)\) ready for ESMTP transfer *$">
     <description>NTMail (http://www.gordano.com)</description>
     <example host.name="foo.bar" service.version="7.02.3037" ntmail.id="NU1319.01.5b000000">foo.bar NTMail (v7.02.3037/NU1319.01.5b000000) ready for ESMTP transfer   </example>
     <param pos="0" name="service.vendor" value="Gordano"/>
@@ -1190,7 +1190,7 @@
     <param pos="4" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]+) Sendmail AIX([^/]+)/UCB ([^/]+)/([^ ]+) ready at (.+)$">
+  <fingerprint pattern="^([^ ]{1,512}) Sendmail AIX([^/]+)/UCB ([^/]+)/([^ ]+) ready at (.+)$">
     <description>Sendmail - AIX (UCB/ready at variant)</description>
     <example>foo.bar Sendmail AIX 4.1/UCB 5.64/4.03 ready at Mon, 30 Jul 2001 00:42:21 -0500</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3172,7 +3172,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:4.3"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 04\.02\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 04\.02\..*$">
     <description>IBM AIX 4.2 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 0040906A4C00 Base Operating System Runtime AIX version: 04.02.0001.0000 TCP/IP Client Support version: 04.02.0001.0000</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 0044B47A4C00 Base Operating System Runtime AIX version: 04.02.0001.0000 TCP/IP Client Support version: 04.02.0001.0000</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1095,7 +1095,7 @@
     <param pos="0" name="hw.device" value="Switch"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^,]+), (VDX\S+), Network Operating System Software Version (\S+)\.$">
+  <fingerprint pattern="^([^,]{1,512}), (VDX\S+), Network Operating System Software Version (\S+)\.$">
     <description>Brocade VDX Switch w/Hostname</description>
     <example host.name="core02" hw.product="VDX6740T-1G" os.version="7.0.1b">core02, VDX6740T-1G, Network Operating System Software Version 7.0.1b.</example>
     <param pos="0" name="os.vendor" value="Brocade"/>
@@ -1109,7 +1109,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^,]+), BR-(\S+), Network Operating System Software Version (\S+)\.$">
+  <fingerprint pattern="^([^,]{1,512}), BR-(\S+), Network Operating System Software Version (\S+)\.$">
     <description>Brocade VDX Switch w/Hostname and BR prefix</description>
     <example host.name="core01" hw.product="VDX6740" os.version="7.0.2b">core01, BR-VDX6740, Network Operating System Software Version 7.0.2b.</example>
     <param pos="0" name="os.vendor" value="Brocade"/>
@@ -1396,7 +1396,7 @@
                            Computer Associates
    =======================================================================-->
 
-  <fingerprint pattern="^(?:Linux )?\s*SystemEDGE.*$">
+  <fingerprint pattern="^(?:Linux )?\s{0,256}SystemEDGE.*$">
     <description>CA SystemEDGE Management Agent</description>
     <example>Linux SystemEDGE Management Agent, Concord Communications, Inc.</example>
     <example>SystemEDGE Management Agent, CA, Inc.</example>
@@ -1453,7 +1453,7 @@
     <param pos="0" name="os.product" value="Switch"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) OPTICAL SW:(\S+) .* Ciena \(R\) Corporation$">
+  <fingerprint pattern="^(\S{1,32}) OPTICAL SW:(\S+) .* Ciena \(R\) Corporation$">
     <description>Ciena Optical - software version variant</description>
     <example>6500 OPTICAL SW:0810 BN:HD (c) Ciena (R) Corporation</example>
     <param pos="0" name="os.vendor" value="Ciena"/>
@@ -2450,9 +2450,9 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:hp-ux:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) .*OpenVMS V(\S+) .*$">
+  <fingerprint pattern="^(\S{1,512}) .*OpenVMS V(\S+) .*$">
     <description>OpenVMS</description>
-    <example>hostname VAX 4000-200 OpenVMS V7.2 Compaq TCP/IP Services for OpenVMS</example>
+    <example host.name="hostname">hostname VAX 4000-200 OpenVMS V7.2 Compaq TCP/IP Services for OpenVMS</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="OpenVMS"/>
     <param pos="0" name="os.product" value="OpenVMS"/>
@@ -2461,7 +2461,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:openvms:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) (.*?) (?:HP|Compaq) Tru64 UNIX V(\S+) \(Rev\. ([^\)]+)\).*TCP/IP$">
+  <fingerprint pattern="^(\S{1,512}) (.*?) (?:HP|Compaq) Tru64 UNIX V(\S+) \(Rev\. ([^\)]+)\).*TCP\/IP$">
     <description>Digital/Compaq/HP Tru64 Unix</description>
     <example host.name="was1" hw.product="AlphaServer DS10 466 MHz" os.version="5.1B" os.version.version="2650">was1 AlphaServer DS10 466 MHz Compaq Tru64 UNIX V5.1B (Rev. 2650); Wed Feb 25 13:29:07 KST 2004 TCP/IP</example>
     <param pos="0" name="os.vendor" value="HP"/>
@@ -2474,7 +2474,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:tru64_unix:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(\S+) (.*?) Digital UNIX V(\S+)\s+\(Rev\. ([^\)]+)\).*TCP/IP$">
+  <fingerprint pattern="^(\S{1,512}) (.*?) Digital UNIX V(\S+)\s+\(Rev\. ([^\)]+)\).*TCP/IP$">
     <description>Digital/Compaq/HP Tru64 Unix - Digital branding variant</description>
     <example host.name="example.com" hw.product="COMPAQ AlphaServer DS10 617 MHz" os.version="4.0F" os.version.version="1229">example.com COMPAQ AlphaServer DS10 617 MHz Digital UNIX V4.0F (Rev. 1229); Wed May 22 13:55:58 CST 2002 TCP/IP</example>
     <example host.name="example.com" hw.product="COMPAQ Professional Workstation XP1000" os.version="4.0F" os.version.version="1229">example.com COMPAQ Professional Workstation XP1000 Digital UNIX V4.0F  (Rev. 1229); Wed Jun 30 14:32:53 MET DST 2004 . TCP/IP</example>
@@ -6265,7 +6265,7 @@ Copyright (c) 1995-2005 by Cisco Systems
                               SGI
    =======================================================================-->
 
-  <fingerprint pattern="^.* IRIX (?:version )?(\d+\S+).*$">
+  <fingerprint pattern="^.{0,256} IRIX (?:version )?(\d+\S+).*$">
     <description>SGI IRIX</description>
     <example os.version="6.5">Silicon Graphics IRIS Indigo2  running IRIX version 6.5</example>
     <example os.version="5.3">Silicon Graphics IRIS Indigo2 Elan running IRIX 5.3</example>
@@ -6280,7 +6280,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:sgi:irix:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^.* IRIX64 (?:version )?(\d+\S+).*$">
+  <fingerprint pattern="^.{0,256} IRIX64 (?:version )?(\d+\S+).*$">
     <description>SGI IRIX64</description>
     <example os.version="6.5">Silicon Graphics Challenge/1 running IRIX64 6.5</example>
     <example os.version="6.5">Silicon Graphics Fuel running IRIX64 version 6.5</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3187,7 +3187,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:4.2"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 04\.03\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 04\.03\..*$">
     <description>IBM AIX 4.3 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 0056BD5A4C00 Base Operating System Runtime AIX version: 04.03.0003.0075 TCP/IP Client Support version: 04.03.0003.0075</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 005A269A4C00 Base Operating System Runtime AIX version: 04.03.0003.0075 TCP/IP Client Support version: 04.03.0003.0075</example>
@@ -3204,7 +3204,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:4.3"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 05\.01\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 05\.01\..*$">
     <description>IBM AIX 5.1 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 0059B7BA4C00 Base Operating System Runtime AIX version: 05.01.0000.0051 TCP/IP Client Support version: 05.01.0000.0070</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 009F12264C00 Base Operating System Runtime AIX version: 05.01.0000.0050 TCP/IP Client Support version: 05.01.0000.0050</example>
@@ -3227,7 +3227,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:5.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Operating System Software: AIX version: 5\.1 Networking Software:.*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Operating System Software: AIX version: 5\.1 Networking Software:.*$">
     <description>IBM AIX 5.1 on PowerPC - network software variant</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 0008FB8A4C00 Operating System Software: AIX version: 5.1 Networking Software: not available!</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 000BD57F4C00 Operating System Software: AIX version: 5.1 Networking Software: not available!</example>
@@ -3239,7 +3239,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:5.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 05\.02\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 05\.02\..*$">
     <description>IBM AIX 5.2 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer.Machine Type: 0x0800004c Processor id: 00C0E53F4C00.Base Operating System Runtime AIX version: 05.02.0000.0105.TCP/IP Client Support version: 05.02.0000.0107</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 00CBEEFA4C00 Base Operating System Runtime AIX version: 05.02.0000.0075 TCP/IP Client Support version: 05.02.0000.0075</example>
@@ -3266,7 +3266,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:5.2"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 05\.03\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 05\.03\..*$">
     <description>IBM AIX 5.3 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer.Machine Type: 0x0800004c Processor id: 000A3CD8D600.Base Operating System Runtime AIX version: 05.03.0000.0060.TCP/IP Client Support version: 05.03.0000.0063</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 00F7BF9F4C00 Base Operating System Runtime AIX version: 05.03.0012.0001 TCP/IP Client Support version: 05.03.0012.0005</example>
@@ -3289,7 +3289,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:5.3"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime VIOS [^:]+: 05\.03\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime VIOS [^:]+: 05\.03\..*$">
     <description>IBM VIOS 5.3 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 00018C4AD400 Base Operating System Runtime VIOS version: 05.03.0008.0000 TCP/IP Client Support version: 05.03.0008.0000</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 0002EBDAD700 Base Operating System Runtime VIOS version: 05.03.0008.0000 TCP/IP Client Support version: 05.03.0008.0001</example>
@@ -3306,7 +3306,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:vios:5.3"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 06\.01\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 06\.01\..*$">
     <description>IBM AIX 6.1 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 00F77AEE4C00 Base Operating System Runtime AIX version: 06.01.0006.0015 TCP/IP Client Support version: 06.01.0006.0015</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 00F77C9A4C00 Base Operating System Runtime AIX version: 06.01.0006.0015 TCP/IP Client Support version: 06.01.0006.0015</example>
@@ -3320,7 +3320,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:6.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime VIOS [^:]+: 06\.01\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime VIOS [^:]+: 06\.01\..*$">
     <description>IBM VIOS 6.1 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 00055539D600 Base Operating System Runtime VIOS version: 06.01.0007.0000 TCP/IP Client Support version: 06.01.0005.0000</example>
     <param pos="0" name="os.vendor" value="IBM"/>
@@ -3330,7 +3330,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:vios:6.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 07\.01\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?(?:Motorola PowerPC|IBM PowerPC|\S+ \S+ PowerPC IBM).*Base Operating System Runtime AIX [^:]+: 07\.01\..*$">
     <description>IBM AIX 7.1 on PowerPC</description>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 000B0148D700 Base Operating System Runtime AIX version: 07.01.0000.0015 TCP/IP Client Support version: 07.01.0000.0015</example>
     <example>IBM PowerPC CHRP Computer Machine Type: 0x0800004c Processor id: 00C5433C4C00 Base Operating System Runtime AIX version: 07.01.0001.0000 TCP/IP Client Support version: 07.01.0001.0003</example>
@@ -3343,7 +3343,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:7.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 05\.01\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 05\.01\..*$">
     <description>IBM AIX 5.1 - unknown machine type variant</description>
     <example>UNIX System Machine Type: not available! Processor id: 0001FDAF4C00 Base Operating System Runtime AIX version: 05.01.0000.0051 TCP/IP Client Support version: 05.01.0000.0070</example>
     <param pos="0" name="os.vendor" value="IBM"/>
@@ -3353,7 +3353,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:5.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 05\.02\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 05\.02\..*$">
     <description>IBM AIX 5.2 - unknown machine type variant</description>
     <example>UNIX System Machine Type: not available! Processor id: 0001FDAF4C00 Base Operating System Runtime AIX version: 05.02.0000.0105 TCP/IP Client Support version: 05.02.0000.0107</example>
     <param pos="0" name="os.vendor" value="IBM"/>
@@ -3363,7 +3363,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:5.2"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 05\.03\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 05\.03\..*$">
     <description>IBM AIX 5.3 - unknown machine type variant</description>
     <example>UNIX System Machine Type: not available! Processor id: 0001FDAF4C00 Base Operating System Runtime AIX version: 05.03.0000.0050 TCP/IP Client Support version: 05.03.0000.0053</example>
     <param pos="0" name="os.vendor" value="IBM"/>
@@ -3373,7 +3373,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:5.3"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 06\.01\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 06\.01\..*$">
     <description>IBM AIX 6.1 - unknown machine type variant</description>
     <example>UNIX System Machine Type: not available! Processor id: 0001FDAF4C00 Base Operating System Runtime AIX version: 06.01.0007.0000 TCP/IP Client Support version: 06.01.0005.0000</example>
     <param pos="0" name="os.vendor" value="IBM"/>
@@ -3383,7 +3383,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:ibm:aix:6.1"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\S+ )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 07\.01\..*$">
+  <fingerprint pattern="^(?:\S{1,1024} )?UNIX System Machine Type: not available.*Base Operating System Runtime AIX [^:]+: 07\.01\..*$">
     <description>IBM AIX 7.1 - unknown machine type variant</description>
     <example>UNIX System Machine Type: not available! Processor id: 0001FDAF4C00 Base Operating System Runtime AIX version: 07.01.0001.0000 TCP/IP Client Support version: 07.01.0001.0002</example>
     <param pos="0" name="os.vendor" value="IBM"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1978,7 +1978,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:ssh:tectia_server:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([0-9\.]+) SSH Secure Shell(?: \(non-commercial\))?$">
+  <fingerprint pattern="^([0-9\.]{1,8}) SSH Secure Shell(?: \(non-commercial\))?$">
     <description>SSH Communications Security Tectia Server</description>
     <example service.version="3.2.9.1">3.2.9.1 SSH Secure Shell (non-commercial)</example>
     <example service.version="4.0.3">4.0.3 SSH Secure Shell</example>
@@ -1990,7 +1990,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:ssh:tectia_server:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([0-9\.]+) SSH Secure Shell Windows NT Server$">
+  <fingerprint pattern="^([0-9\.]{1,8}) SSH Secure Shell Windows NT Server$">
     <description>Unknown Windows SSH server</description>
     <example service.version="4.0.3">4.0.3 SSH Secure Shell Windows NT Server</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1784,7 +1784,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([\d.]+)[ _]sshlib:? (?i:GlobalScape)$">
+  <fingerprint pattern="^([\d.]{1,8})[ _]sshlib:? (?i:GlobalScape)$">
     <description>GlobalScape SSH (which uses Bitvise sshlib)</description>
     <example service.component.version="1.36">1.36_sshlib GlobalSCAPE</example>
     <example service.component.version="1.82">1.82_sshlib Globalscape</example>
@@ -1802,7 +1802,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^\s]+) sshlib: WinSSHD (.*)$">
+  <fingerprint pattern="^([\d.]{1,8}) sshlib: WinSSHD ([\w.-]*)$">
     <description>Bitvise WinSSHD (which uses Bitvise sshlib)</description>
     <example service.component.version="1.78" service.version="4.15a">1.78 sshlib: WinSSHD 4.15a</example>
     <param pos="1" name="service.component.version"/>
@@ -1819,7 +1819,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^\s]+) FlowSsh: (?:Bitvise SSH Server \(WinSSHD\)|WinSSHD) ([\d\.]+):?.*$">
+  <fingerprint pattern="^([\d.]{1,8}) FlowSsh: (?:Bitvise SSH Server \(WinSSHD\)|WinSSHD) ([\d\.]+):?.*$">
     <description>Bitvise WinSSHD (which uses Bitvise flowssh) with version</description>
     <example service.version="5.09" service.component.version="1.03">1.03 FlowSsh: WinSSHD 5.09</example>
     <example service.version="5.20" service.component.version="1.07">1.07 FlowSsh: WinSSHD 5.20: free only for personal non-commercial use</example>
@@ -1838,7 +1838,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^\s]+) FlowSsh: (?:Bitvise SSH Server \(WinSSHD\)|WinSSHD)(?: :.*)?$">
+  <fingerprint pattern="^([\d.]{1,8}) FlowSsh: (?:Bitvise SSH Server \(WinSSHD\)|WinSSHD)(?: :.*)?$">
     <description>Bitvise WinSSHD (which uses Bitvise flowssh) without version</description>
     <example service.component.version="9.99">9.99 FlowSsh: Bitvise SSH Server (WinSSHD)</example>
     <example service.component.version="9.99">9.99 FlowSsh: Bitvise SSH Server (WinSSHD) : free only for personal non-commercial use</example>
@@ -1855,7 +1855,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^\s]+) sshlib: MOVEit DMZ SSH (.*)$">
+  <fingerprint pattern="^([\d.]{1,8}) sshlib: MOVEit DMZ SSH (.*)$">
     <description>MOVEit DMZ (which uses Bitvise sshlib)</description>
     <param pos="1" name="service.component.version"/>
     <param pos="2" name="service.version"/>
@@ -1938,8 +1938,9 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:vandyke:vshell:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([\s]*)\s*VShell$">
+  <fingerprint pattern="^([\d.]{0,8})\s{1,8}VShell$">
     <description>VanDyke VShell</description>
+    <example service.version="1.0.2">1.0.2 VShell</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="VanDyke Software"/>
     <param pos="0" name="service.family" value="VShell"/>
@@ -1958,7 +1959,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:attachmate:reflection_for_secure_it:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^\s]*)\s*F-Secure SSH\s*(?:.*)$">
+  <fingerprint pattern="^(\S{0,256})\s{0,256}F-Secure SSH ">
     <description>Attachmate Reflection (formerly F-Secure SSH)</description>
     <example service.version="3.2.3">3.2.3 F-Secure SSH Windows NT Server</example>
     <param pos="1" name="service.version"/>
@@ -1967,7 +1968,7 @@
     <param pos="0" name="service.product" value="Reflection"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^\s]*)\s*SSH Tectia Server$">
+  <fingerprint pattern="^(\S{0,256})\s{0,256}SSH Tectia Server$">
     <description>SSH Communications Security Tectia Server - branded</description>
     <example service.version="6.4.12.353">6.4.12.353 SSH Tectia Server</example>
     <param pos="1" name="service.version"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -2158,7 +2158,7 @@
     <param pos="0" name="os.certainty" value="0.75"/>
   </fingerprint>
 
-  <fingerprint pattern="^\S+ SSH Secure Shell Tru64 UNIX$">
+  <fingerprint pattern="^\S{1,16} SSH Secure Shell Tru64 UNIX$">
     <description>Digital/Compaq/HP Tru64 Unix</description>
     <example>3.2.0 SSH Secure Shell Tru64 UNIX</example>
     <param pos="0" name="os.vendor" value="HP"/>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -540,7 +540,7 @@
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\r|\n|\s)*Grandstream (GXV[\w-]+)\s+(?:V\d\.\d\w?\s+)?Shell Command.Copyight \d\d\d\d-\d\d\d\d(?:\r|\n)+Username:\s*$">
+  <fingerprint pattern="^(?:\r|\n|\s){0,256}Grandstream (GXV[\w-]+)\s+(?:V\d\.\d\w?\s+)?Shell Command.Copyight \d\d\d\d-\d\d\d\d(?:\r|\n)+Username:\s*$">
     <description>Grandstream IP Cameras</description>
     <!-- Grandstream GXV3674_FHD_VF    Shell Command.Copyight 2011-2014\r\nUsername: -->
 
@@ -1222,7 +1222,7 @@
     <param pos="0" name="os.product" value="Brother Printer"/>
   </fingerprint>
 
-  <fingerprint pattern="^(.*) Copyright by ARESCOM">
+  <fingerprint pattern="^\s{0,256}(\S{1,64}) Copyright by ARESCOM">
     <description>Arescom System</description>
     <!--NDS1260HE-TLI Copyright by ARESCOM 2002\n\n\nPassword: -->
 
@@ -2076,7 +2076,7 @@
     <param pos="0" name="service.component.cpe23" value="cpe:/a:sap:netweaver_application_server:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\r|\n|\s)*UDP/TCP/IP Stack: ACT Video security">
+  <fingerprint pattern="^(?:\r|\n|\s){0,256}UDP/TCP/IP Stack: ACT Video security">
     <description>ACT Security IP Cameras</description>
     <!--
       UDP/TCP/IP Stack: ACT Video security\r\n


### PR DESCRIPTION
## Motivation and Context
  
TL:DR - Fixed an unlikely DoS condition in a pattern in `xml/ssh_banners.xml` and improved performance of certain patterns.  Metrics included here.  This PR doesn't address all of the slower patterns but does get the worst of them.


In a PR ( https://github.com/rapid7/recog-java/pull/7 ) for `recog-java` @hudclark provided some data ( https://github.com/rapid7/recog-java/pull/7#issuecomment-829254286 ) that would cause one of our regexes to hang indefinitely.  That specific problem has already been fixed https://github.com/rapid7/recog/pull/353.

Since `recog` is generally used to process data from untrustworthy sources I wanted to make sure that this specific data and certain other patterns wouldn't cause indefinite hangs or otherwise have unacceptable performance characteristics when processed using any of `recog`'s other fingerprint patterns. In Project Sonar we process 100's of millions of banners on a regular basis so small performance improvements can add up.

Findings:
 - one case of regex that resulted in an indefinite hang when processing large numbers of spaces
 - 50+ cases where performance could be up to **50x** slower than it should be when processing certain strings.

## Testing methodology

Script that processes a specific test string with every fingerprint pattern currently in `recog`. Since the process can be incredibly fast the script timed how long it took to perform this process 100,000 times per pattern. The script then emitted results sorted by duration with the highest duration first. 

There are 3,879 patterns currently in `recog`. Using @hudclark's test string I found that 3,338 took less that 0.1 seconds to process. The longest duration was nearly 9 seconds. Using that as my benchmark I decided that anything over 2 seconds should probably be reviewed. There were 151 of these in this dataset alone.  I did **not** address all of them because later tests revealed patterns that took up to **62.2** seconds and thus took priority.
  
  
  
## First test case - hudclark's 

The data that hudclark provided was string ~1,500 characters long that consisted solely of digits.  It pointed out some patterns that took 2x to 4x longer than I'd like.  These were quickly overshadowed by later tests.


**Original results**
<details>
  <summary>Click to expand results!</summary>
  
```text
8.9967840140    smtp_banners.xml : Some unknown mail server on OpenVMS
7.8108736030    smtp_banners.xml : Postfix - Ubuntu, Mail-in-a-Box package
6.1197626160    smtp_banners.xml : Exim - with version string and optional timestamp
5.8996496320    apache_os.xml    : Sun Cobalt RaQ (Red Hat based Linux)
5.0258794260    ssh_banners.xml  : Attachmate Reflection (formerly F-Secure SSH)
4.8205517380    ssh_banners.xml  : SSH Communications Security Tectia Server - branded
4.7821866920    ftp_banners.xml  : VxWorks on Tenor MultiPath with version information
4.5126619130    html_title.xml   : HPE ProCurve Switch w/Hostname
4.4242824360    ftp_banners.xml  : Simple tnftpd banner with a version
4.3949423450    ftp_banners.xml  : FTPD on Mac OS X Server without a version
4.3856097340    ftp_banners.xml  : FTPD on Mac OS X Server with a version
3.9750543660    smtp_banners.xml : Exim - with digit only version string and optional timestamp
3.8346248230    smtp_banners.xml : Exim - without version string and with optional timestamp
3.7241216040    ssh_banners.xml  : GlobalScape SSH (which uses Bitvise sshlib)
3.6714761190    smtp_banners.xml : Exim - with version string and optional timestamp (Ubuntu)
3.6398599910    smtp_banners.xml : Lotus Domino SMTP MTA
3.6345964780    smtp_banners.xml : IBM Domino SMTP MTA
3.6345602600    smtp_banners.xml : MailEnable - Complex
3.6194079850    smtp_banners.xml : Microsoft IIS builtin SMTP service - Windows Server 2016
3.5649147010    smtp_banners.xml : ArGoSoft Mail Server - freeware version
3.5586633600    smtp_banners.xml : Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each 
3.5554307840    smtp_banners.xml : Microsoft IIS builtin SMTP service - Windows Server 2019
3.4988867800    ftp_banners.xml  : WS_FTP FTP Server on Windows - X2 variant
3.4517308090    smtp_banners.xml : MailEnable - Simple
3.4345158460    smtp_banners.xml : ArGoSoft Mail Server - Pro version
3.2968048820    smtp_banners.xml : Barracuda Email Security Gateway - physical or virtual appliance
3.0335567370    smtp_banners.xml : Postfix - generic banner
2.9669229730    ssh_banners.xml  : MOVEit DMZ (which uses Bitvise sshlib)
```
</details>
 

**Results after changes**
<details>
  <summary>Click to expand results!</summary>
  
```text
4.7759784650    apache_os.xml             : Sun Cobalt RaQ (Red Hat based Linux)
3.1016591790    smtp_banners.xml          : Some unknown mail server on OpenVMS
3.0229940320    smtp_banners.xml          : Postfix - Ubuntu, Mail-in-a-Box package
2.9605090640    ftp_banners.xml           : WU-FTPD on various OS
2.0218865210    smtp_banners.xml          : Some simple PERL SMTP server
1.9946286070    smtp_banners.xml          : Exim - with version string and optional timestamp
1.9475264900    snmp_sysdescr.xml         : IBM AIX 5.1 on PowerPC - network software variant
1.9208211020    snmp_sysdescr.xml         : IBM AIX 4.2 on PowerPC
1.9114472270    snmp_sysdescr.xml         : IBM AIX 7.1 on PowerPC
1.9111828570    snmp_sysdescr.xml         : IBM VIOS 6.1 on PowerPC
1.9071520260    snmp_sysdescr.xml         : IBM AIX 5.3 on PowerPC
1.8773198910    snmp_sysdescr.xml         : IBM VIOS 5.3 on PowerPC
1.8667792300    snmp_sysdescr.xml         : IBM AIX 6.1 on PowerPC
1.8612884210    snmp_sysdescr.xml         : IBM AIX 5.2 on PowerPC
1.8287487190    snmp_sysdescr.xml         : IBM AIX 5.1 on PowerPC
1.8107181170    snmp_sysdescr.xml         : IBM AIX 4.3 on PowerPC
1.6810278930    html_title.xml            : HPE ProCurve Switch w/Hostname
1.6473212850    operating_system.xml      : Linux catch-all
1.6397817460    smtp_banners.xml          : ArGoSoft Mail Server - Pro version
1.5850398950    ftp_banners.xml           : FTPD on Mac OS X Server with a version
1.5735731000    ftp_banners.xml           : FTPD on Mac OS X Server without a version
1.5482504690    ftp_banners.xml           : Simple tnftpd banner with a version
1.4420507300    smtp_banners.xml          : Microsoft IIS builtin SMTP service - Windows Server 2019
1.4401679190    smtp_banners.xml          : Exim - without version string and with optional timestamp
1.4353632330    smtp_banners.xml          : Exim - with digit only version string and optional timestamp
1.4187387360    smtp_banners.xml          : Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each
1.3978994670    smtp_banners.xml          : Exim - with version string and optional timestamp (Ubuntu)
1.3971444610    smtp_banners.xml          : IBM Domino SMTP MTA
1.3892989060    operating_system.xml      : Vendor-based Linux catch-all
1.3832903850    smtp_banners.xml          : Microsoft IIS builtin SMTP service - Windows Server 2016
1.3652716290    smtp_banners.xml          : Lotus Domino SMTP MTA
1.3557667300    smtp_banners.xml          : MailEnable - Complex
1.3427350980    snmp_sysdescr.xml         : ADTRAN TotalAccess shelf
1.3179144220    smtp_banners.xml          : ArGoSoft Mail Server - freeware version
1.3018863310    smtp_banners.xml          : MailEnable - Simple
1.2340919060    http_wwwauth.xml          : Generic F5 Big-IP
1.2201002650    smtp_banners.xml          : Barracuda Email Security Gateway - physical or virtual appliance
1.2120660080    snmp_sysdescr.xml         : Troy PocketPro Print Server
1.2079617100    ftp_banners.xml           : WS_FTP FTP Server on Windows - X2 variant
1.1994696540    http_wwwauth.xml          : HP Instant Support Enterprise Edition with a hostname
1.1949410020    http_wwwauth.xml          : SPIP publishing system (www.spip.net)
1.1658059770    smtp_banners.xml          : AppleShare IP Mail Server
1.1290798350    smtp_banners.xml          : Non-specific banner with optional hostname
1.0990665840    smtp_banners.xml          : MDaemon mail server
1.0765341810    smtp_banners.xml          : Postfix - generic banner
1.0726890780    smtp_banners.xml          : Seattle Labs SLMail server for Windows NT/2k (v2.7 runs on Win9x)
1.0614999190    smtp_banners.xml          : Sendmail - with date, w/o version or platform, optional status string.
1.0576200570    smtp_banners.xml          : Postfix - generic w/o ESMTP
1.0459751810    smtp_banners.xml          : MDaemon mail server - with version revision
1.0398510560    smtp_banners.xml          : MDaemon mail server - with service pack
1.0357135650    imap_banners.xml          : CMU Cyrus IMAP
1.0201472830    smtp_banners.xml          : MDaemon mail server - without timestamp
1.0141742870    smtp_banners.xml          : SonicWall Email Security
1.0035786600    smtp_banners.xml          : MDaemon mail server - with timestamp, unre
```
</details>


  
  
## Second test case - High numbers of spaces

The second test was high numbers of spaces followed by various characters.

`" " * 10000 + "1!(&(HFUH*&GEGG#((@*#(@&#H@H 37H7293H423H4H H&#(@$&H#$H@#$"`

This found some really poorly performing patterns.
  
  
  
**Original results**
<details>
  <summary>Click to expand results!</summary>
  
```text
56.0342034670   telnet_banners.xml        : ACT Security IP Cameras
55.8205223180   telnet_banners.xml        : Grandstream IP Cameras
37.8397985290   apache_os.xml             : Sun Cobalt RaQ (Red Hat based Linux)
25.0883285960   operating_system.xml      : Vendor-based Linux catch-all
21.9379492780   http_servers.xml          : AVM FRITZ! devices of various types
15.9361667600   operating_system.xml      : Many BSD family OSes
12.9748227420   operating_system.xml      : Linux catch-all
11.9357084810   smtp_banners.xml          : Cisco PIX firewall MailGuard banner stripping
11.9207645880   telnet_banners.xml        : Arescom System
11.8829591350   imap_banners.xml          : CMU Cyrus IMAP on Mac OS X
11.8625381440   html_title.xml            : Emerson Network Power IntelliSlot Web Card and rebrands
11.8392341890   html_title.xml            : Digi Terminal Servers
11.8375095510   imap_banners.xml          : CMU Cyrus IMAP
11.7661826580   html_title.xml            : Synology DiskStation
10.1009548480   snmp_sysdescr.xml         : SGI IRIX64
10.0152383050   http_wwwauth.xml          : Generic F5 Big-IP
9.9775247190    http_wwwauth.xml          : HP Instant Support Enterprise Edition with a hostname
9.9719278960    http_wwwauth.xml          : SPIP publishing system (www.spip.net)
9.8582514080    snmp_sysdescr.xml         : Brocade VDX Switch w/Hostname and BR prefix
9.8163400080    snmp_sysdescr.xml         : Brocade VDX Switch w/Hostname
9.6856156550    ftp_banners.xml           : MikroTik with description
9.6665103310    snmp_sysdescr.xml         : SGI IRIX
9.4721248390    html_title.xml            : Jenkins Customized Dashboard
6.7060986900    ftp_banners.xml           : APC device
6.5243437520    snmp_sysdescr.xml         : CA SystemEDGE Management Agent
6.4842920340    ssh_banners.xml           : Attachmate Reflection (formerly F-Secure SSH)
6.4619459850    ssh_banners.xml           : SSH Communications Security Tectia Server - branded
6.4498859630    ssh_banners.xml           : VanDyke VShell
1.6392240520    smtp_banners.xml          : Lotus Domino SMTP MTA
1.6287923250    smtp_banners.xml          : IBM Domino SMTP MTA
1.1259730260    ntp_banners.xml           : Isilon OneFS NTP Server
```
</details>


**Results after changes**
<details>
  <summary>Click to expand results!</summary>
  
```text
4.0261433210    apache_os.xml             : Sun Cobalt RaQ (Red Hat based Linux)
1.6170253780    telnet_banners.xml        : ACT Security IP Cameras
1.4962433150    telnet_banners.xml        : Grandstream IP Cameras
1.4914041500    operating_system.xml      : Linux catch-all
1.3436797230    smtp_banners.xml          : Cisco PIX firewall MailGuard banner stripping
1.1601262450    ftp_banners.xml           : MikroTik with description
1.1225218650    http_wwwauth.xml          : SPIP publishing system (www.spip.net)
1.1219601170    http_wwwauth.xml          : Generic F5 Big-IP
1.0966860850    http_wwwauth.xml          : HP Instant Support Enterprise Edition with a hostname
1.0772802380    html_title.xml            : Jenkins Customized Dashboard
0.9965503540    ftp_banners.xml           : Lexmark printer with OS version
0.9814544530    ftp_banners.xml           : Lexmark printer
0.9703127250    ftp_banners.xml           : Lexmark Optra Printer
0.9638518870    apache_os.xml             : Red Hat Fedora
0.9628669260    ntp_banners.xml           : Greyware Automation Products, Inc. Domain Time II on Windows Server 2003
0.9626863580    apache_os.xml             : Novell SuSE Linux
0.9587067290    apache_os.xml             : Turbolinux
0.9577916020    apache_os.xml             : CentOS Linux
0.9524640540    apache_os.xml             : White Box Enterprise Linux
0.9481747460    apache_os.xml             : Red Hat Linux
```
</details>


It also found an indefinite hang in the following fingerprint. 

```xml
  <fingerprint pattern="^([\s]*)\s*VShell$">
    <description>VanDyke VShell</description>
    <param pos="1" name="service.version"/>
    <param pos="0" name="service.vendor" value="VanDyke Software"/>
    <param pos="0" name="service.family" value="VShell"/>
    <param pos="0" name="service.product" value="VShell"/>
    <param pos="0" name="service.cpe23" value="cpe:/a:vandyke:vshell:{service.version}"/>
  </fingerprint>
```

The problem here, besides the fact that it doesn't actually match what it should match, is that there are two back to back regex patterns, `([\s]*)`, and `\s*`, that match arbitrary length strings consisting solely of whitespace. When processing data that starts with a very long string of whitespace this causes catastrophic backtracking to occur ultimately resulting in a DoS.

This has been fixed so as to actually correctly capture a version  ( `([\s]*)` -> `([\d.]{0,8})`) and I have bounded both the capture and the number of spaces that follow.  I've also located and added an example so that it can be tested.

  
  
  
## Third test case - High numbers of digits


The third test was high numbers of digits followed by various characters.

`"1" * 10000 + " 1 1 1 1 1 1 1!(&(HFUH*&GEGG#((@*#(@&#H@H 37H7293H423H4H H&#(@$&H#$H@#$"`

This found some really poorly performing patterns.


**Original results**
<details>
  <summary>Click to expand results!</summary>
  
```text
62.2014746590   smtp_banners.xml          : Exim - with version string and optional timestamp
52.8767169970   smtp_banners.xml          : Exim - with version string and optional timestamp (Ubuntu)
52.8208191560   smtp_banners.xml          : Exim - with digit only version string and optional timestamp
52.7975289820   smtp_banners.xml          : Exim - without version string and with optional timestamp
52.3167042240   ftp_banners.xml           : WU-FTPD on various OS
51.4864477590   smtp_banners.xml          : Some unknown mail server on OpenVMS
46.1896201370   smtp_banners.xml          : Postfix - Ubuntu, Mail-in-a-Box package
30.9910663220   smtp_banners.xml          : Some simple PERL SMTP server
29.3768304260   ftp_banners.xml           : VxWorks on Tenor MultiPath with version information
27.5495923040   ftp_banners.xml           : FTPD on Mac OS X Server without a version
27.3867953350   ftp_banners.xml           : FTPD on Mac OS X Server with a version
27.2770124840   ftp_banners.xml           : Simple tnftpd banner with a version
27.1238213490   html_title.xml            : HPE ProCurve Switch w/Hostname
23.1229762360   smtp_banners.xml          : Microsoft IIS builtin SMTP service - Windows Server 2019
22.7525733850   smtp_banners.xml          : Microsoft IIS builtin SMTP service - Windows Server 2016
22.6087005870   smtp_banners.xml          : Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each
21.7201759360   ssh_banners.xml           : GlobalScape SSH (which uses Bitvise sshlib)
21.1139485530   smtp_banners.xml          : MailEnable - Complex
20.6582233320   smtp_banners.xml          : ArGoSoft Mail Server - Pro version
20.6220830090   smtp_banners.xml          : MailEnable - Simple
20.5010151230   smtp_banners.xml          : ArGoSoft Mail Server - freeware version
19.9526087580   ftp_banners.xml           : WS_FTP FTP Server on Windows - X2 variant
19.7185171060   smtp_banners.xml          : Barracuda Email Security Gateway - physical or virtual appliance
18.2195681420   smtp_banners.xml          : Sendmail - with date, w/o version or platform, optional status string.
18.1322891150   smtp_banners.xml          : Postfix - generic banner
17.5702630040   ssh_banners.xml           : MOVEit DMZ (which uses Bitvise sshlib)
17.4410302960   smtp_banners.xml          : Non-specific banner with optional hostname
17.3782624710   ssh_banners.xml           : Bitvise WinSSHD (which uses Bitvise flowssh) without version
17.3029551180   ssh_banners.xml           : Bitvise WinSSHD (which uses Bitvise sshlib)
17.2932633670   ssh_banners.xml           : Bitvise WinSSHD (which uses Bitvise flowssh) with version
17.2915634910   telnet_banners.xml        : Arescom System
17.1731641920   smtp_banners.xml          : Postfix - generic w/o ESMTP
17.1022652980   smtp_banners.xml          : Seattle Labs SLMail server for Windows NT/2k (v2.7 runs on Win9x)
17.0683201570   smtp_banners.xml          : SonicWall Email Security
16.7933822220   ftp_banners.xml           : Generic/unknown FTP Server found on HP-UX and AIX systems
16.7673324420   ftp_banners.xml           : Digital/Compaq/HP Tru64 Unix
16.2784882470   smtp_banners.xml          : Exim - with hostname
15.8740536150   ftp_banners.xml           : EMC Celerra
15.8062564010   ftp_banners.xml           : SunOS/Solaris
15.6839181690   ftp_banners.xml           : D-Link DCS-2100 wireless internet camera
15.6799965800   ftp_banners.xml           : SunOS/Solaris 5.7-5.10
15.6286584560   ftp_banners.xml           : SunOS 5.6 (Solaris 2.6)
15.6260092010   http_servers.xml          : TVersity Media Server UPnP Server
15.5651652290   snmp_sysdescr.xml         : OpenVMS
15.5314584070   smtp_banners.xml          : Sendmail - HP-UX
15.5252992790   smtp_banners.xml          : SAP SMTP Server
15.5130025490   smtp_banners.xml          : Sendmail - unknown (date in version string variant)
15.5056539470   smtp_banners.xml          : Twisted SMTP server
15.5043730660   snmp_sysdescr.xml         : Digital/Compaq/HP Tru64 Unix
15.5007399600   snmp_sysdescr.xml         : Digital/Compaq/HP Tru64 Unix - Digital branding variant
15.4999997370   imap_banners.xml          : Nortel CallPilot
15.4992330520   ftp_banners.xml           : ProFTPD no valid servers configured
15.4793170970   smtp_banners.xml          : JAMES SMTP Server
15.4733769450   ftp_banners.xml           : Generic FTP fingerprint with a hostname and a version for a generic FTP implementation
15.4636058210   ftp_banners.xml           : Vermillion FTP Daemon
15.4467479570   nntp_banners.xml          : Lyris Listmanager
15.4423889100   ftp_banners.xml           : Digital/Compaq/HP Tru64 Unix w/o branding
15.4228032960   http_servers.xml          : TVersity Media Server UPnP Server with Service Pack
15.4073356340   snmp_sysdescr.xml         : Ciena Optical - software version variant
15.3926435070   pop_banners.xml           : VMware Zimbra POP
15.3706809290   ftp_banners.xml           : QVT/Net FTP Server
15.3620001270   sip_banners.xml           : Audiocodes-Sip-Gateway
15.3529426880   smtp_banners.xml          : A.K.I PMail
15.3326299790   html_title.xml            : DD-WRT
15.2858002480   imap_banners.xml          : VMware Zimbra IMAP
15.2693765940   smtp_banners.xml          : Postfix - Ubuntu
15.2365666670   html_title.xml            : Opengear Management Console
15.2239056050   ftp_banners.xml           : Generic FTP fingerprint with a hostname
15.2061906910   imap_banners.xml          : VMware Zimbra IMAP with service version
15.1921625270   ftp_banners.xml           : MikroTik
15.1764020960   pop_banners.xml           : VMware Zimbra POP with version
15.0505003690   smtp_banners.xml          : Sendmail - HP-UX with a PHNE (HP Networking patch) installed
14.9730190510   smtp_banners.xml          : Sendmail - optional timezone and timestamp, w/o OS
14.9248020380   ftp_banners.xml           : WU-FTPD on HPUX with a PHNE (HP Networking patch) installed
14.8956099750   smtp_banners.xml          : Sendmail - with timezone and timestamp, w/o timezone offset or OS
14.8876590590   smtp_banners.xml          : Sendmail - revision variant 1
14.8814069040   ftp_banners.xml           : FTP on HPUX with a PHNE (HP Networking patch) installed
14.8648282120   smtp_banners.xml          : Sendmail - revision variant 2
14.8625984880   smtp_banners.xml          : Sendmail - with version and date (optional timezone), w/o config version
14.8164089150   smtp_banners.xml          : TIS FWTK and derivatives (other firewalls, like Gauntlet, are derived from TIS)
14.8158731080   smtp_banners.xml          : MDaemon mail server - with service pack
14.8144348010   pop_banners.xml           : OSX Cyrus POP
14.8026640740   smtp_banners.xml          : Sendmail - Unixware
14.7975874960   smtp_banners.xml          : Rockliffe MailSite - without version (http://www.rockliffe.com)
14.7815324620   smtp_banners.xml          : Rockliffe MailSite - with version (http://www.rockliffe.com)
14.7791759920   smtp_banners.xml          : Merak mail server - http://www.icewarp.com/merakmail/ (runs on 2000/NT/9x)
14.7764297530   smtp_banners.xml          : Critical Path (aka InScribe) Messaging Server on Windows NT4/2k, Solaris 2.6/2.7/2.8 Sparc/Intel, SG
14.7677652510   smtp_banners.xml          : VOPMail http://www.vircom.com/en/products/vopmail/vopmail.shtml
14.7523344680   smtp_banners.xml          : Symantec Mail Security for SMTP
14.7094625760   smtp_banners.xml          : MDaemon mail server - without timestamp
14.7050192040   smtp_banners.xml          : Postfix - Debian
14.7036873650   pop_banners.xml           : CMU Cyrus POP
```
</details>

**Results after changes**
<details>
  <summary>Click to expand results!</summary>
  
```text
8.0470019440    snmp_sysdescr.xml         : IBM AIX 5.2 on PowerPC
7.9755911430    snmp_sysdescr.xml         : IBM AIX 5.1 on PowerPC
7.9641827540    snmp_sysdescr.xml         : IBM AIX 4.3 on PowerPC
7.8851526810    snmp_sysdescr.xml         : IBM VIOS 6.1 on PowerPC
7.8705615730    snmp_sysdescr.xml         : IBM AIX 5.1 on PowerPC - network software variant
7.8687723620    snmp_sysdescr.xml         : IBM AIX 7.1 on PowerPC
7.8554276860    snmp_sysdescr.xml         : IBM AIX 5.3 on PowerPC
7.8470225000    snmp_sysdescr.xml         : IBM VIOS 5.3 on PowerPC
7.8090047600    snmp_sysdescr.xml         : IBM AIX 6.1 on PowerPC
7.7672986410    snmp_sysdescr.xml         : IBM AIX 4.2 on PowerPC
7.5699785390    snmp_sysdescr.xml         : ADTRAN TotalAccess shelf
7.3499280930    snmp_sysdescr.xml         : Troy PocketPro Print Server
4.3804945620    apache_os.xml             : Sun Cobalt RaQ (Red Hat based Linux)
2.8988255560    ftp_banners.xml           : WU-FTPD on various OS
2.6178284110    smtp_banners.xml          : Some unknown mail server on OpenVMS
2.5778376810    smtp_banners.xml          : Postfix - Ubuntu, Mail-in-a-Box package
1.9334668370    smtp_banners.xml          : Exim - with version string and optional timestamp
1.7580667320    smtp_banners.xml          : Some simple PERL SMTP server
1.5651648520    html_title.xml            : HPE ProCurve Switch w/Hostname
1.5619708440    ftp_banners.xml           : FTPD on Mac OS X Server without a version
1.5422140600    ftp_banners.xml           : Simple tnftpd banner with a version
1.5390978490    ftp_banners.xml           : FTPD on Mac OS X Server with a version
1.5137707720    operating_system.xml      : Linux catch-all
1.3914740270    operating_system.xml      : Vendor-based Linux catch-all
1.3657760490    smtp_banners.xml          : Microsoft IIS builtin SMTP service - Windows Server 2016
1.3607990110    smtp_banners.xml          : Lotus Domino SMTP MTA
1.3509236500    smtp_banners.xml          : Exim - with version string and optional timestamp (Ubuntu)
1.3397536240    smtp_banners.xml          : Exim - without version string and with optional timestamp
1.3212323660    smtp_banners.xml          : IBM Domino SMTP MTA
1.3135177590    smtp_banners.xml          : Microsoft IIS builtin SMTP service - Windows Server 2019
1.3102424240    smtp_banners.xml          : Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each
1.3029141200    smtp_banners.xml          : Exim - with digit only version string and optional timestamp
1.2345793420    http_wwwauth.xml          : Generic F5 Big-IP
```
</details>

## Changes

Most of the performance issues are due to unbounded matches at the beginning of a regex pattern (^(.+)`). These are compounded when followed by another unbounded match or optional string `^([\s]*)\s*`.

In general I have modified these matches so as to limit the number of characters that it can match. The count limit is based on the maximum string that I **_think_** is plausible in that location + some padding.  Note, I have only updated specific cases where performance is particularly poor. I don't currently have time to change all of them.

Changes:
- Most limits are some power of two.. for reasons..
- hostnames are limited to 512 characters. DNS hostnames are limited to 256 characters but who can say what folks will do. 512 should be safe *enough* for what we are doing. If we find counter examples we update the fingerprint patterns.
- Version strings have been limited to what I think is reasonable given the examples and, in some cases, round up to the next power of two to account for variations that aren't in the examples.
- Patterns matching spaces (`' '*` or `' '+`) have typically been bounded to 8 spaces. We typically see 1 to 3 in those cases generally.
  - We occasionally see a string where the hostname has been replaced with spaces so 30+ spaces but it's rare.
- Matches for product names or arbitrary text strings have been limited to some limit that I though was reasonable based on context. In some cases these are rounded up to the next power of 2 as well.


## How Has This Been Tested?
test script, rspec + the build in banner examples.


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
