### PR TITLE
Resolve #389: Add line numbers to recog_verify output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,12 @@ end
 require 'cucumber'
 require 'cucumber/rake/task'
 
+def jruby?
+  defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+end
+
 Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = "features --format pretty"
+    t.cucumber_opts = "features --format pretty" + (jruby? ? " --tags 'not @jruby-disabled'" : "")
 end
 
 task :default => [ :tests, :yard ]

--- a/features/verify.feature
+++ b/features/verify.feature
@@ -20,8 +20,8 @@ Feature: Verify
     When I run `recog_verify tests_with_warnings.xml`
     Then it should fail with:
       """
-      tests_with_warnings.xml: WARN: 'Pure-FTPd' has no test cases
-      tests_with_warnings.xml: WARN: 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' which is derived from a capture group
+      tests_with_warnings.xml: WARN (line 10): 'Pure-FTPd' has no test cases
+      tests_with_warnings.xml: WARN (line 10): 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' which is derived from a capture group
       tests_with_warnings.xml: SUMMARY: Test completed with 1 successful, 2 warnings, and 0 failures
       """
     And the exit status should be 2
@@ -39,10 +39,10 @@ Feature: Verify
     When I run `recog_verify tests_with_failures.xml`
     Then it should fail with:
       """
-      tests_with_failures.xml: FAIL: 'foo test' failed to match "bar" with (?-mix:^foo$)'
-      tests_with_failures.xml: FAIL: '' failed to match "This almost matches" with (?-mix:^This matches$)'
-      tests_with_failures.xml: FAIL: 'bar test's os.name is a non-zero pos but specifies a value of 'Bar'
-      tests_with_failures.xml: FAIL: 'bar test' failed to find expected capture group os.version '5.0'. Result was 1.0
+      tests_with_failures.xml: FAIL (line 3): 'foo test' failed to match "bar" with (?-mix:^foo$)'
+      tests_with_failures.xml: FAIL (line 8): '' failed to match "This almost matches" with (?-mix:^This matches$)'
+      tests_with_failures.xml: FAIL (line 13): 'bar test's os.name is a non-zero pos but specifies a value of 'Bar'
+      tests_with_failures.xml: FAIL (line 13): 'bar test' failed to find expected capture group os.version '5.0'. Result was 1.0
       tests_with_failures.xml: SUMMARY: Test completed with 0 successful, 0 warnings, and 4 failures
       """
     And the exit status should be 4

--- a/features/verify.feature
+++ b/features/verify.feature
@@ -15,7 +15,10 @@ Feature: Verify
       successful_tests.xml: SUMMARY: Test completed with 4 successful, 0 warnings, and 0 failures
       """
 
+  # This test is diabled in JRuby because JRuby does not number lines correctly, whereas
+  # CRuby does. See https://github.com/sparklemotion/nokogiri/issues/2380
   @no-clobber
+  @jruby-disabled
   Scenario: Tests with warnings, warnings enabled
     When I run `recog_verify tests_with_warnings.xml`
     Then it should fail with:
@@ -34,7 +37,10 @@ Feature: Verify
       tests_with_warnings.xml: SUMMARY: Test completed with 1 successful, 0 warnings, and 0 failures
       """
 
+  # This test is diabled in JRuby because JRuby does not number lines correctly, whereas
+  # CRuby does. See https://github.com/sparklemotion/nokogiri/issues/2380
   @no-clobber
+  @jruby-disabled
   Scenario: Tests with failures
     When I run `recog_verify tests_with_failures.xml`
     Then it should fail with:

--- a/features/verify.feature
+++ b/features/verify.feature
@@ -20,8 +20,8 @@ Feature: Verify
     When I run `recog_verify tests_with_warnings.xml`
     Then it should fail with:
       """
-      tests_with_warnings.xml: WARN (line 10): 'Pure-FTPd' has no test cases
-      tests_with_warnings.xml: WARN (line 10): 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' which is derived from a capture group
+      tests_with_warnings.xml:10: WARN: 'Pure-FTPd' has no test cases
+      tests_with_warnings.xml:10: WARN: 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' which is derived from a capture group
       tests_with_warnings.xml: SUMMARY: Test completed with 1 successful, 2 warnings, and 0 failures
       """
     And the exit status should be 2
@@ -39,10 +39,10 @@ Feature: Verify
     When I run `recog_verify tests_with_failures.xml`
     Then it should fail with:
       """
-      tests_with_failures.xml: FAIL (line 3): 'foo test' failed to match "bar" with (?-mix:^foo$)'
-      tests_with_failures.xml: FAIL (line 8): '' failed to match "This almost matches" with (?-mix:^This matches$)'
-      tests_with_failures.xml: FAIL (line 13): 'bar test's os.name is a non-zero pos but specifies a value of 'Bar'
-      tests_with_failures.xml: FAIL (line 13): 'bar test' failed to find expected capture group os.version '5.0'. Result was 1.0
+      tests_with_failures.xml:3: FAIL: 'foo test' failed to match "bar" with (?-mix:^foo$)'
+      tests_with_failures.xml:8: FAIL: '' failed to match "This almost matches" with (?-mix:^This matches$)'
+      tests_with_failures.xml:13: FAIL: 'bar test's os.name is a non-zero pos but specifies a value of 'Bar'
+      tests_with_failures.xml:13: FAIL: 'bar test' failed to find expected capture group os.version '5.0'. Result was 1.0
       tests_with_failures.xml: SUMMARY: Test completed with 0 successful, 0 warnings, and 4 failures
       """
     And the exit status should be 4

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -28,6 +28,12 @@ class Fingerprint
   # @return (see #parse_examples)
   attr_reader :tests
 
+  # The line number of the XML entity in the source file for this
+  # fingerprint.
+  #
+  # @return [Integer] The line number of this entity.
+  attr_reader :line
+
   # @param xml [Nokogiri::XML::Element]
   # @param match_key [String] See Recog::DB
   # @param protocol [String] Protocol such as ftp, mssql, http, etc.
@@ -37,6 +43,7 @@ class Fingerprint
     @protocol = protocol
     @name   = parse_description(xml)
     @regex  = create_regexp(xml)
+    @line   = xml.line
     @params = {}
     @tests = []
 

--- a/lib/recog/verifier.rb
+++ b/lib/recog/verifier.rb
@@ -15,9 +15,9 @@ class Verifier
         fp.verify_params do |status, message|
           case status
           when :warn
-            reporter.warning "WARN (line #{fp.line}): #{message}"
+            reporter.warning "WARN: #{message}", fp.line
           when :fail
-            reporter.failure "FAIL (line #{fp.line}): #{message}"
+            reporter.failure "FAIL: #{message}", fp.line
           when :success
             reporter.success(message)
           end
@@ -25,9 +25,9 @@ class Verifier
         fp.verify_tests do |status, message|
           case status
           when :warn
-            reporter.warning "WARN (line #{fp.line}): #{message}"
+            reporter.warning "WARN: #{message}", fp.line
           when :fail
-            reporter.failure "FAIL (line #{fp.line}): #{message}"
+            reporter.failure "FAIL: #{message}", fp.line
           when :success
             reporter.success(message)
           end

--- a/lib/recog/verifier.rb
+++ b/lib/recog/verifier.rb
@@ -15,9 +15,9 @@ class Verifier
         fp.verify_params do |status, message|
           case status
           when :warn
-            reporter.warning "WARN: #{message}"
+            reporter.warning "WARN (line #{fp.line}): #{message}"
           when :fail
-            reporter.failure "FAIL: #{message}"
+            reporter.failure "FAIL (line #{fp.line}): #{message}"
           when :success
             reporter.success(message)
           end
@@ -25,9 +25,9 @@ class Verifier
         fp.verify_tests do |status, message|
           case status
           when :warn
-            reporter.warning "WARN: #{message}"
+            reporter.warning "WARN (line #{fp.line}): #{message}"
           when :fail
-            reporter.failure "FAIL: #{message}"
+            reporter.failure "FAIL (line #{fp.line}): #{message}"
           when :success
             reporter.success(message)
           end

--- a/lib/recog/verify_reporter.rb
+++ b/lib/recog/verify_reporter.rb
@@ -24,15 +24,15 @@ class VerifyReporter
     formatter.success_message("#{padding}#{text}") if detail?
   end
 
-  def warning(text)
+  def warning(text, line=nil)
     return unless @options.warnings
     @warning_count += 1
-    formatter.warning_message("#{path_label}#{padding}#{text}")
+    formatter.warning_message("#{path_label(line)}#{padding}#{text}")
   end
 
-  def failure(text)
+  def failure(text, line=nil)
     @failure_count += 1
-    formatter.failure_message("#{path_label}#{padding}#{text}")
+    formatter.failure_message("#{path_label(line)}#{padding}#{text}")
   end
 
   def print_name(fingerprint)
@@ -65,9 +65,10 @@ class VerifyReporter
     @options.detail
   end
 
-  def path_label
+  def path_label(line=nil)
     unless detail?
-      @path.to_s.empty? ? "" : "#{@path}: "
+      line_label = line ? line.to_s + ":" : ""
+      @path.to_s.empty? ? "" : "#{@path}:#{line_label} "
     end
   end
 


### PR DESCRIPTION
## Description
Just a simple patch to produce line numbers in parsed fingerprints.


## Motivation and Context
Need this to tell which fingerprints are which when diagnosing and fixing problems reported by `recog_verify`

## How Has This Been Tested?
Ran `recog_verify`
Ran `bundle exec rake tests`

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
