### PR TITLE
Correct hw.device capitalization for Web Cam

### DIFF
--- a/identifiers/hw_device.txt
+++ b/identifiers/hw_device.txt
@@ -78,7 +78,7 @@ VoIP Switch
 Voice Appliance
 WAP
 WLAN Repeater
-Web cam
+Web Cam
 Whiteboard
 Wireless Controller
 Wireless Presenter

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -642,7 +642,7 @@
     <example>Digest realm="Use 'live' as User Name",nonce="18e62d241a5358a9650640fa72c1773c",opaque="",stale=FALSE,algorithm=MD5</example>
     <example>Digest realm="Use 'live' as User Name in order to log in to the respective level",nonce="2e6007092c2b28af7e2516b80b5b4f95",opaque="",stale=FALSE,algorithm=MD5,qop="auth"</example>
     <param pos="0" name="hw.vendor" value="Bosch"/>
-    <param pos="0" name="hw.device" value="Web cam"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
     <param pos="0" name="hw.product" value="AutoDome"/>
     <param pos="0" name="hw.certainty" value="0.50"/>
   </fingerprint>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -2141,7 +2141,7 @@
     <example hw.product="AutoDome 800 HD">Welcome to AutoDome 800 HD 1.2.3.4 from 5.6.7.8</example>
     <example hw.product="FLEXIDOME NDC-455-P">Welcome to FLEXIDOME NDC-455-P 1.2.3.4 from 5.6.7.8</example>
     <param pos="0" name="hw.vendor" value="Bosch"/>
-    <param pos="0" name="hw.device" value="Web cam"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
 
@@ -2160,7 +2160,7 @@
     <description>Vadio VNG DocCom</description>
     <example hw.version="1.6+snapshot-20170720" host.mac="54-10-EC-31-2A-19">Vaddio VNG 1.6+snapshot-20170720 vaddio-doccam-54-10-EC-31-2A-19</example>
     <param pos="0" name="hw.vendor" value="Vaddio"/>
-    <param pos="0" name="hw.device" value="Web cam"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
     <param pos="0" name="hw.product" value="DocCam"/>
     <param pos="1" name="hw.version"/>
     <param pos="2" name="host.mac"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -1710,7 +1710,7 @@
     <description>Bosch AutoDome IP Camera</description>
     <example>CN=local.myboschcam.net,O=Bosch Sicherheitssysteme GmbH,L=Grasbrunn,ST=Bayern,C=DE</example>
     <param pos="0" name="hw.vendor" value="Bosch"/>
-    <param pos="0" name="hw.device" value="Web cam"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
     <param pos="0" name="hw.product" value="AutoDome"/>
     <param pos="0" name="hw.certainty" value="0.50"/>
   </fingerprint>
@@ -1727,7 +1727,7 @@
     <description>Vadio DocCom</description>
     <example>CN=Vaddio Device,O=Vaddio,L=Minnetonka,ST=MN,C=US</example>
     <param pos="0" name="hw.vendor" value="Vaddio"/>
-    <param pos="0" name="hw.device" value="Web cam"/>
+    <param pos="0" name="hw.device" value="Web Cam"/>
     <param pos="0" name="hw.product" value="DocCam"/>
     <param pos="0" name="hw.certainty" value="0.50"/>
   </fingerprint>


### PR DESCRIPTION
## Description
Corrects `hw.device` capitalization for "Web Cam".


## Motivation and Context
All `hw.device` values should be formatted using start case.


## How Has This Been Tested?
* `rake tests`
* `./bin/recog_verify --no-warnings xml/*.xml`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
