### PR TITLE
Add explicit certainty for Assert Nothings

### DIFF
--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -17,30 +17,40 @@
   <fingerprint pattern="^$">
     <description>empty string -- assert nothing.</description>
     <example/>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
     <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^none$">
     <description>bare 'none' -- assert nothing.</description>
     <example>none</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
     <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^null$">
     <description>bare 'null' -- assert nothing.</description>
     <example>null</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
     <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^unknown$">
     <description>bare 'unknown' -- assert nothing.</description>
     <example>unknown</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
     <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^no version$">
     <description>bare 'no version' -- assert nothing.</description>
     <example>no version</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
     <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -443,6 +443,9 @@ more text</example>
   <fingerprint pattern="^Welcom to Serv-U FTP Server$">
     <description>Common FTP banner modification to look like Serv-U -- assert nothing.</description>
     <example>Welcom to Serv-U FTP Server</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^zFTPServer v?(\S+), .*ready\.$" flags="REG_ICASE">
@@ -1314,6 +1317,9 @@ more text</example>
     <example host.name="host.example.com">host.example.com FTP server (Version 4.1 Sat Sep 7 14:31:53 CDT 2002) ready.</example>
     <example host.name="host.example.com">host.example.com FTP server (Version 5.3 Sat Jan 10 14:01:03 CDT 2012) ready</example>
     <param pos="1" name="host.name"/>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^Welcome to the (?:Cisco )?(?:TelePresence) ([a-zA-Z\s]*?) ((?:MSE )?\d+), version (\d+.\d+\(\d+.\d+\)).*?" flags="REG_ICASE">
@@ -1648,6 +1654,9 @@ more text</example>
     <description>Generic FTP fingerprint with a hostname</description>
     <example host.name="example.com">example.com FTP server ready.</example>
     <param pos="1" name="host.name"/>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^(\S{1,512}) FTP server \(Version (\d.*)\) ready\.?$" flags="REG_ICASE">
@@ -1666,6 +1675,9 @@ more text</example>
     <example>FTP-Server</example>
     <example>FTP Server</example>
     <example>FTP service ready.</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^Welcom to ProRat Ftp Server$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1,41 +1,62 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<fingerprints matches="html_title" database_type="service" preference="0.90">
+<fingerprints matches="html_title" protocol="http" database_type="service" preference="0.90">
   <!-- HTML Title elements found in HTTP response bodies are matched against these patterns to fingerprint HTTP servers. -->
 
   <fingerprint pattern="^301 Moved Permanently$">
     <description>301 Moved Permanently - generic -- assert nothing.</description>
     <example>301 Moved Permanently</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^302 Found$">
     <description>302 Found - generic -- assert nothing.</description>
     <example>302 Found</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^400 Bad Request$">
     <description>400 Bad Request - generic -- assert nothing.</description>
     <example>400 Bad Request</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^401 Unauthorized$">
     <description>401 Unauthorized - generic -- assert nothing.</description>
     <example>401 Unauthorized</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^403 Forbidden$">
     <description>403 Forbidden - generic -- assert nothing.</description>
     <example>403 Forbidden</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:404 )?Not Found$">
     <description>404 Not Found - generic -- assert nothing.</description>
     <example>404 Not Found</example>
     <example>Not Found</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^Invalid URL$">
     <description>Invalid URL - generic -- assert nothing.</description>
     <example>Invalid URL</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^ERROR: The request could not be satisfied$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2965,29 +2965,28 @@
     <param pos="0" name="service.product" value="2wire"/>
   </fingerprint>
 
-  <!-- junit says,
-     "Example pattern '' from http_servers.xml didn't match pattern '^$'"
-     Figure out if we have a way to support matching empty strings later.
-   <fingerprint pattern="^?">
-      <example></example>
-      <description>A blank banner; assert nothing.</description>
-   </fingerprint>
-
-   -->
-
   <fingerprint pattern="^(?:(?:\d{1,3}\.){3}\d{1,3}):\d{1,4}$">
     <description>A banner consisting of an IPv4 address and port -- assert nothing.</description>
     <example>192.168.0.4:9999</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^Web-Server/(?:\d+\.+\d+)$">
     <description>Obfuscated web server -- assert nothing.</description>
     <example>Web-Server/3.0</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^httpd$">
     <description>httpd - generic -- assert nothing.</description>
     <example>httpd</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <!-- Service provider equipment (CDNs, etc) -->

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -9,6 +9,9 @@
   <fingerprint pattern="^SIP/2.0$">
     <description>Generic SIP/2.0 response -- assert nothing.</description>
     <example>SIP/2.0</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^TP-Link SIP Stack V1.0.0$">

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -45,6 +45,9 @@
   <fingerprint pattern="^Windows 6.1$">
     <description>Spoofed value often used by Samba -- assert nothing.</description>
     <example>Windows 6.1</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^Windows XP (\d+) (Service Pack \d+)$">

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -20,27 +20,42 @@
   <fingerprint pattern="(?i)\A(?:\r|\n)*login:\s*$">
     <description>bare 'login:' -- assert nothing.</description>
     <example>login:</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)\A(?:\r|\n)*User(?:name)?\s*:\s*$">
     <description>bare 'Username:' -- assert nothing.</description>
     <example>Username:</example>
     <example>User:</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)\A(?:\r|\n)*Password:\s*$">
     <description>bare 'Password:' -- assert nothing.</description>
     <example>Password:</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)\A(?:\r|\n)*Account:\s*$">
     <description>bare 'Account:' -- assert nothing.</description>
     <example>Account:</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)\AConnection refused(?:\r|\n)*$">
     <description>bare 'Connection refused' -- assert nothing.</description>
     <example>Connection refused</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <!-- end of assert nothing block -->

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -13,54 +13,84 @@
   <fingerprint pattern="^CN=R3,O=Let's Encrypt,C=US$">
     <description>Lets Encrypt R3 - generic -- assert nothing.</description>
     <example>CN=R3,O=Let's Encrypt,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US$">
     <description>Lets Encrypt X3 - generic -- assert nothing.</description>
     <example>CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=Amazon,OU=Server CA 1B,O=Amazon,C=US$">
     <description>Amazon AWS Server CA 1B - generic -- assert nothing.</description>
     <example>CN=Amazon,OU=Server CA 1B,O=Amazon,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US$">
     <description>DigiCert SHA2 - generic -- assert nothing.</description>
     <example>CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=DigiCert TLS (?:RSA SHA256|Hybrid ECC SHA384) 2020 CA1,O=DigiCert Inc,C=US$">
     <description>DigiCert SHA256 2020 CA1 - generic -- assert nothing.</description>
     <example>CN=DigiCert TLS RSA SHA256 2020 CA1,O=DigiCert Inc,C=US</example>
     <example>CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1,O=DigiCert Inc,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=DigiCert Secure Site ECC CA-1,OU=www.digicert.com,O=DigiCert Inc,C=US$">
     <description>DigiCert ECC CA-1 - generic -- assert nothing.</description>
     <example>CN=DigiCert Secure Site ECC CA-1,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=DigiCert SHA2 (?:Extended Validation|High Assurance) Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US$">
     <description>DigiCert SHA2 EV - generic -- assert nothing.</description>
     <example>CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
     <example>CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=Sectigo RSA (?:Domain|Organization) Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB$">
     <description>Sectigo RSA - generic -- assert nothing.</description>
     <example>CN=Sectigo RSA Domain Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB</example>
     <example>CN=Sectigo RSA Organization Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=GeoTrust RSA CA 2018,OU=www.digicert.com,O=DigiCert Inc,C=US$">
     <description>GeoTrust RSA CA 2018 - generic -- assert nothing.</description>
     <example>CN=GeoTrust RSA CA 2018,OU=www.digicert.com,O=DigiCert Inc,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs\.godaddy\.com/repository/,O=GoDaddy.com\\, Inc\.,L=Scottsdale,ST=Arizona,C=US$">
     <description>Go Daddy G2 - generic -- assert nothing.</description>
     <example>CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\, Inc.,L=Scottsdale,ST=Arizona,C=US</example>
+    <param pos="0" name="hw.certainty" value="0.0"/>
+    <param pos="0" name="os.certainty" value="0.0"/>
+    <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
 
   <!-- Chromecast and various devices that support the Cast protocol -->


### PR DESCRIPTION
## Description
This PR explicitly sets the certainty levels for certain `Assert Nothing` style fingerprint matches.  The intent is to convey that all other matches to a banner or endpoint should be given priority over these specific matches. For example, a http_server match may be too generic to have value but the x509 issuer may also match and we want that second one to win always.

## How Has This Been Tested?
`rspec`


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
