### PR TITLE
Modify telnet patterns to fix recog-java compatibility

### DIFF
--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -655,7 +655,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\r|\n)*HP JetDirect(?:\r|\n)+$">
+  <fingerprint pattern="^(?:\r|\n)*HP JetDirect(?:\r|\n)+">
     <description>HP Printer - Jet Direct</description>
     <!-- HP JetDirect\r\nPassword is not set\r\n\r\nPlease type "menu" for the MENU system, \r\nor "?" for help, or "/" for current settings.\r\n> -->
 
@@ -1209,7 +1209,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^Telnet Server Build (5.*)">
+  <fingerprint pattern="(?m)^Telnet Server Build (5\.[.\d]+)">
     <description>Windows 2000</description>
     <!--Microsoft (R) Windows NT (TM) Version 4.00 (Build 1381)\nWelcome to Microsoft Telnet Service \nTelnet Server Build 5.00.99034.1\nlogin:  -->
 
@@ -1703,7 +1703,7 @@
     <param pos="3" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^HP ([^\s]+) ProCurve Switch">
+  <fingerprint pattern="(?m)^HP ([^\s]+) ProCurve Switch">
     <description>HP ProCurve Switch</description>
     <!-- ==============================================================================\nHP J4121A ProCurve Switch 4000M\n
     Firmware revision v2.2.3\n\nCopyright (C) 1991-2004 Hewlett-Packard Co. All Rights Reserved.\n\n


### PR DESCRIPTION
## Description
Small `xml/telnet_banners.xml` pattern modifications to fix issues with `recog-java` compatibility.


## Motivation and Context
Resolve `recog-java` fingerprint issues introduced when adding support for base64 encoded examples in rapid7/recog-java#15.

### com.rapid7.recog.verify.RecogVerifier failures
```
xml/telnet_banners.xml: FAIL: 'HP Printer - Jet Direct' failed to match "HP JetDirect
<snip>
" with '^(?:\r|\n)*HP JetDirect(?:\r|\n)+$'
xml/telnet_banners.xml: FAIL: 'HP Printer - Jet Direct' failed to match "HP JetDirect
<snip>
" with '^(?:\r|\n)*HP JetDirect(?:\r|\n)+$'
xml/telnet_banners.xml: FAIL: 'Windows 2000' failed to match "Microsoft (R) Windows NT (TM) Version 4.00 (Build 1381)
<snip>
login: " with '^Telnet Server Build (5.*)'
xml/telnet_banners.xml: WARN: 'Arescom System' is missing an example that checks for parameter 'hw.model' which is derived from a capture group
xml/telnet_banners.xml: FAIL: 'HP ProCurve Switch' failed to match "
<snip>
Username: " with '^HP ([^\s]+) ProCurve Switch'
xml/telnet_banners.xml: SUMMARY: Test completed with 154 successful, 1 warnings, and 4 failures
```


## How Has This Been Tested?
* `rake tests`
* `mvn --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="$(ls -1 xml/*.xml | xargs)"`
  ```
  ...
  xml/telnet_banners.xml: WARN: 'Arescom System' is missing an example that checks for parameter 'hw.model' which is derived from a capture group
  xml/telnet_banners.xml: SUMMARY: Test completed with 158 successful, 1 warnings, and 0 failures
  ...
  ```


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
