### PR TITLE
Remove unnecessary word from verify message

### DIFF
--- a/features/verify.feature
+++ b/features/verify.feature
@@ -21,7 +21,7 @@ Feature: Verify
     Then it should fail with:
       """
       WARN: 'Pure-FTPd' has no test cases
-      WARN: 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' messsage which is derived from a capture group
+      WARN: 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' which is derived from a capture group
       SUMMARY: Test completed with 1 successful, 2 warnings, and 0 failures
       """
     And the exit status should be 2

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -223,7 +223,7 @@ class Fingerprint
     capture_group_used.each do |param_name, param_used|
       if !param_used
         message = "'#{@name}' is missing an example that checks for parameter '#{param_name}' " +
-                  "messsage which is derived from a capture group"
+                  "which is derived from a capture group"
         yield :warn, message
       end
     end


### PR DESCRIPTION
## Description
Removes the word "messsage" from a message string since it appears to be there by mistake.


## Motivation and Context
To fix an error.


## How Has This Been Tested?
Ran `./bin/recog_verify` and verified the message was output correctly.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
