### PR TITLE
Add a jarm fingerprint for HP Printers

### DIFF
--- a/xml/tls_jarm.xml
+++ b/xml/tls_jarm.xml
@@ -159,4 +159,13 @@
     <param pos="0" name="service.product" value="Merlin"/>
   </fingerprint>
 
+  <fingerprint pattern="^16d16d16d14d16d00016d16d16d16da6fda484e06f95db4f56339284c90672$">
+    <description>HP Printer</description>
+    <example>16d16d16d14d16d00016d16d16d16da6fda484e06f95db4f56339284c90672</example>
+    <param pos="0" name="hw.device" value="Printer"/>
+    <param pos="0" name="hw.vendor" value="HP"/>
+    <param pos="0" name="os.vendor" value="HP"/>
+    <param pos="0" name="os.device" value="Printer"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Add a jarm fingerprint for HP Printers

## Motivation and Context
More ways to detect HP Printers, yay!

## How Has This Been Tested?
Tested on my LAN, as well as on https://www.shodan.io/search?query=ssl.jarm%3A16d16d16d14d16d00016d16d16d16da6fda484e06f95db4f56339284c90672

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.