### PR TITLE
Add multi-language recog verify to GitHub verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,7 +64,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn --batch-mode --no-transfer-progress install
+        run: mvn --batch-mode --no-transfer-progress install -Dmaven.antrun.skip=true -DskipTests
       - name: Run recog verify
         run: mvn --batch-mode --no-transfer-progress --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="--no-warnings recog-content/xml/*.xml"
   go-verify:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,5 +22,68 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Run recog_standardize
+      - name: Run recog standardize
         run: bundle exec bin/recog_standardize xml/*.xml
+  ruby-verify:
+    name: 'Ruby Verify'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout Ruby implementation
+        uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run recog verify
+        run: bundle exec recog_verify --no-warnings xml/*.xml
+  java-verify:
+    name: 'Java Verify'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout Java implementation
+        uses: actions/checkout@v2
+        with:
+          repository: rapid7/recog-java
+      - name: Checkout recog content
+        uses: actions/checkout@v2
+        with:
+          path: recog-content
+      - uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: '17'
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn --batch-mode --no-transfer-progress install
+      - name: Run recog verify
+        run: mvn --batch-mode --no-transfer-progress --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="--no-warnings recog-content/xml/*.xml"
+  go-verify:
+    name: 'Go Verify'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout Go implementation
+        uses: actions/checkout@v2
+        with:
+          repository: RumbleDiscovery/recog-go
+      - name: Checkout recog content
+        uses: actions/checkout@v2
+        with:
+          path: recog-content
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.1'
+      - name: Run recog verify
+        run: go run cmd/recog_verify/main.go recog-content/xml/


### PR DESCRIPTION
## Description
Enhances the GitHub verify workflow to run Ruby, Java and Go implementations of the recog fingerprint verification tool on any modified XML fingerprint files. This will help contributors and pull request reviewers verify at a minimum that each fingerprint example is matched and all parameters that are defined by capture groups have the expected value. Note, warnings are currently disabled in the tools that provide warnings (Ruby and Java), and will be enabled once all of the warnings in the existing fingerprints are corrected.


## Motivation and Context
Help contributors and pull request reviewers catch concerns.


## How Has This Been Tested?
1. Opened PR against my recog fork
2. Patched `xml/` fingerprints to introduce issues
3. Committed and pushed changes
4. Confirmed Ruby Verify, Java Verify, and Go Verify workflow jobs all failed
5. Committed and pushed changes to undo the changes applied by the patch
6. Confirmed all Verify workflows were not run since xml files under `xml/` were no longer different


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
