### PR TITLE
Add missing parameters on x509.subject examples

### DIFF
--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -217,7 +217,7 @@
 
   <fingerprint pattern="^CN=([A-Za-z0-9\_\-\.]+),OU=ISS,O=Hewlett-Packard Company,L=Houston,ST=Texas,C=US$">
     <description>HP iLO</description>
-    <example>CN=SERVER-1231,OU=ISS,O=Hewlett-Packard Company,L=Houston,ST=Texas,C=US</example>
+    <example host.name="SERVER-1231">CN=SERVER-1231,OU=ISS,O=Hewlett-Packard Company,L=Houston,ST=Texas,C=US</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
@@ -248,7 +248,7 @@
 
   <fingerprint pattern="^CN=OA\-([a-fA-F0-9]+),OU=Onboard Administrator,">
     <description>HP iLO (Onboard Administrator)</description>
-    <example>CN=OA-001F296E21A3,OU=Onboard Administrator,O=Corp.,L=Location,ST=N/A,C=US</example>
+    <example host.mac="001F296E21A3">CN=OA-001F296E21A3,OU=Onboard Administrator,O=Corp.,L=Location,ST=N/A,C=US</example>
     <example>CN=OA-80C16E999999,OU=Onboard Administrator,O=Hewlett-Packard</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
@@ -265,7 +265,7 @@
 
   <fingerprint pattern="^CN=([A-Za-z0-9\_\-\.]+),OU=Hewlett Packard Enterprise Network Management Software \(SMH\),O=Hewlett Packard Enterprise,L=Houston,ST=Texas,C=US$">
     <description>HP iLO - Enterprise Mgmt variant</description>
-    <example>CN=bigsrv99,OU=Hewlett Packard Enterprise Network Management Software (SMH),O=Hewlett Packard Enterprise,L=Houston,ST=Texas,C=US</example>
+    <example host.name="bigsrv99">CN=bigsrv99,OU=Hewlett Packard Enterprise Network Management Software (SMH),O=Hewlett Packard Enterprise,L=Houston,ST=Texas,C=US</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
@@ -508,7 +508,7 @@
 
   <fingerprint pattern="^CN=([a-zA-Z0-9\.\-\_]+),OU=VMware ESX Server Default Certificate,O=VMware\\, Inc,L=Palo Alto,ST=California,C=US$">
     <description>VMware ESX</description>
-    <example>CN=server99.,OU=VMware ESX Server Default Certificate,O=VMware\, Inc,L=Palo Alto,ST=California,C=US</example>
+    <example host.name="server99.">CN=server99.,OU=VMware ESX Server Default Certificate,O=VMware\, Inc,L=Palo Alto,ST=California,C=US</example>
     <param pos="0" name="service.vendor" value="VMware"/>
     <param pos="0" name="os.vendor" value="VMware"/>
     <param pos="0" name="os.family" value="VMware ESX/ESXi"/>
@@ -1242,7 +1242,7 @@
 
   <fingerprint pattern="^CN=Canon (iR-[a-zA-Z0-9\.\-\_]+)$">
     <description>Canon iR-ADV Printer with product info</description>
-    <example os.product="iR-ADV">CN=Canon iR-ADV</example>
+    <example os.product="iR-ADV" hw.product="iR-ADV">CN=Canon iR-ADV</example>
     <param pos="0" name="hw.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="Canon"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1320,7 +1320,7 @@
 
   <fingerprint pattern="^CN=DT([^\s]+) Series,O=NEC Corporation,ST=Tokyo,C=JP$">
     <description>NEC DT Series IP Phone</description>
-    <example>CN=DT800 Series,O=NEC Corporation,ST=Tokyo,C=JP</example>
+    <example hw.product="800">CN=DT800 Series,O=NEC Corporation,ST=Tokyo,C=JP</example>
     <param pos="0" name="os.vendor" value="NEC"/>
     <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="NEC"/>
@@ -1656,7 +1656,7 @@
 
   <fingerprint pattern="^CN=(.{1,256}),OU=PVE Cluster Node,O=Proxmox Virtual Environment$">
     <description>Proxmox open-source virtualization platform</description>
-    <example>CN=pve.example.org,OU=PVE Cluster Node,O=Proxmox Virtual Environment</example>
+    <example host.name="pve.example.org">CN=pve.example.org,OU=PVE Cluster Node,O=Proxmox Virtual Environment</example>
     <param pos="1" name="host.name"/>
     <param pos="0" name="service.vendor" value="Proxmox"/>
     <param pos="0" name="service.product" value="Virtual Environment"/>


### PR DESCRIPTION
## Description
Adds missing parameters on x509.subject examples in order to address `recog_verify` warnings.

#### Before
```
./bin/recog_verify xml/x509_subjects.xml
xml/x509_subjects.xml: WARN: 'HP iLO' is missing an example that checks for parameter 'host.name' which is derived from a capture group
xml/x509_subjects.xml: WARN: 'HP iLO (Onboard Administrator)' is missing an example that checks for parameter 'host.mac' which is derived from a capture group
xml/x509_subjects.xml: WARN: 'HP iLO - Enterprise Mgmt variant' is missing an example that checks for parameter 'host.name' which is derived from a capture group
xml/x509_subjects.xml: WARN: 'VMware ESX' is missing an example that checks for parameter 'host.name' which is derived from a capture group
xml/x509_subjects.xml: WARN: 'Canon iR-ADV Printer with product info' is missing an example that checks for parameter 'hw.product' which is derived from a capture group
xml/x509_subjects.xml: WARN: 'NEC DT Series IP Phone' is missing an example that checks for parameter 'hw.product' which is derived from a capture group
xml/x509_subjects.xml: WARN: 'Proxmox open-source virtualization platform' is missing an example that checks for parameter 'host.name' which is derived from a capture group
xml/x509_subjects.xml: SUMMARY: Test completed with 182 successful, 7 warnings, and 0 failures
```

#### After
```
./bin/recog_verify xml/x509_subjects.xml
xml/x509_subjects.xml: SUMMARY: Test completed with 182 successful, 0 warnings, and 0 failures
```


## Motivation and Context
Clean up examples.


## How Has This Been Tested?
* `./bin/recog_verify xml/x509_subjects.xml`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
