### PR TITLE
Add recog_standardize pre-commit hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ Generally, this should only need to be done once, or if you need to start over.
     git fetch --all
     ```
 
+1. Set up git hooks to help identify potential issues with your contributions:
+
+    ```bash
+    ln -sf ../../tools/dev/hooks/pre-commit .git/hooks/pre-commit
+    ```
+
 [^back to top](#contributing-to-recog)
 
 ### Branch and Improve

--- a/bin/recog_standardize
+++ b/bin/recog_standardize
@@ -61,6 +61,7 @@ hw_device = load_identifiers(File.join(bdir, "hw_device.txt"))
 svc_prod = load_identifiers(File.join(bdir, "service_product.txt"))
 svc_family = load_identifiers(File.join(bdir, "service_family.txt"))
 
+missing_count = 0
 
 ARGV.each do |arg|
   Dir.glob(arg).each do |file|
@@ -70,6 +71,7 @@ ARGV.each do |arg|
         paramIndex, val = v
         if ! fields[k]
           puts "FIELD MISSING: #{k}"
+          missing_count += 1
           fields[k] = true
         end
         next if paramIndex != 0
@@ -79,51 +81,61 @@ ARGV.each do |arg|
         when "os.vendor", "service.vendor", "service.component.vendor", "hw.vendor"
           if ! vendors[val]
             puts "VENDOR MISSING: #{val}"
+            missing_count += 1
             vendors[val] = true
           end
         when "os.arch"
           if ! os_arch[val]
             puts "OS ARCH MISSING: #{val}"
+            missing_count += 1
             os_arch[val] = true
           end          
         when "os.product"
           if ! os_prod[val]
             puts "OS PRODUCT MISSING: #{val}"
+            missing_count += 1
             os_prod[val] = true
           end
         when "os.family"
           if ! os_family[val]
             puts "OS FAMILY MISSING: #{val}"
+            missing_count += 1
             os_family[val] = true
           end
         when "os.device"
           if ! os_device[val]
             puts "OS DEVICE MISSING: #{val}"
+            missing_count += 1
             os_device[val] = true
           end
         when "hw.product"
           if ! hw_prod[val]
             puts "HW PRODUCT MISSING: #{val}"
+            missing_count += 1
             hw_prod[val] = true
           end
         when "hw.family"
           if ! hw_family[val]
             puts "HW FAMILY MISSING: #{val}"
+            missing_count += 1
             hw_family[val] = true
           end
         when "hw.device"
           if ! hw_device[val]
             puts "HW DEVICE MISSING: #{val}"
+            missing_count += 1
             hw_device[val] = true
           end          
         when "service.product", "service.component.product"
           if ! svc_prod[val]
             puts "SERVICE PRODUCT MISSING: #{val}"
+            missing_count += 1
             svc_prod[val] = true
           end            
         when "service.family"
           if ! svc_family[val]
             puts "SERVICE FAMILY MISSING: #{val}"
+            missing_count += 1
             svc_family[val] = true
           end          
         end
@@ -132,17 +144,20 @@ ARGV.each do |arg|
   end
 end
 
-exit if ! options.write
+if options.write
+  # Write back the unique identifiers
+  write_identifiers(vendors, File.join(bdir, "vendor.txt"))
+  write_identifiers(fields, File.join(bdir, "fields.txt"))
+  write_identifiers(os_arch, File.join(bdir, "os_architecture.txt"))
+  write_identifiers(os_prod, File.join(bdir, "os_product.txt"))
+  write_identifiers(os_family, File.join(bdir, "os_family.txt"))
+  write_identifiers(os_device, File.join(bdir, "os_device.txt"))
+  write_identifiers(hw_prod, File.join(bdir, "hw_product.txt"))
+  write_identifiers(hw_family, File.join(bdir, "hw_family.txt"))
+  write_identifiers(hw_device, File.join(bdir, "hw_device.txt"))
+  write_identifiers(svc_prod, File.join(bdir, "service_product.txt"))
+  write_identifiers(svc_family, File.join(bdir, "service_family.txt"))
+end
 
-# Write back the unique identifiers
-write_identifiers(vendors, File.join(bdir, "vendor.txt"))
-write_identifiers(fields, File.join(bdir, "fields.txt"))
-write_identifiers(os_arch, File.join(bdir, "os_architecture.txt"))
-write_identifiers(os_prod, File.join(bdir, "os_product.txt"))
-write_identifiers(os_family, File.join(bdir, "os_family.txt"))
-write_identifiers(os_device, File.join(bdir, "os_device.txt"))
-write_identifiers(hw_prod, File.join(bdir, "hw_product.txt"))
-write_identifiers(hw_family, File.join(bdir, "hw_family.txt"))
-write_identifiers(hw_device, File.join(bdir, "hw_device.txt"))
-write_identifiers(svc_prod, File.join(bdir, "service_product.txt"))
-write_identifiers(svc_family, File.join(bdir, "service_family.txt"))
+exit_code = (missing_count > 0 ? 1 : 0)
+exit(exit_code)

--- a/tools/dev/hooks/pre-commit
+++ b/tools/dev/hooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Hook script to verify changes about to be committed.
+# The hook should exit with non-zero status after issuing an appropriate
+# message if it wants to stop the commit.
+
+# Verify that each fingerprint asserts known identifiers.
+git diff --cached --name-only --diff-filter=ACM -z xml/*.xml | xargs -0 ./bin/recog_standardize --write
+
+# get status
+status=$?
+
+if [ $status -ne 0 ]; then
+    echo "Please review any new additions to the text files under 'identifiers/'."
+    echo "If any of these names are close to an existing name, update the offending"
+    echo "fingerprint to use the existing name instead. Once the fingerprints are fixed,"
+    echo "remove the 'extra' names from the identifiers files, and run the tool again."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Description
Introduces a git pre-commit hook to run `bin/recog_standardize` on any staged XML fingerprint files. This will help contributors verify that each fingerprint asserts known identifiers. These changes required enhancement of `bin/recog_standardize` to return an exit code in order to support scripting.


## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.
Help contributors catch concerns before changes are committed and pull requests are opened. Save everyone a little time and help get contributions merged quicker!


## How Has This Been Tested?
New field names and new field values were added to xml fingerprints, then attempted to commit the changes to trigger the pre-commit hook script.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
