### PR TITLE
Increment lower JRuby version to 9.2.20.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', 'jruby-9.1.17.0', 'jruby']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', 'jruby-9.2.20.1', 'jruby']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Increments the lower JRuby version to `9.2.20.1` to match the Ruby 2.5 lower version.

> JRuby 9.2.20.1 is our point release of our Ruby 2.5.x support.

## Motivation and Context
Keeping testing consistent and resolving a test issue on #393.


## How Has This Been Tested?
Changes will be tested via the GitHub Action.


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
