### PR TITLE
Modify telnet patterns to fix recog-java compatibility (2)

### DIFF
--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -2192,7 +2192,7 @@
     <param pos="0" name="hw.family" value="LX Series"/>
   </fingerprint>
 
-  <fingerprint pattern="(?m)\*\*\* Lantronix ([\S+ ]+) Device Server .{0,1000}MAC address ([a-fA-F0-9]{12}).{0,1000}Software version V(\S+)">
+  <fingerprint pattern="(?m)\*\*\* Lantronix ([\S]+) Device Server \*\*\*(?:\r|\n)+MAC address ([a-fA-F0-9]{12})(?:\r|\n)+Software version V(\S+)">
     <description>Lantronix device server - w/o Serial</description>
     <!--
       *** Lantronix UDS1100-IAP Device Server ***
@@ -2214,7 +2214,7 @@
     <param pos="3" name="hw.version"/>
   </fingerprint>
 
-  <fingerprint pattern="(?m)\*\*\* Lantronix Universal Device Server .{0,1000}Serial Number (\d+)\s+MAC address ([a-fA-F0-9:]{17}).{0,1000}Software version (\S+)">
+  <fingerprint pattern="(?m)\*\*\* Lantronix Universal Device Server \*\*\*(?:\r|\n)+Serial Number (\d+)\s+MAC address ([a-fA-F0-9:]{17})(?:\r|\n)+Software version (\S+)">
     <description>Lantronix device server - w/ Serial</description>
     <!--
       *** Lantronix Universal Device Server ***


### PR DESCRIPTION
## Description
Small `xml/telnet_banners.xml` pattern modifications to fix issues with `recog-java` compatibility.


## Motivation and Context
Resolve `recog-java` fingerprint issues introduced with new fingerprints from #382.

### com.rapid7.recog.verify.RecogVerifier failures
```
$ mvn --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="--no-warnings xml/telnet_banners.xml"
...

xml/telnet_banners.xml: FAIL: 'Lantronix device server - w/o Serial' failed to match "*** Lantronix UDS1100-IAP Device Server ***
<snip>
" with '(?m)\*\*\* Lantronix ([\S+ ]+) Device Server .{0,1000}MAC address ([a-fA-F0-9]{12}).{0,1000}Software version V(\S+)'

xml/telnet_banners.xml: FAIL: 'Lantronix device server - w/ Serial' failed to match "*** Lantronix Universal Device Server ***
<snip>
" with '(?m)\*\*\* Lantronix Universal Device Server .{0,1000}Serial Number (\d+)\s+MAC address ([a-fA-F0-9:]{17}).{0,1000}Software version (\S+)'
xml/telnet_banners.xml: SUMMARY: Test completed with 171 successful, 0 warnings, and 2 failures
```


## How Has This Been Tested?
* `rake tests`
* `mvn --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="--no-warnings xml/telnet_banners.xml"`
  ```
  ...
  xml/telnet_banners.xml: SUMMARY: Test completed with 173 successful, 0 warnings, and 0 failures
  ```


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
