### PR TITLE
Add html based fingerprinting

### DIFF
--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -73,7 +73,9 @@ EP-series
 EXA Signal Analyzer
 Eagle Eye Director II
 EchoLife Home Gateway
+EdgeRouter Infinity 8-XG
 EdgeRouter X
+EdgeRouter X-SFP
 EdgeSwitch
 Elevation
 Email Security Gateway

--- a/xml/html_body.xml
+++ b/xml/html_body.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<fingerprints matches="html_body" protocol="http" database_type="service" preference="0.90">
+  <!-- HTML found in HTTP response bodies are matched against these patterns. -->
+
+  <fingerprint pattern="EDGE.DeviceModel = 'ER-X-SFP'">
+    <description>Ubiquiti EdgeRouter X-SFP</description>
+    <example>EDGE.DeviceModel = 'ER-X-SFP'</example>
+    <param pos="0" name="hw.certainty" value="9.0"/>
+    <param pos="0" name="os.certainty" value="9.0"/>
+    <param pos="0" name="service.certainty" value="9.0"/>
+    <param pos="0" name="os.vendor" value="Ubiquiti"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="EdgeOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ui:edgeos:-"/>
+    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
+    <param pos="0" name="hw.product" value="EdgeRouter X-SFP"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:ui:er-x-sfp:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="EDGE.DeviceModel = 'ER-8-XG'">
+    <description>Ubiquiti EdgeRouter Infinity ER-8-XG</description>
+    <example>EDGE.DeviceModel = 'ER-8-XG'</example>
+    <param pos="0" name="hw.certainty" value="9.0"/>
+    <param pos="0" name="os.certainty" value="9.0"/>
+    <param pos="0" name="service.certainty" value="9.0"/>
+    <param pos="0" name="os.vendor" value="Ubiquiti"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="EdgeOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ui:edgeos:-"/>
+    <param pos="0" name="hw.vendor" value="Ubiquiti"/>
+    <param pos="0" name="hw.product" value="EdgeRouter Infinity 8-XG"/>
+  </fingerprint>
+
+</fingerprints>


### PR DESCRIPTION
## Description
Add html based fingerprinting

## Motivation and Context
This is an easy way to fingerprint Edgerouter models.

## How Has This Been Tested?
Tested on my LAN, as well as on [here]( https://spyse.com/target/as/209113/ip-with-open-ports?target=ip&search_params=%5B%7B%22open_port%22%3A%7B%22operator%22%3A%22exists%22%7D%7D,%7B%22as_num%22%3A%7B%22operator%22%3A%22eq%22,%22value%22%3A%22209113%22%7D%7D%5D ) and [here](https://spyse.com/target/as/209409/ip-with-open-ports?target=ip&search_params=%5B%7B%22open_port%22%3A%7B%22operator%22%3A%22exists%22%7D%7D,%7B%22as_num%22%3A%7B%22operator%22%3A%22eq%22,%22value%22%3A%22209409%22%7D%7D%5D)


## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
