### PR TITLE
Add fingerprinting for html body

### DIFF
--- a/xml/html_body.xml
+++ b/xml/html_body.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<fingerprints matches="html_body" protocol="http" database_type="service" preference="0.90">
+  <!-- The first 4k of HTML found in HTTP response bodies are matched against these patterns. -->
+
+  <fingerprint pattern="EDGE.DeviceModel = 'ER-X-SFP'">
+    <description>Ubiquiti EdgeRouter X-SFP</description>
+    <example>EDGE.DeviceModel = 'ER-X-SFP'</example>
+    <param pos="0" name="hw.certainty" value="9.0"/>
+    <param pos="0" name="os.certainty" value="9.0"/>
+    <param pos="0" name="service.certainty" value="9.0"/>
+    <param pos="0" name="os.vendor" value="Ubiquiti"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="EdgeOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ui:edgeos:-"/>
+    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
+    <param pos="0" name="hw.product" value="EdgeRouter X-SFP"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:ui:er-x-sfp:-"/>
+  </fingerprint>
+
+</fingerprints>


### PR DESCRIPTION
For performance reasons, the fingerprint
should only be checked against the first 4k
of html.