### PR TITLE
Scripted update to add missing example attributes

### DIFF
--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -48,7 +48,7 @@
     <example hw.family="OfficeJet">Hewlett-Packard OfficeJet</example>
     <example hw.family="LaserJet">HP LaserJet</example>
     <example hw.family="Printer">HP Printer</example>
-    <example>Hewlett-Packard JetDirect</example>
+    <example hw.family="JetDirect">Hewlett-Packard JetDirect</example>
     <param pos="0" name="hw.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="1" name="hw.family"/>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -68,8 +68,8 @@
     <example service.version="9.3.6-P1" os.version="5" os.version.version="11">9.3.6-P1-RedHat-9.3.6-25.P1.el5_11.12</example>
     <example service.version="9.9.1-P3" os.version="6">9.9.1-P3-RedHat-9.9.1.P3.el6</example>
     <example service.version="9.9.3-rpz2+rl.13208.13-P2" os.version="6">9.9.3-rpz2+rl.13208.13-P2-RedHat-9.9.3-4.P2.el6</example>
-    <example os.version="6" os.version.version="1">9.7.3-P3-RedHat-9.7.3-2.el6_1.P3.3</example>
-    <example os.version="6" os.version.version="">9.8.2rc1-RedHat-9.8.2-0.47.rc1.el6</example>
+    <example os.version="6" os.version.version="1" service.version="9.7.3-P3">9.7.3-P3-RedHat-9.7.3-2.el6_1.P3.3</example>
+    <example os.version="6" os.version.version="" service.version="9.8.2rc1">9.8.2rc1-RedHat-9.8.2-0.47.rc1.el6</example>
     <param pos="0" name="service.vendor" value="ISC"/>
     <param pos="0" name="service.family" value="BIND"/>
     <param pos="0" name="service.product" value="BIND"/>
@@ -85,11 +85,11 @@
 
   <fingerprint pattern="^(9.[^-]+(?:-rl[.\d]+)?(?:-[SP]\d)?)-RedHat-[\d.]+-[\w.]+fc([\d]+)$">
     <description>ISC BIND: Fedora</description>
-    <example service.version="9.10.4-P8">9.10.4-P8-RedHat-9.10.4-4.P8.fc25</example>
+    <example service.version="9.10.4-P8" os.version="25">9.10.4-P8-RedHat-9.10.4-4.P8.fc25</example>
     <!-- The '-rl' in the example below indicates a rate limiting patch -->
 
-    <example service.version="9.9.3-rl.13207.22-P2">9.9.3-rl.13207.22-P2-RedHat-9.9.3-5.P2.fc19</example>
-    <example os.version="10">9.5.2-RedHat-9.5.2-1.fc10</example>
+    <example service.version="9.9.3-rl.13207.22-P2" os.version="19">9.9.3-rl.13207.22-P2-RedHat-9.9.3-5.P2.fc19</example>
+    <example os.version="10" service.version="9.5.2">9.5.2-RedHat-9.5.2-1.fc10</example>
     <param pos="0" name="service.vendor" value="ISC"/>
     <param pos="0" name="service.family" value="BIND"/>
     <param pos="0" name="service.product" value="BIND"/>
@@ -843,8 +843,8 @@
 
   <fingerprint pattern="^ALU DNS ([\d\.]+) Build (\d+)$">
     <description>ALU (Alcatel Lucent?) DNS</description>
-    <example service.version="6.2">ALU DNS 6.2 Build 22</example>
-    <example service.version.version="9">ALU DNS 6.2 Build 9</example>
+    <example service.version="6.2" service.version.version="22">ALU DNS 6.2 Build 22</example>
+    <example service.version.version="9" service.version="6.2">ALU DNS 6.2 Build 9</example>
     <param pos="0" name="service.vendor" value="ALU"/>
     <param pos="0" name="service.family" value="DNS"/>
     <param pos="0" name="service.product" value="DNS"/>
@@ -910,8 +910,8 @@
 
   <fingerprint pattern="^Meta IP[\s\/]DNS (?:V[\d\.]+ )?- BIND V([\d\.]+(?:-REL)?) \(Build (\d+)\s?\)$">
     <description>Check Point Meta IP</description>
-    <example service.version="8.2.7-REL">Meta IP DNS - BIND V8.2.7-REL (Build 31)</example>
-    <example service.version.version="4704">Meta IP/DNS V4.1 - BIND V8.1.2 (Build 4704 )</example>
+    <example service.version="8.2.7-REL" service.version.version="31">Meta IP DNS - BIND V8.2.7-REL (Build 31)</example>
+    <example service.version.version="4704" service.version="8.1.2">Meta IP/DNS V4.1 - BIND V8.1.2 (Build 4704 )</example>
     <param pos="0" name="service.vendor" value="Check Point"/>
     <param pos="0" name="service.family" value="META IP"/>
     <param pos="0" name="service.product" value="DNS"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -78,7 +78,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +FTP +Server \(Version ([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
     <description>FTP on HPUX with a PHNE (HP Networking patch) installed</description>
-    <example>example.com FTP server (Version 1.1.214.4(PHNE_38458) Mon Feb 15 06:03:12 GMT 2010) ready.</example>
+    <example host.name="example.com" service.version="1.1.214.4">example.com FTP server (Version 1.1.214.4(PHNE_38458) Mon Feb 15 06:03:12 GMT 2010) ready.</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="FTPD"/>
     <param pos="0" name="os.vendor" value="HP"/>
@@ -91,7 +91,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +FTP +Server \(Revision \S+ Version wuftpd-([^\(]+)\(PHNE_\d+\) [^\)]+\) ready.?$" flags="REG_ICASE">
     <description>WU-FTPD on HPUX with a PHNE (HP Networking patch) installed</description>
-    <example>example.com FTP server (Revision 1.1 Version wuftpd-2.6.1(PHNE_38578) Fri Sep 5 12:10:54 GMT 2008) ready.</example>
+    <example host.name="example.com" service.version="2.6.1">example.com FTP server (Revision 1.1 Version wuftpd-2.6.1(PHNE_38578) Fri Sep 5 12:10:54 GMT 2008) ready.</example>
     <param pos="0" name="service.vendor" value="Washington University"/>
     <param pos="0" name="service.product" value="WU-FTPD"/>
     <param pos="0" name="os.vendor" value="HP"/>
@@ -187,7 +187,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
 
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Debian\) \[(.+)\]$">
     <description>ProFTPD on Debian Linux</description>
-    <example>ProFTPD 1.3.0rc2 Server (Debian) [host]</example>
+    <example service.version="1.3.0rc2" host.name="host">ProFTPD 1.3.0rc2 Server (Debian) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
@@ -202,7 +202,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
 
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Linksys(W.+)\) \[(.+)\]$">
     <description>ProFTPD on a Linksys Wireless Access Point/Router</description>
-    <example>ProFTPD 1.3.0rc2 Server (LinksysWRT350N) [host]</example>
+    <example service.version="1.3.0rc2" os.product="WRT350N" host.name="host">ProFTPD 1.3.0rc2 Server (LinksysWRT350N) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
@@ -256,9 +256,9 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
 
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \((.*)\) \[(.+)\]$">
     <description>ProFTPD with version info but no obvious OS info</description>
-    <example service.version="1.2.10">ProFTPD 1.2.10 Server (Main FTP Server) [host]</example>
-    <example proftpd.server.name="ProFTPD">ProFTPD 1.2.10 Server (ProFTPD) [host]</example>
-    <example host.name="host">ProFTPD 1.2.10rc3 Server (ProFTPD Default Installation) [host]</example>
+    <example service.version="1.2.10" proftpd.server.name="Main FTP Server" host.name="host">ProFTPD 1.2.10 Server (Main FTP Server) [host]</example>
+    <example proftpd.server.name="ProFTPD" service.version="1.2.10" host.name="host">ProFTPD 1.2.10 Server (ProFTPD) [host]</example>
+    <example host.name="host" service.version="1.2.10rc3" proftpd.server.name="ProFTPD Default Installation">ProFTPD 1.2.10rc3 Server (ProFTPD Default Installation) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
@@ -333,9 +333,9 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
 
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \((.*)\) \[[a-f\d.:\]]*$">
     <description>ProFTPD with version info - truncated</description>
-    <example service.version="1.3.2c">ProFTPD 1.3.2c Server (ProFTPD Default Installation) [</example>
-    <example proftpd.server.name="svrname.hosting.com">ProFTPD 1.3.0 Server (svrname.hosting.com) [10.10.10.</example>
-    <example>ProFTPD 1.3.3a Server (randomstring) [::ff</example>
+    <example service.version="1.3.2c" proftpd.server.name="ProFTPD Default Installation">ProFTPD 1.3.2c Server (ProFTPD Default Installation) [</example>
+    <example proftpd.server.name="svrname.hosting.com" service.version="1.3.0">ProFTPD 1.3.0 Server (svrname.hosting.com) [10.10.10.</example>
+    <example service.version="1.3.3a" proftpd.server.name="randomstring">ProFTPD 1.3.3a Server (randomstring) [::ff</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
@@ -369,11 +369,11 @@ more stuff</example>
 
   <fingerprint pattern="^-{9,10}(?:.*)\s+Pure-FTPd\s+(.*)-{9,10}">
     <description>Pure-FTPd versions &gt;= 1.0.14 - Config data can be zero or more of: [privsep] [TLS]</description>
-    <example>---------- Welcome to Pure-FTPd ----------</example>
-    <example>--------- Bienvenido a Pure-FTPd [privsep] [TLS] ----------</example>
-    <example>---------  Pure-FTPd [privsep] ----------</example>
-    <example>--------- Welcome to Pure-FTPd [privsep] [TLS] ----------</example>
-    <example>--------- Welcome to Pure-FTPd [privsep] [TLS] ----------&#13;
+    <example pureftpd.config="-">---------- Welcome to Pure-FTPd ----------</example>
+    <example pureftpd.config="[privsep] [TLS] -">--------- Bienvenido a Pure-FTPd [privsep] [TLS] ----------</example>
+    <example pureftpd.config="[privsep] -">---------  Pure-FTPd [privsep] ----------</example>
+    <example pureftpd.config="[privsep] [TLS] -">--------- Welcome to Pure-FTPd [privsep] [TLS] ----------</example>
+    <example pureftpd.config="[privsep] [TLS] -">--------- Welcome to Pure-FTPd [privsep] [TLS] ----------&#13;
 more text</example>
     <param pos="1" name="pureftpd.config"/>
     <param pos="0" name="service.vendor" value="PureFTPd"/>
@@ -462,7 +462,7 @@ more text</example>
 
   <fingerprint pattern="^\(vsFTPd (\d+\..+)\)(?: (.+))?$">
     <description>vsFTPd (Very Secure FTP Daemon)</description>
-    <example service.version="1.1.3">(vsFTPd 1.1.3) host</example>
+    <example service.version="1.1.3" host.name="host">(vsFTPd 1.1.3) host</example>
     <example service.version="2.0.5">(vsFTPd 2.0.5)</example>
     <param pos="0" name="service.vendor" value="vsFTPd Project"/>
     <param pos="0" name="service.family" value="vsFTPd"/>
@@ -531,9 +531,9 @@ more text</example>
 
   <fingerprint pattern="^(\S{1,64}) Network Management Card AOS v(\d+\..+) FTP server ready\.$">
     <description>APC power/cooling device</description>
-    <example service.version="3.3.4">AP7932 Network Management Card AOS v3.3.4 FTP server ready.</example>
-    <example os.version="3.6.1">ACRC103 Network Management Card AOS v3.6.1 FTP server ready.</example>
-    <example os.product="0G-9354-01">0G-9354-01 Network Management Card AOS v3.6.1 FTP server ready.</example>
+    <example service.version="3.3.4" os.product="AP7932" os.version="3.3.4">AP7932 Network Management Card AOS v3.3.4 FTP server ready.</example>
+    <example os.version="3.6.1" service.version="3.6.1" os.product="ACRC103">ACRC103 Network Management Card AOS v3.6.1 FTP server ready.</example>
+    <example os.product="0G-9354-01" service.version="3.6.1" os.version="3.6.1">0G-9354-01 Network Management Card AOS v3.6.1 FTP server ready.</example>
     <param pos="0" name="service.vendor" value="APC"/>
     <param pos="0" name="service.product" value="AOS"/>
     <param pos="0" name="service.family" value="AOS"/>
@@ -548,9 +548,9 @@ more text</example>
 
   <fingerprint pattern="^(\S{1,512}) FTP server \(EMC-SNAS: ([^\)]+)\)(?: \S+)?$">
     <description>EMC Celerra</description>
-    <example service.version="5.6.47.11">foo2 FTP server (EMC-SNAS: 5.6.47.11)</example>
-    <example service.version="5.6.50.203">foo2 FTP server (EMC-SNAS: 5.6.50.203) ready.</example>
-    <example service.version="5.5.31.6">foo4 FTP server (EMC-SNAS: 5.5.31.6) r</example>
+    <example service.version="5.6.47.11" os.version="5.6.47.11" host.name="foo2">foo2 FTP server (EMC-SNAS: 5.6.47.11)</example>
+    <example service.version="5.6.50.203" os.version="5.6.50.203" host.name="foo2">foo2 FTP server (EMC-SNAS: 5.6.50.203) ready.</example>
+    <example service.version="5.5.31.6" os.version="5.5.31.6" host.name="foo4">foo4 FTP server (EMC-SNAS: 5.5.31.6) r</example>
     <param pos="0" name="service.vendor" value="EMC"/>
     <param pos="0" name="service.product" value="Celerra"/>
     <param pos="2" name="service.version"/>
@@ -617,7 +617,7 @@ more text</example>
 
   <fingerprint pattern="^[^ ]{1,512} IBM FTP CS (V1R\d+) at ([^,]*),">
     <description>IBM z/OS FTP Service</description>
-    <example>SFTPD1 IBM FTP CS V1R4 at x.y.z, 21:02:19 on 2007-12-15.</example>
+    <example os.version="V1R4" host.name="x.y.z">SFTPD1 IBM FTP CS V1R4 at x.y.z, 21:02:19 on 2007-12-15.</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="z/OS FTP Server"/>
     <param pos="0" name="os.vendor" value="IBM"/>
@@ -643,7 +643,7 @@ more text</example>
   <fingerprint pattern="^([^ ]{1,512}) NcFTPd Server \(licensed copy\) ready\.$">
     <description>NcFTPd Server
       http://www.ncftp.com/ncftpd/</description>
-    <example>ftp.example.com NcFTPd Server (licensed copy) ready.</example>
+    <example host.name="ftp.example.com">ftp.example.com NcFTPd Server (licensed copy) ready.</example>
     <param pos="0" name="service.vendor" value="NcFTP Software"/>
     <param pos="0" name="service.product" value="NcFTPd Server"/>
     <param pos="1" name="host.name"/>
@@ -651,7 +651,7 @@ more text</example>
 
   <fingerprint pattern="^(\S{1,512}) DCS-2100 FTP server ready\.$">
     <description>D-Link DCS-2100 wireless internet camera</description>
-    <example>hostname DCS-2100 FTP server ready.</example>
+    <example host.name="hostname">hostname DCS-2100 FTP server ready.</example>
     <param pos="0" name="os.vendor" value="D-Link"/>
     <param pos="0" name="os.product" value="DCS-2100"/>
     <param pos="0" name="os.device" value="IP Camera"/>
@@ -669,7 +669,7 @@ more text</example>
 
   <fingerprint pattern="^SUN StorEdge (\S+) RAID FTP server ready\.$">
     <description>Sun StorEdge disk array</description>
-    <example>SUN StorEdge 3511 RAID FTP server ready.</example>
+    <example os.product="3511">SUN StorEdge 3511 RAID FTP server ready.</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="StorEdge"/>
     <param pos="1" name="os.product"/>
@@ -695,9 +695,9 @@ more text</example>
 
   <fingerprint pattern="(?i)^AXIS (\S+) (?:(?:Mk II )?Video) (?:Encoder|Encoder Blade|Module|Server|Decoder) (\S+)">
     <description>Axis Video encoders/servers</description>
-    <example hw.product="Q7406">AXIS Q7406 Video Encoder Blade 5.01 (Aug 01 2008) ready.</example>
-    <example hw.product="241Q">AXIS 241Q Video Server 4.47.2 (Dec 11 2008) ready.</example>
-    <example hw.version="5.07.2">AXIS P7701 Video Decoder 5.07.2 (Apr 20 2010) ready.</example>
+    <example hw.product="Q7406" hw.version="Blade">AXIS Q7406 Video Encoder Blade 5.01 (Aug 01 2008) ready.</example>
+    <example hw.product="241Q" hw.version="4.47.2">AXIS 241Q Video Server 4.47.2 (Dec 11 2008) ready.</example>
+    <example hw.version="5.07.2" hw.product="P7701">AXIS P7701 Video Decoder 5.07.2 (Apr 20 2010) ready.</example>
     <example hw.product="Q7401" hw.version="5.01">AXIS Q7401 Video Encoder 5.01 (Aug 01 2008) ready.</example>
     <example hw.product="Q7401" hw.version="5.50.2_cst_412205_1">AXIS Q7401 Video Encoder 5.50.2_cst_412205_1 (2013)</example>
     <example hw.product="Q7424-R" hw.version="5.51.3.1">AXIS Q7424-R Mk II Video Encoder 5.51.3.1 (2016) ready.</example>
@@ -731,9 +731,9 @@ more text</example>
 
   <fingerprint pattern="^AXIS (\S+) .*FTP Network Print Server V?([\d\.]+\S+) .* ready\.?$" flags="REG_ICASE">
     <description>Axis print servers</description>
-    <example hw.product="5600+">AXIS 5600+ (rev 3) FTP Network Print Server V7.00 Sep 10 2004 ready.</example>
-    <example hw.product="560">AXIS 560 FTP Network Print Server V6.00 Jul 7 1999 ready.</example>
-    <example hw.version="6.30.beta2">AXIS 5470e FTP Network Print Server V6.30.beta2 Sep 25 2002 ready.</example>
+    <example hw.product="5600+" hw.version="7.00">AXIS 5600+ (rev 3) FTP Network Print Server V7.00 Sep 10 2004 ready.</example>
+    <example hw.product="560" hw.version="6.00">AXIS 560 FTP Network Print Server V6.00 Jul 7 1999 ready.</example>
+    <example hw.version="6.30.beta2" hw.product="5470e">AXIS 5470e FTP Network Print Server V6.30.beta2 Sep 25 2002 ready.</example>
     <param pos="0" name="hw.vendor" value="Axis"/>
     <param pos="0" name="hw.device" value="Print Server"/>
     <param pos="1" name="hw.product"/>
@@ -742,9 +742,9 @@ more text</example>
 
   <fingerprint pattern="^RICOH Aficio ((?:[MS]P )?\S+) FTP server \(([0-9\.a-zA-Z]+)\) ready.?$" flags="REG_ICASE">
     <description>Ricoh Aficio multifunction device</description>
-    <example os.product="2045e">RICOH Aficio 2045e FTP server (4.12) ready.</example>
-    <example os.version="8.63">RICOH Aficio SP 4210N FTP server (8.63) ready.</example>
-    <example hw.product="MP C3000">RICOH Aficio MP C3000 FTP server (5.11) ready.</example>
+    <example os.product="2045e" hw.product="2045e" os.version="4.12">RICOH Aficio 2045e FTP server (4.12) ready.</example>
+    <example os.version="8.63" hw.product="SP 4210N" os.product="SP 4210N">RICOH Aficio SP 4210N FTP server (8.63) ready.</example>
+    <example hw.product="MP C3000" os.product="MP C3000" os.version="5.11">RICOH Aficio MP C3000 FTP server (5.11) ready.</example>
     <param pos="0" name="hw.vendor" value="Ricoh"/>
     <param pos="0" name="hw.family" value="Aficio"/>
     <param pos="0" name="hw.device" value="Multifunction Device"/>
@@ -758,14 +758,14 @@ more text</example>
 
   <fingerprint pattern="^NRG ((?:[MS]P )?\S+) FTP server \(([0-9\.a-zA-Z]+)\) ready.?$" flags="REG_ICASE">
     <description>Ricoh NRG multifunction device</description>
-    <example>NRG MP C2800 FTP server (8.25) ready.</example>
-    <example>NRG MP 3350 FTP server (7.05) ready.</example>
-    <example>NRG MP C3500 FTP server (5.17) ready.</example>
-    <example>NRG MP 171 FTP server (9.02.1) ready.</example>
-    <example>NRG MP C2550 FTP server (8.25) ready.</example>
-    <example>NRG MP C3500 FTP server (5.19) ready.</example>
-    <example>NRG MP C4000 FTP server (8.30) ready.</example>
-    <example>NRG MP C4500 FTP server (5.14) ready.</example>
+    <example os.product="MP C2800" os.version="8.25" hw.product="MP C2800">NRG MP C2800 FTP server (8.25) ready.</example>
+    <example os.product="MP 3350" os.version="7.05" hw.product="MP 3350">NRG MP 3350 FTP server (7.05) ready.</example>
+    <example os.product="MP C3500" os.version="5.17" hw.product="MP C3500">NRG MP C3500 FTP server (5.17) ready.</example>
+    <example os.product="MP 171" os.version="9.02.1" hw.product="MP 171">NRG MP 171 FTP server (9.02.1) ready.</example>
+    <example os.product="MP C2550" os.version="8.25" hw.product="MP C2550">NRG MP C2550 FTP server (8.25) ready.</example>
+    <example os.product="MP C3500" os.version="5.19" hw.product="MP C3500">NRG MP C3500 FTP server (5.19) ready.</example>
+    <example os.product="MP C4000" os.version="8.30" hw.product="MP C4000">NRG MP C4000 FTP server (8.30) ready.</example>
+    <example os.product="MP C4500" os.version="5.14" hw.product="MP C4500">NRG MP C4500 FTP server (5.14) ready.</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -792,8 +792,8 @@ more text</example>
 
   <fingerprint pattern="^Xerox Phaser (\S+)$" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>
-    <example>Xerox Phaser 6130N</example>
-    <example>Xerox Phaser 6180MFP-D</example>
+    <example os.product="6130N" hw.product="6130N">Xerox Phaser 6130N</example>
+    <example os.product="6180MFP-D" hw.product="6180MFP-D">Xerox Phaser 6180MFP-D</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -806,7 +806,7 @@ more text</example>
 
   <fingerprint pattern="^XEROX (\d+) Wide Format" certainty="1.0">
     <description>Xerox Wide Format Series of Printers</description>
-    <example>XEROX 6204 Wide Format FTP server ready</example>
+    <example os.product="6204" hw.product="6204">XEROX 6204 Wide Format FTP server ready</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Wide Format"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -819,9 +819,9 @@ more text</example>
 
   <fingerprint pattern="^FUJI XEROX DocuPrint (.*)$" certainty="1.0">
     <description>FUJI XEROX DocuPrint Series of Printers</description>
-    <example>FUJI XEROX DocuPrint 3055</example>
-    <example>FUJI XEROX DocuPrint C1190 FS</example>
-    <example>FUJI XEROX DocuPrint C2100</example>
+    <example os.product="3055">FUJI XEROX DocuPrint 3055</example>
+    <example os.product="C1190 FS">FUJI XEROX DocuPrint C1190 FS</example>
+    <example os.product="C2100">FUJI XEROX DocuPrint C2100</example>
     <param pos="0" name="os.vendor" value="FUJI XEROX"/>
     <param pos="0" name="os.family" value="DocuPrint"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -930,8 +930,8 @@ more text</example>
 
   <fingerprint pattern="^TASKalfa (\d+c?i) FTP server" certainty="1.0">
     <description>Taskalfa Series of Printers</description>
-    <example>TASKalfa 300ci FTP server</example>
-    <example>TASKalfa 520i FTP server</example>
+    <example os.product="300ci" hw.product="300ci">TASKalfa 300ci FTP server</example>
+    <example os.product="520i" hw.product="520i">TASKalfa 520i FTP server</example>
     <param pos="0" name="os.vendor" value="Kyocera"/>
     <param pos="0" name="os.family" value="TASKalfa"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -944,16 +944,16 @@ more text</example>
 
   <fingerprint pattern="^SAVIN (\S+) FTP server \((.*)\) ready.$" certainty="1.0">
     <description>SAVIN Printer FTP Server</description>
-    <example os.product="4075">SAVIN 4075 FTP server (4.08) ready.</example>
-    <example hw.product="9025">SAVIN 9025 FTP server (7.23) ready.</example>
-    <example os.version="7.30">SAVIN 9050 FTP server (7.30) ready.</example>
-    <example os.version="9.03">SAVIN 917 FTP server (9.03) ready.</example>
-    <example>SAVIN 917 FTP server (9.05.2) ready.</example>
-    <example>SAVIN C2525 FTP server (5.14) ready.</example>
-    <example>SAVIN C3528 FTP server (4.08.3) ready.</example>
-    <example>SAVIN C3528 FTP server (4.17) ready.</example>
-    <example>SAVIN C6055 FTP server (7.16) ready.</example>
-    <example>SAVIN C9145 FTP server (10.51) ready.</example>
+    <example os.product="4075" os.version="4.08" hw.product="4075">SAVIN 4075 FTP server (4.08) ready.</example>
+    <example hw.product="9025" os.product="9025" os.version="7.23">SAVIN 9025 FTP server (7.23) ready.</example>
+    <example os.version="7.30" os.product="9050" hw.product="9050">SAVIN 9050 FTP server (7.30) ready.</example>
+    <example os.version="9.03" os.product="917" hw.product="917">SAVIN 917 FTP server (9.03) ready.</example>
+    <example os.product="917" os.version="9.05.2" hw.product="917">SAVIN 917 FTP server (9.05.2) ready.</example>
+    <example os.product="C2525" os.version="5.14" hw.product="C2525">SAVIN C2525 FTP server (5.14) ready.</example>
+    <example os.product="C3528" os.version="4.08.3" hw.product="C3528">SAVIN C3528 FTP server (4.08.3) ready.</example>
+    <example os.product="C3528" os.version="4.17" hw.product="C3528">SAVIN C3528 FTP server (4.17) ready.</example>
+    <example os.product="C6055" os.version="7.16" hw.product="C6055">SAVIN C6055 FTP server (7.16) ready.</example>
+    <example os.product="C9145" os.version="10.51" hw.product="C9145">SAVIN C9145 FTP server (10.51) ready.</example>
     <param pos="0" name="os.vendor" value="Savin"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -965,8 +965,8 @@ more text</example>
 
   <fingerprint pattern="^Oce (im\d+) Ver (\S+) FTP server\.$" certainty="1.0">
     <description>OCE IM series Printer</description>
-    <example>Oce im4512 Ver 01.04.00.0c FTP server.</example>
-    <example>Oce im3512 Ver 01.04.00.0c FTP server.</example>
+    <example os.product="im4512" os.version="01.04.00.0c">Oce im4512 Ver 01.04.00.0c FTP server.</example>
+    <example os.product="im3512" os.version="01.04.00.0c">Oce im3512 Ver 01.04.00.0c FTP server.</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.family" value="IM Series"/>
@@ -976,7 +976,7 @@ more text</example>
 
   <fingerprint pattern="^Oce (Plotwave\d+) FTP Service \(Version (\S+)\)\.$" certainty="1.0">
     <description>OCE Printer</description>
-    <example>Oce Plotwave300 FTP Service (Version 4.5.7).</example>
+    <example os.product="Plotwave300" os.version="4.5.7">Oce Plotwave300 FTP Service (Version 4.5.7).</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="Plotwave Series"/>
@@ -1005,10 +1005,10 @@ more text</example>
 
   <fingerprint pattern="^LXKE\S+ IBM Infoprint (\d+) FTP Server (\d+\.\d+\.\d+) ready.$" certainty="1.0">
     <description>IBM Infoprint FTP</description>
-    <example>LXKE82124 IBM Infoprint 1332 FTP Server 55.10.21 ready.</example>
-    <example>LXKE8255D IBM Infoprint 1332 FTP Server 55.10.21 ready.</example>
-    <example>LXKE825A0 IBM Infoprint 1332 FTP Server 55.10.21 ready.</example>
-    <example>LXKE93276 IBM Infoprint 1332 FTP Server 55.10.19 ready.</example>
+    <example os.product="1332" os.version="55.10.21">LXKE82124 IBM Infoprint 1332 FTP Server 55.10.21 ready.</example>
+    <example os.product="1332" os.version="55.10.21">LXKE8255D IBM Infoprint 1332 FTP Server 55.10.21 ready.</example>
+    <example os.product="1332" os.version="55.10.21">LXKE825A0 IBM Infoprint 1332 FTP Server 55.10.21 ready.</example>
+    <example os.product="1332" os.version="55.10.19">LXKE93276 IBM Infoprint 1332 FTP Server 55.10.19 ready.</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Infoprint"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1020,9 +1020,9 @@ more text</example>
     <description>Gestetner Printer FTP</description>
     <example os.product="Gestetner MP5500/DSm755" os.version="5.11c">Gestetner MP5500/DSm755 FTP server (5.11c) ready.</example>
     <example os.product="Gestetner MP C4502" os.version="11.77">Gestetner MP C4502 FTP server (11.77) ready.</example>
-    <example>Gestetner MP 161/DSm416 FTP server (6.11) ready. </example>
-    <example>Gestetner 3502 FTP server (1.66.1) ready</example>
-    <example>Gestetner C7526dn FTP server (6.05.1) ready.</example>
+    <example os.product="Gestetner MP 161/DSm416" os.version="6.11">Gestetner MP 161/DSm416 FTP server (6.11) ready. </example>
+    <example os.product="Gestetner 3502" os.version="1.66.1">Gestetner 3502 FTP server (1.66.1) ready</example>
+    <example os.product="Gestetner C7526dn" os.version="6.05.1">Gestetner C7526dn FTP server (6.05.1) ready.</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -1031,7 +1031,7 @@ more text</example>
 
   <fingerprint pattern="^(Gestetner \S+)$" certainty="1.0">
     <description>Gestetner Printer FTP - short banner</description>
-    <example>Gestetner MPC2500</example>
+    <example os.product="Gestetner MPC2500">Gestetner MPC2500</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -1039,7 +1039,7 @@ more text</example>
 
   <fingerprint pattern="^EUFSALE MarkNet (\S+) FTP Server (\d+\.\d+\.\d+) ready.$" certainty="1.0">
     <description>Lexmark Marknet Printers FTP</description>
-    <example>EUFSALE MarkNet X2011e FTP Server 4.20.21 ready.</example>
+    <example os.product="X2011e" os.version="4.20.21">EUFSALE MarkNet X2011e FTP Server 4.20.21 ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="MarkNet"/>
     <param pos="0" name="os.device" value="Print Server"/>
@@ -1049,9 +1049,9 @@ more text</example>
 
   <fingerprint pattern="^ET(\S{1,12}) Source Technologies (ST-96\S+) FTP Server (\S+) ready\.?$">
     <description>Source Technologies ST9600 Series Secure Printer</description>
-    <example>ET0021B730F70E Source Technologies ST-9620 FTP Server NJ.APS.N254e ready.</example>
-    <example>ET0021B7549AF2 Source Technologies ST-9620 FTP Server NR.APS.N447b2 ready.</example>
-    <example>ET0021B7300F01 Source Technologies ST-9620 FTP Server NJ.APS.N254e ready.</example>
+    <example host.mac="0021B730F70E" os.product="ST-9620" os.version="NJ.APS.N254e">ET0021B730F70E Source Technologies ST-9620 FTP Server NJ.APS.N254e ready.</example>
+    <example host.mac="0021B7549AF2" os.product="ST-9620" os.version="NR.APS.N447b2">ET0021B7549AF2 Source Technologies ST-9620 FTP Server NR.APS.N447b2 ready.</example>
+    <example host.mac="0021B7300F01" os.product="ST-9620" os.version="NJ.APS.N254e">ET0021B7300F01 Source Technologies ST-9620 FTP Server NJ.APS.N254e ready.</example>
     <param pos="0" name="os.vendor" value="Source Technologies"/>
     <param pos="0" name="os.family" value="ST9600 Series"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1075,7 +1075,7 @@ more text</example>
 
   <fingerprint pattern="^ET(\S{1,12}) Lexmark Forms Printer (\d+) Ethernet FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Lexmark Forms Printer</description>
-    <example os.product="2590">ET0020004F54EE Lexmark Forms Printer 2590 Ethernet FTP Server LCL.CU.P012c ready.</example>
+    <example os.product="2590" host.mac="0020004F54EE" os.version="LCL.CU.P012c" hw.product="2590">ET0020004F54EE Lexmark Forms Printer 2590 Ethernet FTP Server LCL.CU.P012c ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="Forms Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1090,8 +1090,8 @@ more text</example>
 
   <fingerprint pattern="^ET(\S{1,12}) TOSHIBA e-STUDIO500S FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Toshiba e-STUDIO Printer with MAC address</description>
-    <example os.version="NC2.NPS.N221">ET0004001E9C00 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N221 ready.</example>
-    <example host.mac="00040089BE42">ET00040089BE42 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N211 ready.</example>
+    <example os.version="NC2.NPS.N221" host.mac="0004001E9C00">ET0004001E9C00 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N221 ready.</example>
+    <example host.mac="00040089BE42" os.version="NC2.NPS.N211">ET00040089BE42 TOSHIBA e-STUDIO500S FTP Server NC2.NPS.N211 ready.</example>
     <param pos="0" name="os.vendor" value="Toshiba"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.product" value="e-STUDIO"/>
@@ -1116,8 +1116,8 @@ more text</example>
 
   <fingerprint pattern="Lexmark Optra (\S+) FTP Server (\S+) ready\.$" certainty="1.0">
     <description>Lexmark Optra Printer</description>
-    <example os.product="T612">lex142785470853 Lexmark Optra T612 FTP Server 3.20.30 ready.</example>
-    <example os.version="3.20.20">oppr1.s02504.us Lexmark Optra T610 FTP Server 3.20.20 ready.</example>
+    <example os.product="T612" os.version="3.20.30" hw.product="T612">lex142785470853 Lexmark Optra T612 FTP Server 3.20.30 ready.</example>
+    <example os.version="3.20.20" os.product="T610" hw.product="T610">oppr1.s02504.us Lexmark Optra T610 FTP Server 3.20.20 ready.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="Optra"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1131,15 +1131,15 @@ more text</example>
 
   <fingerprint pattern="^SHARP (MX-\S+) Ver (\S+) FTP server\.$" certainty="1.0">
     <description>Sharp Printer/Copier/Scanne</description>
-    <example os.product="MX-6200N" os.version="01.02.00.0e">SHARP MX-6200N Ver 01.02.00.0e FTP server.</example>
-    <example>SHARP MX-M363N Ver 01.05.00.0k FTP server.</example>
-    <example>SHARP MX-M363N Ver 01.05.00.1k FTP server.</example>
-    <example>SHARP MX-5001N Ver 01.05.00.0n FTP server.</example>
-    <example>SHARP MX-5500N Ver 01.02.00.09 FTP server.</example>
-    <example>SHARP MX-M453N Ver 01.05.00.0k FTP server.</example>
-    <example>SHARP MX-M503N Ver 01.05.00.1k FTP server.</example>
-    <example>SHARP MX-M620U Ver 01.03.00 FTP server.</example>
-    <example>SHARP MX-M620U Ver 01.04.00.04 FTP server.</example>
+    <example os.product="MX-6200N" os.version="01.02.00.0e" hw.product="MX-6200N">SHARP MX-6200N Ver 01.02.00.0e FTP server.</example>
+    <example os.product="MX-M363N" os.version="01.05.00.0k" hw.product="MX-M363N">SHARP MX-M363N Ver 01.05.00.0k FTP server.</example>
+    <example os.product="MX-M363N" os.version="01.05.00.1k" hw.product="MX-M363N">SHARP MX-M363N Ver 01.05.00.1k FTP server.</example>
+    <example os.product="MX-5001N" os.version="01.05.00.0n" hw.product="MX-5001N">SHARP MX-5001N Ver 01.05.00.0n FTP server.</example>
+    <example os.product="MX-5500N" os.version="01.02.00.09" hw.product="MX-5500N">SHARP MX-5500N Ver 01.02.00.09 FTP server.</example>
+    <example os.product="MX-M453N" os.version="01.05.00.0k" hw.product="MX-M453N">SHARP MX-M453N Ver 01.05.00.0k FTP server.</example>
+    <example os.product="MX-M503N" os.version="01.05.00.1k" hw.product="MX-M503N">SHARP MX-M503N Ver 01.05.00.1k FTP server.</example>
+    <example os.product="MX-M620U" os.version="01.03.00" hw.product="MX-M620U">SHARP MX-M620U Ver 01.03.00 FTP server.</example>
+    <example os.product="MX-M620U" os.version="01.04.00.04" hw.product="MX-M620U">SHARP MX-M620U Ver 01.04.00.04 FTP server.</example>
     <param pos="0" name="os.vendor" value="Sharp"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="MX Series"/>
@@ -1153,9 +1153,9 @@ more text</example>
 
   <fingerprint pattern="^(FS-\S+MFP\S*?) FTP server\.?$" certainty="1.0">
     <description>Kyocera Printer with version string</description>
-    <example os.product="FS-C2126MFP">FS-C2126MFP FTP server</example>
-    <example hw.product="FS-C2026MFP+">FS-C2026MFP+ FTP server</example>
-    <example hw.product="FS-1128MFP">FS-1128MFP FTP server</example>
+    <example os.product="FS-C2126MFP" hw.product="FS-C2126MFP">FS-C2126MFP FTP server</example>
+    <example hw.product="FS-C2026MFP+" os.product="FS-C2026MFP+">FS-C2026MFP+ FTP server</example>
+    <example hw.product="FS-1128MFP" os.product="FS-1128MFP">FS-1128MFP FTP server</example>
     <param pos="0" name="os.vendor" value="Kyocera"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -1166,8 +1166,8 @@ more text</example>
 
   <fingerprint pattern="^(FS-\S+(?:DN|D|N)) FTP server\.?$" certainty="1.0">
     <description>Kyocera Printer</description>
-    <example os.product="FS-1370DN">FS-1370DN FTP server</example>
-    <example hw.product="FS-C5015N">FS-C5015N FTP server.</example>
+    <example os.product="FS-1370DN" hw.product="FS-1370DN">FS-1370DN FTP server</example>
+    <example hw.product="FS-C5015N" os.product="FS-C5015N">FS-C5015N FTP server.</example>
     <param pos="0" name="os.vendor" value="Kyocera"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="FS"/>
@@ -1180,16 +1180,16 @@ more text</example>
 
   <fingerprint pattern="^(ESI-\S+) Version (\S+) ready\.$" certainty="1.0">
     <description>Extended Systems ExtendNet Print Server</description>
-    <example os.product="ESI-2941B">ESI-2941B Version 6.34 ready.</example>
-    <example os.version="6.03">ESI-2941A Version 6.03 ready.</example>
-    <example hw.product="ESI-2933A">ESI-2933A Version 6.40 ready.</example>
-    <example>ESI-2831 Version 2.1 ready.</example>
-    <example>ESI-2833A Version 6.3 ready.</example>
-    <example>ESI-2900A Version 6.31 ready.</example>
-    <example>ESI-2841B Version 3.01 ready.</example>
-    <example>ESI-2841C Version 5.09e ready.</example>
-    <example>ESI-2933A Version 6.40a.05 ready.</example>
-    <example>ESI-2999A Version 6.30a.07 ready.</example>
+    <example os.product="ESI-2941B" os.version="6.34" hw.product="ESI-2941B">ESI-2941B Version 6.34 ready.</example>
+    <example os.version="6.03" os.product="ESI-2941A" hw.product="ESI-2941A">ESI-2941A Version 6.03 ready.</example>
+    <example hw.product="ESI-2933A" os.product="ESI-2933A" os.version="6.40">ESI-2933A Version 6.40 ready.</example>
+    <example os.product="ESI-2831" os.version="2.1" hw.product="ESI-2831">ESI-2831 Version 2.1 ready.</example>
+    <example os.product="ESI-2833A" os.version="6.3" hw.product="ESI-2833A">ESI-2833A Version 6.3 ready.</example>
+    <example os.product="ESI-2900A" os.version="6.31" hw.product="ESI-2900A">ESI-2900A Version 6.31 ready.</example>
+    <example os.product="ESI-2841B" os.version="3.01" hw.product="ESI-2841B">ESI-2841B Version 3.01 ready.</example>
+    <example os.product="ESI-2841C" os.version="5.09e" hw.product="ESI-2841C">ESI-2841C Version 5.09e ready.</example>
+    <example os.product="ESI-2933A" os.version="6.40a.05" hw.product="ESI-2933A">ESI-2933A Version 6.40a.05 ready.</example>
+    <example os.product="ESI-2999A" os.version="6.30a.07" hw.product="ESI-2999A">ESI-2999A Version 6.30a.07 ready.</example>
     <param pos="0" name="os.vendor" value="Sybase"/>
     <param pos="0" name="os.family" value="Extended Systems ExtendNet"/>
     <param pos="0" name="os.device" value="Print Server"/>
@@ -1203,7 +1203,7 @@ more text</example>
   <fingerprint pattern="^SATO SATO PRINTER Ver (\S+) FTP server\.$" certainty="1.0">
     <description>SATO Printer</description>
     <example os.version="A1.2.3">SATO SATO PRINTER Ver A1.2.3 FTP server.</example>
-    <example>SATO SATO PRINTER Ver A2.3.0 FTP server.</example>
+    <example os.version="A2.3.0">SATO SATO PRINTER Ver A2.3.0 FTP server.</example>
     <param pos="0" name="os.vendor" value="SATO"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.version"/>
@@ -1213,11 +1213,11 @@ more text</example>
 
   <fingerprint pattern="^Printer FTP (\d+\.\d+\.\d+) ready at (\w{3} \d{2} \d{2}:\d{2}:\d{2})$" certainty="1.0">
     <description>AMTDatasouth Fastmark M5</description>
-    <example os.version="4.8.7">Printer FTP 4.8.7 ready at Apr 30 20:13:23</example>
-    <example system.time="Aug 31 16:43:22">Printer FTP 4.8.7 ready at Aug 31 16:43:22</example>
-    <example>Printer FTP 4.8.7 ready at Feb 28 11:27:46</example>
-    <example>Printer FTP 4.8.7 ready at Jan 31 00:40:04</example>
-    <example>Printer FTP 4.8.7 ready at Mar 31 06:28:25</example>
+    <example os.version="4.8.7" system.time="Apr 30 20:13:23">Printer FTP 4.8.7 ready at Apr 30 20:13:23</example>
+    <example system.time="Aug 31 16:43:22" os.version="4.8.7">Printer FTP 4.8.7 ready at Aug 31 16:43:22</example>
+    <example os.version="4.8.7" system.time="Feb 28 11:27:46">Printer FTP 4.8.7 ready at Feb 28 11:27:46</example>
+    <example os.version="4.8.7" system.time="Jan 31 00:40:04">Printer FTP 4.8.7 ready at Jan 31 00:40:04</example>
+    <example os.version="4.8.7" system.time="Mar 31 06:28:25">Printer FTP 4.8.7 ready at Mar 31 06:28:25</example>
     <param pos="0" name="os.vendor" value="AMTDatasouth"/>
     <param pos="0" name="os.product" value="Fastmark M5"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1243,7 +1243,7 @@ more text</example>
 
   <fingerprint pattern="^SHARP (AR-\S+) Ver (\S+) FTP server">
     <description>Sharp AR Series multifunction device</description>
-    <example os.product="AR-M450">SHARP AR-M450 Ver 01.05.00.0k FTP server.</example>
+    <example os.product="AR-M450" os.version="01.05.00.0k" hw.product="AR-M450">SHARP AR-M450 Ver 01.05.00.0k FTP server.</example>
     <param pos="0" name="os.vendor" value="Sharp"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.family" value="AR Series"/>
@@ -1271,13 +1271,13 @@ more text</example>
   <fingerprint pattern="^(KM\S+) FTP server \(KM FTPD version (\d*(?:\.\d*))\) ready\.?$">
     <description>Konica Minolta FTP Server</description>
     <example os.product="KM23BC97" service.version="1.00">KM23BC97 FTP server (KM FTPD version 1.00) ready.</example>
-    <example>KM23BF0A FTP server (KM FTPD version 1.00) ready.</example>
-    <example>KM23CBDB FTP server (KM FTPD version 1.00) ready.</example>
-    <example>KM23E608 FTP server (KM FTPD version 1.00) ready.</example>
-    <example>KM23E8A2 FTP server (KM FTPD version 1.00) ready.</example>
-    <example>KM25015E FTP server (KM FTPD version 1.00) ready.</example>
-    <example>KM250E38 FTP server (KM FTPD version 1.00) ready.</example>
-    <example>KM251A4C FTP server (KM FTPD version 1.00) ready.</example>
+    <example os.product="KM23BF0A" service.version="1.00">KM23BF0A FTP server (KM FTPD version 1.00) ready.</example>
+    <example os.product="KM23CBDB" service.version="1.00">KM23CBDB FTP server (KM FTPD version 1.00) ready.</example>
+    <example os.product="KM23E608" service.version="1.00">KM23E608 FTP server (KM FTPD version 1.00) ready.</example>
+    <example os.product="KM23E8A2" service.version="1.00">KM23E8A2 FTP server (KM FTPD version 1.00) ready.</example>
+    <example os.product="KM25015E" service.version="1.00">KM25015E FTP server (KM FTPD version 1.00) ready.</example>
+    <example os.product="KM250E38" service.version="1.00">KM250E38 FTP server (KM FTPD version 1.00) ready.</example>
+    <example os.product="KM251A4C" service.version="1.00">KM251A4C FTP server (KM FTPD version 1.00) ready.</example>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.vendor" value="Konica Minolta"/>
     <param pos="1" name="os.product"/>
@@ -1288,9 +1288,9 @@ more text</example>
 
   <fingerprint pattern="^(ZBR-\d+) Version (\S+) ready\.?$">
     <description>ZebraNet Print Server FTP</description>
-    <example os.product="ZBR-46686">ZBR-46686 Version 7.02 ready.</example>
-    <example os.version="V56.17.5Z">ZBR-79071 Version V56.17.5Z ready.</example>
-    <example os.version="7.02">ZBR-46687 Version 7.02 ready.</example>
+    <example os.product="ZBR-46686" os.version="7.02" hw.product="ZBR-46686">ZBR-46686 Version 7.02 ready.</example>
+    <example os.version="V56.17.5Z" os.product="ZBR-79071" hw.product="ZBR-79071">ZBR-79071 Version V56.17.5Z ready.</example>
+    <example os.version="7.02" os.product="ZBR-46687" hw.product="ZBR-46687">ZBR-46687 Version 7.02 ready.</example>
     <param pos="0" name="os.vendor" value="ZebraNet"/>
     <param pos="0" name="os.device" value="Print Server"/>
     <param pos="1" name="os.product"/>
@@ -1641,8 +1641,8 @@ more text</example>
 
   <fingerprint pattern="^TiMOS-[CB]-([\S]+) cpm\/[\w]+ ALCATEL (SR [\S]+) Copyright .{1,4}$">
     <description>ALCATEL Service Router running TiMOS</description>
-    <example os.version="13.0.R9">TiMOS-C-13.0.R9 cpm/hops64 ALCATEL SR 7750 Copyright (</example>
-    <example hw.product="SR 7750">TiMOS-C-9.0.R8 cpm/hops ALCATEL SR 7750 Copyright (c) </example>
+    <example os.version="13.0.R9" hw.product="SR 7750">TiMOS-C-13.0.R9 cpm/hops64 ALCATEL SR 7750 Copyright (</example>
+    <example hw.product="SR 7750" os.version="9.0.R8">TiMOS-C-9.0.R8 cpm/hops ALCATEL SR 7750 Copyright (c) </example>
     <param pos="0" name="os.vendor" value="ALCATEL"/>
     <param pos="1" name="os.version"/>
     <param pos="0" name="hw.vendor" value="ALCATEL"/>
@@ -1774,7 +1774,7 @@ more text</example>
 
   <fingerprint pattern="^Welcome to Honeywell Printer (PM\d+)\S+?$">
     <description>Honeywell Thermal Label Printer (Previously Intermec)</description>
-    <example hw.product="Thermal Label Printer PM43">Welcome to Honeywell Printer PM43c</example>
+    <example hw.product="Thermal Label Printer PM43" hw.model="PM43">Welcome to Honeywell Printer PM43c</example>
     <param pos="0" name="hw.vendor" value="Honeywell"/>
     <param pos="1" name="hw.model"/>
     <param pos="0" name="hw.product" value="Thermal Label Printer {hw.model}"/>
@@ -1786,8 +1786,8 @@ more text</example>
 
   <fingerprint pattern="^SurgeFTP ([\S]+) \(Version ([a-f\d.]+)\)$">
     <description>NetWin SurgeFTP</description>
-    <example service.version="2.3a12">SurgeFTP 192.168.0.0 (Version 2.3a12)</example>
-    <example host.name="foo.bar.baz">SurgeFTP foo.bar.baz (Version 2.2f9)</example>
+    <example service.version="2.3a12" host.name="192.168.0.0">SurgeFTP 192.168.0.0 (Version 2.3a12)</example>
+    <example host.name="foo.bar.baz" service.version="2.2f9">SurgeFTP foo.bar.baz (Version 2.2f9)</example>
     <param pos="0" name="service.vendor" value="NetWin"/>
     <param pos="0" name="service.product" value="SurgeFTP"/>
     <param pos="2" name="service.version"/>

--- a/xml/h323_callresp.xml
+++ b/xml/h323_callresp.xml
@@ -91,7 +91,7 @@
 
   <fingerprint pattern="^0x0900003d\:(.*)\:.*?(\d*\.*\d*\.*\d*)" flags="REG_ICASE">
     <description>Equivalence (OpenH323) H.323 Server</description>
-    <example>0x0900003D:Null Team YATE:3.3.2 (OpenH323 v1.19.0)</example>
+    <example service.product="Null Team YATE" service.version="3.3.2">0x0900003D:Null Team YATE:3.3.2 (OpenH323 v1.19.0)</example>
     <param pos="0" name="service.vendor" value="Equivalence (OpenH323)"/>
     <param pos="1" name="service.product"/>
     <param pos="2" name="service.version"/>
@@ -596,7 +596,7 @@
 
   <fingerprint pattern="^0xb5002331\:(.*)\:Release\s[\s-]*(\d+\.+\d+\.*\d*)" flags="REG_ICASE">
     <description>ViaVideo/PolyCom H.323 Server</description>
-    <example>0xb5002331:ViewStation 7.0:Release 7.5.4 - 04 Mar 2005</example>
+    <example service.product="ViewStation 7.0" service.version="7.5.4">0xb5002331:ViewStation 7.0:Release 7.5.4 - 04 Mar 2005</example>
     <param pos="0" name="service.vendor" value="ViaVideo/PolyCom"/>
     <param pos="1" name="service.product"/>
     <param pos="2" name="service.version"/>

--- a/xml/hp_pjl_id.xml
+++ b/xml/hp_pjl_id.xml
@@ -15,11 +15,11 @@
 
   <fingerprint pattern="(?i)laserjet (.*)(?: series)?">
     <description>HP JetDirect Printer</description>
-    <example>HP LaserJet 4100 Series</example>
-    <example>HP LaserJet 2200</example>
-    <example>LASERJET 4050</example>
-    <example>LASERJET 4 PLUS</example>
-    <example>HP LaserJet Professional P1606dn</example>
+    <example os.product="4100 Series">HP LaserJet 4100 Series</example>
+    <example os.product="2200">HP LaserJet 2200</example>
+    <example os.product="4050">LASERJET 4050</example>
+    <example os.product="4 PLUS">LASERJET 4 PLUS</example>
+    <example os.product="Professional P1606dn">HP LaserJet Professional P1606dn</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="JetDirect"/>
     <param pos="0" name="service.family" value="JetDirect"/>
@@ -31,10 +31,10 @@
 
   <fingerprint pattern="(?i)(designjet \S+)">
     <description>HP Designjet printer</description>
-    <example>hp designjet 110plus</example>
-    <example>DESIGNJET 1050C</example>
-    <example>DESIGNJET 1055CM</example>
-    <example>DESIGNJET 700</example>
+    <example os.product="designjet 110plus">hp designjet 110plus</example>
+    <example os.product="DESIGNJET 1050C">DESIGNJET 1050C</example>
+    <example os.product="DESIGNJET 1055CM">DESIGNJET 1055CM</example>
+    <example os.product="DESIGNJET 700">DESIGNJET 700</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="JetDirect"/>
     <param pos="0" name="service.family" value="JetDirect"/>
@@ -46,9 +46,9 @@
 
   <fingerprint pattern="^Xerox ColorQube (\S+)$">
     <description>Xerox ColorQube Multifunction Printer</description>
-    <example>Xerox ColorQube 8570DN</example>
-    <example>Xerox ColorQube 8570DT</example>
-    <example>Xerox ColorQube 8570N</example>
+    <example os.product="8570DN">Xerox ColorQube 8570DN</example>
+    <example os.product="8570DT">Xerox ColorQube 8570DT</example>
+    <example os.product="8570N">Xerox ColorQube 8570N</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="ColorQube"/>
     <param pos="1" name="os.product"/>
@@ -57,7 +57,7 @@
 
   <fingerprint pattern="^Brother (.+)$">
     <description>Brother Printer</description>
-    <example>Brother HL-1660e</example>
+    <example os.product="HL-1660e">Brother HL-1660e</example>
     <param pos="0" name="os.vendor" value="Brother"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -67,9 +67,9 @@
 
   <fingerprint pattern="^(iR ?\S+)">
     <description>Canon iR multifunction device</description>
-    <example>iR 3180C EUR</example>
-    <example>iR C4080/C4580</example>
-    <example>iR1020/1024/1025</example>
+    <example os.product="iR 3180C">iR 3180C EUR</example>
+    <example os.product="iR C4080/C4580">iR C4080/C4580</example>
+    <example os.product="iR1020/1024/1025">iR1020/1024/1025</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.family" value="iR Series"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -78,16 +78,16 @@
 
   <fingerprint pattern="^(?:Dell (?:Color Laser |Laser Printer )?|(?:Color Laser |Laser Printer ))(\d+(?:n|cn|dn|cdn))(?: Color Laser| Laser Printer)?$">
     <description>Dell Laser Printer</description>
-    <example>Dell Laser Printer 1710n</example>
-    <example>Dell Color Laser 3110cn</example>
-    <example>Laser Printer 5100cn</example>
-    <example>Dell 2130cn Color Laser</example>
-    <example>Dell 2330dn Laser Printer</example>
-    <example>Dell 2350dn Laser Printer</example>
-    <example>Dell 3130cn Color Laser</example>
-    <example>Dell 5130cdn Color Laser</example>
-    <example>Dell 5230n Laser Printer</example>
-    <example>Dell 2145cn</example>
+    <example os.product="1710n">Dell Laser Printer 1710n</example>
+    <example os.product="3110cn">Dell Color Laser 3110cn</example>
+    <example os.product="5100cn">Laser Printer 5100cn</example>
+    <example os.product="2130cn">Dell 2130cn Color Laser</example>
+    <example os.product="2330dn">Dell 2330dn Laser Printer</example>
+    <example os.product="2350dn">Dell 2350dn Laser Printer</example>
+    <example os.product="3130cn">Dell 3130cn Color Laser</example>
+    <example os.product="5130cdn">Dell 5130cdn Color Laser</example>
+    <example os.product="5230n">Dell 5230n Laser Printer</example>
+    <example os.product="2145cn">Dell 2145cn</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="Laser Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -96,8 +96,8 @@
 
   <fingerprint pattern="^Dell (\d+(?:n|cn|dn|cdn)) MFP$">
     <description>Dell Laser multifunction device</description>
-    <example>Dell 2135cn MFP</example>
-    <example>Dell 2335dn MFP</example>
+    <example os.product="2135cn">Dell 2135cn MFP</example>
+    <example os.product="2335dn">Dell 2335dn MFP</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="Laser Printer"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -106,7 +106,7 @@
 
   <fingerprint pattern="^HP (\S+ Digital Sender)$">
     <description>HP Digital Sender scanner</description>
-    <example>HP 9250C Digital Sender</example>
+    <example os.product="9250C Digital Sender">HP 9250C Digital Sender</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Scanner"/>
     <param pos="0" name="os.family" value="Digital Sender"/>
@@ -123,7 +123,7 @@
 
   <fingerprint pattern="^KM-(.*)$">
     <description>Konica Minolta printer</description>
-    <example>KM-5050</example>
+    <example os.product="5050">KM-5050</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -131,9 +131,9 @@
 
   <fingerprint pattern="^(FS-\S+MFP\S*)$">
     <description>Kyocera Mita Multifunction device</description>
-    <example>FS-C2126MFP</example>
-    <example>FS-C2126MFP+</example>
-    <example>FS-1035MFP/DP</example>
+    <example os.product="FS-C2126MFP">FS-C2126MFP</example>
+    <example os.product="FS-C2126MFP+">FS-C2126MFP+</example>
+    <example os.product="FS-1035MFP/DP">FS-1035MFP/DP</example>
     <param pos="0" name="os.vendor" value="Kyocera Mita"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.family" value="FS"/>
@@ -142,9 +142,9 @@
 
   <fingerprint pattern="^(FS-(?:C)?\d+(?:D|DN))$">
     <description>Kyocera Mita Printer</description>
-    <example>FS-C8500DN</example>
-    <example>FS-4100DN</example>
-    <example>FS-2020D</example>
+    <example os.product="FS-C8500DN">FS-C8500DN</example>
+    <example os.product="FS-4100DN">FS-4100DN</example>
+    <example os.product="FS-2020D">FS-2020D</example>
     <param pos="0" name="os.vendor" value="Kyocera Mita"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.family" value="FS"/>
@@ -153,9 +153,9 @@
 
   <fingerprint pattern="^(TASKalfa \S+)$">
     <description>Kyocera Mita TASKalfa multifunction device</description>
-    <example>TASKalfa 300ci</example>
-    <example>TASKalfa 520i</example>
-    <example>TASKalfa 250ci</example>
+    <example os.product="TASKalfa 300ci">TASKalfa 300ci</example>
+    <example os.product="TASKalfa 520i">TASKalfa 520i</example>
+    <example os.product="TASKalfa 250ci">TASKalfa 250ci</example>
     <param pos="0" name="os.vendor" value="Kyocera Mita"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.family" value="TASKalfa"/>
@@ -164,9 +164,9 @@
 
   <fingerprint pattern="^Lexmark (.*)$">
     <description>Lexmark JetDirect printer</description>
-    <example>Lexmark C910</example>
-    <example>Lexmark Optra LaserPrinter</example>
-    <example>Lexmark Optra S 1250</example>
+    <example os.product="C910">Lexmark C910</example>
+    <example os.product="Optra LaserPrinter">Lexmark Optra LaserPrinter</example>
+    <example os.product="Optra S 1250">Lexmark Optra S 1250</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -183,7 +183,7 @@
 
   <fingerprint pattern="(?i)^Oce (VL\S+):">
     <description>Oce VarioLink multifunction device</description>
-    <example>Oce VL3200:8C5-D92:Ver.B</example>
+    <example os.product="VL3200:8C5-D92">Oce VL3200:8C5-D92:Ver.B</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="VarioLink"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -205,7 +205,7 @@
 
   <fingerprint pattern="(?i)^Imagistics (im\S+) (.+)">
     <description>Oce IM series multifunction device</description>
-    <example>Imagistics im3510/4510 02-Aug-04 10:56</example>
+    <example os.product="im3510/4510" system.time="02-Aug-04 10:56">Imagistics im3510/4510 02-Aug-04 10:56</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="IM Series"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -218,9 +218,9 @@
 
   <fingerprint pattern="^OKI (C\d+)\S*$">
     <description>Okidata color printer</description>
-    <example>OKI C610</example>
-    <example>OKI C710</example>
-    <example>OKI C710dn</example>
+    <example os.product="C610">OKI C610</example>
+    <example os.product="C710">OKI C710</example>
+    <example os.product="C710">OKI C710dn</example>
     <param pos="0" name="os.vendor" value="Okidata"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -228,7 +228,7 @@
 
   <fingerprint pattern="^OKI (MC\d+)\S*$">
     <description>Okidata multifunction device</description>
-    <example>OKI MC860</example>
+    <example os.product="MC860">OKI MC860</example>
     <param pos="0" name="os.vendor" value="Okidata"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -236,10 +236,10 @@
 
   <fingerprint pattern="(?i)^RICOH ((?:Aficio|MP|SP) .*)$">
     <description>Ricoh Aficio Printer</description>
-    <example>RICOH Aficio 2075</example>
-    <example>RICOH Aficio AP610N</example>
-    <example>RICOH Aficio SP 8100DN</example>
-    <example>RICOH MP C1500/615C</example>
+    <example os.product="Aficio 2075">RICOH Aficio 2075</example>
+    <example os.product="Aficio AP610N">RICOH Aficio AP610N</example>
+    <example os.product="Aficio SP 8100DN">RICOH Aficio SP 8100DN</example>
+    <example os.product="MP C1500/615C">RICOH MP C1500/615C</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Aficio"/>
     <param pos="1" name="os.product"/>
@@ -251,14 +251,14 @@
 
   <fingerprint pattern="(?i)^NRG ([MS]P \S+)$">
     <description>Ricoh NRG printer</description>
-    <example>NRG MP 171</example>
-    <example>NRG MP 3350</example>
-    <example>NRG MP C2550</example>
-    <example>NRG MP C2800</example>
-    <example>NRG MP C3500</example>
-    <example>NRG MP C4000</example>
-    <example>NRG MP C4500</example>
-    <example>NRG SP C231SF</example>
+    <example os.product="MP 171">NRG MP 171</example>
+    <example os.product="MP 3350">NRG MP 3350</example>
+    <example os.product="MP C2550">NRG MP C2550</example>
+    <example os.product="MP C2800">NRG MP C2800</example>
+    <example os.product="MP C3500">NRG MP C3500</example>
+    <example os.product="MP C4000">NRG MP C4000</example>
+    <example os.product="MP C4500">NRG MP C4500</example>
+    <example os.product="SP C231SF">NRG SP C231SF</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -269,7 +269,7 @@
 
   <fingerprint pattern="(?i)^Gestetner (MP\S+/DSc\S+)$">
     <description>Ricoh Gestetner multifunction device</description>
-    <example>Gestetner MPC2500/DSc525</example>
+    <example os.product="MPC2500/DSc525">Gestetner MPC2500/DSc525</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -285,7 +285,7 @@
 
   <fingerprint pattern="(?i)^Savin (\S+)$">
     <description>Savin Printer</description>
-    <example>SAVIN 4075</example>
+    <example os.product="4075">SAVIN 4075</example>
     <param pos="0" name="os.vendor" value="Savin"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -293,8 +293,8 @@
 
   <fingerprint pattern="(?i)^Samsung ((?:SCX|CLX)-\S+) Series$">
     <description>Samsung multifunction device</description>
-    <example>Samsung SCX-5835_5935 Series</example>
-    <example>Samsung CLX-4195 Series</example>
+    <example os.product="SCX-5835_5935">Samsung SCX-5835_5935 Series</example>
+    <example os.product="CLX-4195">Samsung CLX-4195 Series</example>
     <param pos="0" name="os.vendor" value="Samsung"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -302,8 +302,8 @@
 
   <fingerprint pattern="(?i)^Samsung ((?:ML|CLP)-\S+) Series$">
     <description>Samsung printer</description>
-    <example>Samsung CLP-680 Series</example>
-    <example>Samsung ML-5012_5512 Series</example>
+    <example os.product="CLP-680">Samsung CLP-680 Series</example>
+    <example os.product="ML-5012_5512">Samsung ML-5012_5512 Series</example>
     <param pos="0" name="os.vendor" value="Samsung"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -311,8 +311,8 @@
 
   <fingerprint pattern="(?i)^SHARP (\S+-\S+)">
     <description>Sharp Printer</description>
-    <example>Sharp MX-NBX3 18-Mar-08 10:22</example>
-    <example>Sharp AR-P17 24-Mar-04 19:55</example>
+    <example os.product="MX-NBX3">Sharp MX-NBX3 18-Mar-08 10:22</example>
+    <example os.product="AR-P17">Sharp AR-P17 24-Mar-04 19:55</example>
     <param pos="0" name="os.vendor" value="Sharp"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -320,7 +320,7 @@
 
   <fingerprint pattern="(?i)^Source Technologies (\S+)$">
     <description>Source Technologies Printer</description>
-    <example>Source Technologies ST-9620</example>
+    <example os.product="ST-9620">Source Technologies ST-9620</example>
     <param pos="0" name="os.vendor" value="Source Technologies"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -330,10 +330,10 @@
 
   <fingerprint pattern="^TOSHIBA (e-STUDIO\S+)(?:\s+.*)?" certainty="0.9">
     <description>Toshiba e-STUDIO multifunction device</description>
-    <example>TOSHIBA e-STUDIO350 V468Z 20061013</example>
-    <example>TOSHIBA e-STUDIO350-450 V444Z 20041104</example>
-    <example>TOSHIBA e-STUDIO450 V468Z 20061013</example>
-    <example>TOSHIBA e-STUDIO500S</example>
+    <example os.product="e-STUDIO350">TOSHIBA e-STUDIO350 V468Z 20061013</example>
+    <example os.product="e-STUDIO350-450">TOSHIBA e-STUDIO350-450 V444Z 20041104</example>
+    <example os.product="e-STUDIO450">TOSHIBA e-STUDIO450 V468Z 20061013</example>
+    <example os.product="e-STUDIO500S">TOSHIBA e-STUDIO500S</example>
     <param pos="0" name="os.vendor" value="Toshiba"/>
     <param pos="0" name="os.family" value="e-STUDIO"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -351,8 +351,8 @@
 
   <fingerprint pattern="^(?:ID=)?Xerox (Phaser \S+)$" certainty="0.9">
     <description>Xerox Phaser Printer</description>
-    <example>Xerox Phaser 6180MFP-D</example>
-    <example>ID=Xerox Phaser 5400</example>
+    <example os.product="Phaser 6180MFP-D">Xerox Phaser 6180MFP-D</example>
+    <example os.product="Phaser 5400">ID=Xerox Phaser 5400</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -361,9 +361,9 @@
 
   <fingerprint pattern="^Xerox (WorkCentre .*)$" certainty="0.9">
     <description>Xerox Workcentre Printer</description>
-    <example>Xerox WorkCentre 7425</example>
-    <example>Xerox WorkCentre Pro 245</example>
-    <example>Xerox WorkCentre Pro 55, v1 Multifunction System</example>
+    <example os.product="WorkCentre 7425">Xerox WorkCentre 7425</example>
+    <example os.product="WorkCentre Pro 245">Xerox WorkCentre Pro 245</example>
+    <example os.product="WorkCentre Pro 55, v1 Multifunction System">Xerox WorkCentre Pro 55, v1 Multifunction System</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="WorkCentre"/>
     <param pos="1" name="os.product"/>
@@ -372,7 +372,7 @@
 
   <fingerprint pattern="^(XC\S+)$" certainty="0.9">
     <description>Xerox XC Printer</description>
-    <example>XC560</example>
+    <example os.product="XC560">XC560</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="XC"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -381,7 +381,7 @@
 
   <fingerprint pattern="^(DC\S+)$" certainty="0.9">
     <description>Xerox DocuColor Printer</description>
-    <example>DC250</example>
+    <example os.product="DC250">DC250</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="DocuColor"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -390,7 +390,7 @@
 
   <fingerprint pattern="^(EX\d+-\d+)$" certainty="0.9">
     <description>Xerox EX Print Server, powered by EFI Fiery</description>
-    <example>EX4112-4127</example>
+    <example os.product="EX4112-4127">EX4112-4127</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="EX"/>
     <param pos="0" name="os.device" value="Print Server"/>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -635,8 +635,8 @@
 
   <fingerprint pattern="^Wowza Streaming Engine 4 (Subscription|Perpetual Pro) Edition (\d\.[\w.]+) build(\d+)$">
     <description>Wowza Streaming Engine</description>
-    <example service.version="4.7.7.01" service.version.version="20190222144406">Wowza Streaming Engine 4 Subscription Edition 4.7.7.01 build20190222144406</example>
-    <example service.edition="Perpetual Pro">Wowza Streaming Engine 4 Perpetual Pro Edition 4.8.8.01 build20201216140014</example>
+    <example service.version="4.7.7.01" service.version.version="20190222144406" service.edition="Subscription">Wowza Streaming Engine 4 Subscription Edition 4.7.7.01 build20190222144406</example>
+    <example service.edition="Perpetual Pro" service.version="4.8.8.01" service.version.version="20201216140014">Wowza Streaming Engine 4 Perpetual Pro Edition 4.8.8.01 build20201216140014</example>
     <param pos="0" name="service.vendor" value="Wowza"/>
     <param pos="0" name="service.product" value="Streaming Engine"/>
     <param pos="1" name="service.edition"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -79,7 +79,7 @@
 
   <fingerprint pattern="^ANsession\d+=(\S+);">
     <description>Array Networks Secure Access Gateway / SSL VPN</description>
-    <example>ANsession0002262072457555=IPMI; path=/;secure</example>
+    <example cookie="IPMI">ANsession0002262072457555=IPMI; path=/;secure</example>
     <param pos="1" name="cookie"/>
     <param pos="0" name="service.vendor" value="Array Networks"/>
     <param pos="0" name="service.family" value="Secure Access Gateway"/>
@@ -271,7 +271,7 @@
 
   <fingerprint pattern="(?i)^(BIGipServer([^=]+))=">
     <description>F5 BIG-IP LTM - Server variant</description>
-    <example loadbalancer.poolname="CustomerRP">BigIpServerCustomerRP=5a; path=/; domain=.foo.bar; secure; HttpOnly</example>
+    <example loadbalancer.poolname="CustomerRP" cookie="BigIpServerCustomerRP">BigIpServerCustomerRP=5a; path=/; domain=.foo.bar; secure; HttpOnly</example>
     <param pos="1" name="cookie"/>
     <param pos="2" name="loadbalancer.poolname"/>
     <param pos="0" name="service.vendor" value="F5"/>
@@ -399,7 +399,7 @@
     <description>Nextcloud</description>
     <example cookie="nc_sameSiteCookiestrict">nc_sameSiteCookiestrict=true; path=/nextcloud; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=strict</example>
     <example cookie="nc_sameSiteCookielax">nc_sameSiteCookielax=true; path=/nextcloud; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax</example>
-    <example>oc_sessionPassphrase=Y%2BZjBn8Gn%2B8jIJPVx468Tlt8qDNm%2B5IVXLxgtwlY%2BQU2T7edVmDS4091nQrT; path=/nextcloud; secure; HttpOnly</example>
+    <example cookie="oc_sessionPassphrase">oc_sessionPassphrase=Y%2BZjBn8Gn%2B8jIJPVx468Tlt8qDNm%2B5IVXLxgtwlY%2BQU2T7edVmDS4091nQrT; path=/nextcloud; secure; HttpOnly</example>
     <param pos="1" name="cookie"/>
     <param pos="0" name="service.vendor" value="Nextcloud"/>
     <param pos="0" name="service.product" value="Nextcloud Server"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -124,8 +124,8 @@
 
   <fingerprint pattern="^Stronghold/(\d\.\d) Apache/([012][\d.]*)\s*(.*)$">
     <description>Red Hat Stronghold Enterprise Apache</description>
-    <example service.version="1.3.19" service.cpe23="cpe:/a:apache:http_server:1.3.19" service.component.cpe23="cpe:/a:redhat:stronghold:3.0">Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
-    <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22" service.component.cpe23="cpe:/a:redhat:stronghold:4.0" apache.info="(Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
+    <example service.version="1.3.19" service.cpe23="cpe:/a:apache:http_server:1.3.19" service.component.cpe23="cpe:/a:redhat:stronghold:3.0" service.component.version="3.0" apache.info="RedHat/3014c">Stronghold/3.0 Apache/1.3.19 RedHat/3014c</example>
+    <example service.version="1.3.22" service.cpe23="cpe:/a:apache:http_server:1.3.22" service.component.cpe23="cpe:/a:redhat:stronghold:4.0" apache.info="(Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26" service.component.version="4.0">Stronghold/4.0 Apache/1.3.22 (Unix) mod_ssl/2.8.7 OpenSSL/0.9.6c mod_perl/1.26</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -175,22 +175,22 @@
 
   <fingerprint pattern="(?i)^Apache(?:-AdvancedExtranetServer)?(?:/([012][\d.]*)\s*(.*))?$">
     <description>Apache</description>
-    <example>Apache-AdvancedExtranetServer/2.0.44 (Mandrake Linux/11mdk) mod_perl/1.99_08 Perl/v5.8.0 mod_ssl/2.0.44 OpenSSL/0.9.7a PHP/4.3.1 mod_jk2/2.0.0</example>
-    <example>Apache-AdvancedExtranetServer/2.0.47 (Mandrake Linux/6.12.92mdk) mod_perl/1.99_09 Perl/v5.8.1 mod_ssl/2.0.47 OpenSSL/0.9.7b PHP/4.3.2</example>
-    <example>Apache-AdvancedExtranetServer/2.0.47 (Mandrake Linux/6.3.92mdk) mod_ssl/2.0.47 OpenSSL/0.9.7b PHP/4.3.2</example>
-    <example>Apache-AdvancedExtranetServer/2.0.48 (Mandrake Linux/6.8.100mdk) mod_perl/1.99_11 Perl/v5.8.3 mod_ssl/2.0.48 OpenSSL/0.9.7c PHP/4.3.4</example>
-    <example>Apache-AdvancedExtranetServer/2.0.48 (Mandrake Linux/6mdk) PHP/4.3.4</example>
-    <example>Apache-AdvancedExtranetServer/2.0.53 (Mandrakelinux/PREFORK-9mdk) mod_ssl/2.0.53 OpenSSL/0.9.7e PHP/4.3.10 mod_perl/1.999.21 Perl/v5.8.6</example>
-    <example>Apache/0.6.5</example>
-    <example>Apache/1.1.3</example>
-    <example>Apache/1.2.42 (PalmOS)</example>
-    <example>Apache/1.3.28 (SolutionIP) mod_perl/1.28 mod_ssl/2.8.15 OpenSSL/0.9.7b</example>
-    <example>Apache/1.3.28 (Unix)</example>
-    <example>Apache/1.3.28 (Unix) mod_auth_pam/1.1.1</example>
-    <example>Apache/2.2.3 (Red Hat)</example>
-    <example>Apache/2.2.4 (Win32) PHP/5.2.2</example>
-    <example>Apache/2.2.4 (Win32) PHP/5.2.3</example>
-    <example>APACHE/1.3.9</example>
+    <example service.version="2.0.44" apache.info="(Mandrake Linux/11mdk) mod_perl/1.99_08 Perl/v5.8.0 mod_ssl/2.0.44 OpenSSL/0.9.7a PHP/4.3.1 mod_jk2/2.0.0">Apache-AdvancedExtranetServer/2.0.44 (Mandrake Linux/11mdk) mod_perl/1.99_08 Perl/v5.8.0 mod_ssl/2.0.44 OpenSSL/0.9.7a PHP/4.3.1 mod_jk2/2.0.0</example>
+    <example service.version="2.0.47" apache.info="(Mandrake Linux/6.12.92mdk) mod_perl/1.99_09 Perl/v5.8.1 mod_ssl/2.0.47 OpenSSL/0.9.7b PHP/4.3.2">Apache-AdvancedExtranetServer/2.0.47 (Mandrake Linux/6.12.92mdk) mod_perl/1.99_09 Perl/v5.8.1 mod_ssl/2.0.47 OpenSSL/0.9.7b PHP/4.3.2</example>
+    <example service.version="2.0.47" apache.info="(Mandrake Linux/6.3.92mdk) mod_ssl/2.0.47 OpenSSL/0.9.7b PHP/4.3.2">Apache-AdvancedExtranetServer/2.0.47 (Mandrake Linux/6.3.92mdk) mod_ssl/2.0.47 OpenSSL/0.9.7b PHP/4.3.2</example>
+    <example service.version="2.0.48" apache.info="(Mandrake Linux/6.8.100mdk) mod_perl/1.99_11 Perl/v5.8.3 mod_ssl/2.0.48 OpenSSL/0.9.7c PHP/4.3.4">Apache-AdvancedExtranetServer/2.0.48 (Mandrake Linux/6.8.100mdk) mod_perl/1.99_11 Perl/v5.8.3 mod_ssl/2.0.48 OpenSSL/0.9.7c PHP/4.3.4</example>
+    <example service.version="2.0.48" apache.info="(Mandrake Linux/6mdk) PHP/4.3.4">Apache-AdvancedExtranetServer/2.0.48 (Mandrake Linux/6mdk) PHP/4.3.4</example>
+    <example service.version="2.0.53" apache.info="(Mandrakelinux/PREFORK-9mdk) mod_ssl/2.0.53 OpenSSL/0.9.7e PHP/4.3.10 mod_perl/1.999.21 Perl/v5.8.6">Apache-AdvancedExtranetServer/2.0.53 (Mandrakelinux/PREFORK-9mdk) mod_ssl/2.0.53 OpenSSL/0.9.7e PHP/4.3.10 mod_perl/1.999.21 Perl/v5.8.6</example>
+    <example service.version="0.6.5">Apache/0.6.5</example>
+    <example service.version="1.1.3">Apache/1.1.3</example>
+    <example service.version="1.2.42" apache.info="(PalmOS)">Apache/1.2.42 (PalmOS)</example>
+    <example service.version="1.3.28" apache.info="(SolutionIP) mod_perl/1.28 mod_ssl/2.8.15 OpenSSL/0.9.7b">Apache/1.3.28 (SolutionIP) mod_perl/1.28 mod_ssl/2.8.15 OpenSSL/0.9.7b</example>
+    <example service.version="1.3.28" apache.info="(Unix)">Apache/1.3.28 (Unix)</example>
+    <example service.version="1.3.28" apache.info="(Unix) mod_auth_pam/1.1.1">Apache/1.3.28 (Unix) mod_auth_pam/1.1.1</example>
+    <example service.version="2.2.3" apache.info="(Red Hat)">Apache/2.2.3 (Red Hat)</example>
+    <example service.version="2.2.4" apache.info="(Win32) PHP/5.2.2">Apache/2.2.4 (Win32) PHP/5.2.2</example>
+    <example service.version="2.2.4" apache.info="(Win32) PHP/5.2.3">Apache/2.2.4 (Win32) PHP/5.2.3</example>
+    <example service.version="1.3.9">APACHE/1.3.9</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -252,7 +252,7 @@
 
   <fingerprint pattern="^Microsoft-IIS/([1234]\.0)$">
     <description>Microsoft IIS 1.0 - 4.0 runs on Windows NT 4.0</description>
-    <example>Microsoft-IIS/4.0</example>
+    <example service.version="4.0">Microsoft-IIS/4.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
@@ -378,7 +378,7 @@
 
   <fingerprint pattern="^Microsoft-IIS/([\d\.]+)$">
     <description>Microsoft IIS new, unknown Windows version</description>
-    <example>Microsoft-IIS/9.0</example>
+    <example service.version="9.0">Microsoft-IIS/9.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
@@ -399,7 +399,7 @@
 
   <fingerprint pattern="^MS .NET Remoting, MS .NET CLR (\d+\.\d+\.\d+\.\d+)$">
     <description>Microsoft .NET Remoting and Common Language Runtime (CLR)</description>
-    <example>MS .NET Remoting, MS .NET CLR 2.0.50727.42</example>
+    <example service.component.version="2.0.50727.42">MS .NET Remoting, MS .NET CLR 2.0.50727.42</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value=".NET Remoting"/>
     <param pos="0" name="service.family" value=".NET"/>
@@ -415,9 +415,9 @@
 
   <fingerprint pattern="^Microsoft-WinCE/(\d\.\d+)$">
     <description>Windows CE embedded devices, including HP iPAQ, Palm Treo, Motorola phones, and many more</description>
-    <example os.version="4.10">Microsoft-WinCE/4.10</example>
-    <example>Microsoft-WinCE/4.20</example>
-    <example>Microsoft-WinCE/5.0</example>
+    <example os.version="4.10" service.version="4.10">Microsoft-WinCE/4.10</example>
+    <example service.version="4.20" os.version="4.20">Microsoft-WinCE/4.20</example>
+    <example service.version="5.0" os.version="5.0">Microsoft-WinCE/5.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="Windows CE Web Server"/>
     <param pos="0" name="service.family" value="Windows CE Web Server"/>
@@ -432,7 +432,7 @@
 
   <fingerprint pattern="^Microsoft-PWS/(\d\.\d+)$">
     <description>Microsoft Personal Web Server runs on Windows 9x, ME, etc.</description>
-    <example>Microsoft-PWS/4.0</example>
+    <example service.version="4.0">Microsoft-PWS/4.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="PWS"/>
     <param pos="0" name="service.product" value="PWS"/>
@@ -446,7 +446,7 @@
 
   <fingerprint pattern="^Microsoft-PWS-95/(\d\.\d+)$">
     <description>Microsoft Personal Web Server for Windows 95</description>
-    <example>Microsoft-PWS-95/4.0</example>
+    <example service.version="4.0">Microsoft-PWS-95/4.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="PWS"/>
     <param pos="0" name="service.product" value="PWS"/>
@@ -469,8 +469,8 @@
 
   <fingerprint pattern="^Apache[ -]Coyote/(\d\.\d)$">
     <description>HTTP connector for Apache Tomcat to run as a standalone HTTP server - Coyote variant</description>
-    <example>Apache-Coyote/1.1</example>
-    <example>Apache Coyote/1.0</example>
+    <example service.component.version="1.1">Apache-Coyote/1.1</example>
+    <example service.component.version="1.0">Apache Coyote/1.0</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
     <param pos="0" name="service.family" value="Tomcat"/>
@@ -568,10 +568,10 @@
 
   <fingerprint pattern="^Tomcat Web Server/(\d\.[\dA-Z.]+)(?: Final)?(?:\s\(([^\)]+)\))?$">
     <description>HTTP connector for Apache Tomcat to run as a standalone HTTP server</description>
-    <example>Tomcat Web Server/3.2.2 (JSP 1.1; Servlet 2.2; Java 1.3.1; Windows 2000 5.0 x86; java.vendor=Sun Microsystems Inc.)</example>
-    <example>Tomcat Web Server/3.2.2 (JSP 1.1; Servlet 2.2; Java 1.4.2_13; Windows 2003 5.2 x86; java.vendor=Sun Microsystems Inc.)</example>
-    <example>Tomcat Web Server/3.1M1 (JSP 1.1; Servlet 2.2; Java 1.3.1; AIX 5.3 ppc; java.vendor=IBM Corporation)</example>
-    <example>Tomcat Web Server/3.3.1 Final ( JSP 1.1; Servlet 2.2 )</example>
+    <example service.version="3.2.2" tomcat.info="JSP 1.1; Servlet 2.2; Java 1.3.1; Windows 2000 5.0 x86; java.vendor=Sun Microsystems Inc.">Tomcat Web Server/3.2.2 (JSP 1.1; Servlet 2.2; Java 1.3.1; Windows 2000 5.0 x86; java.vendor=Sun Microsystems Inc.)</example>
+    <example service.version="3.2.2" tomcat.info="JSP 1.1; Servlet 2.2; Java 1.4.2_13; Windows 2003 5.2 x86; java.vendor=Sun Microsystems Inc.">Tomcat Web Server/3.2.2 (JSP 1.1; Servlet 2.2; Java 1.4.2_13; Windows 2003 5.2 x86; java.vendor=Sun Microsystems Inc.)</example>
+    <example service.version="3.1M1" tomcat.info="JSP 1.1; Servlet 2.2; Java 1.3.1; AIX 5.3 ppc; java.vendor=IBM Corporation">Tomcat Web Server/3.1M1 (JSP 1.1; Servlet 2.2; Java 1.3.1; AIX 5.3 ppc; java.vendor=IBM Corporation)</example>
+    <example service.version="3.3.1" tomcat.info=" JSP 1.1; Servlet 2.2 ">Tomcat Web Server/3.3.1 Final ( JSP 1.1; Servlet 2.2 )</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="Tomcat"/>
     <param pos="0" name="service.family" value="Tomcat"/>
@@ -618,7 +618,7 @@
 
   <fingerprint pattern="^Oracle Application Server Containers for J2EE 10g \(([\d.]+)\)$">
     <description>Oracle Application Server Containers for J2EE 10g</description>
-    <example>Oracle Application Server Containers for J2EE 10g (9.0.4.0.0)</example>
+    <example service.version="9.0.4.0.0">Oracle Application Server Containers for J2EE 10g (9.0.4.0.0)</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
     <param pos="0" name="service.product" value="Oracle Application Server Containers"/>
     <param pos="0" name="service.family" value="Oracle"/>
@@ -635,7 +635,7 @@
 
   <fingerprint pattern="^Oracle Application Server/10g \(([\d.]+)\) Apache/([12][\d.]+)\s*(.*)$">
     <description>Oracle Application Server 10g with Apache info (powered by Apache)</description>
-    <example>Oracle Application Server/10g (10.1.2) Apache/1.3.34 (Unix) mod_perl/1.29 mod_jk/1.2.14 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=119642322340,0)</example>
+    <example service.version="1.3.34" apache.info="(Unix) mod_perl/1.29 mod_jk/1.2.14 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=119642322340,0)" apache.variant.version="10.1.2">Oracle Application Server/10g (10.1.2) Apache/1.3.34 (Unix) mod_perl/1.29 mod_jk/1.2.14 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=119642322340,0)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -652,10 +652,10 @@
     <description>Oracle Application Server 10g (powered by Apache)</description>
     <example>Oracle-Application-Server-11g</example>
     <example>Oracle-Application-Server-10g</example>
-    <example>Oracle-Application-Server-10g/10.1.2.0.2 Oracle-HTTP-Server</example>
-    <example>Oracle-Application-Server-10g/10.1.2.2.0 Oracle-HTTP-Server (Unix) mod_plsql/10.1.2.2.0 mod_ossl/10.1.2.0.0 mod_perl/1.29 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=89116016562,0)</example>
-    <example>Oracle-Application-Server-10g/10.1.2.2.0 Oracle-HTTP-Server OracleAS-Web-Cache-10g/10.1.2.2.0 (N;ecid=153541209221,0)</example>
-    <example>Oracle-Application-Server-10g/9.0.4.1.0 Oracle-HTTP-Server</example>
+    <example apache.variant.version="10.1.2.0.2">Oracle-Application-Server-10g/10.1.2.0.2 Oracle-HTTP-Server</example>
+    <example apache.info="(Unix) mod_plsql/10.1.2.2.0 mod_ossl/10.1.2.0.0 mod_perl/1.29 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=89116016562,0)" apache.variant.version="10.1.2.2.0">Oracle-Application-Server-10g/10.1.2.2.0 Oracle-HTTP-Server (Unix) mod_plsql/10.1.2.2.0 mod_ossl/10.1.2.0.0 mod_perl/1.29 OracleAS-Web-Cache-10g/10.1.2.0.2 (N;ecid=89116016562,0)</example>
+    <example apache.info="OracleAS-Web-Cache-10g/10.1.2.2.0 (N;ecid=153541209221,0)" apache.variant.version="10.1.2.2.0">Oracle-Application-Server-10g/10.1.2.2.0 Oracle-HTTP-Server OracleAS-Web-Cache-10g/10.1.2.2.0 (N;ecid=153541209221,0)</example>
+    <example apache.variant.version="9.0.4.1.0">Oracle-Application-Server-10g/9.0.4.1.0 Oracle-HTTP-Server</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -667,8 +667,8 @@
 
   <fingerprint pattern="^Oracle9iAS/([\d.]+) Oracle HTTP Server\s*(.*)$">
     <description>Oracle 9i Application Server</description>
-    <example>Oracle9iAS/9.0.2.3.0 Oracle HTTP Server Oracle9iAS-Web-Cache/9.0.2.3.0 (N)</example>
-    <example>Oracle9iAS/9.0.3.1 Oracle HTTP Server Oracle9iAS-Web-Cache/9.0.3.1.0 (N)</example>
+    <example apache.info="Oracle9iAS-Web-Cache/9.0.2.3.0 (N)" apache.variant.version="9.0.2.3.0">Oracle9iAS/9.0.2.3.0 Oracle HTTP Server Oracle9iAS-Web-Cache/9.0.2.3.0 (N)</example>
+    <example apache.info="Oracle9iAS-Web-Cache/9.0.3.1.0 (N)" apache.variant.version="9.0.3.1">Oracle9iAS/9.0.3.1 Oracle HTTP Server Oracle9iAS-Web-Cache/9.0.3.1.0 (N)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -680,9 +680,9 @@
 
   <fingerprint pattern="^Oracle HTTP Server Powered by Apache/([12][\d.]*)\s*(.*)$">
     <description>Oracle HTTP Server (powered by Apache) - version string variant</description>
-    <example>Oracle HTTP Server Powered by Apache/1.3.12 (Unix) ApacheJServ/1.1 mod_ssl/2.6.4 OpenSSL/0.9.5a</example>
-    <example>Oracle HTTP Server Powered by Apache/1.3.19 (Unix) mod_plsql/3.0.9.8.3b PHP/4.3.10 mod_fastcgi/2.2.10 mod_perl/1.25 mod_oprocmgr/1.0</example>
-    <example>Oracle HTTP Server Powered by Apache/1.3.19 (Win32) mod_ssl/2.8.1 OpenSSL/0.9.5a mod_fastcgi/2.2.10 mod_oprocmgr/1.0 mod_perl/1.25</example>
+    <example service.version="1.3.12" apache.info="(Unix) ApacheJServ/1.1 mod_ssl/2.6.4 OpenSSL/0.9.5a">Oracle HTTP Server Powered by Apache/1.3.12 (Unix) ApacheJServ/1.1 mod_ssl/2.6.4 OpenSSL/0.9.5a</example>
+    <example service.version="1.3.19" apache.info="(Unix) mod_plsql/3.0.9.8.3b PHP/4.3.10 mod_fastcgi/2.2.10 mod_perl/1.25 mod_oprocmgr/1.0">Oracle HTTP Server Powered by Apache/1.3.19 (Unix) mod_plsql/3.0.9.8.3b PHP/4.3.10 mod_fastcgi/2.2.10 mod_perl/1.25 mod_oprocmgr/1.0</example>
+    <example service.version="1.3.19" apache.info="(Win32) mod_ssl/2.8.1 OpenSSL/0.9.5a mod_fastcgi/2.2.10 mod_oprocmgr/1.0 mod_perl/1.25">Oracle HTTP Server Powered by Apache/1.3.19 (Win32) mod_ssl/2.8.1 OpenSSL/0.9.5a mod_fastcgi/2.2.10 mod_oprocmgr/1.0 mod_perl/1.25</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -722,8 +722,8 @@
 
   <fingerprint pattern="^HP Apache-based Web Server/([012][\d.]*)\s*\(Unix\)\s*(.*)$">
     <description>Apache running on HP-UX</description>
-    <example>HP Apache-based Web Server/1.3.26 (Unix) mod_ssl/2.8.9 OpenSSL/0.9.6c</example>
-    <example>HP Apache-based Web Server/1.3.26 (Unix)</example>
+    <example service.version="1.3.26" apache.info="mod_ssl/2.8.9 OpenSSL/0.9.6c">HP Apache-based Web Server/1.3.26 (Unix) mod_ssl/2.8.9 OpenSSL/0.9.6c</example>
+    <example service.version="1.3.26">HP Apache-based Web Server/1.3.26 (Unix)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -739,11 +739,11 @@
 
   <fingerprint pattern="^CompaqHTTPServer/([0-9.]*)(?: HP System Management Homepage(?:/.*)?)?$">
     <description>HP/Compaq HTTP Server</description>
-    <example>CompaqHTTPServer/9.9 HP System Management Homepage/2.1.5.146</example>
-    <example>CompaqHTTPServer/9.9 HP System Management Homepage/3.0.1.73 httpd/2.2.6+</example>
-    <example>CompaqHTTPServer/9.9 HP System Management Homepage/6.0.0.96 httpd/2.2.6+</example>
-    <example>CompaqHTTPServer/9.9 HP System Management Homepage</example>
-    <example>CompaqHTTPServer/4.1</example>
+    <example service.version="9.9">CompaqHTTPServer/9.9 HP System Management Homepage/2.1.5.146</example>
+    <example service.version="9.9">CompaqHTTPServer/9.9 HP System Management Homepage/3.0.1.73 httpd/2.2.6+</example>
+    <example service.version="9.9">CompaqHTTPServer/9.9 HP System Management Homepage/6.0.0.96 httpd/2.2.6+</example>
+    <example service.version="9.9">CompaqHTTPServer/9.9 HP System Management Homepage</example>
+    <example service.version="4.1">CompaqHTTPServer/4.1</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="Compaq HTTP Server"/>
@@ -958,7 +958,7 @@
 
   <fingerprint pattern="(?i)^Linux UPnP/1.0 Sonos/([\d\.\-a-z]+) \(ANVIL\)$">
     <description>Sonos Subwoofer Speaker</description>
-    <example>Linux UPnP/1.0 Sonos/31.3-22220 (ANVIL)</example>
+    <example hw.version="31.3-22220">Linux UPnP/1.0 Sonos/31.3-22220 (ANVIL)</example>
     <param pos="0" name="hw.vendor" value="Sonos"/>
     <param pos="0" name="hw.product" value="Sub"/>
     <param pos="0" name="hw.device" value="Network Audio"/>
@@ -1025,7 +1025,7 @@
 
   <fingerprint pattern="^Helix Server Version ([0-9.]*) \(win32\) \(RealServer compatible\)$">
     <description>RealMedia Helix Server - Windows</description>
-    <example>Helix Server Version 9.0.4.960 (win32) (RealServer compatible)</example>
+    <example service.version="9.0.4.960">Helix Server Version 9.0.4.960 (win32) (RealServer compatible)</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -1038,7 +1038,7 @@
 
   <fingerprint pattern="^Helix Server Version ([0-9.]*) \(linux-\S+\) \(RealServer compatible\)$">
     <description>RealMedia Helix Server - Linux</description>
-    <example>Helix Server Version 9.0.4.960 (linux-2.2-libc6-i586-server) (RealServer compatible)</example>
+    <example service.version="9.0.4.960">Helix Server Version 9.0.4.960 (linux-2.2-libc6-i586-server) (RealServer compatible)</example>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="service.vendor" value="RealMedia"/>
@@ -1064,7 +1064,7 @@
 
   <fingerprint pattern="^Cougar/([0-9.]*)$">
     <description>Windows Media Services (older versions)</description>
-    <example>Cougar/9.01.01.3841</example>
+    <example service.version="9.01.01.3841">Cougar/9.01.01.3841</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -1077,7 +1077,7 @@
 
   <fingerprint pattern="^WMServer/([0-9.]*)$">
     <description>Windows Media Services (newer versions)</description>
-    <example>WMServer/9.1.1.3841</example>
+    <example service.version="9.1.1.3841">WMServer/9.1.1.3841</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
@@ -1152,7 +1152,7 @@
 
   <fingerprint pattern="^MiniServ/([0-9.]*)$">
     <description>mini_httpd</description>
-    <example>MiniServ/0.01</example>
+    <example service.version="0.01">MiniServ/0.01</example>
     <param pos="0" name="service.product" value="HTTP"/>
     <param pos="0" name="service.family" value="WebServer"/>
     <param pos="1" name="service.version"/>
@@ -1160,7 +1160,7 @@
 
   <fingerprint pattern="^IBM HTTP Server/(V\d+R\d+M\d+)$">
     <description>IBM HTTP server running on AS/400</description>
-    <example>IBM HTTP Server/V5R3M0</example>
+    <example os.version="V5R3M0">IBM HTTP Server/V5R3M0</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="HTTP Server"/>
     <param pos="0" name="service.family" value="HTTP Server"/>
@@ -1175,16 +1175,16 @@
 
   <fingerprint pattern="^(?:IBM_HTTP_Server|IBM_HTTP_SERVER)/([\w.-]+)\s+Apache/([12][\d.]+)\s*(.*)$">
     <description>IBM HTTP Server</description>
-    <example>IBM_HTTP_SERVER/1.3.19.2  Apache/1.3.20 (Win32)</example>
-    <example>IBM_HTTP_SERVER/1.3.28.1-PK16139  Apache/1.3.28 (Unix)</example>
-    <example>IBM_HTTP_Server/1.3.12 Apache/1.3.12 (Unix)</example>
-    <example>IBM_HTTP_Server/2.0.42.2-PK25355 Apache/2.0.47 (Unix) DAV/2</example>
-    <example>IBM_HTTP_Server/2.0.47.1-PK01070 Apache/2.0.47 (Win32) PHP/5.0.4</example>
-    <example>IBM_HTTP_Server/2.0.47.1 Apache/2.0.47 (Unix) DAV/2 PHP/4.3.8</example>
-    <example>IBM_HTTP_Server/6.0 Apache/2.0.47 (Unix) DAV/2</example>
-    <example>IBM_HTTP_Server/6.0.2 Apache/2.0.47 (Unix)</example>
-    <example>IBM_HTTP_Server/6.0.2.19 Apache/2.0.47 (Unix)</example>
-    <example>IBM_HTTP_Server/6.1 Apache/2.0.47 (Win32) PHP/5.1.1</example>
+    <example service.version="1.3.20" apache.info="(Win32)" apache.variant.version="1.3.19.2">IBM_HTTP_SERVER/1.3.19.2  Apache/1.3.20 (Win32)</example>
+    <example service.version="1.3.28" apache.info="(Unix)" apache.variant.version="1.3.28.1-PK16139">IBM_HTTP_SERVER/1.3.28.1-PK16139  Apache/1.3.28 (Unix)</example>
+    <example service.version="1.3.12" apache.info="(Unix)" apache.variant.version="1.3.12">IBM_HTTP_Server/1.3.12 Apache/1.3.12 (Unix)</example>
+    <example service.version="2.0.47" apache.info="(Unix) DAV/2" apache.variant.version="2.0.42.2-PK25355">IBM_HTTP_Server/2.0.42.2-PK25355 Apache/2.0.47 (Unix) DAV/2</example>
+    <example service.version="2.0.47" apache.info="(Win32) PHP/5.0.4" apache.variant.version="2.0.47.1-PK01070">IBM_HTTP_Server/2.0.47.1-PK01070 Apache/2.0.47 (Win32) PHP/5.0.4</example>
+    <example service.version="2.0.47" apache.info="(Unix) DAV/2 PHP/4.3.8" apache.variant.version="2.0.47.1">IBM_HTTP_Server/2.0.47.1 Apache/2.0.47 (Unix) DAV/2 PHP/4.3.8</example>
+    <example service.version="2.0.47" apache.info="(Unix) DAV/2" apache.variant.version="6.0">IBM_HTTP_Server/6.0 Apache/2.0.47 (Unix) DAV/2</example>
+    <example service.version="2.0.47" apache.info="(Unix)" apache.variant.version="6.0.2">IBM_HTTP_Server/6.0.2 Apache/2.0.47 (Unix)</example>
+    <example service.version="2.0.47" apache.info="(Unix)" apache.variant.version="6.0.2.19">IBM_HTTP_Server/6.0.2.19 Apache/2.0.47 (Unix)</example>
+    <example service.version="2.0.47" apache.info="(Win32) PHP/5.1.1" apache.variant.version="6.1">IBM_HTTP_Server/6.1 Apache/2.0.47 (Win32) PHP/5.1.1</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -1197,8 +1197,8 @@
 
   <fingerprint pattern="(?i)^(?:IBM_HTTP_SERVER|IBM-HTTP-SERVER)/(\S+)(?: \(\S+\))?$">
     <description>IBM HTTP Server with hardly useful version info</description>
-    <example>IBM-HTTP-Server/1.0</example>
-    <example>IBM_HTTP_Server/7.0.0.9 (Unix)</example>
+    <example apache.variant.version="1.0">IBM-HTTP-Server/1.0</example>
+    <example apache.variant.version="7.0.0.9">IBM_HTTP_Server/7.0.0.9 (Unix)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -1234,7 +1234,7 @@
 
   <fingerprint pattern="^Sun[ -]Java[ -]System[ /]Application[ -]Server Platform Edition (\d\.[\d_]+)?$">
     <description>Sun Java System Application Server Platform Edition(formerly iPlanet Application Server, Sun ONE Application Server)</description>
-    <example>Sun Java System Application Server Platform Edition 9.0</example>
+    <example service.version="9.0">Sun Java System Application Server Platform Edition 9.0</example>
     <example service.version="9.0_01">Sun Java System Application Server Platform Edition 9.0_01</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Application Server"/>
@@ -1283,9 +1283,9 @@
 
   <fingerprint pattern="^Netscape-Enterprise/(\d+\.[\w\s.]+)$">
     <description>Netscape Enterprise Server (subsequently iPlanet Web Server, Sun ONE Web Server, presently Sun Java System Web Server)</description>
-    <example>Netscape-Enterprise/3.5.1</example>
-    <example>Netscape-Enterprise/3.6 SP3</example>
-    <example>Netscape-Enterprise/6.0</example>
+    <example service.version="3.5.1">Netscape-Enterprise/3.5.1</example>
+    <example service.version="3.6 SP3">Netscape-Enterprise/3.6 SP3</example>
+    <example service.version="6.0">Netscape-Enterprise/6.0</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Server"/>
     <param pos="0" name="service.product" value="Java System Web Server"/>
@@ -1318,7 +1318,7 @@
 
   <fingerprint pattern="^iPlanet-Web-Proxy-Server/(.*)$">
     <description>iPlanet WebProxy Server (subsequently Sun ONE WebProxy Server, presently Sun Java System Web Proxy Server)</description>
-    <example>iPlanet-Web-Proxy-Server/3.6</example>
+    <example service.version="3.6">iPlanet-Web-Proxy-Server/3.6</example>
     <example service.version="3.6-SP5">iPlanet-Web-Proxy-Server/3.6-SP5</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
@@ -1339,8 +1339,8 @@
 
   <fingerprint pattern="^Sun-Java-System-Web-Proxy-Server/(\d\.[\d.]+)$">
     <description>Sun Java System Web Proxy Server (formerly iPlanet WebProxy Server, Sun ONE WebProxy Server)</description>
-    <example>Sun-Java-System-Web-Proxy-Server/4.0.2</example>
-    <example>Sun-Java-System-Web-Proxy-Server/4.0</example>
+    <example service.version="4.0.2">Sun-Java-System-Web-Proxy-Server/4.0.2</example>
+    <example service.version="4.0">Sun-Java-System-Web-Proxy-Server/4.0</example>
     <param pos="0" name="service.vendor" value="Sun"/>
     <param pos="0" name="service.family" value="Java System Web Proxy Server"/>
     <param pos="0" name="service.product" value="Java System Web Proxy Server"/>
@@ -1461,7 +1461,7 @@
     <example>thttpd</example>
     <example service.version="2.04">thttpd/2.04 10aug98</example>
     <example service.version="2.20b">thttpd/2.20b</example>
-    <example>thttpd/2.21b PHP/20030920</example>
+    <example service.version="2.21b">thttpd/2.21b PHP/20030920</example>
     <example service.version="2.23beta1">thttpd/2.23beta1 26may2002</example>
     <param pos="0" name="service.vendor" value="ACME"/>
     <param pos="0" name="service.product" value="thttpd"/>
@@ -1475,7 +1475,7 @@
     <example>lighttpd</example>
     <example>Lighttpd</example>
     <example service.version="1.4.16">lighttpd/1.4.16</example>
-    <example>lighttpd/1.3.7 (Mar 23 2007/16:00:15)</example>
+    <example service.version="1.3.7">lighttpd/1.3.7 (Mar 23 2007/16:00:15)</example>
     <param pos="0" name="service.vendor" value="lighttpd"/>
     <param pos="0" name="service.product" value="lighttpd"/>
     <param pos="0" name="service.family" value="lighttpd"/>
@@ -1495,7 +1495,7 @@
   <fingerprint pattern="^nginx\/?([\d.]+)?">
     <description>nginx with version info and/or mods</description>
     <example service.version="0.8.53">nginx/0.8.53 + Phusion Passenger 3.0.0 (mod_rails/mod_rack)</example>
-    <example>nginx/0.8.53</example>
+    <example service.version="0.8.53">nginx/0.8.53</example>
     <example>nginx + Phusion Passenger 5.1.11</example>
     <example>nginx + Phusion Passenger</example>
     <param pos="0" name="service.product" value="nginx"/>
@@ -1519,8 +1519,8 @@
 
   <fingerprint pattern="^Lotus(?:-Domino)?/(?:Release-?)?([4-7][\d.]+)\s*(?:.*)$">
     <description>IBM Lotus Notes/Domino with version info</description>
-    <example>Lotus-Domino/5.0.8</example>
-    <example>Lotus-Domino/Release-4.6.7(Intl)</example>
+    <example service.version="5.0.8">Lotus-Domino/5.0.8</example>
+    <example service.version="4.6.7">Lotus-Domino/Release-4.6.7(Intl)</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
@@ -1553,9 +1553,9 @@
 
   <fingerprint pattern="^Resin/(\S+)$">
     <description>Caucho Resin</description>
-    <example>Resin/2.1.13</example>
-    <example>Resin/3.0.23</example>
-    <example>Resin/2.1.s030827</example>
+    <example service.version="2.1.13">Resin/2.1.13</example>
+    <example service.version="3.0.23">Resin/3.0.23</example>
+    <example service.version="2.1.s030827">Resin/2.1.s030827</example>
     <param pos="0" name="service.vendor" value="Caucho"/>
     <param pos="0" name="service.product" value="Resin"/>
     <param pos="0" name="service.family" value="Resin"/>
@@ -1565,9 +1565,9 @@
 
   <fingerprint pattern="^Ipswitch-IMail/(\d\.\d+)$">
     <description>Ipswitch IMail Server</description>
-    <example>Ipswitch-IMail/5.08</example>
-    <example>Ipswitch-IMail/7.07</example>
-    <example>Ipswitch-IMail/8.05</example>
+    <example service.version="5.08">Ipswitch-IMail/5.08</example>
+    <example service.version="7.07">Ipswitch-IMail/7.07</example>
+    <example service.version="8.05">Ipswitch-IMail/8.05</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="0" name="service.product" value="IMail Server"/>
     <param pos="0" name="service.family" value="IMail Server"/>
@@ -1623,7 +1623,7 @@
 
   <fingerprint pattern="^Abyss/(\d\.[\d.]+)-X2-Win32 AbyssLib/(?:\d\.[\d.]+)$">
     <description>Aprelium Technologies Abyss Web Server X2 (licensed professional edition) on Windows</description>
-    <example>Abyss/2.14.2-X2-Win32 AbyssLib/2.14</example>
+    <example service.version="2.14.2">Abyss/2.14.2-X2-Win32 AbyssLib/2.14</example>
     <param pos="0" name="service.vendor" value="Aprelium Technologies"/>
     <param pos="0" name="service.product" value="Abyss Web Server X2"/>
     <param pos="0" name="service.family" value="Abyss Web Server"/>
@@ -1671,7 +1671,7 @@
 
   <fingerprint pattern="^NetWare-Enterprise-Web-Server/(\d+\.\d+)$">
     <description>NetWare Enterprise Web Server (runs on NetWare 5.1)</description>
-    <example service.version="5.1">NetWare-Enterprise-Web-Server/5.1</example>
+    <example service.version="5.1" os.version="5.1">NetWare-Enterprise-Web-Server/5.1</example>
     <param pos="0" name="service.vendor" value="Novell"/>
     <param pos="0" name="service.product" value="NetWare Enterprise Web Server"/>
     <param pos="0" name="service.family" value="NetWare Enterprise Web Server"/>
@@ -1903,11 +1903,11 @@
   <fingerprint pattern="^NetCache appliance \(NetApp/+(\d+\.\d+[\w.]+)\)$">
     <description>NetCache appliance (product line formerly owned by Network Appliances, now owned by Blue Coat Systems).</description>
     <example service.version="5.3.1R3">NetCache appliance (NetApp/5.3.1R3)</example>
-    <example>NetCache appliance (NetApp/5.4R2D2)</example>
-    <example>NetCache appliance (NetApp/5.6.1D22)</example>
-    <example>NetCache appliance (NetApp/6.0.2P1)</example>
-    <example>NetCache appliance (NetApp/6.0.4)</example>
-    <example>NetCache appliance (NetApp/6.1RC2)</example>
+    <example service.version="5.4R2D2">NetCache appliance (NetApp/5.4R2D2)</example>
+    <example service.version="5.6.1D22">NetCache appliance (NetApp/5.6.1D22)</example>
+    <example service.version="6.0.2P1">NetCache appliance (NetApp/6.0.2P1)</example>
+    <example service.version="6.0.4">NetCache appliance (NetApp/6.0.4)</example>
+    <example service.version="6.1RC2">NetCache appliance (NetApp/6.1RC2)</example>
     <param pos="0" name="service.vendor" value="Blue Coat"/>
     <param pos="0" name="service.family" value="NetCache"/>
     <param pos="0" name="service.product" value="NetCache"/>
@@ -1920,9 +1920,9 @@
 
   <fingerprint pattern="^NetApp/+(.*)$">
     <description>NetApp file servers</description>
-    <example>NetApp/7.3.4P1</example>
-    <example>NetApp/7.2.1.1</example>
-    <example>NetApp//8.1RC2</example>
+    <example os.version="7.3.4P1">NetApp/7.3.4P1</example>
+    <example os.version="7.2.1.1">NetApp/7.2.1.1</example>
+    <example os.version="8.1RC2">NetApp//8.1RC2</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="NetApp"/>
     <param pos="0" name="os.family" value="Data ONTAP"/>
@@ -1973,8 +1973,8 @@
 
   <fingerprint pattern="^HP-Chai(?:Server|SOE)/(\d+\.\d+)$">
     <description>HP Printer running the Chai embedded web server</description>
-    <example>HP-ChaiServer/2.2</example>
-    <example>HP-ChaiSOE/1.0</example>
+    <example service.version="2.2">HP-ChaiServer/2.2</example>
+    <example service.version="1.0">HP-ChaiSOE/1.0</example>
     <param pos="0" name="service.vendor" value="HP"/>
     <param pos="0" name="service.product" value="JetDirect"/>
     <param pos="0" name="service.family" value="JetDirect"/>
@@ -2089,7 +2089,7 @@
 
   <fingerprint pattern="^cisco-IOS/([^\s]+) HTTP-server/">
     <description>Cisco IOS with version information</description>
-    <example>cisco-IOS/12.1 HTTP-server/1.0(1)</example>
+    <example os.version="12.1">cisco-IOS/12.1 HTTP-server/1.0(1)</example>
     <param pos="0" name="service.vendor" value="Cisco"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.product" value="IOS"/>
@@ -2104,7 +2104,7 @@
 
   <fingerprint pattern="^Cisco AWARE (.*)$">
     <description>Cisco ASA</description>
-    <example>Cisco AWARE 2.0</example>
+    <example service.version="2.0">Cisco AWARE 2.0</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="Cisco"/>
     <param pos="0" name="service.product" value="HTTP"/>
@@ -2211,8 +2211,8 @@
 
   <fingerprint pattern="^(?:Raptor )?Simple, Secure Web Server ([\d.]+)$">
     <description>Symantec Raptor Firewall</description>
-    <example>Simple, Secure Web Server 1.1</example>
-    <example>Raptor Simple, Secure Web Server 1.0</example>
+    <example os.version="1.1">Simple, Secure Web Server 1.1</example>
+    <example os.version="1.0">Raptor Simple, Secure Web Server 1.0</example>
     <param pos="0" name="os.vendor" value="Symantec"/>
     <param pos="0" name="os.family" value="Raptor"/>
     <param pos="0" name="os.device" value="Firewall"/>
@@ -2310,7 +2310,7 @@
 
   <fingerprint pattern="^ListManagerWeb/(\S+)">
     <description>Lyris ListManager</description>
-    <example>ListManagerWeb/8.8a (based on Tcl-Webserver/3.4.2)</example>
+    <example service.version="8.8a">ListManagerWeb/8.8a (based on Tcl-Webserver/3.4.2)</example>
     <param pos="0" name="service.vendor" value="Lyris"/>
     <param pos="0" name="service.product" value="ListManager"/>
     <param pos="1" name="service.version"/>
@@ -2318,7 +2318,7 @@
 
   <fingerprint pattern="^kHTTPd (\S+)" certainty="0.50">
     <description>TUX web server, an in-kernel Linux HTTP Accelerator</description>
-    <example>kHTTPd 0.1.6</example>
+    <example service.version="0.1.6">kHTTPd 0.1.6</example>
     <param pos="0" name="service.product" value="TUX Web Server"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linux"/>
@@ -2329,8 +2329,8 @@
 
   <fingerprint pattern="^VNC Server (Enterprise|Personal) Edition/(?:E|P)([\d.]+) \(r([\d.]+)\)$">
     <description>RealVNC built-in webserver - Enterprise edition</description>
-    <example service.version="4.5.1" service.version.version="27892">VNC Server Enterprise Edition/E4.5.1 (r27892)</example>
-    <example service.edition="Personal">VNC Server Personal Edition/P4.5.3 (r39012)</example>
+    <example service.version="4.5.1" service.version.version="27892" service.edition="Enterprise">VNC Server Enterprise Edition/E4.5.1 (r27892)</example>
+    <example service.edition="Personal" service.version="4.5.3" service.version.version="39012">VNC Server Personal Edition/P4.5.3 (r39012)</example>
     <param pos="0" name="service.vendor" value="RealVNC Ltd."/>
     <param pos="0" name="service.product" value="RealVNC"/>
     <param pos="1" name="service.edition"/>
@@ -2369,7 +2369,7 @@
 
   <fingerprint pattern="^SecureTransport (\d+[\d\.]+) \(build: (\d+)\)$">
     <description>AxWay SecureTransport</description>
-    <example>SecureTransport 5.3.6 (build: 412)</example>
+    <example service.version="5.3.6" securetransport.build="412">SecureTransport 5.3.6 (build: 412)</example>
     <param pos="0" name="service.vendor" value="Axway"/>
     <param pos="0" name="service.product" value="SecureTransport"/>
     <param pos="1" name="service.version"/>
@@ -2379,22 +2379,22 @@
 
   <fingerprint pattern="(Agranat|Conexant|(?:Globespan)?Virata)-EmWeb/(.*)$">
     <description>EmWeb variants</description>
-    <example>Agranat-EmWeb/R4_01</example>
-    <example>Agranat-EmWeb/R5_1_2</example>
-    <example>Agranat-EmWeb/R5_2_4</example>
-    <example>Agranat-EmWeb/R5_2_6</example>
-    <example>Conexant-EmWeb/R6_1_0</example>
-    <example>ISOS/9.0 UPnP/1.0 Conexant-EmWeb/R6_1_0</example>
-    <example>Nucleus/4.3 UPnP/1.0 Virata-EmWeb/R6_2_0</example>
-    <example>Unknown/0.0 UPnP/1.0 Conexant-EmWeb/R6_1_0</example>
-    <example>Unknown/0.0 UPnP/1.0 GlobespanVirata-EmWeb/R6_1_0</example>
-    <example>Unknown/0.0 UPnP/1.0 Virata-EmWeb/R6_1_0</example>
-    <example>Virata-EmWeb/R5_3_0</example>
-    <example>Virata-EmWeb/R5_3_2</example>
-    <example>Virata-EmWeb/R6_0_1</example>
-    <example>Virata-EmWeb/R6_1_0</example>
-    <example>Virata-EmWeb/R6_2_0</example>
-    <example>Virata-EmWeb/R6_2_1</example>
+    <example service.vendor="Agranat" service.version="R4_01">Agranat-EmWeb/R4_01</example>
+    <example service.vendor="Agranat" service.version="R5_1_2">Agranat-EmWeb/R5_1_2</example>
+    <example service.vendor="Agranat" service.version="R5_2_4">Agranat-EmWeb/R5_2_4</example>
+    <example service.vendor="Agranat" service.version="R5_2_6">Agranat-EmWeb/R5_2_6</example>
+    <example service.vendor="Conexant" service.version="R6_1_0">Conexant-EmWeb/R6_1_0</example>
+    <example service.vendor="Conexant" service.version="R6_1_0">ISOS/9.0 UPnP/1.0 Conexant-EmWeb/R6_1_0</example>
+    <example service.vendor="Virata" service.version="R6_2_0">Nucleus/4.3 UPnP/1.0 Virata-EmWeb/R6_2_0</example>
+    <example service.vendor="Conexant" service.version="R6_1_0">Unknown/0.0 UPnP/1.0 Conexant-EmWeb/R6_1_0</example>
+    <example service.vendor="GlobespanVirata" service.version="R6_1_0">Unknown/0.0 UPnP/1.0 GlobespanVirata-EmWeb/R6_1_0</example>
+    <example service.vendor="Virata" service.version="R6_1_0">Unknown/0.0 UPnP/1.0 Virata-EmWeb/R6_1_0</example>
+    <example service.vendor="Virata" service.version="R5_3_0">Virata-EmWeb/R5_3_0</example>
+    <example service.vendor="Virata" service.version="R5_3_2">Virata-EmWeb/R5_3_2</example>
+    <example service.vendor="Virata" service.version="R6_0_1">Virata-EmWeb/R6_0_1</example>
+    <example service.vendor="Virata" service.version="R6_1_0">Virata-EmWeb/R6_1_0</example>
+    <example service.vendor="Virata" service.version="R6_2_0">Virata-EmWeb/R6_2_0</example>
+    <example service.vendor="Virata" service.version="R6_2_1">Virata-EmWeb/R6_2_1</example>
     <param pos="1" name="service.vendor"/>
     <param pos="0" name="service.family" value="EmWeb"/>
     <param pos="0" name="service.product" value="EmWeb"/>
@@ -2468,9 +2468,9 @@
   <fingerprint pattern="^SentinelProtectionServer/((?:\d+\.)*\d+)$">
     <description>Sentinel Protection Server - Embedded httpd in SafeNet's memory key dongles</description>
     <example service.version="7.1">SentinelProtectionServer/7.1</example>
-    <example>SentinelProtectionServer/7.3</example>
-    <example>SentinelProtectionServer/7.0</example>
-    <example>SentinelProtectionServer/7</example>
+    <example service.version="7.3">SentinelProtectionServer/7.3</example>
+    <example service.version="7.0">SentinelProtectionServer/7.0</example>
+    <example service.version="7">SentinelProtectionServer/7</example>
     <param pos="0" name="service.vendor" value="SafeNet"/>
     <param pos="0" name="service.product" value="Sentinel Protection Server"/>
     <param pos="0" name="service.family" value="Sentinel"/>
@@ -2480,8 +2480,8 @@
   <fingerprint pattern="^SentinelKeysServer/((?:\d+\.)*\d+)$">
     <description>Sentinel Key Server - Embedded httpd in SafeNet's memory key dongles</description>
     <example service.version="1.3.1">SentinelKeysServer/1.3.1</example>
-    <example>SentinelKeysServer/1.0</example>
-    <example>SentinelKeysServer/1</example>
+    <example service.version="1.0">SentinelKeysServer/1.0</example>
+    <example service.version="1">SentinelKeysServer/1</example>
     <param pos="0" name="service.vendor" value="SafeNet"/>
     <param pos="0" name="service.product" value="Sentinel Keys Server"/>
     <param pos="0" name="service.family" value="Sentinel"/>
@@ -2490,8 +2490,8 @@
 
   <fingerprint pattern="^CherryPy/((?:\d+\.)*\d+)$">
     <description>Web server component of CherryPy web application framework.</description>
-    <example>CherryPy/3.1.2</example>
-    <example>CherryPy/3</example>
+    <example service.version="3.1.2">CherryPy/3.1.2</example>
+    <example service.version="3">CherryPy/3</example>
     <param pos="0" name="service.vendor" value="CherryPy"/>
     <param pos="0" name="service.product" value="CherryPy"/>
     <param pos="0" name="service.family" value="CherryPy"/>
@@ -2501,7 +2501,7 @@
 
   <fingerprint pattern="(?i)^TornadoServer/((?:\d+\.)*\d+)$">
     <description>Tornado Python web framework and asynchronous networking library.</description>
-    <example>TornadoServer/4.0.2</example>
+    <example service.version="4.0.2">TornadoServer/4.0.2</example>
     <param pos="0" name="service.vendor" value="TornadoWeb"/>
     <param pos="0" name="service.product" value="Tornado"/>
     <param pos="0" name="service.family" value="Tornado"/>
@@ -2511,8 +2511,8 @@
 
   <fingerprint pattern="(?i)^SimpleHTTP/((?:\d+\.)*\d+)\s*Python/((?:\d+\.)*\d+)$">
     <description>SimpleHTTPRequestHandler Python class is a simple HTTP request handler.</description>
-    <example service.version="0.6">SimpleHTTP/0.6 Python/2.7.6</example>
-    <example python.version="3.4.0">SimpleHTTP/0.6 Python/3.4.0</example>
+    <example service.version="0.6" python.version="2.7.6">SimpleHTTP/0.6 Python/2.7.6</example>
+    <example python.version="3.4.0" service.version="0.6">SimpleHTTP/0.6 Python/3.4.0</example>
     <param pos="0" name="service.vendor" value="Python Software Foundation"/>
     <param pos="0" name="service.product" value="SimpleHTTP"/>
     <param pos="0" name="service.family" value="Python"/>
@@ -2522,8 +2522,8 @@
 
   <fingerprint pattern="^Python/(\d\.[\d.]+) aiohttp/(\d[\w.]+)$">
     <description>AIOHTTP Project AIOHTTP</description>
-    <example service.version="3.7.4.post0">Python/3.8 aiohttp/3.7.4.post0</example>
-    <example python.version="3.4">Python/3.4 aiohttp/1.0.5</example>
+    <example service.version="3.7.4.post0" python.version="3.8">Python/3.8 aiohttp/3.7.4.post0</example>
+    <example python.version="3.4" service.version="1.0.5">Python/3.4 aiohttp/1.0.5</example>
     <param pos="0" name="service.vendor" value="AIOHTTP Project"/>
     <param pos="0" name="service.product" value="AIOHTTP"/>
     <param pos="2" name="service.version"/>
@@ -2550,8 +2550,8 @@
 
   <fingerprint pattern="^HP Web Jetadmin/((?:\d+\.)*\d+)\s*(.*)$">
     <description>Apache variant for web access to HP printers.</description>
-    <example>HP Web Jetadmin/2.0.50 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
-    <example>HP Web Jetadmin/2 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
+    <example service.version="2.0.50" apache.info="(Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m">HP Web Jetadmin/2.0.50 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
+    <example service.version="2" apache.info="(Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m">HP Web Jetadmin/2 (Win32) mod_auth_sspi/1.0.1 mod_ssl/2.0.50 OpenSSL/0.9.6m</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="HTTPD"/>
     <param pos="0" name="service.family" value="Apache"/>
@@ -2593,8 +2593,8 @@
 
   <fingerprint pattern="^ScreenConnect/([\d.]+)-(\d+)(?: Microsoft-HTTPAPI/2.0)?$">
     <description>ConnectWise Control formerly ScreenConnect</description>
-    <example service.version="6.3.13446.6374">ScreenConnect/6.3.13446.6374-4039728469 Microsoft-HTTPAPI/2.0</example>
-    <example service.version.version="3841999031">ScreenConnect/19.3.25270.7185-3841999031</example>
+    <example service.version="6.3.13446.6374" service.version.version="4039728469">ScreenConnect/6.3.13446.6374-4039728469 Microsoft-HTTPAPI/2.0</example>
+    <example service.version.version="3841999031" service.version="19.3.25270.7185">ScreenConnect/19.3.25270.7185-3841999031</example>
     <param pos="0" name="service.vendor" value="ConnectWise"/>
     <param pos="0" name="service.product" value="Control"/>
     <param pos="1" name="service.version"/>
@@ -2604,8 +2604,8 @@
 
   <fingerprint pattern="^Lotus Expeditor Web Container/((?:\d+\.)*\d+)$">
     <description>Expeditor is a framework used by IBM in many products in the Lotus brand, such as Sametime and Notes.</description>
-    <example>Lotus Expeditor Web Container/6.1</example>
-    <example>Lotus Expeditor Web Container/6</example>
+    <example service.version="6.1">Lotus Expeditor Web Container/6.1</example>
+    <example service.version="6">Lotus Expeditor Web Container/6</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="Lotus Expeditor Server"/>
     <param pos="0" name="service.family" value="Lotus Expeditor"/>
@@ -2630,7 +2630,7 @@
     <description>GoAhead-Webs - version</description>
     <example service.version="2.5.0">GoAhead-Webs/2.5.0 PeerSec-MatrixSSL/3.4.2-OPEN</example>
     <example service.version="2.5.0">Goahead/2.5.0 PeerSec-MatrixSSL/3.2.1-OPEN</example>
-    <example>GoAhead-Webs/2.5.0</example>
+    <example service.version="2.5.0">GoAhead-Webs/2.5.0</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
     <param pos="0" name="service.product" value="GoAhead Webserver"/>
     <param pos="0" name="service.family" value="GoAhead Webserver"/>
@@ -2643,8 +2643,8 @@
     <description>Mbedthis Appweb</description>
     <example service.version="2.4.0">Mbedthis-Appweb/2.4.0</example>
     <example service.version="2.4.0">Mbedthis-AppWeb/2.4.0</example>
-    <example>Mbedthis-Appweb/2.4.2</example>
-    <example>Mbedthis-Appweb/2</example>
+    <example service.version="2.4.2">Mbedthis-Appweb/2.4.2</example>
+    <example service.version="2">Mbedthis-Appweb/2</example>
     <param pos="0" name="service.vendor" value="Mbedthis Software"/>
     <param pos="0" name="service.product" value="Appweb"/>
     <param pos="0" name="service.family" value="Appweb"/>
@@ -2665,8 +2665,8 @@
 
   <fingerprint pattern="^Avaya CMBE/((?:\d+\.)*\d+)$">
     <description>Web server for Avaya Aura Communication Manager Branch, a SIP-based communications platform.</description>
-    <example>Avaya CMBE/2.0.0</example>
-    <example>Avaya CMBE/2</example>
+    <example service.version="2.0.0">Avaya CMBE/2.0.0</example>
+    <example service.version="2">Avaya CMBE/2</example>
     <param pos="0" name="service.vendor" value="Avaya"/>
     <param pos="0" name="service.product" value="Aura Communication Manager"/>
     <param pos="0" name="service.family" value="Aura"/>
@@ -2713,7 +2713,7 @@
 
   <fingerprint pattern="^TwistedWeb/([\d.rc]+)$">
     <description>Twisted Matrix Labs - TwistedWeb</description>
-    <example>TwistedWeb/2.5.0</example>
+    <example service.version="2.5.0">TwistedWeb/2.5.0</example>
     <example service.version="16.4.0">TwistedWeb/16.4.0</example>
     <example service.version="16.5.0rc2">TwistedWeb/16.5.0rc2</example>
     <param pos="0" name="service.vendor" value="TwistedMatrix"/>
@@ -2725,8 +2725,8 @@
 
   <fingerprint pattern="^Twisted/([\d.]+) TwistedWeb/([\d.]+)$">
     <description>Twisted Matrix Labs - TwistedWeb - verbose variant</description>
-    <example service.version="13.0.0">Twisted/13.0.0 TwistedWeb/9.0.0</example>
-    <example service.version.version="9.0.0">Twisted/17.9.0 TwistedWeb/9.0.0</example>
+    <example service.version="13.0.0" service.version.version="9.0.0">Twisted/13.0.0 TwistedWeb/9.0.0</example>
+    <example service.version.version="9.0.0" service.version="17.9.0">Twisted/17.9.0 TwistedWeb/9.0.0</example>
     <param pos="0" name="service.vendor" value="TwistedMatrix"/>
     <param pos="0" name="service.product" value="Twisted Web"/>
     <param pos="0" name="service.family" value="Twisted Web"/>
@@ -2737,8 +2737,8 @@
 
   <fingerprint pattern="^mini_httpd/((?:\d+\.)*\d+) \S*$">
     <description>ACME mini_httpd with version and date</description>
-    <example>mini_httpd/1.14 23jun2000</example>
-    <example>mini_httpd/1 23jun2000</example>
+    <example service.version="1.14">mini_httpd/1.14 23jun2000</example>
+    <example service.version="1">mini_httpd/1 23jun2000</example>
     <param pos="0" name="service.vendor" value="ACME"/>
     <param pos="0" name="service.product" value="mini_httpd"/>
     <param pos="0" name="service.family" value="mini_httpd"/>
@@ -2749,7 +2749,7 @@
   <fingerprint pattern="^thin ((?:\d+\.)*\d+) codename .+$">
     <description>Marc-André Cournoyer's thin webserver</description>
     <example service.version="1.2.4">thin 1.2.4 codename Flaming Astroboy</example>
-    <example>thin 1 codename Flaming Astroboy</example>
+    <example service.version="1">thin 1 codename Flaming Astroboy</example>
     <param pos="0" name="service.product" value="Thin"/>
     <param pos="0" name="service.family" value="Thin"/>
     <param pos="1" name="service.version"/>
@@ -2757,8 +2757,8 @@
 
   <fingerprint pattern="^Avocent DSView \d+/((?:\d+\.)*\d+)$">
     <description>Web server interface for controlling data centers.</description>
-    <example>Avocent DSView 3/3.7.0.71</example>
-    <example>Avocent DSView 3/3</example>
+    <example service.version="3.7.0.71">Avocent DSView 3/3.7.0.71</example>
+    <example service.version="3">Avocent DSView 3/3</example>
     <param pos="0" name="service.vendor" value="Avocent"/>
     <param pos="0" name="service.product" value="DSView"/>
     <param pos="0" name="service.family" value="DSView"/>
@@ -2769,7 +2769,7 @@
   <fingerprint pattern="^Mongrel ((?:\d+\.)*\d+)$">
     <description>Ruby-based web server and HTTP library.</description>
     <example service.version="1.1.5">Mongrel 1.1.5</example>
-    <example>Mongrel 1</example>
+    <example service.version="1">Mongrel 1</example>
     <param pos="0" name="service.vendor" value="Zed Shaw"/>
     <param pos="0" name="service.product" value="Mongrel"/>
     <param pos="0" name="service.family" value="Mongrel"/>
@@ -2779,9 +2779,9 @@
 
   <fingerprint pattern="^Microplex emHTTPD/((?:\d+\.)*\d+)$">
     <description>Embedded web server used by Microplex.</description>
-    <example>Microplex emHTTPD/1.0</example>
-    <example>Microplex emHTTPD/1.1</example>
-    <example>Microplex emHTTPD/1</example>
+    <example service.version="1.0">Microplex emHTTPD/1.0</example>
+    <example service.version="1.1">Microplex emHTTPD/1.1</example>
+    <example service.version="1">Microplex emHTTPD/1</example>
     <param pos="0" name="service.vendor" value="Microplex"/>
     <param pos="0" name="service.product" value="emHTTPD"/>
     <param pos="0" name="service.family" value="emHTTPD"/>
@@ -2792,8 +2792,8 @@
 
   <fingerprint pattern="^UPS_Server/((?:\d+\.)*\d+)$">
     <description>An embedded web server used for UPS management; primarily by Eaton, but also by APC.</description>
-    <example>UPS_Server/1.0</example>
-    <example>UPS_Server/1</example>
+    <example service.version="1.0">UPS_Server/1.0</example>
+    <example service.version="1">UPS_Server/1</example>
     <param pos="0" name="service.vendor" value="Eaton"/>
     <param pos="0" name="service.product" value="ConnectUPS"/>
     <param pos="0" name="service.family" value="ConnectUPS"/>
@@ -2804,8 +2804,8 @@
 
   <fingerprint pattern="^JC-HTTPD/((?:\d+\.)*\d+)$">
     <description>An embedded web server, used notably by Oki and Kyocera in printers.</description>
-    <example>JC-HTTPD/1.11.14</example>
-    <example>JC-HTTPD/1</example>
+    <example service.version="1.11.14">JC-HTTPD/1.11.14</example>
+    <example service.version="1">JC-HTTPD/1</example>
     <param pos="0" name="service.product" value="JC-HTTPD"/>
     <param pos="0" name="service.family" value="JC-HTTPD"/>
     <param pos="1" name="service.version"/>
@@ -2814,7 +2814,7 @@
   <fingerprint pattern="^JC-SHTTPD/((?:\d+\.)*\d+)$">
     <description>An embedded web server.</description>
     <example service.version="1.17.20">JC-SHTTPD/1.17.20</example>
-    <example>JC-SHTTPD/1</example>
+    <example service.version="1">JC-SHTTPD/1</example>
     <param pos="0" name="service.product" value="JC-SHTTPD"/>
     <param pos="0" name="service.family" value="JC-SHTTPD"/>
     <param pos="1" name="service.version"/>
@@ -2823,7 +2823,7 @@
   <fingerprint pattern="^Oracle XML DB/Oracle\S+ (?:Enterprise Edition )?Release ((?:\d+\.)*\d+) - Production$">
     <description>Web server providing web services for Oracle's XML DB - with version string</description>
     <example service.version="9.2.0.1.0">Oracle XML DB/Oracle9i Enterprise Edition Release 9.2.0.1.0 - Production</example>
-    <example>Oracle XML DB/Oracle9i Enterprise Edition Release 9 - Production</example>
+    <example service.version="9">Oracle XML DB/Oracle9i Enterprise Edition Release 9 - Production</example>
     <example service.version="9.2.0.1.0">Oracle XML DB/Oracle9i Release 9.2.0.1.0 - Production</example>
     <param pos="0" name="service.vendor" value="Oracle"/>
     <param pos="0" name="service.product" value="XML DB"/>
@@ -2863,8 +2863,8 @@
 
   <fingerprint pattern="^Ews/((?:\d+\.)*\d+)$">
     <description>IBM Network Printer Manager.</description>
-    <example>Ews/0.1</example>
-    <example>Ews/0</example>
+    <example service.version="0.1">Ews/0.1</example>
+    <example service.version="0">Ews/0</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.product" value="Network Printer Manager"/>
     <param pos="0" name="service.family" value="Network Printer Manager"/>
@@ -2877,10 +2877,10 @@
 
   <fingerprint pattern="^\$ProjectRevision:[\s\w:]* ([\d\.]+) \$$">
     <description>This banner is used to see if devices have Treck TCP/IP</description>
-    <example>$ProjectRevision: 4.0.2.38 $</example>
-    <example>$ProjectRevision: 4.2 $</example>
-    <example>$ProjectRevision: 6.0.1.5 $</example>
-    <example>$ProjectRevision: Last Checkpoint: 4.2.2.13 $</example>
+    <example service.version="4.0.2.38">$ProjectRevision: 4.0.2.38 $</example>
+    <example service.version="4.2">$ProjectRevision: 4.2 $</example>
+    <example service.version="6.0.1.5">$ProjectRevision: 6.0.1.5 $</example>
+    <example service.version="4.2.2.13">$ProjectRevision: Last Checkpoint: 4.2.2.13 $</example>
     <param pos="0" name="service.vendor" value="Treck"/>
     <param pos="0" name="service.product" value="TCP/IP"/>
     <param pos="1" name="service.version"/>
@@ -2947,8 +2947,8 @@
 
   <fingerprint pattern="^NET-DK[/ ](\d+\.\d+)$">
     <description>Web server found on ARRIS cable modems</description>
-    <example>NET-DK/1.0</example>
-    <example>NET-DK 1.1</example>
+    <example service.version="1.0">NET-DK/1.0</example>
+    <example service.version="1.1">NET-DK 1.1</example>
     <param pos="0" name="service.vendor" value="ARRIS"/>
     <param pos="0" name="service.product" value="Net-DK Web Server"/>
     <param pos="1" name="service.version"/>
@@ -3016,8 +3016,8 @@
 
   <fingerprint pattern="^GFE/((?:\d+\.)*\d+)$">
     <description>Google Front End for apps running on Google services.</description>
-    <example>GFE/1.3</example>
-    <example>GFE/1</example>
+    <example service.version="1.3">GFE/1.3</example>
+    <example service.version="1">GFE/1</example>
     <param pos="0" name="service.vendor" value="Google"/>
     <param pos="0" name="service.family" value="Google Web Server"/>
     <param pos="0" name="service.product" value="Google Front End"/>
@@ -3306,9 +3306,9 @@
 
   <fingerprint pattern="(?i)^Linux/(\S+) UPnP/[\d\.]+ miniupnpd/([\d\.]+)$">
     <description>Linux MiniUPnPd UPnP Server</description>
-    <example service.version="1.0">Linux/Cross_compiled UPnP/1.0 miniupnpd/1.0</example>
-    <example>Linux/2.6.29.6-217.2.3.fc11.i686.PAE UPnP/1.0 miniupnpd/1.0</example>
-    <example>Linux/2.4.21 UPnP/1.0 miniupnpd/1.0</example>
+    <example service.version="1.0" os.version="Cross_compiled">Linux/Cross_compiled UPnP/1.0 miniupnpd/1.0</example>
+    <example service.version="1.0" os.version="2.6.29.6-217.2.3.fc11.i686.PAE">Linux/2.6.29.6-217.2.3.fc11.i686.PAE UPnP/1.0 miniupnpd/1.0</example>
+    <example service.version="1.0" os.version="2.4.21">Linux/2.4.21 UPnP/1.0 miniupnpd/1.0</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
     <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
@@ -3330,7 +3330,7 @@
 
   <fingerprint pattern="(?i)^(RT-\w+) UPnP/\S+ MiniUPnPd/([\d.]+)$">
     <description>Asus WAP UPnP Server</description>
-    <example service.version="1.2">RT-G32 UPnP/1.0 MiniUPnPd/1.2</example>
+    <example service.version="1.2" os.product="RT-G32">RT-G32 UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
     <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
@@ -3401,9 +3401,9 @@
 
   <fingerprint pattern="^[^/]+/(\S+) DLNADOC/\S+ UPnP/\S+ MiniDLNA/(\S+)$">
     <description>DLNADOC UPnP Server</description>
-    <example>Debian/4.0r8 DLNADOC/1.50 UPnP/1.0 MiniDLNA/1.0</example>
-    <example>FreeBSD/8.2-RELEASE-p4 DLNADOC/1.50 UPnP/1.0 MiniDLNA/1.0.24</example>
-    <example>Linux/2.6.36+ DLNADOC/1.50 UPnP/1.0 MiniDLNA/1.0</example>
+    <example service.version="1.0" os.version="4.0r8">Debian/4.0r8 DLNADOC/1.50 UPnP/1.0 MiniDLNA/1.0</example>
+    <example service.version="1.0.24" os.version="8.2-RELEASE-p4">FreeBSD/8.2-RELEASE-p4 DLNADOC/1.50 UPnP/1.0 MiniDLNA/1.0.24</example>
+    <example service.version="1.0" os.version="2.6.36+">Linux/2.6.36+ DLNADOC/1.50 UPnP/1.0 MiniDLNA/1.0</example>
     <param pos="0" name="service.product" value="MiniDLNA"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linux"/>
@@ -3669,7 +3669,7 @@
 
   <fingerprint pattern="(?i)^Linux Mips (\S+) UPnP/\S+ MiniUPnPd/(\S+)$">
     <description>Linux MIPS UPnP Server</description>
-    <example>Linux Mips 2.4.20 UPnP/1.0 MiniUPnPd/1.2</example>
+    <example service.version="1.2" os.version="2.4.20">Linux Mips 2.4.20 UPnP/1.0 MiniUPnPd/1.2</example>
     <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
     <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="2" name="service.version"/>
@@ -3695,8 +3695,8 @@
 
   <fingerprint pattern="^(\S{1,16}) \d+/Service Pack \d+, UPnP/[\d\.]+, TVersity Media Server$">
     <description>TVersity Media Server UPnP Server with Service Pack</description>
-    <example>5.2.3790 2/Service Pack 1, UPnP/1.0, TVersity Media Server</example>
-    <example>5.1.2600 2/Service Pack 3, UPnP/1.0, TVersity Media Server</example>
+    <example service.version="5.2.3790">5.2.3790 2/Service Pack 1, UPnP/1.0, TVersity Media Server</example>
+    <example service.version="5.1.2600">5.1.2600 2/Service Pack 3, UPnP/1.0, TVersity Media Server</example>
     <param pos="0" name="service.vendor" value="TVersity"/>
     <param pos="0" name="service.product" value="Media Server"/>
     <param pos="1" name="service.version"/>
@@ -3704,10 +3704,10 @@
 
   <fingerprint pattern="^(\S{1,16}) 2/, UPnP/\S+, TVersity Media Server$">
     <description>TVersity Media Server UPnP Server</description>
-    <example>6.2.8400 2/, UPnP/1.0, TVersity Media Server</example>
-    <example>6.2.9200 2/, UPnP/1.0, TVersity Media Server</example>
-    <example>6.0.6000 2/, UPnP/1.0, TVersity Media Server</example>
-    <example>6.1.7600 2/, UPnP/1.0, TVersity Media Server</example>
+    <example service.version="6.2.8400">6.2.8400 2/, UPnP/1.0, TVersity Media Server</example>
+    <example service.version="6.2.9200">6.2.9200 2/, UPnP/1.0, TVersity Media Server</example>
+    <example service.version="6.0.6000">6.0.6000 2/, UPnP/1.0, TVersity Media Server</example>
+    <example service.version="6.1.7600">6.1.7600 2/, UPnP/1.0, TVersity Media Server</example>
     <param pos="0" name="service.vendor" value="TVersity"/>
     <param pos="0" name="service.product" value="Media Server"/>
     <param pos="1" name="service.version"/>
@@ -3715,7 +3715,7 @@
 
   <fingerprint pattern="^LINUX/([\d\.]+) UPnP/[\d\.]+ BRCM400/([\d\.]+)$">
     <description>Belkin/Linksys BRCM400 Wireless Router UPnP Server</description>
-    <example>LINUX/2.4 UPnP/1.0 BRCM400/1.0</example>
+    <example service.version="1.0" os.version="2.4">LINUX/2.4 UPnP/1.0 BRCM400/1.0</example>
     <param pos="0" name="service.vendor" value="Linksys"/>
     <param pos="0" name="service.product" value="BRCM400"/>
     <param pos="2" name="service.version"/>
@@ -3727,8 +3727,8 @@
 
   <fingerprint pattern="^Linux-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
     <description>PlayStation3 Media Server UPnP Server - linux</description>
-    <example>Linux-amd64-2.6.18-238.9.1.el5, UPnP/1.0, PMS/1.52.1</example>
-    <example>Linux-i386-2.6.33.2, UPnP/1.0, PMS/1.21.1</example>
+    <example service.version="1.52.1" os.version="amd64-2.6.18-238.9.1.el5">Linux-amd64-2.6.18-238.9.1.el5, UPnP/1.0, PMS/1.52.1</example>
+    <example service.version="1.21.1" os.version="i386-2.6.33.2">Linux-i386-2.6.33.2, UPnP/1.0, PMS/1.21.1</example>
     <param pos="0" name="service.vendor" value="Sony"/>
     <param pos="0" name="service.product" value="PMS"/>
     <param pos="2" name="service.version"/>
@@ -3740,8 +3740,8 @@
 
   <fingerprint pattern="^Windows_XP-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
     <description>PlayStation3 Media Server UPnP Server - Windows XP</description>
-    <example>Windows_XP-amd64-5.2, UPnP/1.0, PMS/1.54.0</example>
-    <example>Windows_XP-x86-5.1, UPnP/1.0, PMS/1.20.400</example>
+    <example service.version="1.54.0" os.version="amd64-5.2">Windows_XP-amd64-5.2, UPnP/1.0, PMS/1.54.0</example>
+    <example service.version="1.20.400" os.version="x86-5.1">Windows_XP-x86-5.1, UPnP/1.0, PMS/1.20.400</example>
     <param pos="0" name="service.vendor" value="Sony"/>
     <param pos="0" name="service.product" value="PMS"/>
     <param pos="2" name="service.version"/>
@@ -3753,13 +3753,13 @@
 
   <fingerprint pattern="^Windows_7-x86-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
     <description>PlayStation3 Media Server UPnP Server - Windows 7 x86</description>
-    <example service.version="1.20">Windows_7-x86-6.1, UPnP/1.0, PMS/1.20</example>
-    <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.22.0</example>
-    <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.20.412</example>
-    <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.71.0</example>
-    <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.20.409</example>
-    <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.72.0</example>
-    <example>Windows_7-x86-6.1, UPnP/1.0, PMS/1.10.51</example>
+    <example service.version="1.20" os.version="6.1">Windows_7-x86-6.1, UPnP/1.0, PMS/1.20</example>
+    <example service.version="1.22.0" os.version="6.1">Windows_7-x86-6.1, UPnP/1.0, PMS/1.22.0</example>
+    <example service.version="1.20.412" os.version="6.1">Windows_7-x86-6.1, UPnP/1.0, PMS/1.20.412</example>
+    <example service.version="1.71.0" os.version="6.1">Windows_7-x86-6.1, UPnP/1.0, PMS/1.71.0</example>
+    <example service.version="1.20.409" os.version="6.1">Windows_7-x86-6.1, UPnP/1.0, PMS/1.20.409</example>
+    <example service.version="1.72.0" os.version="6.1">Windows_7-x86-6.1, UPnP/1.0, PMS/1.72.0</example>
+    <example service.version="1.10.51" os.version="6.1">Windows_7-x86-6.1, UPnP/1.0, PMS/1.10.51</example>
     <param pos="0" name="service.vendor" value="Sony"/>
     <param pos="0" name="service.product" value="PMS"/>
     <param pos="2" name="service.version"/>
@@ -3790,7 +3790,7 @@
 
   <fingerprint pattern="^Mac_OS_X-x86_64-(\S+), UPnP/[\d\.]+, PMS/([\d\.]+)$">
     <description>PlayStation3 Media Server UPnP Server - macOS x86_64</description>
-    <example>Mac_OS_X-x86_64-10.5.8, UPnP/1.0, PMS/1.20</example>
+    <example service.version="1.20" os.version="10.5.8">Mac_OS_X-x86_64-10.5.8, UPnP/1.0, PMS/1.20</example>
     <param pos="0" name="service.vendor" value="Sony"/>
     <param pos="0" name="service.product" value="PMS"/>
     <param pos="2" name="service.version"/>
@@ -3855,8 +3855,8 @@
 
   <fingerprint pattern="Linux, STUNNEL/1.0, (DIR-8\d+\w*) Ver (\S+)$">
     <description>D-Link DIR-8XX Router</description>
-    <example hw.product="DIR-850L">Linux, STUNNEL/1.0, DIR-850L Ver 1.09</example>
-    <example os.version="2.00W">Linux, STUNNEL/1.0, DIR-820LW Ver 2.00W</example>
+    <example hw.product="DIR-850L" os.version="1.09">Linux, STUNNEL/1.0, DIR-850L Ver 1.09</example>
+    <example os.version="2.00W" hw.product="DIR-820LW">Linux, STUNNEL/1.0, DIR-820LW Ver 2.00W</example>
     <param pos="0" name="hw.vendor" value="D-Link"/>
     <param pos="1" name="hw.product"/>
     <param pos="0" name="hw.device" value="Router"/>
@@ -3867,9 +3867,9 @@
 
   <fingerprint pattern="Linux, WEBACCESS/1.0, (DIR-\d+\w*) Ver (\S+)$">
     <description>D-Link DIR-XXX Router - WEBACCESS variant</description>
-    <example hw.product="DIR-850L">Linux, WEBACCESS/1.0, DIR-850L Ver 1.09</example>
-    <example os.version="1.14WW">Linux, WEBACCESS/1.0, DIR-850L Ver 1.14WW</example>
-    <example os.version="1.04">Linux, WEBACCESS/1.0, DIR-645 Ver 1.04</example>
+    <example hw.product="DIR-850L" os.version="1.09">Linux, WEBACCESS/1.0, DIR-850L Ver 1.09</example>
+    <example os.version="1.14WW" hw.product="DIR-850L">Linux, WEBACCESS/1.0, DIR-850L Ver 1.14WW</example>
+    <example os.version="1.04" hw.product="DIR-645">Linux, WEBACCESS/1.0, DIR-645 Ver 1.04</example>
     <param pos="0" name="hw.vendor" value="D-Link"/>
     <param pos="1" name="hw.product"/>
     <param pos="0" name="hw.device" value="Router"/>
@@ -3922,15 +3922,15 @@
 
   <fingerprint pattern="^ipos/([\d\.]+) UPnP/[\d\.]+ (TL-\w+)/(\S+)$">
     <description>TP-Link WAP UPnP Server</description>
-    <example>ipos/7.0 UPnP/1.0 TL-WR841N/6.0/7.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR841N/8.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR740N/4.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR940N/1.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR741N/4.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR740N/1.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR741N/1.0/2.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR740N/1.0/2.0</example>
-    <example>ipos/7.0 UPnP/1.0 TL-WR941N/2.0</example>
+    <example service.product="TL-WR841N" service.version="6.0/7.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR841N/6.0/7.0</example>
+    <example service.product="TL-WR841N" service.version="8.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR841N/8.0</example>
+    <example service.product="TL-WR740N" service.version="4.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR740N/4.0</example>
+    <example service.product="TL-WR940N" service.version="1.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR940N/1.0</example>
+    <example service.product="TL-WR741N" service.version="4.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR741N/4.0</example>
+    <example service.product="TL-WR740N" service.version="1.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR740N/1.0</example>
+    <example service.product="TL-WR741N" service.version="1.0/2.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR741N/1.0/2.0</example>
+    <example service.product="TL-WR740N" service.version="1.0/2.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR740N/1.0/2.0</example>
+    <example service.product="TL-WR941N" service.version="2.0" os.version="7.0">ipos/7.0 UPnP/1.0 TL-WR941N/2.0</example>
     <param pos="0" name="service.vendor" value="TP-LINK"/>
     <param pos="2" name="service.product"/>
     <param pos="3" name="service.version"/>
@@ -3961,7 +3961,7 @@
 
   <fingerprint pattern="^Linux/(\S+\_eureka_1), UPnP/[\d\.]+, Portable SDK for UPnP devices/(\S+)$">
     <description>Siqura Video Encoder</description>
-    <example>Linux/2.6.37_eureka_1, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
+    <example os.version="2.6.37_eureka_1" service.version="1.6.6">Linux/2.6.37_eureka_1, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
     <param pos="0" name="hw.vendor" value="Siqura"/>
     <param pos="0" name="hw.device" value="Video Encoder"/>
     <param pos="0" name="os.vendor" value="Siqura"/>
@@ -3974,7 +3974,7 @@
 
   <fingerprint pattern="^Linux/(\S+\-Mozart-8G), UPnP/[\d\.]+, Portable SDK for UPnP devices/(\S+)$">
     <description>Steinsvik Orbit IP Camera (Truen TCAM Rebrand)</description>
-    <example>Linux/2.6.28.9-Mozart-8G, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
+    <example os.version="2.6.28.9-Mozart-8G" service.version="1.6.6">Linux/2.6.28.9-Mozart-8G, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
     <param pos="0" name="hw.vendor" value="Steinsvik"/>
     <param pos="0" name="hw.device" value="IP Camera"/>
     <param pos="0" name="hw.product" value="Orbit IP Camera"/>
@@ -3988,7 +3988,7 @@
 
   <fingerprint pattern="^Linux/(\S+\-ami), UPnP/[\d\.]+, Portable SDK for UPnP devices/(\S+)$">
     <description>AMI MegaRAC LOM UPnP</description>
-    <example>Linux/3.14.17-ami, UPnP/1.0, Portable SDK for UPnP devices/1.6.20</example>
+    <example os.version="3.14.17-ami" service.version="1.6.20">Linux/3.14.17-ami, UPnP/1.0, Portable SDK for UPnP devices/1.6.20</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="AMI"/>
     <param pos="0" name="hw.family" value="MegaRAC"/>
@@ -4004,7 +4004,7 @@
 
   <fingerprint pattern="^Linux/(\S+\-axis[^,]+), UPnP/[\d\.]+, Portable SDK for UPnP devices/(\S+)$">
     <description>Axis Network Camera</description>
-    <example>Linux/4.9.94-axis5, UPnP/1.0, Portable SDK for UPnP devices/1.6.22</example>
+    <example os.version="4.9.94-axis5" service.version="1.6.22">Linux/4.9.94-axis5, UPnP/1.0, Portable SDK for UPnP devices/1.6.22</example>
     <param pos="0" name="hw.vendor" value="AXIS"/>
     <param pos="0" name="hw.device" value="IP Camera"/>
     <param pos="0" name="os.vendor" value="AXIS"/>
@@ -4018,23 +4018,23 @@
 
   <fingerprint pattern="^Linux/(\S+), UPnP/[\d\.]+, Portable SDK for UPnP devices/(\S+)$">
     <description>Portable SDK for UPnP Server - Linux</description>
-    <example>Linux/2.4.20-46.7asp, UPnP/1.0, Portable SDK for UPnP devices/1.6.17</example>
-    <example>Linux/2.6.10-iop1-1, UPnP/1.0, Portable SDK for UPnP devices/1.4.1</example>
-    <example>Linux/2.6.12-5.1-brcmstb-dm800, UPnP/1.0, Portable SDK for UPnP devices/1.6.0</example>
-    <example>Linux/2.6.12.6-VENUS, UPnP/1.0, Portable SDK for UPnP devices/1.6.10</example>
-    <example>Linux/2.6.12.6-arm1-040, UPnP/1.0, Portable SDK for UPnP devices/1.6.5.2</example>
-    <example>Linux/2.6.13, UPnP/1.0, Portable SDK for UPnP devices/1.6.0</example>
-    <example>Linux/2.6.18_pro500-davinci_N03A_IPCAM_1.0-g5c649288-dirty, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
-    <example>Linux/2.6.28, UPnP/1.0, Portable SDK for UPnP devices/1.6.10</example>
-    <example>Linux/2.6.28-11-server, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
-    <example>Linux/2.6.28-17-generic, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
-    <example>Linux/2.6.28.1-xxxx-std-ipv4-32, UPnP/1.0, Portable SDK for UPnP devices/1.4.3</example>
-    <example>Linux/2.6.32-220.7.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.14</example>
-    <example>Linux/2.6.32-24-generic, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
-    <example>Linux/2.6.32-279.1.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.13</example>
-    <example>Linux/2.6.32-279.11.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.14</example>
-    <example>Linux/2.6.32-279.14.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.14</example>
-    <example>Linux/2.6.32-279.14.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.15</example>
+    <example service.version="1.6.17" os.version="2.4.20-46.7asp">Linux/2.4.20-46.7asp, UPnP/1.0, Portable SDK for UPnP devices/1.6.17</example>
+    <example service.version="1.4.1" os.version="2.6.10-iop1-1">Linux/2.6.10-iop1-1, UPnP/1.0, Portable SDK for UPnP devices/1.4.1</example>
+    <example service.version="1.6.0" os.version="2.6.12-5.1-brcmstb-dm800">Linux/2.6.12-5.1-brcmstb-dm800, UPnP/1.0, Portable SDK for UPnP devices/1.6.0</example>
+    <example service.version="1.6.10" os.version="2.6.12.6-VENUS">Linux/2.6.12.6-VENUS, UPnP/1.0, Portable SDK for UPnP devices/1.6.10</example>
+    <example service.version="1.6.5.2" os.version="2.6.12.6-arm1-040">Linux/2.6.12.6-arm1-040, UPnP/1.0, Portable SDK for UPnP devices/1.6.5.2</example>
+    <example service.version="1.6.0" os.version="2.6.13">Linux/2.6.13, UPnP/1.0, Portable SDK for UPnP devices/1.6.0</example>
+    <example service.version="1.6.6" os.version="2.6.18_pro500-davinci_N03A_IPCAM_1.0-g5c649288-dirty">Linux/2.6.18_pro500-davinci_N03A_IPCAM_1.0-g5c649288-dirty, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
+    <example service.version="1.6.10" os.version="2.6.28">Linux/2.6.28, UPnP/1.0, Portable SDK for UPnP devices/1.6.10</example>
+    <example service.version="1.6.6" os.version="2.6.28-11-server">Linux/2.6.28-11-server, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
+    <example service.version="1.6.6" os.version="2.6.28-17-generic">Linux/2.6.28-17-generic, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
+    <example service.version="1.4.3" os.version="2.6.28.1-xxxx-std-ipv4-32">Linux/2.6.28.1-xxxx-std-ipv4-32, UPnP/1.0, Portable SDK for UPnP devices/1.4.3</example>
+    <example service.version="1.6.14" os.version="2.6.32-220.7.1.el6.x86_64">Linux/2.6.32-220.7.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.14</example>
+    <example service.version="1.6.6" os.version="2.6.32-24-generic">Linux/2.6.32-24-generic, UPnP/1.0, Portable SDK for UPnP devices/1.6.6</example>
+    <example service.version="1.6.13" os.version="2.6.32-279.1.1.el6.x86_64">Linux/2.6.32-279.1.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.13</example>
+    <example service.version="1.6.14" os.version="2.6.32-279.11.1.el6.x86_64">Linux/2.6.32-279.11.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.14</example>
+    <example service.version="1.6.14" os.version="2.6.32-279.14.1.el6.x86_64">Linux/2.6.32-279.14.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.14</example>
+    <example service.version="1.6.15" os.version="2.6.32-279.14.1.el6.x86_64">Linux/2.6.32-279.14.1.el6.x86_64, UPnP/1.0, Portable SDK for UPnP devices/1.6.15</example>
     <param pos="0" name="service.product" value="libupnp"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linux"/>
@@ -4045,8 +4045,8 @@
 
   <fingerprint pattern="^Linux/(\S+) UPnP/[\d\.]+ DLNADOC/[\d\.]+ Portable SDK for UPnP devices/(\S+)$">
     <description>DLNADOC Portable SDK for UPnP Server - Linux DNLADOC variant</description>
-    <example>Linux/3.0.8 UPnP/1.0 DLNADOC/1.50 Portable SDK for UPnP devices/1.6.6</example>
-    <example>Linux/2.6.23.17_stm23_0125dorade00 UPnP/1.0 DLNADOC/1.50 Portable SDK for UPnP devices/1.4.6-5</example>
+    <example service.version="1.6.6" os.version="3.0.8">Linux/3.0.8 UPnP/1.0 DLNADOC/1.50 Portable SDK for UPnP devices/1.6.6</example>
+    <example service.version="1.4.6-5" os.version="2.6.23.17_stm23_0125dorade00">Linux/2.6.23.17_stm23_0125dorade00 UPnP/1.0 DLNADOC/1.50 Portable SDK for UPnP devices/1.4.6-5</example>
     <param pos="0" name="service.product" value="libupnp"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linux"/>
@@ -4057,8 +4057,8 @@
 
   <fingerprint pattern="^Linux/(\S+), UPnP/[\d\.]+, Intel SDK for UPnP devices ?/(\S+)$">
     <description>Intel SDK for UPnP Server with verbose banner</description>
-    <example>Linux/2.6.10_dev-malta-mips2_fp_le, UPnP/1.0, Intel SDK for UPnP devices /1.2</example>
-    <example>Linux/2.4.18_mvl30-ixdp425, UPnP/1.0, Intel SDK for UPnP devices/1.3.1</example>
+    <example service.version="1.2" os.version="2.6.10_dev-malta-mips2_fp_le">Linux/2.6.10_dev-malta-mips2_fp_le, UPnP/1.0, Intel SDK for UPnP devices /1.2</example>
+    <example service.version="1.3.1" os.version="2.4.18_mvl30-ixdp425">Linux/2.4.18_mvl30-ixdp425, UPnP/1.0, Intel SDK for UPnP devices/1.3.1</example>
     <param pos="0" name="service.product" value="libupnp"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="os.vendor" value="Linux"/>
@@ -4069,7 +4069,7 @@
 
   <fingerprint pattern="^Linux, UPnP/[\d\.]+, Intel SDK for UPnP devices ?/(\S+)$">
     <description>Intel SDK for UPnP Server</description>
-    <example>Linux, UPnP/1.0, Intel SDK for UPnP devices /1.2</example>
+    <example service.version="1.2">Linux, UPnP/1.0, Intel SDK for UPnP devices /1.2</example>
     <param pos="0" name="service.product" value="libupnp"/>
     <param pos="1" name="service.version"/>
   </fingerprint>
@@ -4140,10 +4140,10 @@
 
   <fingerprint pattern="^UPnP/\S+, DLNADOC/\S+, Platinum/(\S+)$">
     <description>Xbox Media Center UPnP Server</description>
-    <example>UPnP/1.0, DLNADOC/1.50, Platinum/0.5.1</example>
-    <example>UPnP/1.0, DLNADOC/1.50, Platinum/0.6.6.0</example>
-    <example>UPnP/1.0, DLNADOC/1.50, Platinum/0.5.4.0</example>
-    <example>UPnP/1.0, DLNADOC/1.50, Platinum/0.5.3.0</example>
+    <example service.version="0.5.1">UPnP/1.0, DLNADOC/1.50, Platinum/0.5.1</example>
+    <example service.version="0.6.6.0">UPnP/1.0, DLNADOC/1.50, Platinum/0.6.6.0</example>
+    <example service.version="0.5.4.0">UPnP/1.0, DLNADOC/1.50, Platinum/0.5.4.0</example>
+    <example service.version="0.5.3.0">UPnP/1.0, DLNADOC/1.50, Platinum/0.5.3.0</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="XBMC"/>
     <param pos="1" name="service.version"/>
@@ -4383,7 +4383,7 @@
   <fingerprint pattern="^IX Series IX21\d\d \(magellan-sec\) Software, Version ([^, ]+), (?:MAINTENANCE )?RELEASE SOFTWARE$">
     <description>NEC Univerge Router - enterprise class with VPN, UTM, etc</description>
     <example hw.version="10.2.20">IX Series IX2106 (magellan-sec) Software, Version 10.2.20, RELEASE SOFTWARE</example>
-    <example>IX Series IX2105 (magellan-sec) Software, Version 9.6.12A, MAINTENANCE RELEASE SOFTWARE</example>
+    <example hw.version="9.6.12A">IX Series IX2105 (magellan-sec) Software, Version 9.6.12A, MAINTENANCE RELEASE SOFTWARE</example>
     <param pos="0" name="hw.vendor" value="NEC"/>
     <param pos="0" name="hw.product" value="Univerge"/>
     <param pos="1" name="hw.version"/>
@@ -4402,8 +4402,8 @@
   <fingerprint pattern="^MoxaHttp/(\d\.\d)$">
     <description>Moxa devices - service used on multiple families of devices</description>
     <example service.version="2.3">MoxaHttp/2.3</example>
-    <example>MoxaHttp/2.2</example>
-    <example>MoxaHttp/1.0</example>
+    <example service.version="2.2">MoxaHttp/2.2</example>
+    <example service.version="1.0">MoxaHttp/1.0</example>
     <param pos="0" name="service.vendor" value="Moxa"/>
     <param pos="0" name="service.product" value="httpd"/>
     <param pos="1" name="service.version"/>
@@ -4571,7 +4571,7 @@
 
   <fingerprint pattern="UNMS (\d+\.\d+\.\d+)">
     <description>Ubiquiti UNMS</description>
-    <example>302 Found UNMS 1.2.7</example>
+    <example service.version="1.2.7">302 Found UNMS 1.2.7</example>
     <param pos="0" name="service.vendor" value="Ubiquiti"/>
     <param pos="0" name="service.product" value="UNMS"/>
     <param pos="1" name="service.version"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -289,7 +289,7 @@
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(?:SmartAX )?(MT\d+[^ ]*)(?: ADSL Router)?&quot;$">
     <description>Huawei xDSL routers</description>
-    <example hw.product="MT882">Basic realm="SmartAX MT882"</example>
+    <example hw.product="MT882" service.product="MT882" os.product="MT882">Basic realm="SmartAX MT882"</example>
     <param pos="0" name="service.vendor" value="Huawei"/>
     <param pos="0" name="service.family" value="MT"/>
     <param pos="1" name="service.product"/>
@@ -322,10 +322,10 @@
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(WRT54G\w*)&quot;$">
     <description>Linksys WRT54G wireless access point (dozen of variants of the product)</description>
-    <example hw.product="WRT54G">Basic realm="WRT54G"</example>
-    <example hw.product="WRT54GL">Basic realm="WRT54GL"</example>
-    <example hw.product="WRT54GSV4">Basic realm="WRT54GSV4"</example>
-    <example hw.product="WRT54GCv3">Basic realm="WRT54GCv3"</example>
+    <example hw.product="WRT54G" os.product="WRT54G">Basic realm="WRT54G"</example>
+    <example hw.product="WRT54GL" os.product="WRT54GL">Basic realm="WRT54GL"</example>
+    <example hw.product="WRT54GSV4" os.product="WRT54GSV4">Basic realm="WRT54GSV4"</example>
+    <example hw.product="WRT54GCv3" os.product="WRT54GCv3">Basic realm="WRT54GCv3"</example>
     <param pos="0" name="os.vendor" value="Linksys"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.product"/>
@@ -336,9 +336,9 @@
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(TD-[VW8][A-Z0-9]+)(?:| \d+\.\d+)&quot;$">
     <description>TP-LINK SoHo Router - dash variant</description>
-    <example os.product="TD-W8901G">Basic realm="TD-W8901G"</example>
-    <example>Basic realm="TD-8840T 2.0"</example>
-    <example hw.product="TD-8811">Basic realm="TD-8811"</example>
+    <example os.product="TD-W8901G" hw.product="TD-W8901G">Basic realm="TD-W8901G"</example>
+    <example os.product="TD-8840T" hw.product="TD-8840T">Basic realm="TD-8840T 2.0"</example>
+    <example hw.product="TD-8811" os.product="TD-8811">Basic realm="TD-8811"</example>
     <param pos="0" name="os.vendor" value="TP-LINK"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -349,10 +349,10 @@
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(TD8[A-Z0-9]+)&quot;$">
     <description>TP-LINK SoHo Router</description>
-    <example os.product="TD854W">Basic realm="TD854W"</example>
-    <example hw.product="TD811">Basic realm="TD811"</example>
-    <example>Basic realm="TD821"</example>
-    <example>Basic realm="TD841"</example>
+    <example os.product="TD854W" hw.product="TD854W">Basic realm="TD854W"</example>
+    <example hw.product="TD811" os.product="TD811">Basic realm="TD811"</example>
+    <example os.product="TD821" hw.product="TD821">Basic realm="TD821"</example>
+    <example os.product="TD841" hw.product="TD841">Basic realm="TD841"</example>
     <param pos="0" name="os.vendor" value="TP-LINK"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -363,22 +363,22 @@
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;TP-LINK.*(?:Access Point|Extender|AP) ([A-Z0-9\-\+]+)&quot;">
     <description>TP-LINK SoHo Router - verbose variant</description>
-    <example os.product="WA801N">Basic realm="TP-LINK Wireless N Access Point WA801N"</example>
-    <example hw.product="WA830RE">Basic realm="TP-LINK Wireless Range Extender WA830RE"</example>
-    <example>Basic realm="TP-LINK Wireless Range Extender WA850RE"</example>
-    <example>Basic realm="TP-LINK Wireless AP WA501G"</example>
-    <example>Basic realm="TP-LINK Wireless N Access Point WA701ND"</example>
-    <example>Basic realm="TP-LINK Wireless N Access Point WA901ND"</example>
-    <example>Basic realm="TP-LINK Wireless AP WA601G"</example>
-    <example>Basic realm="TP-LINK Wireless AP WR710N"</example>
-    <example>Basic realm="TP-LINK Wireless AP WR700N"</example>
-    <example>Basic realm="TP-LINK Wireless Range Extender WA750RE"</example>
-    <example>Basic realm="TP-LINK Wireless AP WR702N"</example>
-    <example>Basic realm="TP-LINK Wireless AP WR800N"</example>
-    <example>Basic realm="TP-LINK Wireless Range Extender WA730RE"</example>
-    <example>Basic realm="TP-LINK Wireless N Access Point WA805N"</example>
-    <example>Basic realm="TP-LINK Wireless N Access Point WA701N"</example>
-    <example>Basic realm="TP-LINK Wireless AP WR706N"</example>
+    <example os.product="WA801N" hw.product="WA801N">Basic realm="TP-LINK Wireless N Access Point WA801N"</example>
+    <example hw.product="WA830RE" os.product="WA830RE">Basic realm="TP-LINK Wireless Range Extender WA830RE"</example>
+    <example os.product="WA850RE" hw.product="WA850RE">Basic realm="TP-LINK Wireless Range Extender WA850RE"</example>
+    <example os.product="WA501G" hw.product="WA501G">Basic realm="TP-LINK Wireless AP WA501G"</example>
+    <example os.product="WA701ND" hw.product="WA701ND">Basic realm="TP-LINK Wireless N Access Point WA701ND"</example>
+    <example os.product="WA901ND" hw.product="WA901ND">Basic realm="TP-LINK Wireless N Access Point WA901ND"</example>
+    <example os.product="WA601G" hw.product="WA601G">Basic realm="TP-LINK Wireless AP WA601G"</example>
+    <example os.product="WR710N" hw.product="WR710N">Basic realm="TP-LINK Wireless AP WR710N"</example>
+    <example os.product="WR700N" hw.product="WR700N">Basic realm="TP-LINK Wireless AP WR700N"</example>
+    <example os.product="WA750RE" hw.product="WA750RE">Basic realm="TP-LINK Wireless Range Extender WA750RE"</example>
+    <example os.product="WR702N" hw.product="WR702N">Basic realm="TP-LINK Wireless AP WR702N"</example>
+    <example os.product="WR800N" hw.product="WR800N">Basic realm="TP-LINK Wireless AP WR800N"</example>
+    <example os.product="WA730RE" hw.product="WA730RE">Basic realm="TP-LINK Wireless Range Extender WA730RE"</example>
+    <example os.product="WA805N" hw.product="WA805N">Basic realm="TP-LINK Wireless N Access Point WA805N"</example>
+    <example os.product="WA701N" hw.product="WA701N">Basic realm="TP-LINK Wireless N Access Point WA701N"</example>
+    <example os.product="WR706N" hw.product="WR706N">Basic realm="TP-LINK Wireless AP WR706N"</example>
     <param pos="0" name="os.vendor" value="TP-LINK"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.product"/>
@@ -389,9 +389,9 @@
 
   <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;TP-LINK (.*Router.*)&quot;">
     <description>TP-LINK Routers</description>
-    <example>Basic realm="TP-LINK Wireless N Router WR841N"</example>
-    <example>Basic realm="TP-LINK Gigabit Broadband VPN Router R600VPN"</example>
-    <example>Basic realm="TP-LINK Wireless Lite N Router WR740N/WR741ND"</example>
+    <example hw.product="Wireless N Router WR841N">Basic realm="TP-LINK Wireless N Router WR841N"</example>
+    <example hw.product="Gigabit Broadband VPN Router R600VPN">Basic realm="TP-LINK Gigabit Broadband VPN Router R600VPN"</example>
+    <example hw.product="Wireless Lite N Router WR740N/WR741ND">Basic realm="TP-LINK Wireless Lite N Router WR740N/WR741ND"</example>
     <param pos="0" name="hw.vendor" value="TP-LINK"/>
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="1" name="hw.product"/>
@@ -504,7 +504,7 @@
 
   <fingerprint pattern="(?i)^(?:Basic|Digest).*realm=&quot;ZXHN (\S+)&quot;">
     <description>ZTE ZXHN router</description>
-    <example>Basic realm="ZXHN H108L"</example>
+    <example hw.product="H108L">Basic realm="ZXHN H108L"</example>
     <param pos="0" name="hw.vendor" value="ZTE"/>
     <param pos="0" name="hw.device" value="Router"/>
     <param pos="0" name="hw.family" value="ZXHN"/>

--- a/xml/imap_banners.xml
+++ b/xml/imap_banners.xml
@@ -168,8 +168,8 @@
 
   <fingerprint pattern="^(\S{1,512}) CallPilot IMAP4rev1 v(\S+) server ready\.?$">
     <description>Nortel CallPilot</description>
-    <example>nottest.localdomain CallPilot IMAP4rev1 v42.02.05.22 server ready.</example>
-    <example>test.localdomain CallPilot IMAP4rev1 v43.03.19.22 server ready.</example>
+    <example service.version="42.02.05.22" host.name="nottest.localdomain">nottest.localdomain CallPilot IMAP4rev1 v42.02.05.22 server ready.</example>
+    <example service.version="43.03.19.22" host.name="test.localdomain">test.localdomain CallPilot IMAP4rev1 v43.03.19.22 server ready.</example>
     <param pos="0" name="service.vendor" value="Nortel"/>
     <param pos="0" name="service.product" value="CallPilot"/>
     <param pos="2" name="service.version"/>

--- a/xml/nntp_banners.xml
+++ b/xml/nntp_banners.xml
@@ -24,8 +24,8 @@
 
   <fingerprint pattern="^NNTP Service (?:.*) Version: (5.0.2195.[0-9]+)">
     <description>Microsoft IIS NNTP Server on Windows 2000</description>
-    <example>NNTP Service 5.00.0984 Version: 5.0.2195.7034 Posting Allowed</example>
-    <example>NNTP Service 5.00.0984 Version: 5.0.2195.5329 Posting Allowed</example>
+    <example service.version="5.0.2195.7034" ms.nttp.version="5.0.2195.7034">NNTP Service 5.00.0984 Version: 5.0.2195.7034 Posting Allowed</example>
+    <example service.version="5.0.2195.5329" ms.nttp.version="5.0.2195.5329">NNTP Service 5.00.0984 Version: 5.0.2195.5329 Posting Allowed</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>
@@ -40,8 +40,8 @@
 
   <fingerprint pattern="^NNTP Service (?:.*) Version: (6.0.3790.[0-9]+)">
     <description>Microsoft IIS NNTP Server on Windows Server 2003</description>
-    <example>NNTP Service 6.0.3790.3959 Version: 6.0.3790.3959 Posting Allowed</example>
-    <example>NNTP Service 6.0.3790.206 Version: 6.0.3790.206 Posting Allowed</example>
+    <example service.version="6.0.3790.3959" ms.nttp.version="6.0.3790.3959">NNTP Service 6.0.3790.3959 Version: 6.0.3790.3959 Posting Allowed</example>
+    <example service.version="6.0.3790.206" ms.nttp.version="6.0.3790.206">NNTP Service 6.0.3790.206 Version: 6.0.3790.206 Posting Allowed</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.product" value="IIS"/>
     <param pos="0" name="service.family" value="IIS"/>

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -92,7 +92,7 @@
 
   <fingerprint pattern="version=&quot;ntpd (\S+)[^&quot;]+&quot;,.*system=&quot;Equallogic \(R\) storage array&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on an EqualLogic Storage Array that includes the NTP version</description>
-    <example>
+    <example service.version="4.2.0-r">
       version="ntpd 4.2.0-r Fri Feb  5 15:18:30 EST 2010 (1)",
       processor="Working", system="EqualLogic (R) storage array", leap=0,
       stratum=3, precision=-7, rootdelay=102.894, rootdispersion=245.154,
@@ -140,7 +140,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;Linux/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Linux</description>
-    <example>
+    <example service.version="4.2.4p3@1.1502-o" os.arch="i686" os.version="2.4.29">
       version="ntpd 4.2.4p3@1.1502-o Wed Jul 18 11:45:01 UTC 2007 (1)",
       processor="i686", system="Linux/2.4.29", leap=00, stratum=3,
     </example>
@@ -157,7 +157,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^&quot;]+)&quot;,.*system=&quot;Darwin/?6\.([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Mac OSX 10.2/Jaguar</description>
-    <example service.version="4.1.1@1.786" os.version.version="8">
+    <example service.version="4.1.1@1.786" os.version.version="8" os.arch="Power Macintosh">
       version="ntpd 4.1.1@1.786 Tue Nov 12 09:30:41 PST 2002 (1)", processor="Power Macintosh", system="Darwin6.8",
     </example>
     <param pos="0" name="service.family" value="NTP"/>
@@ -190,7 +190,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^&quot;]+)&quot;,.*system=&quot;Darwin/?8\.([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Mac OSX 10.4/Tiger</description>
-    <example>
+    <example service.version="4.2.0@1.1161-r" os.arch="i386" os.version.version="11.1">
       version="ntpd 4.2.0@1.1161-r Fri Jan 13 11:36:23 PST 2006 (1)",
       processor="i386", system="Darwin/8.11.1", leap=11, stratum=16,
     </example>
@@ -209,7 +209,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^&quot;]+)&quot;,.*system=&quot;Darwin/?9\.([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Mac OSX 10.5/Leopard</description>
-    <example>
+    <example service.version="4.2.2@1.1532-o" os.arch="Power Macintosh" os.version.version="0.0">
       version="ntpd 4.2.2@1.1532-o Mon Sep 24 01:42:27 UTC 2007 (1)",
       processor="Power Macintosh", system="Darwin/9.0.0", leap=3, stratum=16,
     </example>
@@ -228,7 +228,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^&quot;]+)&quot;,.*system=&quot;Darwin/?10\.([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Mac OSX 10.6/Snow Leopard</description>
-    <example>
+    <example service.version="4.2.4p4@1.1520-o" os.arch="i386" os.version.version="8.0">
       version="ntpd 4.2.4p4@1.1520-o Mon May 18 19:38:25 UTC 2009 (1)",
       processor="i386", system="Darwin/10.8.0", leap=0, stratum=3,
     </example>
@@ -267,7 +267,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^&quot;]+)&quot;,.*system=&quot;Darwin/?11\.([^&quot;]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Mac OSX 10.7/Lion</description>
-    <example>
+    <example service.version="4.2.6@1.2089-o" os.arch="x86_64" os.version.version="2.0">
       version="ntpd 4.2.6@1.2089-o Fri May 28 01:20:53 UTC 2010 (1)",
       processor="x86_64", system="Darwin/11.2.0", leap=11, stratum=16,
     </example>
@@ -367,7 +367,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on FreeBSD</description>
-    <example>
+    <example service.version="4.2.6p2@1.2194" os.arch="i386" os.version="7.4-PRERELEASE">
       version="ntpd 4.2.6p2@1.2194 Wed Nov 24 15:54:11 UTC 2010 (1)",
       processor="i386", system="FreeBSD/7.4-PRERELEASE", leap=00, stratum=3,
     </example>
@@ -400,7 +400,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;NetBSD/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on NetBSD</description>
-    <example>
+    <example service.version="4.2.4p6-o" os.arch="sparc64" os.version="5.0_STABLE">
       version="ntpd 4.2.4p6-o Thu Jan  8 21:02:40 MET 2009 (import)",
       processor="sparc64", system="NetBSD/5.0_STABLE", leap=00, stratum=1,
     </example>
@@ -420,34 +420,34 @@
     <example os.arch="i386" os.version="1.5.3">
       processor="i386", system="NetBSD1.5.3"
     </example>
-    <example>
+    <example os.arch="i386" os.version="1.6">
       processor="i386", system="NetBSD1.6"
     </example>
-    <example>
+    <example os.arch="i386" os.version="1.6.1">
       processor="i386", system="NetBSD1.6.1"
     </example>
-    <example>
+    <example os.arch="i386" os.version="1.6.2_STABLE">
       processor="i386", system="NetBSD1.6.2_STABLE"
     </example>
-    <example>
+    <example os.arch="sbmips" os.version="3.0">
       processor="sbmips", system="NetBSD3.0"
     </example>
-    <example>
+    <example os.arch="se100" os.version="1.5.3">
       processor="se100", system="NetBSD1.5.3"
     </example>
-    <example>
+    <example os.arch="seil3" os.version="1.6.1_STABLE">
       processor="seil3", system="NetBSD1.6.1_STABLE"
     </example>
-    <example>
+    <example os.arch="seil3" os.version="1.6.2_STABLE">
       processor="seil3", system="NetBSD1.6.2_STABLE"
     </example>
-    <example>
+    <example os.arch="seil4" os.version="1.6.1_STABLE">
       processor="seil4", system="NetBSD1.6.1_STABLE"
     </example>
-    <example>
+    <example os.arch="seil4" os.version="1.6.2_STABLE">
       processor="seil4", system="NetBSD1.6.2_STABLE"
     </example>
-    <example>
+    <example os.arch="siara2k" os.version="1.5.3">
       processor="siara2k", system="NetBSD1.5.3"
     </example>
     <param pos="0" name="os.vendor" value="NetBSD"/>
@@ -818,7 +818,7 @@
 
   <fingerprint pattern="system=&quot;UNIX/SunOS ([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>SunOS with no ntp version</description>
-    <example>
+    <example os.version="4.x">
       system="UNIX/SunOS 4.x",
     </example>
     <param pos="0" name="os.vendor" value="Sun"/>
@@ -830,7 +830,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;JUNOS/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Juniper/Netscreen JunOS</description>
-    <example>
+    <example service.version="4.2.0-a" os.arch="i386" os.version="9.3R4.4">
       version="ntpd 4.2.0-a Wed Aug 12 04:22:47 UTC 2009 (1)",
       processor="i386", system="JUNOS9.3R4.4", leap=11, stratum=16,
     </example>
@@ -860,11 +860,11 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;Windows/?([^ ]+)?&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on Windows</description>
-    <example>
+    <example service.version="4.2.4p7@copenhagen-o" os.arch="x86">
       version="ntpd 4.2.4p7@copenhagen-o May 22 11:25:36 (UTC+02:00) 2009  (3)",
       processor="x86", system="Windows", leap=00, stratum=2, precision=-19,
     </example>
-    <example>
+    <example service.version="4.2.4p4@1.1520-modena-o" os.arch="unknown" os.version="NT">
       version="ntpd 4.2.4p4@1.1520-modena-o Dec 05 9:35:28 (UTC+01:00) 2007  (11)",
       processor="unknown", system="WINDOWS/NT", leap=00, stratum=2,
     </example>
@@ -881,7 +881,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;HP-UX/?([^ ]+)?&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on HP-UX</description>
-    <example>
+    <example service.version="4.2.2@1.1532-o" os.arch="9000/800" os.version="B.11.11">
       version="ntpd 4.2.2@1.1532-o Wed Sep  6 16:49:43 EDT 2006 (2)",
       processor="9000/800", system="HP-UX/B.11.11", leap=00, stratum=1,
     </example>
@@ -913,7 +913,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;[^ ]+&quot;,.*system=&quot;([^ ]+)-hp-hpux([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on HP-UX, where the processor is in the 'system' variable</description>
-    <example>
+    <example service.version="4.2.5p154@1.1802" os.arch="ia64" os.version="11.31">
       version="ntpd 4.2.5p154@1.1802 Tue Mar 22 22:09:00 UTC 2011 (39)",
       processor="unknown", system="ia64-hp-hpux11.31", leap=00, stratum=1,
     </example>
@@ -935,7 +935,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;VMkernel/?([^ ]+)?&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on VMware ESXi</description>
-    <example>
+    <example service.version="4.2.4p6@1.1495" os.arch="x86_64" os.version="4.1.0">
       version="ntpd 4.2.4p6@1.1495 Wed Sep 22 02:33:15 UTC 2010 (1)",
       processor="x86_64", system="VMkernel/4.1.0", leap=11, stratum=16,
     </example>
@@ -1031,7 +1031,7 @@
 
   <fingerprint pattern="system=&quot;Data ONTAP/+(\S+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>NetApp file servers</description>
-    <example>
+    <example os.version="8.1RC2">
       system="Data ONTAP/8.1RC2"
     </example>
     <param pos="0" name="os.vendor" value="NetApp"/>
@@ -1110,7 +1110,7 @@
 
   <fingerprint pattern="system=&quot;UNIX/Unixware([^ ]+)&quot;" flags="REG_ICASE">
     <description>SCO Unixware NTP</description>
-    <example>
+    <example os.product="2">
       system="UNIX/Unixware2", leap=3, stratum=16, rootdelay=0.00,
       rootdispersion=0.00, peer=0, refid=0.0.0.0, reftime=0x00000000.00000000,
       poll=4, clock=0xd1d874b7.051ec000, phase=0.000, freq=0.00, error=0.00
@@ -1134,7 +1134,7 @@
 
   <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*\s*processor=&quot;([^ ]+)&quot;,.*system=&quot;SecureOS/([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>McAfee Network Firewall Enterprise NTP (SecureOS)</description>
-    <example>
+    <example service.version="4.2.0-r" os.arch="i386" os.version="7.0.1.00">
       version="ntpd 4.2.0-r Thu Aug 11 12:41:19 CDT 2005 (1)",
       processor="i386", system="SecureOS/7.0.1.00", leap=0, stratum=3,
       precision=-19, rootdelay=27.044, rootdispersion=87.845, peer=2357,
@@ -1142,7 +1142,7 @@
       clock=0xd2636c8e.d5e2d427, state=4, offset=0.519, frequency=-3.027,
       jitter=5.132, stability=0.394
     </example>
-    <example>
+    <example service.version="4.2.0-r" os.arch="i386" os.version="7.0.0.04">
       version="ntpd 4.2.0-r Thu Aug 11 12:41:19 CDT 2005 (1)",
       processor="i386", system="SecureOS/7.0.0.04", leap=0, stratum=2,
       precision=-19, rootdelay=56.480, rootdispersion=35.772, peer=8677,
@@ -1161,14 +1161,14 @@
 
   <fingerprint pattern="processor=&quot;([^ ]+)&quot;.*system=&quot;Linux([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on linux</description>
-    <example>
+    <example os.arch="i686" os.version="2.6.10">
       processor="i686", system="Linux2.6.10", leap=0, stratum=2,
       precision=-17, rootdelay=44.644, rootdispersion=29.933, peer=13317,
       refid=A.B.C.D, reftime=0xd2c29f69.407570c5, poll=10,
       clock=0xd2c2a335.360999dc, state=4, phase=1.037, frequency=55.898,
       jitter=0.203, stability=0.004
     </example>
-    <example>
+    <example os.arch="i686" os.version="2.6.23.waas">
       processor="i686", system="Linux2.6.23.waas", leap=0, stratum=2,
       precision=-18, rootdelay=37.550, rootdispersion=427.047, peer=40613,
       refid=172.20.62.191, reftime=0xd297a442.8b66c6de, poll=14,
@@ -1188,7 +1188,7 @@
 
   <fingerprint pattern="version=&quot;ntpd (\S+)[^&quot;]+&quot;,.*\s*processor=&quot;([^ ]+)&quot;.*system=&quot;Isilon OneFS/v([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>Isilon OneFS NTP Server</description>
-    <example>
+    <example service.version="4.2.4p4-o" os.arch="i386" os.version="5.5.4.21">
       version="ntpd 4.2.4p4-o Thu Feb  4 20:43:00 UTC 2010 (1)",
       processor="i386", system="Isilon OneFS/v5.5.4.21", leap=0, stratum=14,
       precision=-19, rootdelay=0.000, rootdispersion=11.260, peer=60044,

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -28,7 +28,7 @@
 
   <fingerprint pattern="^(?i:(?:Microsoft )?Windows 10 Mobile(?:\s([a-z]+))?(?: Edition)?)$">
     <description>Windows 10 Mobile</description>
-    <example os.product="Windows 10 Mobile">Windows 10 Mobile Edition</example>
+    <example os.product="Windows 10 Mobile" os.edition="Edition">Windows 10 Mobile Edition</example>
     <example os.product="Windows 10 Mobile" os.edition="Enterprise">Windows 10 Mobile Enterprise Edition</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -253,7 +253,7 @@
 
   <fingerprint pattern="^(?i:Kubuntu(?: Linux)?\s(\d+?(?:\.\d+?)*?)?\s?(LTS)?)$">
     <description>Kubuntu Linux</description>
-    <example os.version="12.04.4">Kubuntu 12.04.4 LTS</example>
+    <example os.version="12.04.4" os.edition="LTS">Kubuntu 12.04.4 LTS</example>
     <example os.version="14.04">Kubuntu Linux 14.04</example>
     <example os.version="16.04" os.edition="LTS">Kubuntu 16.04 LTS</example>
     <param pos="0" name="os.vendor" value="Kubuntu"/>
@@ -358,7 +358,7 @@
 
   <fingerprint pattern="^(?i:Ubuntu(?: Linux)?(?:\s|-)(\d+?(?:\.\d+?)*?)?\s?(LTS)?)$">
     <description>Ubuntu Linux</description>
-    <example os.version="12.04.4">Ubuntu 12.04.4 LTS</example>
+    <example os.version="12.04.4" os.edition="LTS">Ubuntu 12.04.4 LTS</example>
     <example os.version="14.04">Ubuntu Linux 14.04</example>
     <example os.version="16.04" os.edition="LTS">Ubuntu 16.04 LTS</example>
     <example os.version="16.04" os.edition="LTS">Ubuntu-16.04 LTS</example>
@@ -374,7 +374,7 @@
 
   <fingerprint pattern="^(?i:Xubuntu(?: Linux)?\s(\d+?(?:\.\d+?)*?)?\s?(LTS)?)$">
     <description>Xubuntu Linux</description>
-    <example os.version="12.04.4">Xubuntu 12.04.4 LTS</example>
+    <example os.version="12.04.4" os.edition="LTS">Xubuntu 12.04.4 LTS</example>
     <example os.version="14.04">Xubuntu Linux 14.04</example>
     <example os.version="16.04" os.edition="LTS">Xubuntu 16.04 LTS</example>
     <param pos="0" name="os.vendor" value="Xubuntu"/>
@@ -590,11 +590,11 @@
 
   <fingerprint pattern="(?i)^(.{0,256}?BSD)\s?(\d+?(?:\.\d+?)*?(?:[\-\/_ ]?\w+?)?(?:-[a-z]\d+?)?)?$">
     <description>Many BSD family OSes</description>
-    <example os.version="10.3-RELEASE" os.product="FreeBSD">FreeBSD 10.3-RELEASE</example>
-    <example os.version="10.3-RELEASE-p4" os.product="FreeBSD">FreeBSD 10.3-RELEASE-p4</example>
-    <example os.version="7.0" os.product="NetBSD">NetBSD 7.0</example>
-    <example os.version="5.9" os.product="OpenBSD">OpenBSD 5.9</example>
-    <example os.product="PC-BSD">PC-BSD</example>
+    <example os.version="10.3-RELEASE" os.product="FreeBSD" os.vendor="FreeBSD" os.family="FreeBSD">FreeBSD 10.3-RELEASE</example>
+    <example os.version="10.3-RELEASE-p4" os.product="FreeBSD" os.vendor="FreeBSD" os.family="FreeBSD">FreeBSD 10.3-RELEASE-p4</example>
+    <example os.version="7.0" os.product="NetBSD" os.vendor="NetBSD" os.family="NetBSD">NetBSD 7.0</example>
+    <example os.version="5.9" os.product="OpenBSD" os.vendor="OpenBSD" os.family="OpenBSD">OpenBSD 5.9</example>
+    <example os.product="PC-BSD" os.vendor="PC-BSD" os.family="PC-BSD">PC-BSD</example>
     <param pos="1" name="os.vendor"/>
     <param pos="1" name="os.family"/>
     <param pos="1" name="os.product"/>
@@ -662,14 +662,14 @@
 
   <fingerprint pattern="^(?i:(?:IBM\s?)?(AIX|MVS|OS/(?:\d{1,3})|VM/CMS|VM/ESA|z/OS)\s?(\d+?(?:\.\d+?)*?)?)$">
     <description>IBM OSes</description>
-    <example os.product="AIX">AIX</example>
-    <example os.product="MVS">IBM MVS</example>
-    <example os.product="OS/2">IBM OS/2</example>
-    <example os.product="OS/390">IBM OS/390</example>
-    <example os.product="OS/400">OS/400</example>
-    <example os.product="VM/CMS">IBM VM/CMS</example>
-    <example os.product="VM/ESA">IBM VM/ESA</example>
-    <example os.product="z/OS">IBM z/OS</example>
+    <example os.product="AIX" os.family="AIX">AIX</example>
+    <example os.product="MVS" os.family="MVS">IBM MVS</example>
+    <example os.product="OS/2" os.family="OS/2">IBM OS/2</example>
+    <example os.product="OS/390" os.family="OS/390">IBM OS/390</example>
+    <example os.product="OS/400" os.family="OS/400">OS/400</example>
+    <example os.product="VM/CMS" os.family="VM/CMS">IBM VM/CMS</example>
+    <example os.product="VM/ESA" os.family="VM/ESA">IBM VM/ESA</example>
+    <example os.product="z/OS" os.family="z/OS">IBM z/OS</example>
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="1" name="os.family"/>
     <param pos="1" name="os.product"/>
@@ -678,8 +678,8 @@
 
   <fingerprint pattern="^(?i:(?:HP\s?)?(Digital UNIX|HP-UX|iLO|OpenVMS|ProLiant|Tru64 UNIX)\s?(\d+?(?:\.\d+?)*?)?)$">
     <description>HP OSes</description>
-    <example os.product="HP-UX">HP-UX</example>
-    <example os.product="OpenVMS">OpenVMS</example>
+    <example os.product="HP-UX" os.family="HP-UX">HP-UX</example>
+    <example os.product="OpenVMS" os.family="OpenVMS">OpenVMS</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="1" name="os.family"/>
     <param pos="1" name="os.product"/>
@@ -692,8 +692,8 @@
 
   <fingerprint pattern="^(?i:(?:Juniper\s?)?(Junos|Junos OS|ScreenOS)\s?(\d+?(?:\.\d+?)*?)?)$">
     <description>Juniper</description>
-    <example>Junos</example>
-    <example>ScreenOS</example>
+    <example os.family="Junos" os.product="Junos">Junos</example>
+    <example os.family="ScreenOS" os.product="ScreenOS">ScreenOS</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="1" name="os.family"/>
     <param pos="1" name="os.product"/>
@@ -704,8 +704,8 @@
 
   <fingerprint pattern="^(?i:(?:Cisco\s?)?(ASA|Adaptive Security Appliance|IOS|IOS-XE|IOS-XR|NX-OS|PIX-OS|SAN-OS)\s?(?:Version (\S+))?)$">
     <description>Cisco</description>
-    <example>Cisco ASA</example>
-    <example>Cisco IOS</example>
+    <example os.family="ASA" os.product="ASA">Cisco ASA</example>
+    <example os.family="IOS" os.product="IOS">Cisco IOS</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="1" name="os.family"/>
     <param pos="1" name="os.product"/>

--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -52,7 +52,7 @@
 
   <fingerprint pattern="^Qpopper \(version (\d+\.\d+\.\d+), modified by Sphera Technologies\) at (.+) starting\.">
     <description>Qpopper with Sphera mods</description>
-    <example>Qpopper (version 4.0.3, modified by Sphera Technologies) at domain starting.  &lt;xxx@domain&gt;</example>
+    <example service.version="4.0.3" host.domain="domain">Qpopper (version 4.0.3, modified by Sphera Technologies) at domain starting.  &lt;xxx@domain&gt;</example>
     <param pos="0" name="service.vendor" value="Sphera"/>
     <param pos="0" name="service.family" value="Qpopper"/>
     <param pos="0" name="service.product" value="Qpopper"/>
@@ -62,7 +62,7 @@
 
   <fingerprint pattern="^Qpopper \(version (\d+\.\d+\.\d+)-mysql-(.+)\) at (.+) starting\.">
     <description>Qpopper with MySQL auth module</description>
-    <example>Qpopper (version 4.0.3-mysql-0.13) at domain starting.  &lt;xxx@domain&gt;</example>
+    <example service.version="4.0.3" service.component.version="0.13" host.domain="domain">Qpopper (version 4.0.3-mysql-0.13) at domain starting.  &lt;xxx@domain&gt;</example>
     <param pos="0" name="service.vendor" value="Qualcomm"/>
     <param pos="0" name="service.family" value="Qpopper"/>
     <param pos="0" name="service.product" value="Qpopper"/>
@@ -75,9 +75,9 @@
 
   <fingerprint pattern="(?i)^Qpop(?:per)? \(version ([\d\.]+)\) at (.+)(?: starting\.)?">
     <description>Qpopper missing version info</description>
-    <example>Qpopper (version 4.0.16) at foo.example.com</example>
-    <example>QPOP (version 2.53) at domain starting.  &lt;xxx@domain&gt;</example>
-    <example>Qpopper (version 4.0.3) at domain starting.  &lt;xxx@domain&gt;</example>
+    <example service.version="4.0.16" host.domain="foo.example.com">Qpopper (version 4.0.16) at foo.example.com</example>
+    <example service.version="2.53" host.domain="domain starting.  &lt;xxx@domain&gt;">QPOP (version 2.53) at domain starting.  &lt;xxx@domain&gt;</example>
+    <example service.version="4.0.3" host.domain="domain starting.  &lt;xxx@domain&gt;">Qpopper (version 4.0.3) at domain starting.  &lt;xxx@domain&gt;</example>
     <param pos="0" name="service.vendor" value="Qualcomm"/>
     <param pos="0" name="service.family" value="Qpopper"/>
     <param pos="0" name="service.product" value="Qpopper"/>
@@ -87,7 +87,7 @@
 
   <fingerprint pattern="^QPOP \(version (.*)\) at (.+) starting\.">
     <description>Qpopper with missing version info</description>
-    <example>QPOP (version ?) at domain starting.  &lt;xxx@domain&gt;</example>
+    <example qpopper.version="?" host.domain="domain">QPOP (version ?) at domain starting.  &lt;xxx@domain&gt;</example>
     <param pos="0" name="service.vendor" value="Qualcomm"/>
     <param pos="0" name="service.family" value="Qpopper"/>
     <param pos="0" name="service.product" value="Qpopper"/>
@@ -97,7 +97,7 @@
 
   <fingerprint pattern="^Microsoft Exchange Server 2003 POP3 server version (\d+\.\d+\.\d+\.\d+) (.+) ready.$">
     <description>Microsoft Exchange Server 2003</description>
-    <example>Microsoft Exchange Server 2003 POP3 server version 6.5.6944.0 (host) ready.</example>
+    <example service.version="6.5.6944.0" host.name="(host)">Microsoft Exchange Server 2003 POP3 server version 6.5.6944.0 (host) ready.</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="Exchange Server"/>
     <param pos="0" name="service.product" value="Exchange 2003 Server"/>
@@ -112,7 +112,7 @@
 
   <fingerprint pattern="^Microsoft Exchange 2000 POP3 server version (\d+\.\d+\.\d+\.\d+) (.+) ready.$">
     <description>Microsoft Exchange Server 2000</description>
-    <example>Microsoft Exchange 2000 POP3 server version 6.0.6603.0 (host) ready.</example>
+    <example service.version="6.0.6603.0" host.name="(host)">Microsoft Exchange 2000 POP3 server version 6.0.6603.0 (host) ready.</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="Exchange Server"/>
     <param pos="0" name="service.product" value="Exchange 2000 Server"/>
@@ -127,7 +127,7 @@
 
   <fingerprint pattern="^Microsoft Exchange POP3 server version (\d+\.\d+\.\d+\.\d+) ready$">
     <description>Microsoft Exchange Server</description>
-    <example>Microsoft Exchange POP3 server version 5.5.2654.50 ready</example>
+    <example service.version="5.5.2654.50">Microsoft Exchange POP3 server version 5.5.2654.50 ready</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="Exchange Server"/>
     <param pos="0" name="service.product" value="Exchange Server"/>
@@ -141,7 +141,7 @@
 
   <fingerprint pattern="^Microsoft Windows POP3 Service Version 1.0 &lt;.+@(.+)&gt; ready.$">
     <description>Microsoft POP3 Services on Windows 2003</description>
-    <example>Microsoft Windows POP3 Service Version 1.0 &lt;xxx@host&gt; ready.</example>
+    <example host.name="host">Microsoft Windows POP3 Service Version 1.0 &lt;xxx@host&gt; ready.</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="E-mail Services"/>
     <param pos="0" name="service.product" value="E-mail Services"/>
@@ -240,7 +240,7 @@
 
   <fingerprint pattern="^(\S{1,512}) Zimbra (\S+) POP3 server ready\.?$">
     <description>VMware Zimbra POP with version</description>
-    <example host.name="foo.bar">foo.bar Zimbra 7.0.0_GA_3079 POP3 server ready</example>
+    <example host.name="foo.bar" service.version="7.0.0_GA_3079">foo.bar Zimbra 7.0.0_GA_3079 POP3 server ready</example>
     <param pos="0" name="service.vendor" value="VMware"/>
     <param pos="0" name="service.product" value="Zimbra"/>
     <param pos="2" name="service.version"/>
@@ -250,15 +250,15 @@
 
   <fingerprint pattern="^(?:S?POP3? server ready |Hello there.? )?&lt;.*@([^&gt;]+)&gt;$">
     <description>Generic masked POP3 server</description>
-    <example>POP3 server ready &lt;58c29ae4-7316-429e-8109-060444ab1a28@foo.example.com&gt;</example>
-    <example>&lt;84427.1298535083@foo.example.com&gt;</example>
+    <example host.name="foo.example.com">POP3 server ready &lt;58c29ae4-7316-429e-8109-060444ab1a28@foo.example.com&gt;</example>
+    <example host.name="foo.example.com">&lt;84427.1298535083@foo.example.com&gt;</example>
     <param pos="1" name="host.name"/>
   </fingerprint>
 
   <fingerprint pattern="^ApplePasswordServer ([\d\.]+) password">
     <description>Apple Open Directory</description>
-    <example>ApplePasswordServer 10.6.0.0 password server at 10.2.90.228 ready.</example>
-    <example>ApplePasswordServer 10.5.0.1 password serv</example>
+    <example os.version="10.6.0.0">ApplePasswordServer 10.6.0.0 password server at 10.2.90.228 ready.</example>
+    <example os.version="10.5.0.1">ApplePasswordServer 10.5.0.1 password serv</example>
     <param pos="0" name="service.vendor" value="Apple"/>
     <param pos="0" name="service.product" value="Open Directory"/>
     <param pos="0" name="os.vendor" value="Apple"/>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -184,7 +184,7 @@
     <description>Cisco/Tandberg TelePresence</description>
     <example os.version="TC7.0.2.aecf2d9" tandberg.model="519" hw.product="TANDBERG/519">TANDBERG/519 (TC7.0.2.aecf2d9)</example>
     <example os.version="X12.5.2" tandberg.model="4137" hw.product="TANDBERG/4137">TANDBERG/4137 (X12.5.2 (TEST SW))</example>
-    <example os.version="X8.2.1" hw.product="TANDBERG/4130">TANDBERG/4130 (X8.2.1)</example>
+    <example os.version="X8.2.1" hw.product="TANDBERG/4130" tandberg.model="4130">TANDBERG/4130 (X8.2.1)</example>
     <example os.version="XC2.2.1-b2bua-1.0" hw.product="TANDBERG/4353" tandberg.model="4353">TANDBERG/4353 (XC2.2.1-b2bua-1.0)</example>
     <example os.version="TC5.1.4.295090" hw.product="TANDBERG/516" tandberg.model="516">TANDBERG/516 (TC5.1.4.295090)</example>
     <example os.version="TCNC5.1.4.295090" hw.product="TANDBERG/517" tandberg.model="517">TANDBERG/517 (TCNC5.1.4.295090)</example>
@@ -312,9 +312,9 @@
 
   <fingerprint pattern="^Grandstream (UCM6\d\d\d)V(\d\.\d\w) ([\d.]+)$">
     <description>Grandstream UCM 6xxx series generic</description>
-    <example hw.product="UCM6102" os.version="1.0.6.10">Grandstream UCM6102V1.5A 1.0.6.10</example>
-    <example hw.product="UCM6302" hw.version="1.2B">Grandstream UCM6302V1.2B 1.0.3.10</example>
-    <example hw.product="UCM6510">Grandstream UCM6510V1.4B 1.0.14.23</example>
+    <example hw.product="UCM6102" os.version="1.0.6.10" hw.version="1.5A">Grandstream UCM6102V1.5A 1.0.6.10</example>
+    <example hw.product="UCM6302" hw.version="1.2B" os.version="1.0.3.10">Grandstream UCM6302V1.2B 1.0.3.10</example>
+    <example hw.product="UCM6510" os.version="1.0.14.23" hw.version="1.4B">Grandstream UCM6510V1.4B 1.0.14.23</example>
     <param pos="0" name="os.vendor" value="Grandstream"/>
     <param pos="3" name="os.version"/>
     <param pos="0" name="os.device" value="SIP Gateway"/>
@@ -668,7 +668,7 @@
     <description>Fortinet FortiVoice</description>
     <example hw.product="200D">FortiVoice-200D</example>
     <example hw.product="VM-Azure">FortiVoice-VM-Azure</example>
-    <example>FortiVoice-1000E</example>
+    <example hw.product="1000E">FortiVoice-1000E</example>
     <param pos="0" name="service.vendor" value="Fortinet"/>
     <param pos="0" name="service.product" value="FortiVoice"/>
     <param pos="0" name="service.device" value="SIP Gateway"/>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -28,7 +28,7 @@
 
   <fingerprint pattern="^Home&amp;Life HUB/([\d.]+)$">
     <description>Zyxel home routers</description>
-    <example>Home&amp;Life HUB/1.1.26.00</example>
+    <example os.version="1.1.26.00">Home&amp;Life HUB/1.1.26.00</example>
     <param pos="0" name="os.vendor" value="Zyxel"/>
     <param pos="1" name="os.version"/>
     <param pos="0" name="os.device" value="Router"/>
@@ -65,11 +65,11 @@
     <description>Technicolor TGxxx Router with build info</description>
     <example hw.product="TG784n" os.version="10.2.1.O">Technicolor TG784n v3 Build 10.2.1.O</example>
     <example hw.product="TG789vn" os.version="10.5.2.Z.EC">Technicolor TG789vn v3 Build 10.5.2.Z.EC</example>
-    <example>MediaAccess TG789vac v2 Build 10.5.8.Y.GX CP1916SAQHD</example>
+    <example os.version="10.5.8.Y.GX" hw.product="TG789vac">MediaAccess TG789vac v2 Build 10.5.8.Y.GX CP1916SAQHD</example>
     <example hw.product="TG799vn" os.version="10.5.2.T.JF">Technicolor TG799vn v2 Build 10.5.2.T.JF</example>
     <example hw.product="TG788vn" os.version="10.5.2.S.GD">MediaAccess TG788vn v2 Build 10.5.2.S.GD</example>
     <example hw.product="TG799vac" os.version="17.2.0405-1021">MediaAccess TG799vac Build 17.2.0405-1021</example>
-    <example hw.product="TG389">MediaAccess TG389 Build 10.5.2.T.AQ</example>
+    <example hw.product="TG389" os.version="10.5.2.T.AQ">MediaAccess TG389 Build 10.5.2.T.AQ</example>
     <param pos="0" name="os.vendor" value="Technicolor"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="2" name="os.version"/>
@@ -122,7 +122,7 @@
 
   <fingerprint pattern="^Cisco-SIPGateway/IOS-([\d\.x]+)$">
     <description>Cisco SIPGateway</description>
-    <example>Cisco-SIPGateway/IOS-12.x</example>
+    <example os.version="12.x">Cisco-SIPGateway/IOS-12.x</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="IOS"/>
     <param pos="1" name="os.version"/>
@@ -171,18 +171,18 @@
 
   <fingerprint pattern="^(?:AVM )?(FRITZ!Box .*) +(\d+\.\d+\.\d+)">
     <description>AVM FritzBox</description>
-    <example>AVM FRITZ!Box Fon 06.03.13</example>
-    <example>AVM FRITZ!Box Fon 06.03.65 (Jun  7 2005)</example>
-    <example>AVM FRITZ!Box Fon 5010 Annex A (ITA) 48.04.46 (Sep 14 2007)</example>
-    <example>AVM FRITZ!Box Fon 5012 (UI) 25.03.90 (3.01.03 tested by accredited T-Com test lab) (Oct 28 2005)</example>
-    <example>AVM FRITZ!Box Fon 5113 Annex A 83.04.69 (Dec  2 2008)</example>
-    <example>AVM FRITZ!Box Fon 5124 56.04.77 (Feb 14 2014)</example>
-    <example>AVM FRITZ!Box Fon 7170 Annex A.B ML Speedport W701V 58.04.67 (Dec 18 2008)</example>
-    <example>AVM FRITZ!Box 3272 126.05.50 (Feb 27 2013)</example>
-    <example>AVM FRITZ!Box 7170 Annex A 58.04.85 (Apr  4 2011)</example>
-    <example>AVM FRITZ!Box 7312 117.05.23 TAL (Jun  1 2012)</example>
-    <example>AVM FRITZ!Box WLAN 3270 v3 Edition Italia 125.05.52 (Feb  7 2014)</example>
-    <example>AVM FRITZ!Box Speedport W701V Annex A 58.04.82 (May 12 2010)</example>
+    <example os.product="FRITZ!Box Fon" os.version="06.03.13">AVM FRITZ!Box Fon 06.03.13</example>
+    <example os.product="FRITZ!Box Fon" os.version="06.03.65">AVM FRITZ!Box Fon 06.03.65 (Jun  7 2005)</example>
+    <example os.product="FRITZ!Box Fon 5010 Annex A (ITA)" os.version="48.04.46">AVM FRITZ!Box Fon 5010 Annex A (ITA) 48.04.46 (Sep 14 2007)</example>
+    <example os.product="FRITZ!Box Fon 5012 (UI)" os.version="25.03.90">AVM FRITZ!Box Fon 5012 (UI) 25.03.90 (3.01.03 tested by accredited T-Com test lab) (Oct 28 2005)</example>
+    <example os.product="FRITZ!Box Fon 5113 Annex A" os.version="83.04.69">AVM FRITZ!Box Fon 5113 Annex A 83.04.69 (Dec  2 2008)</example>
+    <example os.product="FRITZ!Box Fon 5124" os.version="56.04.77">AVM FRITZ!Box Fon 5124 56.04.77 (Feb 14 2014)</example>
+    <example os.product="FRITZ!Box Fon 7170 Annex A.B ML Speedport W701V" os.version="58.04.67">AVM FRITZ!Box Fon 7170 Annex A.B ML Speedport W701V 58.04.67 (Dec 18 2008)</example>
+    <example os.product="FRITZ!Box 3272" os.version="126.05.50">AVM FRITZ!Box 3272 126.05.50 (Feb 27 2013)</example>
+    <example os.product="FRITZ!Box 7170 Annex A" os.version="58.04.85">AVM FRITZ!Box 7170 Annex A 58.04.85 (Apr  4 2011)</example>
+    <example os.product="FRITZ!Box 7312" os.version="117.05.23">AVM FRITZ!Box 7312 117.05.23 TAL (Jun  1 2012)</example>
+    <example os.product="FRITZ!Box WLAN 3270 v3 Edition Italia" os.version="125.05.52">AVM FRITZ!Box WLAN 3270 v3 Edition Italia 125.05.52 (Feb  7 2014)</example>
+    <example os.product="FRITZ!Box Speedport W701V Annex A" os.version="58.04.82">AVM FRITZ!Box Speedport W701V Annex A 58.04.82 (May 12 2010)</example>
     <param pos="0" name="os.vendor" value="AVM"/>
     <param pos="0" name="os.family" value="FRITZ!Box"/>
     <param pos="1" name="os.product"/>
@@ -193,8 +193,8 @@
 
   <fingerprint pattern="^(?:AVM )?(FRITZ!Fon .*) +(\d+\.\d+\.\d+)">
     <description>AVM FritzFon</description>
-    <example>AVM FRITZ!Fon 7150 (fs) 38.04.56 (Mar 31 2008)</example>
-    <example>AVM FRITZ!Fon WLAN 7150 Annex A 58.04.84 (Apr  4 2011)</example>
+    <example os.product="FRITZ!Fon 7150 (fs)" os.version="38.04.56">AVM FRITZ!Fon 7150 (fs) 38.04.56 (Mar 31 2008)</example>
+    <example os.product="FRITZ!Fon WLAN 7150 Annex A" os.version="58.04.84">AVM FRITZ!Fon WLAN 7150 Annex A 58.04.84 (Apr  4 2011)</example>
     <param pos="0" name="os.vendor" value="AVM"/>
     <param pos="0" name="os.family" value="FRITZ!Fon"/>
     <param pos="1" name="os.product"/>
@@ -205,7 +205,7 @@
 
   <fingerprint pattern="^(?:AVM )?(Multibox .*) +(\d+\.\d+\.\d+)">
     <description>AVM Multibox - Generic</description>
-    <example>AVM Multibox 7390 NGN 84.05.09 (Jan 13 2012)</example>
+    <example os.product="Multibox 7390 NGN" os.version="84.05.09" hw.product="Multibox 7390 NGN">AVM Multibox 7390 NGN 84.05.09 (Jan 13 2012)</example>
     <param pos="0" name="os.vendor" value="AVM"/>
     <param pos="0" name="os.family" value="Multibox"/>
     <param pos="1" name="os.product"/>
@@ -269,10 +269,10 @@
 
   <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(SoundPoint|VVX|SoundStation)\S+_(\d+)-UA/([\d\.]+)(?:_(.{12}))?$">
     <description>Polycom SoundPoint, SountdStation, VVX VoIP phones</description>
-    <example hw.version="5.8.0.13337" hw.family="VVX" hw.product="VVX 350">PolycomVVX-VVX_350-UA/5.8.0.13337</example>
-    <example hw.version="4.1.4.7430" hw.family="VVX" hw.product="VVX 400" host.mac="010203040506">PolycomVVX-VVX_400-UA/4.1.4.7430_010203040506</example>
-    <example hw.version="5.5.0.23866" hw.family="VVX" hw.product="VVX 501">Polycom/5.5.0.23866 PolycomVVX-VVX_501-UA/5.5.0.23866</example>
-    <example hw.version="4.0.7.2514" hw.family="SoundPoint" hw.product="SoundPoint 670">PolycomSoundPointIP-SPIP_670-UA/4.0.7.2514</example>
+    <example hw.version="5.8.0.13337" hw.family="VVX" hw.product="VVX 350" hw.model="350">PolycomVVX-VVX_350-UA/5.8.0.13337</example>
+    <example hw.version="4.1.4.7430" hw.family="VVX" hw.product="VVX 400" host.mac="010203040506" hw.model="400">PolycomVVX-VVX_400-UA/4.1.4.7430_010203040506</example>
+    <example hw.version="5.5.0.23866" hw.family="VVX" hw.product="VVX 501" hw.model="501">Polycom/5.5.0.23866 PolycomVVX-VVX_501-UA/5.5.0.23866</example>
+    <example hw.version="4.0.7.2514" hw.family="SoundPoint" hw.product="SoundPoint 670" hw.model="670">PolycomSoundPointIP-SPIP_670-UA/4.0.7.2514</example>
     <example hw.version="4.0.8.1608" hw.model="7000" hw.family="SoundStation" hw.product="SoundStation 7000">PolycomSoundStationIP-SSIP_7000-UA/4.0.8.1608</example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="VoIP"/>
@@ -285,9 +285,9 @@
 
   <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(?:RealPresenceTrio)-Trio_(\S+)-UA/([\d\.]+)(?:_(.{12}))?$">
     <description>Polycom RealPresence Trio Phones</description>
-    <example hw.version="5.4.0.12197" hw.product="RealPresence Trio 8800">PolycomRealPresenceTrio-Trio_8800-UA/5.4.0.12197</example>
-    <example hw.version="5.7.2.3123" hw.product="RealPresence Trio Visual+">PolycomRealPresenceTrio-Trio_Visual+-UA/5.7.2.3123</example>
-    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389</example>
+    <example hw.version="5.4.0.12197" hw.product="RealPresence Trio 8800" hw.model="8800">PolycomRealPresenceTrio-Trio_8800-UA/5.4.0.12197</example>
+    <example hw.version="5.7.2.3123" hw.product="RealPresence Trio Visual+" hw.model="Visual+">PolycomRealPresenceTrio-Trio_Visual+-UA/5.7.2.3123</example>
+    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389</example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.family" value="RealPresence"/>
@@ -596,7 +596,7 @@
 
   <fingerprint pattern="^Valcom (VIP-\w+) sw([\d.]+)">
     <description>Valcom SIP device with version</description>
-    <example os.version="1.50.28">Valcom VIP-204 sw1.50.28</example>
+    <example os.version="1.50.28" hw.product="VIP-204">Valcom VIP-204 sw1.50.28</example>
     <param pos="0" name="os.vendor" value="Valcom"/>
     <param pos="0" name="os.product" value="{hw.product} Firmware"/>
     <param pos="2" name="os.version"/>

--- a/xml/smb_native_lm.xml
+++ b/xml/smb_native_lm.xml
@@ -39,12 +39,12 @@
 
   <fingerprint pattern="^Samba (\d\.\d+.\d+\w*)">
     <description>Samba</description>
-    <example>Samba 3.0.24</example>
+    <example service.version="3.0.24">Samba 3.0.24</example>
     <example service.version="3.0.28a">Samba 3.0.28a</example>
-    <example>Samba 3.0.32-0.2-2210-SUSE-SL10.3</example>
-    <example>Samba 3.6.3</example>
-    <example>Samba 3.6.6</example>
-    <example>Samba 3.6.9-151.el6_4.1</example>
+    <example service.version="3.0.32">Samba 3.0.32-0.2-2210-SUSE-SL10.3</example>
+    <example service.version="3.6.3">Samba 3.6.3</example>
+    <example service.version="3.6.6">Samba 3.6.6</example>
+    <example service.version="3.6.9">Samba 3.6.9-151.el6_4.1</example>
     <param pos="0" name="service.vendor" value="Samba"/>
     <param pos="0" name="service.product" value="Samba"/>
     <param pos="1" name="service.version"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -156,8 +156,8 @@
 
   <fingerprint pattern="^Windows Server \(R\) 2008 (\w+|\w+ \w+|\w+ \w+ \w+)(?: (?:with|without) Hyper-V|) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2008</description>
-    <example os.edition="Enterprise" os.version="Service Pack 1">Windows Server (R) 2008 Enterprise without Hyper-V 6001 Service Pack 1</example>
-    <example os.edition="Enterprise" os.version="Service Pack 2">Windows Server (R) 2008 Enterprise 6002 Service Pack 2, v.275</example>
+    <example os.edition="Enterprise" os.version="Service Pack 1" os.build="6001">Windows Server (R) 2008 Enterprise without Hyper-V 6001 Service Pack 1</example>
+    <example os.edition="Enterprise" os.version="Service Pack 2" os.build="6002">Windows Server (R) 2008 Enterprise 6002 Service Pack 2, v.275</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -169,7 +169,7 @@
 
   <fingerprint pattern="^Windows \(R\) Web Server 2008 (\d+) (Service Pack \d+)$">
     <description>Windows Web Server 2008 (SP)</description>
-    <example os.edition="Web" os.version="Service Pack 2">Windows (R) Web Server 2008 6002 Service Pack 2</example>
+    <example os.edition="Web" os.version="Service Pack 2" os.build="6002">Windows (R) Web Server 2008 6002 Service Pack 2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -181,7 +181,7 @@
 
   <fingerprint pattern="^Windows \(R\) Web Server 2008 (\d+)$">
     <description>Windows Web Server 2008</description>
-    <example>Windows (R) Web Server 2008 6002</example>
+    <example os.build="6002">Windows (R) Web Server 2008 6002</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -217,7 +217,7 @@
 
   <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 HPC</description>
-    <example>Windows Server 2008 HPC Edition 7601 Service Pack 1</example>
+    <example os.build="7601" os.version="Service Pack 1">Windows Server 2008 HPC Edition 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -229,7 +229,7 @@
 
   <fingerprint pattern="^Windows Server 2008 HPC Edition (\d+)$">
     <description>Windows Web Server 2008 HPC</description>
-    <example>Windows Server 2008 HPC Edition 7600</example>
+    <example os.build="7600">Windows Server 2008 HPC Edition 7600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008"/>
@@ -242,8 +242,8 @@
 
   <fingerprint pattern="^Windows Server 2008 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows Server 2008 R2</description>
-    <example>Windows Server 2008 R2 Enterprise 7601 Service Pack 1</example>
-    <example>Windows Server 2008 R2 Standard 7601 Service Pack 1</example>
+    <example os.edition="Enterprise" os.build="7601" os.version="Service Pack 1">Windows Server 2008 R2 Enterprise 7601 Service Pack 1</example>
+    <example os.edition="Standard" os.build="7601" os.version="Service Pack 1">Windows Server 2008 R2 Standard 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -255,9 +255,9 @@
 
   <fingerprint pattern="^Windows Server 2008 R2 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2008 R2 without Service Pack</description>
-    <example os.edition="Enterprise">Windows Server 2008 R2 Enterprise 7600</example>
-    <example os.edition="Standard">Windows Server 2008 R2 Standard 7600</example>
-    <example os.edition="Datacenter">Windows Server 2008 R2 Datacenter 7600</example>
+    <example os.edition="Enterprise" os.build="7600">Windows Server 2008 R2 Enterprise 7600</example>
+    <example os.edition="Standard" os.build="7600">Windows Server 2008 R2 Standard 7600</example>
+    <example os.edition="Datacenter" os.build="7600">Windows Server 2008 R2 Datacenter 7600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -268,7 +268,7 @@
 
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+) (Service Pack \d+)$">
     <description>Windows Server 2008 R2 Web</description>
-    <example os.version="Service Pack 1">Windows Web Server 2008 R2 7601 Service Pack 1</example>
+    <example os.version="Service Pack 1" os.build="7601">Windows Web Server 2008 R2 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -280,7 +280,7 @@
 
   <fingerprint pattern="^Windows Web Server 2008 R2 (\d+)$">
     <description>Windows Web Server 2008 R2 Web</description>
-    <example>Windows Web Server 2008 R2 7600</example>
+    <example os.build="7600">Windows Web Server 2008 R2 7600</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2008 R2"/>
@@ -378,7 +378,7 @@
 
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)$">
     <description>Windows Vista (SP)</description>
-    <example os.edition="Home Premium" os.version="Service Pack 2">Windows Vista (TM) Home Premium 6002 Service Pack 2</example>
+    <example os.edition="Home Premium" os.version="Service Pack 2" os.build="6002">Windows Vista (TM) Home Premium 6002 Service Pack 2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
@@ -390,7 +390,7 @@
 
   <fingerprint pattern="^Windows Vista \(TM\) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Vista</description>
-    <example os.edition="Home Premium">Windows Vista (TM) Home Premium 6000</example>
+    <example os.edition="Home Premium" os.build="6000">Windows Vista (TM) Home Premium 6000</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Vista"/>
@@ -401,9 +401,9 @@
 
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+) (Service Pack \d+)(?:, v\.\d+)?$">
     <description>Windows 7/8 (SP + Edition)</description>
-    <example os.edition="Enterprise" os.version="Service Pack 1">Windows 7 Enterprise 7601 Service Pack 1</example>
-    <example os.edition="Starter" os.version="Service Pack 1">Windows 7 Starter 7601 Service Pack 1</example>
-    <example os.edition="Ultimate" os.build="7601" os.version="Service Pack 1">Windows 7 Ultimate 7601 Service Pack 1, v.178</example>
+    <example os.edition="Enterprise" os.version="Service Pack 1" os.product="Windows 7" os.build="7601">Windows 7 Enterprise 7601 Service Pack 1</example>
+    <example os.edition="Starter" os.version="Service Pack 1" os.product="Windows 7" os.build="7601">Windows 7 Starter 7601 Service Pack 1</example>
+    <example os.edition="Ultimate" os.build="7601" os.version="Service Pack 1" os.product="Windows 7">Windows 7 Ultimate 7601 Service Pack 1, v.178</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -414,7 +414,7 @@
 
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\d+) (Service Pack \d+)$">
     <description>Windows 7/8 (SP)</description>
-    <example os.version="Service Pack 1">Windows 7 7601 Service Pack 1</example>
+    <example os.version="Service Pack 1" os.product="Windows 7" os.build="7601">Windows 7 7601 Service Pack 1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -424,9 +424,9 @@
 
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows 7/8 (Edition)</description>
-    <example os.edition="Enterprise">Windows 7 Enterprise 7600</example>
-    <example os.edition="Enterprise">Windows 8.1 Enterprise 9600</example>
-    <example os.edition="Enterprise">Windows 8 Enterprise 9200</example>
+    <example os.edition="Enterprise" os.product="Windows 7" os.build="7600">Windows 7 Enterprise 7600</example>
+    <example os.edition="Enterprise" os.product="Windows 8.1" os.build="9600">Windows 8.1 Enterprise 9600</example>
+    <example os.edition="Enterprise" os.product="Windows 8" os.build="9200">Windows 8 Enterprise 9200</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -436,7 +436,7 @@
 
   <fingerprint pattern="^(Windows (?:7|8|8\.1)(?:| RT)) (\d+)$">
     <description>Windows 7/8</description>
-    <example>Windows 8 9200</example>
+    <example os.product="Windows 8" os.build="9200">Windows 8 9200</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="1" name="os.product"/>
@@ -508,7 +508,7 @@
 
   <fingerprint pattern="^Windows Server 2012 (\w+|\w+ \w+|\w+ \w+ \w+) (\d+)$">
     <description>Windows Server 2012</description>
-    <example>Windows Server 2012 Standard 9200</example>
+    <example os.edition="Standard" os.build="9200">Windows Server 2012 Standard 9200</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.product" value="Windows Server 2012"/>
@@ -637,7 +637,7 @@
 
   <fingerprint pattern="^EMC-SNAS:T([\d\.]+)?$">
     <description>EMC Celerra</description>
-    <example service.version="7.1.80.7">EMC-SNAS:T7.1.80.7</example>
+    <example service.version="7.1.80.7" os.version="7.1.80.7">EMC-SNAS:T7.1.80.7</example>
     <param pos="0" name="service.vendor" value="EMC"/>
     <param pos="0" name="service.product" value="Celerra"/>
     <param pos="1" name="service.version"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -23,7 +23,7 @@
 
   <fingerprint pattern="^X1 NT-ESMTP Server ([^ ]+) \(IMail (\d+\.[^ ]+) EVAL \d+-\d+\)$">
     <description>IMail - EVAL version</description>
-    <example service.version="6.06">X1 NT-ESMTP Server foo.bar (IMail 6.06 EVAL 11347-1)</example>
+    <example service.version="6.06" host.name="foo.bar">X1 NT-ESMTP Server foo.bar (IMail 6.06 EVAL 11347-1)</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="0" name="service.family" value="IMail Server"/>
     <param pos="0" name="service.product" value="IMail Server"/>
@@ -35,7 +35,7 @@
 
   <fingerprint pattern="^X1 NT-ESMTP Server ([^ ]+) \(IMail (\d+\.[^ ]+) \d+-\d+\)$">
     <description>IMail - non-EVAL version</description>
-    <example service.version="6.06">X1 NT-ESMTP Server foo.bar (IMail 6.06 899085-1)</example>
+    <example service.version="6.06" host.name="foo.bar">X1 NT-ESMTP Server foo.bar (IMail 6.06 899085-1)</example>
     <param pos="0" name="service.vendor" value="Ipswitch"/>
     <param pos="0" name="service.family" value="IMail Server"/>
     <param pos="0" name="service.product" value="IMail Server"/>
@@ -115,8 +115,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +AppleShare IP Mail Server ([^ ]+\.[\d.]+) SMTP Server Ready *$">
     <description>AppleShare IP Mail Server</description>
-    <example service.version="6.2.1">foo.bar AppleShare IP Mail Server 6.2.1 SMTP Server Ready</example>
-    <example service.version="6.2">foo.bar AppleShare IP Mail Server 6.2 SMTP Server Ready</example>
+    <example service.version="6.2.1" host.name="foo.bar">foo.bar AppleShare IP Mail Server 6.2.1 SMTP Server Ready</example>
+    <example service.version="6.2" host.name="foo.bar">foo.bar AppleShare IP Mail Server 6.2 SMTP Server Ready</example>
     <param pos="0" name="service.vendor" value="Apple"/>
     <param pos="0" name="service.family" value="AppleShare IP Mail Server"/>
     <param pos="0" name="service.product" value="AppleShare IP Mail Server"/>
@@ -249,7 +249,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) Microsoft ESMTP MAIL Service ready at">
     <description>Microsoft Exchange 2007/2010 (for sure, can't be confused with the IIS builtin SMTP service)</description>
-    <example>foo.bar Microsoft ESMTP MAIL Service ready at Wed, 21 Jul 2010 19:04:24 -0700</example>
+    <example host.name="foo.bar">foo.bar Microsoft ESMTP MAIL Service ready at Wed, 21 Jul 2010 19:04:24 -0700</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="Exchange Server"/>
     <param pos="0" name="service.product" value="Exchange Server"/>
@@ -263,8 +263,8 @@
 
   <fingerprint pattern="^([^ ]{1,512})? ?Microsoft ESMTP MAIL Service, Version: +(10\.0\.14393\.[\d.]+) +ready +(?:at +)?(.+)$">
     <description>Microsoft IIS builtin SMTP service - Windows Server 2016</description>
-    <example host.name="foo.bar" service.version="10.0.14393.2608">foo.bar Microsoft ESMTP MAIL Service, Version: 10.0.14393.2608 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
-    <example service.version="10.0.14393.2608"> Microsoft ESMTP MAIL Service, Version: 10.0.14393.2608 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
+    <example host.name="foo.bar" service.version="10.0.14393.2608" system.time="Sun, 19 May 2019 09:04:29 -0500">foo.bar Microsoft ESMTP MAIL Service, Version: 10.0.14393.2608 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
+    <example service.version="10.0.14393.2608" system.time="Sun, 19 May 2019 09:04:29 -0500"> Microsoft ESMTP MAIL Service, Version: 10.0.14393.2608 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
@@ -281,7 +281,7 @@
 
   <fingerprint pattern="^([^ ]{1,512})? ?Microsoft ESMTP MAIL Service, Version: +(10\.0\.17763\.[\d.]+) +ready +(?:at +)?(.+)$">
     <description>Microsoft IIS builtin SMTP service - Windows Server 2019</description>
-    <example host.name="foo.bar" service.version="10.0.17763.1">foo.bar Microsoft ESMTP MAIL Service, Version: 10.0.17763.1 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
+    <example host.name="foo.bar" service.version="10.0.17763.1" system.time="Sun, 19 May 2019 09:04:29 -0500">foo.bar Microsoft ESMTP MAIL Service, Version: 10.0.17763.1 ready at  Sun, 19 May 2019 09:04:29 -0500</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
@@ -298,7 +298,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) Microsoft SMTP MAIL ready at (.+) Version: +(\d+\.\d+\.\d+\.\d+\.\d+) *$">
     <description>Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each other in smtp-iis.clp)  - variant 1</description>
-    <example host.name="foo.bar" service.version="5.5.1877.197.19">foo.bar Microsoft SMTP MAIL ready at Wed, 29 Nov 2017 23:48:59 +0000 Version: 5.5.1877.197.19</example>
+    <example host.name="foo.bar" service.version="5.5.1877.197.19" system.time="Wed, 29 Nov 2017 23:48:59 +0000">foo.bar Microsoft SMTP MAIL ready at Wed, 29 Nov 2017 23:48:59 +0000 Version: 5.5.1877.197.19</example>
     <param pos="0" name="service.vendor" value="Microsoft"/>
     <param pos="0" name="service.family" value="IIS"/>
     <param pos="0" name="service.product" value="IIS"/>
@@ -315,8 +315,8 @@
 
   <fingerprint pattern="^([^ ]{1,512})? ?Microsoft ESMTP MAIL Service, Version: +(\d+\.\d+\.\d+\.\d+)(?: +ready)?(?: +(?:at +)?(\w\w\w, \d.+))?$">
     <description>Microsoft IIS builtin SMTP service, or Microsoft Exchange Server (they are differentiated from each other in smtp-iis.clp) - variant 2 </description>
-    <example service.version="5.0.2195.5329"> Microsoft ESMTP MAIL Service, Version: 5.0.2195.5329 ready Thu, 30 Nov 2017 11:40:25 +0200</example>
-    <example service.version="6.0.3790.4675" host.name="foo.bar">foo.bar Microsoft ESMTP MAIL Service, Version: 6.0.3790.4675 ready at Wed, 21 Jul 2010 19:04:24 -0700</example>
+    <example service.version="5.0.2195.5329" system.time="Thu, 30 Nov 2017 11:40:25 +0200"> Microsoft ESMTP MAIL Service, Version: 5.0.2195.5329 ready Thu, 30 Nov 2017 11:40:25 +0200</example>
+    <example service.version="6.0.3790.4675" host.name="foo.bar" system.time="Wed, 21 Jul 2010 19:04:24 -0700">foo.bar Microsoft ESMTP MAIL Service, Version: 6.0.3790.4675 ready at Wed, 21 Jul 2010 19:04:24 -0700</example>
     <example service.version="6.0.2600.5512" system.time="Thu, 30 Nov 2017 18:22:40 +0900">Microsoft ESMTP MAIL Service, Version: 6.0.2600.5512 ready at  Thu, 30 Nov 2017 18:22:40 +0900</example>
     <example service.version="6.0.3790.3959" host.name="foo.bar">foo.bar Microsoft ESMTP MAIL Service, Version: 6.0.3790.3959 ready</example>
     <example service.version="6.0.3790.1830" host.name="foo.bar">foo.bar Microsoft ESMTP MAIL Service, Version: 6.0.3790.1830</example>
@@ -347,17 +347,17 @@
 
   <fingerprint pattern="^ ?([^, ]{1,512}),? +ESMTP \(?(?i:Exim) +(\d+\.[\d_.bdRC-]+)\)?(?: +#\d+)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d{3,4})?) *(?:We do not authorize the use of this system to transport unsolicited, and\/or bulk e-mail.)?$">
     <description>Exim - with version string and optional timestamp</description>
-    <example service.version="4.91" host.name="foo.bar">foo.bar  ESMTP Exim 4.91 Thu, 29 Apr 2021 05:41:36 +400</example>
+    <example service.version="4.91" host.name="foo.bar" system.time="Thu, 29 Apr 2021 05:41:36 +400">foo.bar  ESMTP Exim 4.91 Thu, 29 Apr 2021 05:41:36 +400</example>
     <example service.version="4.89" host.name="foo.bar">foo.bar ESMTP Exim 4.89 "</example>
     <example service.version="4.83" host.name="foo.bar">foo.bar, ESMTP EXIM 4.83</example>
     <example service.version="4.84_2" host.name="foo.bar">foo.bar ESMTP Exim 4.84_2 </example>
-    <example service.version="4.90_RC3" host.name="foo.bar">foo.bar ESMTP Exim 4.90_RC3 Thu, 30 Nov 2017 03:52:16 -0700 </example>
-    <example service.version="4.89_1b" host.name="foo.bar">foo.bar ESMTP Exim 4.89_1b Thu, 05 Apr 2018 21:30:37 +0200</example>
-    <example service.version="4.89-122312">foo.bar ESMTP Exim 4.89-122312 Thu, 16 Nov 2017 10:33:38 +0200 </example>
-    <example service.version="4.87">foo.bar ESMTP (Exim 4.87) Thu, 30 Nov 2017 03:25:58 -0800 </example>
-    <example service.version="4.80" system.time="Thu, 16 Nov 2017 01:04:30 -0800">foo.bar ESMTP Exim 4.80 Thu, 16 Nov 2017 01:04:30 -0800 </example>
-    <example service.version="4.92.2" system.time="Thu, 29 Apr 2021 07:43:39 +0200">foo.bar ESMTP Exim 4.92.2 #89 Thu, 29 Apr 2021 07:43:39 +0200 </example>
-    <example service.version="4.89" host.name="foo.bar"> foo.bar ESMTP Exim 4.89 #1 Thu, 16 Nov 2017 04:55:31 -0500 We do not authorize the use of this system to transport unsolicited, and/or bulk e-mail.</example>
+    <example service.version="4.90_RC3" host.name="foo.bar" system.time="Thu, 30 Nov 2017 03:52:16 -0700">foo.bar ESMTP Exim 4.90_RC3 Thu, 30 Nov 2017 03:52:16 -0700 </example>
+    <example service.version="4.89_1b" host.name="foo.bar" system.time="Thu, 05 Apr 2018 21:30:37 +0200">foo.bar ESMTP Exim 4.89_1b Thu, 05 Apr 2018 21:30:37 +0200</example>
+    <example service.version="4.89-122312" host.name="foo.bar" system.time="Thu, 16 Nov 2017 10:33:38 +0200">foo.bar ESMTP Exim 4.89-122312 Thu, 16 Nov 2017 10:33:38 +0200 </example>
+    <example service.version="4.87" host.name="foo.bar" system.time="Thu, 30 Nov 2017 03:25:58 -0800">foo.bar ESMTP (Exim 4.87) Thu, 30 Nov 2017 03:25:58 -0800 </example>
+    <example service.version="4.80" system.time="Thu, 16 Nov 2017 01:04:30 -0800" host.name="foo.bar">foo.bar ESMTP Exim 4.80 Thu, 16 Nov 2017 01:04:30 -0800 </example>
+    <example service.version="4.92.2" system.time="Thu, 29 Apr 2021 07:43:39 +0200" host.name="foo.bar">foo.bar ESMTP Exim 4.92.2 #89 Thu, 29 Apr 2021 07:43:39 +0200 </example>
+    <example service.version="4.89" host.name="foo.bar" system.time="Thu, 16 Nov 2017 04:55:31 -0500"> foo.bar ESMTP Exim 4.89 #1 Thu, 16 Nov 2017 04:55:31 -0500 We do not authorize the use of this system to transport unsolicited, and/or bulk e-mail.</example>
     <param pos="0" name="service.vendor" value="exim"/>
     <param pos="0" name="service.family" value="exim"/>
     <param pos="0" name="service.product" value="exim"/>
@@ -370,7 +370,7 @@
 
   <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim) +(\d+) ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - with digit only version string and optional timestamp</description>
-    <example service.version="125302" host.name="foo.bar">foo.bar ESMTP Exim 125302 Thu, 16 Nov 2017 04:55:11 -0500 </example>
+    <example service.version="125302" host.name="foo.bar" system.time="Thu, 16 Nov 2017 04:55:11 -0500">foo.bar ESMTP Exim 125302 Thu, 16 Nov 2017 04:55:11 -0500 </example>
     <param pos="0" name="service.vendor" value="exim"/>
     <param pos="0" name="service.family" value="exim"/>
     <param pos="0" name="service.product" value="exim"/>
@@ -383,7 +383,7 @@
 
   <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim) +(\d+\.[\d_.]+)(?: +#\d)? Ubuntu ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - with version string and optional timestamp (Ubuntu)</description>
-    <example service.version="4.82" system.time="Thu, 16 Nov 2017 11:30:44 +0300">foo.bar ESMTP Exim 4.82 Ubuntu Thu, 16 Nov 2017 11:30:44 +0300 </example>
+    <example service.version="4.82" system.time="Thu, 16 Nov 2017 11:30:44 +0300" host.name="foo.bar">foo.bar ESMTP Exim 4.82 Ubuntu Thu, 16 Nov 2017 11:30:44 +0300 </example>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -415,8 +415,8 @@
   <fingerprint pattern="^ ?ESMTP (?i:Exim) (\d+\.[\d_.]+)(?: +#\d)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - without hostname</description>
     <example service.version="4.82" system.time="Thu, 16 Nov 2017 12:19:22 +0300">ESMTP Exim 4.82 Thu, 16 Nov 2017 12:19:22 +0300 </example>
-    <example service.version="4.82"> ESMTP Exim 4.82 Thu, 16 Nov 2017 11:41:41 +0300 </example>
-    <example service.version="4.89"> ESMTP Exim 4.89  #1 Thu, 16 Nov 2017 07:32:28 -0200 </example>
+    <example service.version="4.82" system.time="Thu, 16 Nov 2017 11:41:41 +0300"> ESMTP Exim 4.82 Thu, 16 Nov 2017 11:41:41 +0300 </example>
+    <example service.version="4.89" system.time="Thu, 16 Nov 2017 07:32:28 -0200"> ESMTP Exim 4.89  #1 Thu, 16 Nov 2017 07:32:28 -0200 </example>
     <param pos="0" name="service.vendor" value="exim"/>
     <param pos="0" name="service.family" value="exim"/>
     <param pos="0" name="service.product" value="exim"/>
@@ -466,7 +466,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) GroupWise Internet Agent ([^ ]+\.[^ ]+\.[^ ]+) Ready \(C\).* Novell, Inc\. *$">
     <description>Novell GroupWise Internet Agent - versions 5 and higher</description>
-    <example service.version="5.5.1">foo.bar GroupWise Internet Agent 5.5.1 Ready (C)1993, 1998 Novell, Inc.</example>
+    <example service.version="5.5.1" host.name="foo.bar">foo.bar GroupWise Internet Agent 5.5.1 Ready (C)1993, 1998 Novell, Inc.</example>
     <param pos="0" name="service.vendor" value="Novell"/>
     <param pos="0" name="service.family" value="GroupWise"/>
     <param pos="0" name="service.product" value="GroupWise"/>
@@ -477,8 +477,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) GroupWise Internet Agent (\d+\.[\d.]+)  Copyright .*\d{4}-\d{4} Novell, Inc..* All rights reserved. Ready *$">
     <description>Novell GroupWise Internet Agent - versions 5 and higher, second variant</description>
-    <example service.version="8.0.3">foo.bar GroupWise Internet Agent 8.0.3  Copyright (c) 1993-2012 Novell, Inc.  All rights reserved. Ready</example>
-    <example service.version="14.2.1">foo.bar GroupWise Internet Agent 14.2.1  Copyright 1993-2016 Novell, Inc., a Micro Focus Company. All rights reserved. Ready</example>
+    <example service.version="8.0.3" host.name="foo.bar">foo.bar GroupWise Internet Agent 8.0.3  Copyright (c) 1993-2012 Novell, Inc.  All rights reserved. Ready</example>
+    <example service.version="14.2.1" host.name="foo.bar">foo.bar GroupWise Internet Agent 14.2.1  Copyright 1993-2016 Novell, Inc., a Micro Focus Company. All rights reserved. Ready</example>
     <param pos="0" name="service.vendor" value="Novell"/>
     <param pos="0" name="service.family" value="GroupWise"/>
     <param pos="0" name="service.product" value="GroupWise"/>
@@ -501,9 +501,9 @@
 
   <fingerprint pattern="^([^ ]{1,512}) (?:ESMTP )?running IBM VM SMTP (.+)(?:; | on )(.+) *$">
     <description>IBM SMTP server for VM/ESA on IBM S/390 and IBM eserver z/Series 900.</description>
-    <example service.version="Level 640" system.time="Thu, 30 Nov 2017 01:08:59 PDT">foo.bar running IBM VM SMTP Level 640 on Thu, 30 Nov 2017 01:08:59 PDT</example>
-    <example service.version="Level 3A0">foo.bar running IBM VM SMTP Level 3A0 on Mon, 10 Sep 2001 07:21:54 EDT</example>
-    <example service.version="V2R4" system.time="Mon, 10 Sep 2001 07:24:35 -0400 (EDT)">foo.bar ESMTP running IBM VM SMTP V2R4; Mon, 10 Sep 2001 07:24:35 -0400 (EDT)</example>
+    <example service.version="Level 640" system.time="Thu, 30 Nov 2017 01:08:59 PDT" host.name="foo.bar">foo.bar running IBM VM SMTP Level 640 on Thu, 30 Nov 2017 01:08:59 PDT</example>
+    <example service.version="Level 3A0" host.name="foo.bar" system.time="Mon, 10 Sep 2001 07:21:54 EDT">foo.bar running IBM VM SMTP Level 3A0 on Mon, 10 Sep 2001 07:21:54 EDT</example>
+    <example service.version="V2R4" system.time="Mon, 10 Sep 2001 07:24:35 -0400 (EDT)" host.name="foo.bar">foo.bar ESMTP running IBM VM SMTP V2R4; Mon, 10 Sep 2001 07:24:35 -0400 (EDT)</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.family" value="VM"/>
     <param pos="0" name="service.product" value="VM"/>
@@ -528,7 +528,7 @@
 
   <fingerprint pattern="^(\S{1,512}) E?SMTP Server \(JAMES E?SMTP Server ([\d\.]+)\) ready (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) \(.+\)$">
     <description>JAMES SMTP Server</description>
-    <example host.name="foo.bar" service.version="2.3.2">foo.bar SMTP Server (JAMES SMTP Server 2.3.2) ready Tue, 19 May 2015 00:36:13 +0200 (CEST)</example>
+    <example host.name="foo.bar" service.version="2.3.2" system.time="Tue, 19 May 2015 00:36:13 +0200">foo.bar SMTP Server (JAMES SMTP Server 2.3.2) ready Tue, 19 May 2015 00:36:13 +0200 (CEST)</example>
     <param pos="0" name="service.vendor" value="Apache"/>
     <param pos="0" name="service.product" value="James"/>
     <param pos="2" name="service.version"/>
@@ -557,9 +557,9 @@
 
   <fingerprint pattern="^(?:(\S{1,512}) {1,8})?ESMTP MailEnable Service, Version: (?:([\d.]+))?-[\d.]*-[\d.]* (?:ready|denied access) at (\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2})$">
     <description>MailEnable - Complex</description>
-    <example host.name="foo.bar" service.version="1.8">foo.bar ESMTP MailEnable Service, Version: 1.8-- ready at 05/20/15 08:50:22</example>
-    <example host.name="*.foo.bar" service.version="9.53">*.foo.bar ESMTP MailEnable Service, Version: 9.53-9.53- ready at 11/30/17 00:57:37</example>
-    <example host.name="%WPI_HOSTNAME%" service.version="10.27">%WPI_HOSTNAME% ESMTP MailEnable Service, Version: 10.27-- ready at 07/07/21 18:24:47</example>
+    <example host.name="foo.bar" service.version="1.8" system.time="05/20/15 08:50:22">foo.bar ESMTP MailEnable Service, Version: 1.8-- ready at 05/20/15 08:50:22</example>
+    <example host.name="*.foo.bar" service.version="9.53" system.time="11/30/17 00:57:37">*.foo.bar ESMTP MailEnable Service, Version: 9.53-9.53- ready at 11/30/17 00:57:37</example>
+    <example host.name="%WPI_HOSTNAME%" service.version="10.27" system.time="07/07/21 18:24:47">%WPI_HOSTNAME% ESMTP MailEnable Service, Version: 10.27-- ready at 07/07/21 18:24:47</example>
     <example host.name="foo.bar" service.version="9.00" system.time="11/30/17 09:30:34">foo.bar ESMTP MailEnable Service, Version: 9.00--9.00 ready at 11/30/17 09:30:34</example>
     <example host.name="foo.bar" service.version="1.986" system.time="04/05/18 16:15:25">foo.bar ESMTP MailEnable Service, Version: 1.986-- denied access at 04/05/18 16:15:25</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
@@ -578,8 +578,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) \(Mail-Max Version (\d+\.[\d\.]+), (.+, .+)\) ESMTP Mail Server Ready. *$">
     <description>Mail Max</description>
-    <example host.name="foo.bar" service.version="4.2.4.7">foo.bar (Mail-Max Version 4.2.4.7, Wed, 31 Jan 2001 03:44:35 +0100 WST) ESMTP Mail Server Ready.</example>
-    <example host.name="foo.bar" service.version="3.073">foo.bar (Mail-Max Version 3.073, Thu, 30 Nov 2017 17:24:59 +0800 ) ESMTP Mail Server Ready.</example>
+    <example host.name="foo.bar" service.version="4.2.4.7" system.time="Wed, 31 Jan 2001 03:44:35 +0100 WST">foo.bar (Mail-Max Version 4.2.4.7, Wed, 31 Jan 2001 03:44:35 +0100 WST) ESMTP Mail Server Ready.</example>
+    <example host.name="foo.bar" service.version="3.073" system.time="Thu, 30 Nov 2017 17:24:59 +0800 ">foo.bar (Mail-Max Version 3.073, Thu, 30 Nov 2017 17:24:59 +0800 ) ESMTP Mail Server Ready.</example>
     <param pos="0" name="service.vendor" value="Mail-Max"/>
     <param pos="0" name="service.family" value="Mail-Max"/>
     <param pos="0" name="service.product" value="Mail-Max"/>
@@ -620,7 +620,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}MAILsweeper ESMTP Receiver Version (\d\.[\d.]+) Ready *$">
     <description>Content Security MAILsweeper for SMTP (http://www.contenttechnologies.com/products/msw4smtp/default.asp)</description>
-    <example service.version="4.2.1.0">foo.bar MAILsweeper ESMTP Receiver Version 4.2.1.0 Ready</example>
+    <example service.version="4.2.1.0" host.name="foo.bar">foo.bar MAILsweeper ESMTP Receiver Version 4.2.1.0 Ready</example>
     <param pos="0" name="service.vendor" value="Clearswift"/>
     <param pos="0" name="service.family" value="MAILsweeper"/>
     <param pos="0" name="service.product" value="MAILsweeper"/>
@@ -630,7 +630,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) UNREGISTERED; *(.+) *$">
     <description>MDaemon mail server - with timestamp, unregistered</description>
-    <example service.version="4.0.5">foo.bar ESMTP MDaemon 4.0.5 UNREGISTERED; Sat, 06 Oct 2001 09:10:56 +0400</example>
+    <example service.version="4.0.5" host.name="foo.bar" system.time="Sat, 06 Oct 2001 09:10:56 +0400">foo.bar ESMTP MDaemon 4.0.5 UNREGISTERED; Sat, 06 Oct 2001 09:10:56 +0400</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
     <param pos="0" name="service.family" value="MDaemon"/>
     <param pos="0" name="service.product" value="MDaemon"/>
@@ -649,7 +649,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
     <description>MDaemon mail server - with timestamp</description>
-    <example service.version="4.0.2">foo.bar ESMTP MDaemon 4.0.2; Sat, 06 Oct 2001 01:46:44 -0500</example>
+    <example service.version="4.0.2" host.name="foo.bar" system.time="Sat, 06 Oct 2001 01:46:44 -0500">foo.bar ESMTP MDaemon 4.0.2; Sat, 06 Oct 2001 01:46:44 -0500</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
     <param pos="0" name="service.family" value="MDaemon"/>
     <param pos="0" name="service.product" value="MDaemon"/>
@@ -667,7 +667,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP MDaemon ([^ ]+\.[^ ]+\.[^ ]+) ready *$">
     <description>MDaemon mail server - without timestamp</description>
-    <example service.version="3.5.7">foo.bar ESMTP MDaemon 3.5.7 ready</example>
+    <example service.version="3.5.7" host.name="foo.bar">foo.bar ESMTP MDaemon 3.5.7 ready</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
     <param pos="0" name="service.family" value="MDaemon"/>
     <param pos="0" name="service.product" value="MDaemon"/>
@@ -683,9 +683,9 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP service ready \[[0-9]+\] (?:using )?MDaemon v(\d+\.[\d.]+) ([^ ]+) *$">
     <description>MDaemon mail server - with version revision</description>
-    <example service.version="2.84" service.version.version="R">foo.bar ESMTP service ready [1] MDaemon v2.84 R</example>
-    <example service.version="3.0.3" service.version.version="R">foo.bar ESMTP service ready [1] using MDaemon v3.0.3 R</example>
-    <example service.version="2.8.7.0" service.version.version="R">foo.bar ESMTP service ready [1] MDaemon v2.8.7.0 R</example>
+    <example service.version="2.84" service.version.version="R" host.name="foo.bar">foo.bar ESMTP service ready [1] MDaemon v2.84 R</example>
+    <example service.version="3.0.3" service.version.version="R" host.name="foo.bar">foo.bar ESMTP service ready [1] using MDaemon v3.0.3 R</example>
+    <example service.version="2.8.7.0" service.version.version="R" host.name="foo.bar">foo.bar ESMTP service ready [1] MDaemon v2.8.7.0 R</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
     <param pos="0" name="service.family" value="MDaemon"/>
     <param pos="0" name="service.product" value="MDaemon"/>
@@ -702,8 +702,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP service ready \[[0-9]+\] (?:\()?MDaemon v([\d.]+) ([^ ]+) ([^ )]+)(?:\))? *$">
     <description>MDaemon mail server - with service pack</description>
-    <example service.version="2.7" service.version.version="SP5" service.version.version.version="R">foo.bar ESMTP service ready [1] MDaemon v2.7 SP5 R</example>
-    <example service.version="2.7" service.version.version="SP4" service.version.version.version="R">foo.bar ESMTP service ready [1] (MDaemon v2.7 SP4 R)</example>
+    <example service.version="2.7" service.version.version="SP5" service.version.version.version="R" host.name="foo.bar">foo.bar ESMTP service ready [1] MDaemon v2.7 SP5 R</example>
+    <example service.version="2.7" service.version.version="SP4" service.version.version.version="R" host.name="foo.bar">foo.bar ESMTP service ready [1] (MDaemon v2.7 SP4 R)</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
     <param pos="0" name="service.family" value="MDaemon"/>
     <param pos="0" name="service.product" value="MDaemon"/>
@@ -721,7 +721,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP service ready \[[0-9]+\] \(MDaemon v([^ ]+\.[^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)\) *$">
     <description>MDaemon mail server</description>
-    <example service.version="2.5" service.version.version.version="b1">foo.bar ESMTP service ready [1] (MDaemon v2.5 rB b1 32-T)</example>
+    <example service.version="2.5" service.version.version.version="b1" host.name="foo.bar" service.version.version="rB" service.version.version.version.version="32-T">foo.bar ESMTP service ready [1] (MDaemon v2.5 rB b1 32-T)</example>
     <param pos="0" name="service.vendor" value="Alt-N"/>
     <param pos="0" name="service.family" value="MDaemon"/>
     <param pos="0" name="service.product" value="MDaemon"/>
@@ -742,9 +742,9 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +E?SMTP (?i:MERAK) ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
     <description>Merak mail server - http://www.icewarp.com/merakmail/ (runs on 2000/NT/9x)</description>
-    <example host.name="foo.bar" service.version="8.0.3">foo.bar SMTP Merak 8.0.3; Thu, 30 Nov 2017 20:01:41 +1000</example>
-    <example host.name="foo.bar" service.version="8.0.3">foo.bar ESMTP Merak 8.0.3; Thu, 30 Nov 2017 12:08:09 +0200</example>
-    <example host.name="foo.bar" service.version="2.10.284">foo.bar ESMTP MERAK 2.10.284; Thu, 30 Nov 2017 17:55:10 +0800</example>
+    <example host.name="foo.bar" service.version="8.0.3" system.time="Thu, 30 Nov 2017 20:01:41 +1000">foo.bar SMTP Merak 8.0.3; Thu, 30 Nov 2017 20:01:41 +1000</example>
+    <example host.name="foo.bar" service.version="8.0.3" system.time="Thu, 30 Nov 2017 12:08:09 +0200">foo.bar ESMTP Merak 8.0.3; Thu, 30 Nov 2017 12:08:09 +0200</example>
+    <example host.name="foo.bar" service.version="2.10.284" system.time="Thu, 30 Nov 2017 17:55:10 +0800">foo.bar ESMTP MERAK 2.10.284; Thu, 30 Nov 2017 17:55:10 +0800</example>
     <param pos="0" name="service.vendor" value="Merak"/>
     <param pos="0" name="service.family" value="Mail Server"/>
     <param pos="0" name="service.product" value="Mail Server"/>
@@ -756,7 +756,7 @@
 
   <fingerprint pattern="^MERCUR SMTP-Server \(v([^ ]+\.[^ ])0\.([^ ]+) ([^ ]+)\) for (.+) ready at (.+) *$">
     <description>Atrium's MERCUR SMTP server (http://www.atrium-software.com/pub/support_e.cfm)</description>
-    <example service.version="3.3" service.version.version="09" service.version.version.version="SA-0000005" mercur.os.info="Windows NT">MERCUR SMTP-Server (v3.30.09 SA-0000005) for Windows NT ready at Thu, 30 Nov 2017  10:01:06 +0100</example>
+    <example service.version="3.3" service.version.version="09" service.version.version.version="SA-0000005" mercur.os.info="Windows NT" system.time="Thu, 30 Nov 2017  10:01:06 +0100">MERCUR SMTP-Server (v3.30.09 SA-0000005) for Windows NT ready at Thu, 30 Nov 2017  10:01:06 +0100</example>
     <param pos="0" name="service.vendor" value="Atrium Software"/>
     <param pos="0" name="service.family" value="MERCUR"/>
     <param pos="0" name="service.product" value="MERCUR"/>
@@ -783,8 +783,8 @@
 
   <fingerprint pattern="^^([^ ]{1,512}) Mercury\/32 v([^ ]+\.[^ ]+) (?:SMTP\/)?ESMTP server ready.?$">
     <description>Mercury/32 for Win9x/NT/2000 ( http://www.pmail.com/index.cfm )</description>
-    <example service.version="3.01a">foo.bar Mercury/32 v3.01a SMTP/ESMTP server ready.</example>
-    <example service.version="3.30">foo.bar Mercury/32 v3.30 ESMTP server ready.</example>
+    <example service.version="3.01a" host.name="foo.bar">foo.bar Mercury/32 v3.01a SMTP/ESMTP server ready.</example>
+    <example service.version="3.30" host.name="foo.bar">foo.bar Mercury/32 v3.30 ESMTP server ready.</example>
     <param pos="0" name="service.family" value="Mercury Mail Transport System"/>
     <param pos="0" name="service.product" value="Mercury Mail Transport System"/>
     <param pos="0" name="os.vendor" value="Microsoft"/>
@@ -797,7 +797,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) SMTP NAVIEG ([^ ]+\.[^ ]+\.[^ ]+); (.+)* http">
     <description>Norton Antivirus for Internet Email Gateways (becomes NAVGW in 2.1)</description>
-    <example host.name="foo.bar" service.version="2.0.1">foo.bar SMTP NAVIEG 2.0.1; Sun, 29 Jul 2001 22:02:16 -0500 http://www.symantec.com</example>
+    <example host.name="foo.bar" service.version="2.0.1" system.time="Sun, 29 Jul 2001 22:02:16 -0500">foo.bar SMTP NAVIEG 2.0.1; Sun, 29 Jul 2001 22:02:16 -0500 http://www.symantec.com</example>
     <param pos="0" name="service.vendor" value="Norton"/>
     <param pos="0" name="service.family" value="Antivirus for Gateways"/>
     <param pos="0" name="service.product" value="Antivirus for Gateways"/>
@@ -850,15 +850,15 @@
 
   <fingerprint pattern=" ?(?:([^ ]{1,512}))? {0,8}ESMTP Service \(Lotus Domino Release (\d+\.[\w.]+(?: FP\d+)?(?: HF\d+)?)(?: \(Intl\))?\) ready at (.+) *$">
     <description>Lotus Domino SMTP MTA</description>
-    <example service.version="8.5">foo.bar  ESMTP Service (Lotus Domino Release 8.5) ready at Thu, 30 Nov 2017 17:01:45 +0800</example>
-    <example service.version="8.5.3FP6 HF1944">foo.bar ESMTP Service (Lotus Domino Release 8.5.3FP6 HF1944) ready at Thu, 30 Nov 2017 17:17:43 +0800</example>
-    <example service.version="8.0.2 FP1 HF82">foo.bar ESMTP Service (Lotus Domino Release 8.0.2 FP1 HF82) ready at Thu, 5 Apr 2018 22:03:28 +0200</example>
-    <example service.version="5.0.13a"> foo.bar ESMTP Service (Lotus Domino Release 5.0.13a) ready at Thu, 16 Nov 2017 17:47:42 +0800</example>
-    <example service.version="7.0.4">foo.bar ESMTP Service (Lotus Domino Release 7.0.4) ready at Thu, 16 Nov 2017 18:28:36 +0900</example>
-    <example service.version="8.0.2FP2">foo.bar ESMTP Service (Lotus Domino Release 8.0.2FP2) ready at Thu, 16 Nov 2017 02:17:33 -0700</example>
-    <example service.version="8.5.3">foo.bar ESMTP Service (Lotus Domino Release 8.5.3) ready at Thu, 16 Nov 2017 17:52:21 +0800</example>
-    <example service.version="7.0">  ESMTP Service (Lotus Domino Release 7.0) ready at Thu, 30 Nov 2017 17:00:41 +0800</example>
-    <example host.name="foo.bar" service.version="5.0.1">foo.bar ESMTP Service (Lotus Domino Release 5.0.1 (Intl)) ready at Thu, 30 Nov 2017 12:38:43 +0300</example>
+    <example service.version="8.5" host.name="foo.bar" system.time="Thu, 30 Nov 2017 17:01:45 +0800">foo.bar  ESMTP Service (Lotus Domino Release 8.5) ready at Thu, 30 Nov 2017 17:01:45 +0800</example>
+    <example service.version="8.5.3FP6 HF1944" host.name="foo.bar" system.time="Thu, 30 Nov 2017 17:17:43 +0800">foo.bar ESMTP Service (Lotus Domino Release 8.5.3FP6 HF1944) ready at Thu, 30 Nov 2017 17:17:43 +0800</example>
+    <example service.version="8.0.2 FP1 HF82" host.name="foo.bar" system.time="Thu, 5 Apr 2018 22:03:28 +0200">foo.bar ESMTP Service (Lotus Domino Release 8.0.2 FP1 HF82) ready at Thu, 5 Apr 2018 22:03:28 +0200</example>
+    <example service.version="5.0.13a" host.name="foo.bar" system.time="Thu, 16 Nov 2017 17:47:42 +0800"> foo.bar ESMTP Service (Lotus Domino Release 5.0.13a) ready at Thu, 16 Nov 2017 17:47:42 +0800</example>
+    <example service.version="7.0.4" host.name="foo.bar" system.time="Thu, 16 Nov 2017 18:28:36 +0900">foo.bar ESMTP Service (Lotus Domino Release 7.0.4) ready at Thu, 16 Nov 2017 18:28:36 +0900</example>
+    <example service.version="8.0.2FP2" host.name="foo.bar" system.time="Thu, 16 Nov 2017 02:17:33 -0700">foo.bar ESMTP Service (Lotus Domino Release 8.0.2FP2) ready at Thu, 16 Nov 2017 02:17:33 -0700</example>
+    <example service.version="8.5.3" host.name="foo.bar" system.time="Thu, 16 Nov 2017 17:52:21 +0800">foo.bar ESMTP Service (Lotus Domino Release 8.5.3) ready at Thu, 16 Nov 2017 17:52:21 +0800</example>
+    <example service.version="7.0" system.time="Thu, 30 Nov 2017 17:00:41 +0800">  ESMTP Service (Lotus Domino Release 7.0) ready at Thu, 30 Nov 2017 17:00:41 +0800</example>
+    <example host.name="foo.bar" service.version="5.0.1" system.time="Thu, 30 Nov 2017 12:38:43 +0300">foo.bar ESMTP Service (Lotus Domino Release 5.0.1 (Intl)) ready at Thu, 30 Nov 2017 12:38:43 +0300</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
@@ -871,9 +871,9 @@
 
   <fingerprint pattern="^ ?(?:([^ ]{1,512}))? {0,8}ESMTP Service \(IBM Domino Release (\d+\.[\w.]+(?: HF\d+)?)\) ready at (.+) *$">
     <description>IBM Domino SMTP MTA</description>
-    <example host.name="foo.bar" service.version="9.0.1FP8 HF475">foo.bar ESMTP Service (IBM Domino Release 9.0.1FP8 HF475) ready at Thu, 30 Nov 2017 17:55:48 +0900</example>
-    <example host.name="foo.bar" service.version="9.0.1"> foo.bar ESMTP Service (IBM Domino Release 9.0.1) ready at Thu, 30 Nov 2017 10:12:26 +0100</example>
-    <example service.version="9.0.1FP8"> ESMTP Service (IBM Domino Release 9.0.1FP8) ready at Thu, 30 Nov 2017 13:51:59 -0800</example>
+    <example host.name="foo.bar" service.version="9.0.1FP8 HF475" system.time="Thu, 30 Nov 2017 17:55:48 +0900">foo.bar ESMTP Service (IBM Domino Release 9.0.1FP8 HF475) ready at Thu, 30 Nov 2017 17:55:48 +0900</example>
+    <example host.name="foo.bar" service.version="9.0.1" system.time="Thu, 30 Nov 2017 10:12:26 +0100"> foo.bar ESMTP Service (IBM Domino Release 9.0.1) ready at Thu, 30 Nov 2017 10:12:26 +0100</example>
+    <example service.version="9.0.1FP8" system.time="Thu, 30 Nov 2017 13:51:59 -0800"> ESMTP Service (IBM Domino Release 9.0.1FP8) ready at Thu, 30 Nov 2017 13:51:59 -0800</example>
     <param pos="0" name="service.vendor" value="IBM"/>
     <param pos="0" name="service.family" value="IBM Domino"/>
     <param pos="0" name="service.product" value="IBM Domino"/>
@@ -886,8 +886,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Service \(Lotus Domino Build (V?[\w.]+)\) ready at (.+) *$">
     <description>Lotus Domino (some early build)</description>
-    <example notes.build.version="166.1">foo.bar ESMTP Service (Lotus Domino Build 166.1) ready at Thu, 16 Nov 2017 10:39:22 +0200</example>
-    <example notes.build.version="V85_M2_08202008">foo.bar ESMTP Service (Lotus Domino Build V85_M2_08202008) ready at Thu, 16 Nov 2017 03:57:40 -0500</example>
+    <example notes.build.version="166.1" host.name="foo.bar" system.time="Thu, 16 Nov 2017 10:39:22 +0200">foo.bar ESMTP Service (Lotus Domino Build 166.1) ready at Thu, 16 Nov 2017 10:39:22 +0200</example>
+    <example notes.build.version="V85_M2_08202008" host.name="foo.bar" system.time="Thu, 16 Nov 2017 03:57:40 -0500">foo.bar ESMTP Service (Lotus Domino Build V85_M2_08202008) ready at Thu, 16 Nov 2017 03:57:40 -0500</example>
     <param pos="0" name="service.vendor" value="Lotus"/>
     <param pos="0" name="service.family" value="Lotus Domino"/>
     <param pos="0" name="service.product" value="Lotus Domino"/>
@@ -922,7 +922,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) WindowsNT SMTP Server v([^ ]+\.[^ ]+\.[^ ]+)/([^ ]+)/SP ESMTP ready at (.+) *$">
     <description>NTMail - versions 3.x and earlier (it was called Internet Shopper's something or other)</description>
-    <example host.name="foo.bar" service.version="3.03.0018" ntmail.id="7.aavn">foo.bar WindowsNT SMTP Server v3.03.0018/7.aavn/SP ESMTP ready at Thu, 30 Nov 2017 10:15:31 +0100</example>
+    <example host.name="foo.bar" service.version="3.03.0018" ntmail.id="7.aavn" system.time="Thu, 30 Nov 2017 10:15:31 +0100">foo.bar WindowsNT SMTP Server v3.03.0018/7.aavn/SP ESMTP ready at Thu, 30 Nov 2017 10:15:31 +0100</example>
     <param pos="0" name="service.vendor" value="Gordano"/>
     <param pos="0" name="service.family" value="NTMail"/>
     <param pos="0" name="service.product" value="NTMail"/>
@@ -950,8 +950,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) E?SMTP PMailServer(?: \[Free Edition\])? ([\d\.]+); (\w\w\w, +\d+ \w\w\w \d\d\d\d [\d:]+)$">
     <description>A.K.I PMail</description>
-    <example host.name="foo.bar" service.version="1.91">foo.bar ESMTP PMailServer [Free Edition] 1.91; Fri, 22 May 2015 02:04:56</example>
-    <example host.name="foo.bar" service.version="1.78">foo.bar ESMTP PMailServer 1.78; Fri,  6 Apr 2018 04:34:11</example>
+    <example host.name="foo.bar" service.version="1.91" system.time="Fri, 22 May 2015 02:04:56">foo.bar ESMTP PMailServer [Free Edition] 1.91; Fri, 22 May 2015 02:04:56</example>
+    <example host.name="foo.bar" service.version="1.78" system.time="Fri,  6 Apr 2018 04:34:11">foo.bar ESMTP PMailServer 1.78; Fri,  6 Apr 2018 04:34:11</example>
     <param pos="0" name="service.vendor" value="A.K.I Software"/>
     <param pos="0" name="service.product" value="PMail Server"/>
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss"/>
@@ -974,8 +974,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Postfix \(?([\d.]+)\)?$">
     <description>Postfix - Std semantic versioning, w/ optional parens</description>
-    <example service.version="3.1.4">foo.bar ESMTP Postfix (3.1.4)</example>
-    <example service.version="2.7.1">foo.bar ESMTP Postfix 2.7.1</example>
+    <example service.version="3.1.4" host.name="foo.bar">foo.bar ESMTP Postfix (3.1.4)</example>
+    <example service.version="2.7.1" host.name="foo.bar">foo.bar ESMTP Postfix 2.7.1</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
@@ -986,7 +986,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Postfix \((?:Postfix-)?([\d.]+)-([^ ]+)\)$">
     <description>Postfix - version + build</description>
-    <example service.version="2.8" service.version.version="20100306">foo.bar ESMTP Postfix (2.8-20100306)</example>
+    <example service.version="2.8" service.version.version="20100306" host.name="foo.bar">foo.bar ESMTP Postfix (2.8-20100306)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
@@ -998,7 +998,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +E?SMTP Postfix \(Ubuntu\)$">
     <description>Postfix - Ubuntu</description>
-    <example>foo.bar ESMTP Postfix (Ubuntu)</example>
+    <example host.name="foo.bar">foo.bar ESMTP Postfix (Ubuntu)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
@@ -1013,7 +1013,7 @@
   <fingerprint pattern="^([^ ]{1,512})(?: ESMTP)? Hi, I'm a Mail-in-a-Box \(Ubuntu/Postfix; see https://mailinabox.email/\)$">
     <description>Postfix - Ubuntu, Mail-in-a-Box package</description>
     <example host.name="foo.bar">foo.bar ESMTP Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)</example>
-    <example>foo.bar Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)</example>
+    <example host.name="foo.bar">foo.bar Hi, I'm a Mail-in-a-Box (Ubuntu/Postfix; see https://mailinabox.email/)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
@@ -1027,7 +1027,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +E?SMTP Postfix \(Debian/GNU\)$">
     <description>Postfix - Debian</description>
-    <example>foo.bar ESMTP Postfix (Debian/GNU)</example>
+    <example host.name="foo.bar">foo.bar ESMTP Postfix (Debian/GNU)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
@@ -1041,7 +1041,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP.* Postfix *\(.+\) *$">
     <description>Postfix - generic banner with amusing comments in parentheses</description>
-    <example>foo.bar ESMTP Postfix (lol)</example>
+    <example host.name="foo.bar">foo.bar ESMTP Postfix (lol)</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
@@ -1051,8 +1051,8 @@
 
   <fingerprint pattern="(?i)^([^ ]{1,512}) {1,8}E?SMTP.* Postfix *$">
     <description>Postfix - generic banner</description>
-    <example>foo.bar ESMTP Postfix</example>
-    <example>foo.bar SMTP Postfix</example>
+    <example host.name="foo.bar">foo.bar ESMTP Postfix</example>
+    <example host.name="foo.bar">foo.bar SMTP Postfix</example>
     <param pos="0" name="service.vendor" value="Postfix"/>
     <param pos="0" name="service.family" value="Postfix"/>
     <param pos="0" name="service.product" value="Postfix"/>
@@ -1120,7 +1120,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail +([^ ]+) \(PHNE_([^ ]+)\) */ *(.+); *(.+) \(.+\)$">
     <description>Sendmail - HP-UX with a PHNE (HP Networking patch) installed</description>
-    <example host.name="foo.bar" service.version="8.8.6" sendmail.config.version="8.7.1">foo.bar ESMTP Sendmail 8.8.6 (PHNE_14041)/8.7.1; Tue, 6 Feb 2001 10:04:32 -0300 (SAT)</example>
+    <example host.name="foo.bar" service.version="8.8.6" sendmail.config.version="8.7.1" sendmail.hpux.phne.version="14041" system.time="Tue, 6 Feb 2001 10:04:32 -0300">foo.bar ESMTP Sendmail 8.8.6 (PHNE_14041)/8.7.1; Tue, 6 Feb 2001 10:04:32 -0300 (SAT)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1139,7 +1139,7 @@
 
   <fingerprint pattern="^(\S{1,512}) ESMTP Sendmail \S+ version ([\d\.]+) - Revision \S+ HP-UX([\d\.]+).*(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ \w\w\w)$">
     <description>Sendmail - HP-UX</description>
-    <example host.name="foo.bar" os.version="11.31" service.version="8.13.3">foo.bar ESMTP Sendmail @(#)Sendmail version 8.13.3 - Revision 1.004:: HP-UX11.31 - 03rd February,2010/8.11.1; Wed, 20 May 2015 23:35:38 GMT</example>
+    <example host.name="foo.bar" os.version="11.31" service.version="8.13.3" system.time="Wed, 20 May 2015 23:35:38 GMT">foo.bar ESMTP Sendmail @(#)Sendmail version 8.13.3 - Revision 1.004:: HP-UX11.31 - 03rd February,2010/8.11.1; Wed, 20 May 2015 23:35:38 GMT</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1157,7 +1157,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) {1,8}ESMTP +Sendmail +([^ ]+)/UW([^ ]+) ready at *(.+) \(.+\) *$">
     <description>Sendmail - Unixware</description>
-    <example service.version="8.8.7">foo.bar ESMTP Sendmail 8.8.7/UW7.1.0 ready at Tue, 6 Feb 2001 16:39:30 -0300 (GMT-0300)</example>
+    <example service.version="8.8.7" host.name="foo.bar" os.version="7.1.0" system.time="Tue, 6 Feb 2001 16:39:30 -0300">foo.bar ESMTP Sendmail 8.8.7/UW7.1.0 ready at Tue, 6 Feb 2001 16:39:30 -0300 (GMT-0300)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1174,7 +1174,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail AIX([^/]+)/UCB ([^;]+); (.+) \(.+\)$">
     <description>Sendmail - AIX (UCB variant)</description>
-    <example os.version="4.2" service.version="8.7">foo.bar ESMTP Sendmail AIX4.2/UCB 8.7; Sun, 29 Jul 2001 22:34:37 -0400 (EDT)</example>
+    <example os.version="4.2" service.version="8.7" host.name="foo.bar" system.time="Sun, 29 Jul 2001 22:34:37 -0400">foo.bar ESMTP Sendmail AIX4.2/UCB 8.7; Sun, 29 Jul 2001 22:34:37 -0400 (EDT)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1192,7 +1192,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) Sendmail AIX([^/]+)/UCB ([^/]+)/([^ ]+) ready at (.+)$">
     <description>Sendmail - AIX (UCB/ready at variant)</description>
-    <example>foo.bar Sendmail AIX 4.1/UCB 5.64/4.03 ready at Mon, 30 Jul 2001 00:42:21 -0500</example>
+    <example host.name="foo.bar" os.version=" 4.1" service.version="5.64" sendmail.config.version="4.03" system.time="Mon, 30 Jul 2001 00:42:21 -0500">foo.bar Sendmail AIX 4.1/UCB 5.64/4.03 ready at Mon, 30 Jul 2001 00:42:21 -0500</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1211,8 +1211,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail AIX([^/]+)/([^/]+)/([^;]+); (.+)(?: \(.+\))?$">
     <description>Sendmail - AIX</description>
-    <example host.name="foo.bar" os.version="4.2" service.version="8.7" sendmail.config.version="8.8">foo.bar ESMTP Sendmail AIX4.2/8.7/8.8; Sun, 29 Jul 2001 22:34:37 -0400 (EDT)</example>
-    <example host.name="foo.bar" os.version="5.1" service.version="8.11.6p2" sendmail.config.version="8.11.0">foo.bar ESMTP Sendmail AIX5.1/8.11.6p2/8.11.0; Fri, 28 Aug 1970 19:42:05 -0800</example>
+    <example host.name="foo.bar" os.version="4.2" service.version="8.7" sendmail.config.version="8.8" system.time="Sun, 29 Jul 2001 22:34:37 -0400 (EDT)">foo.bar ESMTP Sendmail AIX4.2/8.7/8.8; Sun, 29 Jul 2001 22:34:37 -0400 (EDT)</example>
+    <example host.name="foo.bar" os.version="5.1" service.version="8.11.6p2" sendmail.config.version="8.11.0" system.time="Fri, 28 Aug 1970 19:42:05 -0800">foo.bar ESMTP Sendmail AIX5.1/8.11.6p2/8.11.0; Fri, 28 Aug 1970 19:42:05 -0800</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1231,7 +1231,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/SuSE Linux ([^;]+); (.+)$">
     <description>Sendmail - SuSE Linux</description>
-    <example>foo.bar ESMTP Sendmail 8.9.3/8.9.3/SuSE Linux 8.9.3-0.1; Mon, 30 Jul 2001 04:48:54 +0200</example>
+    <example host.name="foo.bar" service.version="8.9.3" sendmail.config.version="8.9.3" sendmail.vendor.version="8.9.3-0.1" system.time="Mon, 30 Jul 2001 04:48:54 +0200">foo.bar ESMTP Sendmail 8.9.3/8.9.3/SuSE Linux 8.9.3-0.1; Mon, 30 Jul 2001 04:48:54 +0200</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1250,7 +1250,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^ ]+)\+Sun/([^ ]+); (.+)$">
     <description>Sendmail - Solaris with date (no time offeset variant)</description>
-    <example>foo.bar ESMTP Sendmail 8.9.3+Sun/8.9.1; Mon, 30 Jul 2001 02:50:22 GMT</example>
+    <example host.name="foo.bar" service.version="8.9.3" sendmail.config.version="8.9.1" system.time="Mon, 30 Jul 2001 02:50:22 GMT">foo.bar ESMTP Sendmail 8.9.3+Sun/8.9.1; Mon, 30 Jul 2001 02:50:22 GMT</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1268,7 +1268,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^ ]+)\+Sun/([^ ]+) ready at (.+) \(.+\)$">
     <description>Sendmail - Solaris with date (ready variant)</description>
-    <example>foo.bar ESMTP Sendmail 8.8.8+Sun/8.6.4 ready at Thu, 15 Nov 2000 11:40:32 -0800 (PST)</example>
+    <example host.name="foo.bar" service.version="8.8.8" sendmail.config.version="8.6.4" system.time="Thu, 15 Nov 2000 11:40:32 -0800">foo.bar ESMTP Sendmail 8.8.8+Sun/8.6.4 ready at Thu, 15 Nov 2000 11:40:32 -0800 (PST)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1286,8 +1286,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP (?:Debian )?Sendmail ([^/]+)/([^/]+)/Debian ([^/]+); (.+) *$">
     <description>Sendmail - Debian</description>
-    <example service.version="8.12.0.Beta7" sendmail.config.version="8.12.0.Beta7" sendmail.vendor.version="8.12.0.Beta7-1">foo.bar ESMTP Debian Sendmail 8.12.0.Beta7/8.12.0.Beta7/Debian 8.12.0.Beta7-1; Sun, 29 Jul 2001 18:52:20 -0800</example>
-    <example service.version="8.11.0" sendmail.config.version="8.9.3" sendmail.vendor.version="8.9.3-21">foo.bar ESMTP Sendmail 8.11.0/8.9.3/Debian 8.9.3-21; Sun, 29 Jul 2001 19:51:00 -0700</example>
+    <example service.version="8.12.0.Beta7" sendmail.config.version="8.12.0.Beta7" sendmail.vendor.version="8.12.0.Beta7-1" host.name="foo.bar" system.time="Sun, 29 Jul 2001 18:52:20 -0800">foo.bar ESMTP Debian Sendmail 8.12.0.Beta7/8.12.0.Beta7/Debian 8.12.0.Beta7-1; Sun, 29 Jul 2001 18:52:20 -0800</example>
+    <example service.version="8.11.0" sendmail.config.version="8.9.3" sendmail.vendor.version="8.9.3-21" host.name="foo.bar" system.time="Sun, 29 Jul 2001 19:51:00 -0700">foo.bar ESMTP Sendmail 8.11.0/8.9.3/Debian 8.9.3-21; Sun, 29 Jul 2001 19:51:00 -0700</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1306,8 +1306,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+(?:wheezy|deb7u)\d; (.+);">
     <description>Sendmail - Debian 7.x (wheezy)</description>
-    <example host.name="foo.bar" service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4+wheezy1; Thu, 30 Nov 2017 10:33:05 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
-    <example service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4+deb7u1; Thu, 30 Nov 2017 11:00:33 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example host.name="foo.bar" service.version="8.14.4" sendmail.config.version="8.14.4" system.time="Thu, 30 Nov 2017 10:33:05 +0100">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4+wheezy1; Thu, 30 Nov 2017 10:33:05 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.14.4" host.name="foo.bar" sendmail.config.version="8.14.4" system.time="Thu, 30 Nov 2017 11:00:33 +0100">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4+deb7u1; Thu, 30 Nov 2017 11:00:33 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1326,7 +1326,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+deb8u\d; (.+);">
     <description>Sendmail - Debian 8.x (jessie)</description>
-    <example service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-8+deb8u2; Thu, 30 Nov 2017 10:25:48 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.14.4" host.name="foo.bar" sendmail.config.version="8.14.4" system.time="Thu, 30 Nov 2017 10:25:48 +0100">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-8+deb8u2; Thu, 30 Nov 2017 10:25:48 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1345,7 +1345,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+deb9u1; (.+);">
     <description>Sendmail - Debian 9.1 (stretch)</description>
-    <example host.name="foo.bar" service.version="8.15.2">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-8+deb9u1; Thu, 29 Apr 2021 06:45:02 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example host.name="foo.bar" service.version="8.15.2" sendmail.config.version="8.15.2" system.time="Thu, 29 Apr 2021 06:45:02 +0200">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-8+deb9u1; Thu, 29 Apr 2021 06:45:02 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1364,7 +1364,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+lenny\d; (.+);">
     <description>Sendmail - Debian 5.x (lenny)</description>
-    <example service.version="8.14.3">foo.bar ESMTP Sendmail 8.14.3/8.14.3/Debian-5+lenny1; Thu, 30 Nov 2017 12:29:40 +0300; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.14.3" host.name="foo.bar" sendmail.config.version="8.14.3" system.time="Thu, 30 Nov 2017 12:29:40 +0300">foo.bar ESMTP Sendmail 8.14.3/8.14.3/Debian-5+lenny1; Thu, 30 Nov 2017 12:29:40 +0300; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1383,7 +1383,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d\+etch\d; (.+);">
     <description>Sendmail - Debian 4.x (etch)</description>
-    <example service.version="8.13.8" sendmail.config.version="8.13.8">foo.bar ESMTP Sendmail 8.13.8/8.13.8/Debian-3+etch1; Thu, 30 Nov 2017 10:28:23 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.13.8" sendmail.config.version="8.13.8" host.name="foo.bar" system.time="Thu, 30 Nov 2017 10:28:23 +0100">foo.bar ESMTP Sendmail 8.13.8/8.13.8/Debian-3+etch1; Thu, 30 Nov 2017 10:28:23 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1402,7 +1402,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\dsarge\d; (.+);">
     <description>Sendmail - Debian 3.1 (sarge)</description>
-    <example service.version="8.13.4">foo.bar ESMTP Sendmail 8.13.4/8.13.4/Debian-3sarge1; Thu, 30 Nov 2017 10:55:47 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.13.4" host.name="foo.bar" sendmail.config.version="8.13.4" system.time="Thu, 30 Nov 2017 10:55:47 +0100">foo.bar ESMTP Sendmail 8.13.4/8.13.4/Debian-3sarge1; Thu, 30 Nov 2017 10:55:47 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1421,9 +1421,9 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/([^/]+)/Debian-\d(?:\.\d)?(?:build\d)?;+ (.+);">
     <description>Sendmail - Debian patch only</description>
-    <example service.version="8.15.2">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-3; Thu, 30 Nov 2017 10:55:50 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
-    <example service.version="8.14.3">foo.bar ESMTP Sendmail 8.14.3/8.14.3/Debian-9.4; Thu, 30 Nov 2017 10:11:54 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
-    <example service.version="8.14.2">foo.bar ESMTP Sendmail 8.14.2/8.14.2/Debian-2build1; Thu, 30 Nov 2017 04:09:50 -0600; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.15.2" host.name="foo.bar" sendmail.config.version="8.15.2" system.time="Thu, 30 Nov 2017 10:55:50 +0200">foo.bar ESMTP Sendmail 8.15.2/8.15.2/Debian-3; Thu, 30 Nov 2017 10:55:50 +0200; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.14.3" host.name="foo.bar" sendmail.config.version="8.14.3" system.time="Thu, 30 Nov 2017 10:11:54 +0100">foo.bar ESMTP Sendmail 8.14.3/8.14.3/Debian-9.4; Thu, 30 Nov 2017 10:11:54 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.14.2" host.name="foo.bar" sendmail.config.version="8.14.2" system.time="Thu, 30 Nov 2017 04:09:50 -0600">foo.bar ESMTP Sendmail 8.14.2/8.14.2/Debian-2build1; Thu, 30 Nov 2017 04:09:50 -0600; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1441,8 +1441,8 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^/]+)/[^/]+/Debian-[\d.]+ubuntu[^ ]*; (.+);">
     <description>Sendmail - Ubuntu</description>
-    <example service.version="8.13.5.20060308">foo.bar ESMTP Sendmail 8.13.5.20060308/8.13.5/Debian-3ubuntu1.1; Fri, 24 Jul 2009 01:41:21 -0700; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
-    <example service.version="8.14.4">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4.1ubuntu1; Thu, 30 Nov 2017 11:00:30 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.13.5.20060308" host.name="foo.bar" system.time="Fri, 24 Jul 2009 01:41:21 -0700">foo.bar ESMTP Sendmail 8.13.5.20060308/8.13.5/Debian-3ubuntu1.1; Fri, 24 Jul 2009 01:41:21 -0700; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
+    <example service.version="8.14.4" host.name="foo.bar" system.time="Thu, 30 Nov 2017 11:00:30 +0100">foo.bar ESMTP Sendmail 8.14.4/8.14.4/Debian-4.1ubuntu1; Thu, 30 Nov 2017 11:00:30 +0100; (No UCE/UBE) logging access from: xyz.foo.bar(OK)-xyz.foo.bar [10.0.0.1]</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1459,7 +1459,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) (?:E?SMTP )?Sendmail SMI-([^/]+)/(SMI-SVR4) ready at (.+)$">
     <description>Sendmail - Solaris (SMI variant)</description>
-    <example>foo.bar Sendmail SMI-8.6/SMI-SVR4 ready at Sun, 29 Jul 2001 22:58:46 -0400</example>
+    <example host.name="foo.bar" service.version="8.6" sendmail.config.version="SMI-SVR4" system.time="Sun, 29 Jul 2001 22:58:46 -0400">foo.bar Sendmail SMI-8.6/SMI-SVR4 ready at Sun, 29 Jul 2001 22:58:46 -0400</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1477,7 +1477,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP Sendmail ([^ ]+)/(linuxconf); (.+)$">
     <description>Sendmail - unknown platform (linuxconf variant)</description>
-    <example>foo.bar ESMTP Sendmail 8.9.3/linuxconf; Sun, 29 Jul 2001 22:48:28 -0400</example>
+    <example host.name="foo.bar" service.version="8.9.3" sendmail.config.version="linuxconf" system.time="Sun, 29 Jul 2001 22:48:28 -0400">foo.bar ESMTP Sendmail 8.9.3/linuxconf; Sun, 29 Jul 2001 22:48:28 -0400</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1493,7 +1493,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ESMTP MetaInfo Sendmail ([^ ]+) Build ([^ ]+) \(Berkeley ([^ ]+)\)/([^;]+); (.+)$">
     <description>Sendmail - MetaInfo</description>
-    <example host.name="foo.bar" service.version="8.8.6">foo.bar ESMTP MetaInfo Sendmail 2.5 Build 2630 (Berkeley 8.8.6)/8.8.4; Mon, 30 Jul</example>
+    <example host.name="foo.bar" service.version="8.8.6" metainfo.version="2.5" metainfo.version.version="2630" sendmail.config.version="8.8.4" system.time="Mon, 30 Jul">foo.bar ESMTP MetaInfo Sendmail 2.5 Build 2630 (Berkeley 8.8.6)/8.8.4; Mon, 30 Jul</example>
     <param pos="0" name="service.vendor" value="MetaInfo"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1514,10 +1514,10 @@
     <description>Sendmail - optional timezone and timestamp, w/o OS</description>
     <example host.name="foo.bar" service.version="8.9.3+3.4W" sendmail.config.version="8.9.3+3.4W" system.time="Tue, 30 Jan 2001 20:40:09 -0500">foo.bar ESMTP Sendmail 8.9.3+3.4W/8.9.3+3.4W; Tue, 30 Jan 2001 20:40:09 -0500 (EST)</example>
     <example host.name="foo.bar" service.version="8.12.10" sendmail.config.version="8.12.10">foo.bar ESMTP Sendmail 8.12.10/8.12.10;</example>
-    <example host.name="foo.bar" service.version="8.8.8" sendmail.config.version="8.8.9">foo.bar ESMTP Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
-    <example host.name="foo.bar" service.version="8.8.8" sendmail.config.version="8.8.9">foo.bar ESMTP blah Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
-    <example host.name="foo.bar" service.version="8.10.2" sendmail.config.version="8.10.3">foo.bar ESMTP Sendmail 8.10.2/8.10.3; Mon, 10 Sep 2001 08:37:14 -0400</example>
-    <example host.name="foo.bar" service.version="8.13.8" sendmail.config.version="8.13.9">foo.bar ESMTP foo-MTA Sendmail 8.13.8/8.13.9; Mon, 18 Apr 2011 08:52:38 -0700</example>
+    <example host.name="foo.bar" service.version="8.8.8" sendmail.config.version="8.8.9" system.time="Wed, 21 Nov 2001 23:39:07 +0100">foo.bar ESMTP Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
+    <example host.name="foo.bar" service.version="8.8.8" sendmail.config.version="8.8.9" system.time="Wed, 21 Nov 2001 23:39:07 +0100">foo.bar ESMTP blah Sendmail 8.8.8/8.8.9; Wed, 21 Nov 2001 23:39:07 +0100 (CET)</example>
+    <example host.name="foo.bar" service.version="8.10.2" sendmail.config.version="8.10.3" system.time="Mon, 10 Sep 2001 08:37:14 -0400">foo.bar ESMTP Sendmail 8.10.2/8.10.3; Mon, 10 Sep 2001 08:37:14 -0400</example>
+    <example host.name="foo.bar" service.version="8.13.8" sendmail.config.version="8.13.9" system.time="Mon, 18 Apr 2011 08:52:38 -0700">foo.bar ESMTP foo-MTA Sendmail 8.13.8/8.13.9; Mon, 18 Apr 2011 08:52:38 -0700</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
     <param pos="0" name="system.time.format" value="EEE, d MMM yyyy HH:mm:ss Z"/>
@@ -1556,7 +1556,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail ([^ /]+) - \([^\)]+\)/[^ ]+;? *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\)) *$">
     <description>Sendmail - revision variant 1</description>
-    <example>foo.foo.bar ESMTP Sendmail 8.11.1 - (Revision 1.010)/8.9.3; Sat, 22 Jan 2011 10:08:35 -0500 (EST)</example>
+    <example host.name="foo.foo.bar" service.version="8.11.1" system.time="Sat, 22 Jan 2011 10:08:35 -0500">foo.foo.bar ESMTP Sendmail 8.11.1 - (Revision 1.010)/8.9.3; Sat, 22 Jan 2011 10:08:35 -0500 (EST)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1569,7 +1569,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail +(?:[^ ]+) +version +([^ ]+) +- +(?:[^;]+); *(\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)(?: \(.+\)) *$">
     <description>Sendmail - revision variant 2</description>
-    <example>foo.foo.bar ESMTP Sendmail @(#)Sendmail version 8.13.3 - Revision 2.007 - 8 December 2008/8.8.6; Wed, 21 Jul 2010 11:17:01 -0400 (EDT)</example>
+    <example host.name="foo.foo.bar" service.version="8.13.3" system.time="Wed, 21 Jul 2010 11:17:01 -0400">foo.foo.bar ESMTP Sendmail @(#)Sendmail version 8.13.3 - Revision 2.007 - 8 December 2008/8.8.6; Wed, 21 Jul 2010 11:17:01 -0400 (EDT)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1582,11 +1582,11 @@
 
   <fingerprint pattern="(?i)^([^ ]{1,512}) {1,8}(?:ESMTP +)?Sendmail *(?: Ready.? ?)?(?:;|at)? ?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)(?: \(.+\))?$">
     <description>Sendmail - with date, w/o version or platform, optional status string.</description>
-    <example host.name="foo.bar">foo.bar ESMTP Sendmail ; Thu, 30 Nov 2017 17:50:14 +0900</example>
-    <example host.name="foo.bar">foo.bar ESMTP Sendmail; Thu, 30 Nov 2017 17:50:14 +0900</example>
+    <example host.name="foo.bar" system.time="Thu, 30 Nov 2017 17:50:14 +0900">foo.bar ESMTP Sendmail ; Thu, 30 Nov 2017 17:50:14 +0900</example>
+    <example host.name="foo.bar" system.time="Thu, 30 Nov 2017 17:50:14 +0900">foo.bar ESMTP Sendmail; Thu, 30 Nov 2017 17:50:14 +0900</example>
     <example host.name="foo.bar" system.time="Wed, 20 May 2015 17:17:56 -0600">foo.bar ESMTP Sendmail Wed, 20 May 2015 17:17:56 -0600</example>
     <example host.name="foo.bar" system.time="Thu, 30 Nov 2017 10:24:14 +0100">foo.bar ESMTP Sendmail Ready; Thu, 30 Nov 2017 10:24:14 +0100</example>
-    <example host.name="foo.bar">foo.bar ESMTP Sendmail ready at Fri, 6 Apr 2018 04:57:01 +0900</example>
+    <example host.name="foo.bar" system.time="Fri, 6 Apr 2018 04:57:01 +0900">foo.bar ESMTP Sendmail ready at Fri, 6 Apr 2018 04:57:01 +0900</example>
     <example host.name="foo.bar">foo.bar ESMTP Sendmail ready</example>
     <example host.name="foo.bar">foo.bar ESMTP Sendmail ready. </example>
     <example host.name="foo.bar">foo.bar ESMTP Sendmail</example>
@@ -1616,7 +1616,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) +ESMTP +Sendmail ([^ /]+) \([^\)]+\) *(.+) \(.+\)$">
     <description>Sendmail - unknown (date in version string variant)</description>
-    <example>mail.foo.bar ESMTP Sendmail 8.11.1 (1.1.2.11/12Jul01-1016AM) Wed, 8 Jan 2003 11:21:22 +0100 (MET)</example>
+    <example host.name="mail.foo.bar" service.version="8.11.1" system.time="Wed, 8 Jan 2003 11:21:22 +0100">mail.foo.bar ESMTP Sendmail 8.11.1 (1.1.2.11/12Jul01-1016AM) Wed, 8 Jan 2003 11:21:22 +0100 (MET)</example>
     <param pos="0" name="service.vendor" value="Sendmail"/>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
@@ -1668,10 +1668,10 @@
 
   <fingerprint pattern="^(?:2.0.0 )?([^ ]{1,512}) ESMTP ecelerity (\d\.[\d.]+) r\(([^)]+)\) (\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d) *$">
     <description>Ecelerity</description>
-    <example host.name="foo.bar" system.time="Thu, 30 Nov 2017 05:11:00 -0500">2.0.0 foo.bar ESMTP ecelerity 4.0.0.43760 r(Platform:4.0.0.1) Thu, 30 Nov 2017 05:11:00 -0500</example>
-    <example>foo.bar ESMTP ecelerity 3.3.1.44388 r(44388) Thu, 30 Nov 2017 03:10:11 -0700</example>
-    <example>foo.bar ESMTP ecelerity 3.6.25.56547 r(Core:3.6.25.0) Thu, 30 Nov 2017 03:17:07 -0600</example>
-    <example service.version="4.2.37.61980" service.component.version=":">foo.bar ESMTP ecelerity 4.2.37.61980 r(:) Thu, 30 Nov 2017 09:58:54 +0000</example>
+    <example host.name="foo.bar" system.time="Thu, 30 Nov 2017 05:11:00 -0500" service.version="4.0.0.43760" service.component.version="Platform:4.0.0.1">2.0.0 foo.bar ESMTP ecelerity 4.0.0.43760 r(Platform:4.0.0.1) Thu, 30 Nov 2017 05:11:00 -0500</example>
+    <example host.name="foo.bar" service.version="3.3.1.44388" service.component.version="44388" system.time="Thu, 30 Nov 2017 03:10:11 -0700">foo.bar ESMTP ecelerity 3.3.1.44388 r(44388) Thu, 30 Nov 2017 03:10:11 -0700</example>
+    <example host.name="foo.bar" service.version="3.6.25.56547" service.component.version="Core:3.6.25.0" system.time="Thu, 30 Nov 2017 03:17:07 -0600">foo.bar ESMTP ecelerity 3.6.25.56547 r(Core:3.6.25.0) Thu, 30 Nov 2017 03:17:07 -0600</example>
+    <example service.version="4.2.37.61980" service.component.version=":" host.name="foo.bar" system.time="Thu, 30 Nov 2017 09:58:54 +0000">foo.bar ESMTP ecelerity 4.2.37.61980 r(:) Thu, 30 Nov 2017 09:58:54 +0000</example>
     <param pos="0" name="service.vendor" value="Ecelerity"/>
     <param pos="0" name="service.family" value="Ecelerity Mail Server"/>
     <param pos="0" name="service.product" value="Ecelerity Mail Server"/>
@@ -1684,9 +1684,9 @@
 
   <fingerprint pattern="(?i)^([^ ]{1,512}) SMTP Server SLMail v?(\d\.[\d.]+) Ready ESMTP spoken here *$">
     <description>Seattle Labs SLMail server for Windows NT/2k (v2.7 runs on Win9x)</description>
-    <example service.version="2.7">foo.bar Smtp Server SLMail v2.7 Ready ESMTP spoken here</example>
-    <example service.version="3.2.3113">foo.bar SMTP Server SLmail 3.2.3113 Ready ESMTP spoken here</example>
-    <example service.version="5.5.0.4433">foo.bar SMTP Server SLmail 5.5.0.4433 Ready ESMTP spoken here</example>
+    <example service.version="2.7" host.name="foo.bar">foo.bar Smtp Server SLMail v2.7 Ready ESMTP spoken here</example>
+    <example service.version="3.2.3113" host.name="foo.bar">foo.bar SMTP Server SLmail 3.2.3113 Ready ESMTP spoken here</example>
+    <example service.version="5.5.0.4433" host.name="foo.bar">foo.bar SMTP Server SLmail 5.5.0.4433 Ready ESMTP spoken here</example>
     <param pos="0" name="service.vendor" value="Seattle Labs"/>
     <param pos="0" name="service.family" value="SLMail"/>
     <param pos="0" name="service.product" value="SLMail"/>
@@ -1748,9 +1748,9 @@
 
   <fingerprint pattern="^([^ ]{1,512}) VPOP3 E?SMTP Server (?:Ready|access not allowed!)$">
     <description>VPOP3 Email server: http://www.pscs.co.uk/products/vpop3/index.html</description>
-    <example>foo.bar VPOP3 ESMTP Server Ready</example>
-    <example>foo.bar VPOP3 SMTP Server Ready</example>
-    <example>foo.bar VPOP3 SMTP Server access not allowed!</example>
+    <example host.name="foo.bar">foo.bar VPOP3 ESMTP Server Ready</example>
+    <example host.name="foo.bar">foo.bar VPOP3 SMTP Server Ready</example>
+    <example host.name="foo.bar">foo.bar VPOP3 SMTP Server access not allowed!</example>
     <param pos="0" name="service.vendor" value="Paul Smith Computer Services"/>
     <param pos="0" name="service.family" value="VPOP3"/>
     <param pos="0" name="service.product" value="VPOP3"/>
@@ -1759,7 +1759,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) WebShield SMTP V([^ ]+\.[^ ]+) ([^ ]+)? ?Network Associates.*Ready at (.+) *$">
     <description>McAfee WebShield</description>
-    <example host.name="foo.bar" service.version="4.5" service.version.version="MR1a">foo.bar WebShield SMTP V4.5 MR1a Network Associates, Inc. Ready at Thu Nov 30 09:15:32 2017</example>
+    <example host.name="foo.bar" service.version="4.5" service.version.version="MR1a" system.time="Thu Nov 30 09:15:32 2017">foo.bar WebShield SMTP V4.5 MR1a Network Associates, Inc. Ready at Thu Nov 30 09:15:32 2017</example>
     <example host.name="foo.bar" service.version="4.5" system.time="Thu Nov 30 09:15:32 2017">foo.bar WebShield SMTP V4.5 Network Associates, Inc. Ready at Thu Nov 30 09:15:32 2017</example>
     <param pos="0" name="service.vendor" value="McAfee"/>
     <param pos="0" name="service.family" value="WebShield"/>
@@ -1824,7 +1824,7 @@
 
   <fingerprint pattern="^ESMTP - WinRoute Pro ([^ ]+\.[^ ]+) *(?: #\d)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?)$">
     <description>WinRoute Pro w/o hostname</description>
-    <example service.version="4.2.1">ESMTP - WinRoute Pro 4.2.1 Thu, 16 Nov 2017 11:48:15 +0300</example>
+    <example service.version="4.2.1" system.time="Thu, 16 Nov 2017 11:48:15 +0300">ESMTP - WinRoute Pro 4.2.1 Thu, 16 Nov 2017 11:48:15 +0300</example>
     <param pos="0" name="service.family" value="WinRoute"/>
     <param pos="0" name="service.product" value="WinRoute"/>
     <param pos="0" name="system.time.format" value="EEE, dd MMM yyyy HH:mm:ss Z"/>
@@ -1834,7 +1834,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ZMailer Server (\d\.[\d.]+) #([^ ]+) ESMTP ready at (.+) *$">
     <description>ZMailer http://www.zmailer.org/technical.html</description>
-    <example service.version="2.99.57" service.version.version="1">foo.bar ZMailer Server 2.99.57 #1 ESMTP ready at Thu, 16 Nov 2017 12:00:12 +0300</example>
+    <example service.version="2.99.57" service.version.version="1" host.name="foo.bar" system.time="Thu, 16 Nov 2017 12:00:12 +0300">foo.bar ZMailer Server 2.99.57 #1 ESMTP ready at Thu, 16 Nov 2017 12:00:12 +0300</example>
     <param pos="0" name="service.vendor" value="ZMailer"/>
     <param pos="0" name="service.family" value="ZMailer"/>
     <param pos="0" name="service.product" value="ZMailer"/>
@@ -1847,7 +1847,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) ZMailer Server (\d\.[\d.]+) #([^ ]+) ESMTP\+IDENT ready at (.+) *$">
     <description>ZMailer server that supports IDENT</description>
-    <example service.version="2.99.55" service.version.version="16">foo.bar ZMailer Server 2.99.55 #16 ESMTP+IDENT ready at Thu, 16 Nov 2017 06:51:42 -0300</example>
+    <example service.version="2.99.55" service.version.version="16" host.name="foo.bar" system.time="Thu, 16 Nov 2017 06:51:42 -0300">foo.bar ZMailer Server 2.99.55 #16 ESMTP+IDENT ready at Thu, 16 Nov 2017 06:51:42 -0300</example>
     <param pos="0" name="service.vendor" value="ZMailer"/>
     <param pos="0" name="service.family" value="ZMailer"/>
     <param pos="0" name="service.product" value="ZMailer"/>
@@ -1862,7 +1862,7 @@
   <fingerprint pattern="^([^ ]{1,512}) Kerio Connect (\d\.[\d.]+) (?:patch (\d) )?ESMTP ready$">
     <description>Kerio Connect ESMTP</description>
     <example host.name="foo.bar" service.version="8.0.2">foo.bar Kerio Connect 8.0.2 ESMTP ready</example>
-    <example service.version="9.2.5" service.version.version="3">foo.bar Kerio Connect 9.2.5 patch 3 ESMTP ready</example>
+    <example service.version="9.2.5" service.version.version="3" host.name="foo.bar">foo.bar Kerio Connect 9.2.5 patch 3 ESMTP ready</example>
     <param pos="0" name="service.vendor" value="Kerio"/>
     <param pos="0" name="service.family" value="Connect"/>
     <param pos="0" name="service.product" value="ESMTP"/>
@@ -1914,7 +1914,7 @@
 
   <fingerprint pattern="^([^ ]{1,512}) Service ready by David.fx \((\d+)\) ESMTP Server \(Tobit.Software, Germany\)$">
     <description>Tobit Software David</description>
-    <example service.version="0486">foo.bar Service ready by David.fx (0486) ESMTP Server (Tobit.Software, Germany)</example>
+    <example service.version="0486" host.name="foo.bar">foo.bar Service ready by David.fx (0486) ESMTP Server (Tobit.Software, Germany)</example>
     <param pos="0" name="service.vendor" value="Tobit Software"/>
     <param pos="0" name="service.family" value="David"/>
     <param pos="0" name="service.product" value="ESMTP"/>

--- a/xml/smtp_help.xml
+++ b/xml/smtp_help.xml
@@ -148,7 +148,7 @@
 
   <fingerprint pattern="^502[ -]5\.3\.0 Sendmail ([^ ]+) -- HELP not implemented$">
     <description>Sendmail - help not implemented variant</description>
-    <example>502 5.3.0 Sendmail 8.11.2 -- HELP not implemented</example>
+    <example service.version="8.11.2">502 5.3.0 Sendmail 8.11.2 -- HELP not implemented</example>
     <param pos="0" name="service.family" value="Sendmail"/>
     <param pos="0" name="service.product" value="Sendmail"/>
     <param pos="1" name="service.version"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1627,13 +1627,13 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:cisco:vpn_3000_concentrator_series_software:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-[^\)]+\), Version ([^, ]+)[,\s]?">
+  <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-[^\)]+\), Version ([^,\s]+)">
     <description>Cisco Catalyst Network Analysis Module - version variant</description>
-    <example os.version="3.1(1)&#10;Copyright">Network Analysis Module (WS-SVC-NAM-1), Version 3.1(1)
+    <example os.version="3.1(1)">Network Analysis Module (WS-SVC-NAM-1), Version 3.1(1)
 Copyright (c) 1999-2003 by cisco Systems, Inc.</example>
-    <example os.version="3.3(0.9)&#10;Copyright">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.3(0.9)
+    <example os.version="3.3(0.9)">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.3(0.9)
 Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
-    <example os.version="3.4(0.9)&#10;Copyright">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.4(0.9)
+    <example os.version="3.4(0.9)">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.4(0.9)
 Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     <example os.version="5.0(1)">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 5.0(1) RELEASE SOFTWARE [fc4]</example>
     <example os.version="4.1(1)">Cisco Network Analysis Module (WS-SVC-NAM-2-250S), Version 4.1(1) RELEASE SOFTWARE [fc2]</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -14,7 +14,7 @@
 
   <fingerprint pattern="^3Com IntelliJack (\S+)$">
     <description>3Com Intellijack switch</description>
-    <example>3Com IntelliJack NJ220</example>
+    <example os.product="NJ220">3Com IntelliJack NJ220</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="IntelliJack"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -32,8 +32,8 @@
 
   <fingerprint pattern="^3Com-(\S+) - 3CNJ2000 v(\S+)$">
     <description>3Com Intellijack switch - variant 1</description>
-    <example>3Com-NJ2000 - 3CNJ2000 v2.00.03</example>
-    <example>3Com-NJ2000 - 3CNJ2000 v2.00.04</example>
+    <example os.product="NJ2000" os.version="2.00.03">3Com-NJ2000 - 3CNJ2000 v2.00.03</example>
+    <example os.product="NJ2000" os.version="2.00.04">3Com-NJ2000 - 3CNJ2000 v2.00.04</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="IntelliJack"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -53,8 +53,8 @@
 
   <fingerprint pattern="^3COM OfficeConnect Cable Modem.*software version:(\S+)$">
     <description>3COM OfficeConnect Cable Modem</description>
-    <example>3COM OfficeConnect Cable Modem3.1.0L,hardware version:B.2,software version:3.1.0L</example>
-    <example>3COM OfficeConnect Cable Modem3.2.1,hardware version:B.2,software version:3.2.1</example>
+    <example os.version="3.1.0L">3COM OfficeConnect Cable Modem3.1.0L,hardware version:B.2,software version:3.1.0L</example>
+    <example os.version="3.2.1">3COM OfficeConnect Cable Modem3.2.1,hardware version:B.2,software version:3.2.1</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="OfficeConnect"/>
     <param pos="0" name="os.device" value="Cable Modem"/>
@@ -64,7 +64,7 @@
 
   <fingerprint pattern="^3Com HomeConnect ADSL Modem V([^,]+),\s+">
     <description>3COM ADSL Modem</description>
-    <example>3Com HomeConnect ADSL Modem V1.1.8, Built on May 17 2000 at 18:24:32.</example>
+    <example os.version="1.1.8">3Com HomeConnect ADSL Modem V1.1.8, Built on May 17 2000 at 18:24:32.</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="HomeConnect"/>
     <param pos="0" name="os.device" value="ADSL Modem"/>
@@ -74,8 +74,8 @@
 
   <fingerprint pattern="(?i)^3Com (Link(?:Switch|Builder) [^,]+), SW version:(\S+)$">
     <description>3COM LinkBuilder/LinkSwitch</description>
-    <example>3Com LinkBuilder FMS, SW version:3.11</example>
-    <example>3Com LinkSwitch 1000, SW Version:1.04</example>
+    <example os.product="LinkBuilder FMS" os.version="3.11">3Com LinkBuilder FMS, SW version:3.11</example>
+    <example os.product="LinkSwitch 1000" os.version="1.04">3Com LinkSwitch 1000, SW Version:1.04</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="LinkBuilder"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -85,12 +85,12 @@
 
   <fingerprint pattern="(?i)^3Com MCNS external (\S+(?: \S+)?) Cable Modem,.*SW_VER:\s*(.*)$">
     <description>3COM Cable Modem - MCNS variant</description>
-    <example>3Com MCNS external 2-way Cable Modem, HW_REV: 2.00 ,SW_VER: 01.03</example>
-    <example>3Com MCNS external 2-way Cable Modem, HW_REV: A01.3 ,SW_VER: 12.30</example>
-    <example>3Com MCNS external 2-way Cable Modem, HW_REV: A01.3 ,SW_VER: 2.09</example>
-    <example>3Com MCNS external Telco Return Cable Modem, HW_REV: ,SW_VER:</example>
-    <example>3Com MCNS external Telco Return Cable Modem, HW_REV: A01.3 ,SW_VER: 1. 1</example>
-    <example>3Com MCNS external Telco Return Cable Modem, HW_REV: A01.3 ,SW_VER: 1. 4</example>
+    <example os.product="2-way" os.version="01.03">3Com MCNS external 2-way Cable Modem, HW_REV: 2.00 ,SW_VER: 01.03</example>
+    <example os.product="2-way" os.version="12.30">3Com MCNS external 2-way Cable Modem, HW_REV: A01.3 ,SW_VER: 12.30</example>
+    <example os.product="2-way" os.version="2.09">3Com MCNS external 2-way Cable Modem, HW_REV: A01.3 ,SW_VER: 2.09</example>
+    <example os.product="Telco Return">3Com MCNS external Telco Return Cable Modem, HW_REV: ,SW_VER:</example>
+    <example os.product="Telco Return" os.version="1. 1">3Com MCNS external Telco Return Cable Modem, HW_REV: A01.3 ,SW_VER: 1. 1</example>
+    <example os.product="Telco Return" os.version="1. 4">3Com MCNS external Telco Return Cable Modem, HW_REV: A01.3 ,SW_VER: 1. 4</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="MCNS Cable Modem"/>
     <param pos="0" name="os.device" value="Cable Modem"/>
@@ -100,7 +100,7 @@
 
   <fingerprint pattern="^3Com OfficeConnect (Remote ADSL \S+) V([^,]+),">
     <description>3COM Cable Modem - build date variant</description>
-    <example>3Com OfficeConnect Remote ADSL 812 V1.0.5, Built on Mar 16 2000 at 17:27:24.</example>
+    <example os.product="Remote ADSL 812" os.version="1.0.5">3Com OfficeConnect Remote ADSL 812 V1.0.5, Built on Mar 16 2000 at 17:27:24.</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="OfficeConnect"/>
     <param pos="0" name="os.device" value="ADSL Modem"/>
@@ -110,8 +110,8 @@
 
   <fingerprint pattern="^3Com (OfficeConnect-[^,]+), SW version:(\S+)$">
     <description>3COM Cable Modem</description>
-    <example>3Com OfficeConnect-Hub8M, SW version:1.03</example>
-    <example>3Com OfficeConnect-Hub8M, SW version:2.01</example>
+    <example os.product="OfficeConnect-Hub8M" os.version="1.03">3Com OfficeConnect-Hub8M, SW version:1.03</example>
+    <example os.product="OfficeConnect-Hub8M" os.version="2.01">3Com OfficeConnect-Hub8M, SW version:2.01</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="OfficeConnect"/>
     <param pos="0" name="os.device" value="Cable Modem"/>
@@ -121,7 +121,7 @@
 
   <fingerprint pattern="^3Com (OfficeConnect Remote \S+)$">
     <description>3Com OfficeConnect Remote</description>
-    <example>3Com OfficeConnect Remote 510S</example>
+    <example os.product="OfficeConnect Remote 510S">3Com OfficeConnect Remote 510S</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="OfficeConnect"/>
     <param pos="0" name="os.device" value="Router"/>
@@ -130,9 +130,9 @@
 
   <fingerprint pattern="^3Com Router Software V([^,]+), SNMP agent for (Router \S+) with">
     <description>3COM Router - processor variant</description>
-    <example>3Com Router Software V1.10, SNMP agent for Router 3012 with 1 MPC 860 Processor, Copyright (c) Reserved.</example>
-    <example>3Com Router Software V1.10, SNMP agent for Router 5009 with 1 MPC 8241 Processor, Copyright (c) Reserved.</example>
-    <example>3Com Router Software V1.10, SNMP agent for Router 5231 with 1 MPC 8240 Processor, Copyright (c) Reserved.</example>
+    <example os.product="Router 3012" os.version="1.10">3Com Router Software V1.10, SNMP agent for Router 3012 with 1 MPC 860 Processor, Copyright (c) Reserved.</example>
+    <example os.product="Router 5009" os.version="1.10">3Com Router Software V1.10, SNMP agent for Router 5009 with 1 MPC 8241 Processor, Copyright (c) Reserved.</example>
+    <example os.product="Router 5231" os.version="1.10">3Com Router Software V1.10, SNMP agent for Router 5231 with 1 MPC 8240 Processor, Copyright (c) Reserved.</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Router"/>
     <param pos="0" name="os.device" value="Router"/>
@@ -142,24 +142,24 @@
 
   <fingerprint pattern="^3Com (SuperStack\s*II[^,]+),.*SW [vV]ersion:?\s*(\S+)$">
     <description>3COM SuperStack II</description>
-    <example>3Com SuperStack II Hub 10, SW version:3.04</example>
-    <example>3Com SuperStack II Hub 10, SW version:3.14</example>
-    <example>3Com SuperStack II Hub 10, SW version:3.16</example>
-    <example>3Com SuperStack II PS Hub 40, SW Version 1.14</example>
-    <example>3Com SuperStack II Port Switch Hub, SW Version 1.04</example>
-    <example>3Com SuperStack II Port Switch Hub, SW Version 1.10</example>
-    <example>3Com SuperStackII Switch 1000, SW Version:2.00</example>
-    <example>3Com SuperStackII Switch 1000, SW Version:2.10</example>
-    <example>3Com SuperStackII Switch 1000, SW Version:3.10</example>
-    <example>3Com SuperStackII Switch 1000, SW Version:3.21</example>
-    <example>3Com SuperStackII Switch 1000, SW Version:3.23</example>
-    <example>3Com SuperStackII Switch 3000 FX, SW Version:2.10</example>
-    <example>3Com SuperStackII Switch 3000, SW Version:2.00</example>
-    <example>3Com SuperStackII Switch 3000, SW Version:2.10</example>
-    <example>3Com SuperStackII Switch 3000, SW Version:3.10</example>
-    <example>3Com SuperStackII Switch 3000, SW Version:3.21</example>
-    <example>3Com SuperStackII Switch 3000, SW Version:3.22</example>
-    <example>3Com SuperStackII Switch 3000, SW Version:3.23</example>
+    <example os.product="SuperStack II Hub 10" os.version="3.04">3Com SuperStack II Hub 10, SW version:3.04</example>
+    <example os.product="SuperStack II Hub 10" os.version="3.14">3Com SuperStack II Hub 10, SW version:3.14</example>
+    <example os.product="SuperStack II Hub 10" os.version="3.16">3Com SuperStack II Hub 10, SW version:3.16</example>
+    <example os.product="SuperStack II PS Hub 40" os.version="1.14">3Com SuperStack II PS Hub 40, SW Version 1.14</example>
+    <example os.product="SuperStack II Port Switch Hub" os.version="1.04">3Com SuperStack II Port Switch Hub, SW Version 1.04</example>
+    <example os.product="SuperStack II Port Switch Hub" os.version="1.10">3Com SuperStack II Port Switch Hub, SW Version 1.10</example>
+    <example os.product="SuperStackII Switch 1000" os.version="2.00">3Com SuperStackII Switch 1000, SW Version:2.00</example>
+    <example os.product="SuperStackII Switch 1000" os.version="2.10">3Com SuperStackII Switch 1000, SW Version:2.10</example>
+    <example os.product="SuperStackII Switch 1000" os.version="3.10">3Com SuperStackII Switch 1000, SW Version:3.10</example>
+    <example os.product="SuperStackII Switch 1000" os.version="3.21">3Com SuperStackII Switch 1000, SW Version:3.21</example>
+    <example os.product="SuperStackII Switch 1000" os.version="3.23">3Com SuperStackII Switch 1000, SW Version:3.23</example>
+    <example os.product="SuperStackII Switch 3000 FX" os.version="2.10">3Com SuperStackII Switch 3000 FX, SW Version:2.10</example>
+    <example os.product="SuperStackII Switch 3000" os.version="2.00">3Com SuperStackII Switch 3000, SW Version:2.00</example>
+    <example os.product="SuperStackII Switch 3000" os.version="2.10">3Com SuperStackII Switch 3000, SW Version:2.10</example>
+    <example os.product="SuperStackII Switch 3000" os.version="3.10">3Com SuperStackII Switch 3000, SW Version:3.10</example>
+    <example os.product="SuperStackII Switch 3000" os.version="3.21">3Com SuperStackII Switch 3000, SW Version:3.21</example>
+    <example os.product="SuperStackII Switch 3000" os.version="3.22">3Com SuperStackII Switch 3000, SW Version:3.22</example>
+    <example os.product="SuperStackII Switch 3000" os.version="3.23">3Com SuperStackII Switch 3000, SW Version:3.23</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Switch"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -169,7 +169,7 @@
 
   <fingerprint pattern="^3COM (Superstack II Switch \S+)">
     <description>3COM SuperStack II - product only variant</description>
-    <example>3COM Superstack II Switch 3800</example>
+    <example os.product="Superstack II Switch 3800">3COM Superstack II Switch 3800</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Switch"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -178,10 +178,10 @@
 
   <fingerprint pattern="^3COM (VCX .*)$">
     <description>3COM VCX Device</description>
-    <example>3COM VCX Connect 100</example>
-    <example>3COM VCX Connect 200</example>
-    <example>3COM VCX Server</example>
-    <example>3COM VCX V7005</example>
+    <example os.product="VCX Connect 100">3COM VCX Connect 100</example>
+    <example os.product="VCX Connect 200">3COM VCX Connect 200</example>
+    <example os.product="VCX Server">3COM VCX Server</example>
+    <example os.product="VCX V7005">3COM VCX V7005</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="VCX"/>
     <param pos="0" name="os.device" value="VoIP"/>
@@ -190,12 +190,12 @@
 
   <fingerprint pattern="^3Com 3Com (?:SuperStack 4 )?Switch (\S+).*Software Version 3Com OS V(\S+)$">
     <description>3COM SuperStack 4 Switch</description>
-    <example>3Com 3Com SuperStack 4 Switch 5500G-EI 24-Port Software Version 3Com OS V3.02.04s168</example>
-    <example>3Com 3Com SuperStack 4 Switch 5500G-EI 24-Port Software Version 3Com OS V3.02.04s56</example>
-    <example>3Com 3Com SuperStack 4 Switch 5500G-EI SFP 24-Port Software Version 3Com OS V3.02.04s56</example>
-    <example>3Com 3Com Switch 5500G-EI 24-Port Software Version 3Com OS V3.01.00s56p03</example>
-    <example>3Com 3Com Switch 5500G-EI 48-Port Software Version 3Com OS V3.01.00s168</example>
-    <example>3Com 3Com Switch 5500G-EI SFP 24-Port Software Version 3Com OS V3.01.00s56p03</example>
+    <example os.product="5500G-EI" os.version="3.02.04s168">3Com 3Com SuperStack 4 Switch 5500G-EI 24-Port Software Version 3Com OS V3.02.04s168</example>
+    <example os.product="5500G-EI" os.version="3.02.04s56">3Com 3Com SuperStack 4 Switch 5500G-EI 24-Port Software Version 3Com OS V3.02.04s56</example>
+    <example os.product="5500G-EI" os.version="3.02.04s56">3Com 3Com SuperStack 4 Switch 5500G-EI SFP 24-Port Software Version 3Com OS V3.02.04s56</example>
+    <example os.product="5500G-EI" os.version="3.01.00s56p03">3Com 3Com Switch 5500G-EI 24-Port Software Version 3Com OS V3.01.00s56p03</example>
+    <example os.product="5500G-EI" os.version="3.01.00s168">3Com 3Com Switch 5500G-EI 48-Port Software Version 3Com OS V3.01.00s168</example>
+    <example os.product="5500G-EI" os.version="3.01.00s56p03">3Com 3Com Switch 5500G-EI SFP 24-Port Software Version 3Com OS V3.01.00s56p03</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Switch"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -205,12 +205,12 @@
 
   <fingerprint pattern="^3Com Baseline Switch (\S+ \S+)$">
     <description>3COM Baseline Switch</description>
-    <example>3Com Baseline Switch 2226-SFP Plus</example>
-    <example>3Com Baseline Switch 2426-PWR Plus</example>
-    <example>3Com Baseline Switch 2916-SFP Plus</example>
-    <example>3Com Baseline Switch 2924-PWR Plus</example>
-    <example>3Com Baseline Switch 2924-SFP Plus</example>
-    <example>3Com Baseline Switch 2948 Plus</example>
+    <example os.product="2226-SFP Plus">3Com Baseline Switch 2226-SFP Plus</example>
+    <example os.product="2426-PWR Plus">3Com Baseline Switch 2426-PWR Plus</example>
+    <example os.product="2916-SFP Plus">3Com Baseline Switch 2916-SFP Plus</example>
+    <example os.product="2924-PWR Plus">3Com Baseline Switch 2924-PWR Plus</example>
+    <example os.product="2924-SFP Plus">3Com Baseline Switch 2924-SFP Plus</example>
+    <example os.product="2948 Plus">3Com Baseline Switch 2948 Plus</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Switch"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -219,13 +219,13 @@
 
   <fingerprint pattern="(?i)^3Com Baseline Switch (\S+ Plus).* Software Version (\d+\.\S+ release \S+)">
     <description>3COM Baseline Switch with software version</description>
-    <example>3Com Baseline Switch 2920-SFP Plus Software Version 5.20 RELEASE 1101 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
-    <example>3Com Baseline Switch 2920-SFP Plus Software Version 5.20 Release 1101P02 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
-    <example>3Com Baseline Switch 2928-HPWR Plus Software Version 5.20 Release 1101P02 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
-    <example>3Com Baseline Switch 2928-HPWR Plus Software Version 5.20 Release 1101P09 Copyright (c) 2004-2010 3Com Corporation. All rights reserved.</example>
-    <example>3Com Baseline Switch 2928-PWR Plus Software Version 5.20 Release 1101P10 Copyright (c) 2004-2010 3Com Corporation. All rights reserved.</example>
-    <example>3Com Baseline Switch 2928-SFP Plus Software Version 5.20 Release 1511 Copyright (c) 2004-2012 3Com Corporation. All rights reserved.</example>
-    <example>3Com Baseline Switch 2952-SFP Plus Software Version 5.20 Release 1101P02 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
+    <example os.product="2920-SFP Plus" os.version="5.20 RELEASE 1101">3Com Baseline Switch 2920-SFP Plus Software Version 5.20 RELEASE 1101 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
+    <example os.product="2920-SFP Plus" os.version="5.20 Release 1101P02">3Com Baseline Switch 2920-SFP Plus Software Version 5.20 Release 1101P02 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
+    <example os.product="2928-HPWR Plus" os.version="5.20 Release 1101P02">3Com Baseline Switch 2928-HPWR Plus Software Version 5.20 Release 1101P02 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
+    <example os.product="2928-HPWR Plus" os.version="5.20 Release 1101P09">3Com Baseline Switch 2928-HPWR Plus Software Version 5.20 Release 1101P09 Copyright (c) 2004-2010 3Com Corporation. All rights reserved.</example>
+    <example os.product="2928-PWR Plus" os.version="5.20 Release 1101P10">3Com Baseline Switch 2928-PWR Plus Software Version 5.20 Release 1101P10 Copyright (c) 2004-2010 3Com Corporation. All rights reserved.</example>
+    <example os.product="2928-SFP Plus" os.version="5.20 Release 1511">3Com Baseline Switch 2928-SFP Plus Software Version 5.20 Release 1511 Copyright (c) 2004-2012 3Com Corporation. All rights reserved.</example>
+    <example os.product="2952-SFP Plus" os.version="5.20 Release 1101P02">3Com Baseline Switch 2952-SFP Plus Software Version 5.20 Release 1101P02 Copyright (c) 2004-2009 3Com Corporation. All rights reserved.</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Switch"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -235,8 +235,8 @@
 
   <fingerprint pattern="^3Com (CoreBuilder\-\S+).*s/w rev:\s*(\S+)$">
     <description>3COM CoreBuilder Switch</description>
-    <example>3Com CoreBuilder-9000 Enterprise Management Engine (3CB9EME) s/w rev: 3.0.0</example>
-    <example>3Com CoreBuilder-9000 Enterprise Management Engine (3CB9EME) s/w rev: 3.0.5</example>
+    <example os.product="CoreBuilder-9000" os.version="3.0.0">3Com CoreBuilder-9000 Enterprise Management Engine (3CB9EME) s/w rev: 3.0.0</example>
+    <example os.product="CoreBuilder-9000" os.version="3.0.5">3Com CoreBuilder-9000 Enterprise Management Engine (3CB9EME) s/w rev: 3.0.5</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Switch"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -269,10 +269,10 @@
 
   <fingerprint pattern="^3Com (Wireless.*Firewall Router)$">
     <description>3COM WAP - firewall variant</description>
-    <example>3Com Wireless 108Mbps 11g ADSL Firewall Router</example>
-    <example>3Com Wireless 11g ADSL Firewall Router</example>
-    <example>3Com Wireless 11n ADSL Firewall Router</example>
-    <example>3Com Wireless 11n Cable/DSL Firewall Router</example>
+    <example os.product="Wireless 108Mbps 11g ADSL Firewall Router">3Com Wireless 108Mbps 11g ADSL Firewall Router</example>
+    <example os.product="Wireless 11g ADSL Firewall Router">3Com Wireless 11g ADSL Firewall Router</example>
+    <example os.product="Wireless 11n ADSL Firewall Router">3Com Wireless 11n ADSL Firewall Router</example>
+    <example os.product="Wireless 11n Cable/DSL Firewall Router">3Com Wireless 11n Cable/DSL Firewall Router</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -281,7 +281,7 @@
   <fingerprint pattern="^3Com Enterprise AP:\s*v(\S+)">
     <description>3COM Enterprise AP</description>
     <example os.version="3.1.00">3Com Enterprise AP: v3.1.00 v3.0.8</example>
-    <example>3Com Enterprise AP: v3.2.0 v3.0.8</example>
+    <example os.version="3.2.0">3Com Enterprise AP: v3.2.0 v3.0.8</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="0" name="os.product" value="Enterprise AP"/>
@@ -290,9 +290,9 @@
 
   <fingerprint pattern="^3Com (OfficeConnect Managed .*)$">
     <description>3COM OfficeConnect Managed Switch</description>
-    <example hw.product="OfficeConnect Managed Gb PoE">3Com OfficeConnect Managed Gb PoE</example>
-    <example hw.product="OfficeConnect Managed Switch 9">3Com OfficeConnect Managed Switch 9</example>
-    <example hw.product="OfficeConnect Managed Switch 9 FX">3Com OfficeConnect Managed Switch 9 FX</example>
+    <example hw.product="OfficeConnect Managed Gb PoE" os.product="OfficeConnect Managed Gb PoE">3Com OfficeConnect Managed Gb PoE</example>
+    <example hw.product="OfficeConnect Managed Switch 9" os.product="OfficeConnect Managed Switch 9">3Com OfficeConnect Managed Switch 9</example>
+    <example hw.product="OfficeConnect Managed Switch 9 FX" os.product="OfficeConnect Managed Switch 9 FX">3Com OfficeConnect Managed Switch 9 FX</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.family" value="Switch"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -314,26 +314,26 @@
 
   <fingerprint pattern="^3Com (Router \S+) Software (\S+)">
     <description>3COM Router</description>
-    <example hw.product="Router 3012" os.version="Extended_V1.30">3Com Router 3012 Software Extended_V1.30</example>
-    <example>3Com Router 3013 Software V1.40.19</example>
-    <example>3Com Router 3016 Software Extended_V1.20</example>
-    <example>3Com Router 3016 Software V1.40.19</example>
-    <example>3Com Router 3030 Software Extended_V2.04 (build V300R001B06D001SP23)</example>
-    <example>3Com Router 3030 Software V2.04 (build V300R001B06D001SP23)</example>
-    <example>3Com Router 3031 Software Extended_V2.04 (build V300R001B06D001SP23)</example>
-    <example>3Com Router 3036 Software Extended_V2.41.00.P01 (build V300R002B60D021)</example>
-    <example>3Com Router 3040 Software V2.41 (build V300R002B60D021)</example>
-    <example>3Com Router 3041 Software V2.41 (build V300R002B60D021)</example>
-    <example>3Com Router 5012 Software Extended_V2.20 (build V300R002B13D004)</example>
-    <example>3Com Router 5012 Software V3.12 (build V300R002B65D002SP01)</example>
-    <example>3Com Router 5231 Software Extended_V1.30</example>
-    <example>3Com Router 5231 Software V1.20</example>
-    <example>3Com Router 5232 Software Extended_V3.14p03 (build V300R002B68D003)</example>
-    <example>3Com Router 5232 Software V2.10 (build V300R003B01D008SP03)</example>
-    <example>3Com Router 5642 Software V3.01 (build V300R002B62D014)</example>
-    <example>3Com Router 5682 Software Extended_V3.01p09 (build V300R002B62D014)</example>
-    <example>3Com Router 6040 Software V3.12 (build V300R002B65D002SP01)</example>
-    <example>3Com Router 6080 Software V2.31 (build V300R002B13D004)</example>
+    <example hw.product="Router 3012" os.version="Extended_V1.30" os.product="Router 3012">3Com Router 3012 Software Extended_V1.30</example>
+    <example os.product="Router 3013" os.version="V1.40.19" hw.product="Router 3013">3Com Router 3013 Software V1.40.19</example>
+    <example os.product="Router 3016" os.version="Extended_V1.20" hw.product="Router 3016">3Com Router 3016 Software Extended_V1.20</example>
+    <example os.product="Router 3016" os.version="V1.40.19" hw.product="Router 3016">3Com Router 3016 Software V1.40.19</example>
+    <example os.product="Router 3030" os.version="Extended_V2.04" hw.product="Router 3030">3Com Router 3030 Software Extended_V2.04 (build V300R001B06D001SP23)</example>
+    <example os.product="Router 3030" os.version="V2.04" hw.product="Router 3030">3Com Router 3030 Software V2.04 (build V300R001B06D001SP23)</example>
+    <example os.product="Router 3031" os.version="Extended_V2.04" hw.product="Router 3031">3Com Router 3031 Software Extended_V2.04 (build V300R001B06D001SP23)</example>
+    <example os.product="Router 3036" os.version="Extended_V2.41.00.P01" hw.product="Router 3036">3Com Router 3036 Software Extended_V2.41.00.P01 (build V300R002B60D021)</example>
+    <example os.product="Router 3040" os.version="V2.41" hw.product="Router 3040">3Com Router 3040 Software V2.41 (build V300R002B60D021)</example>
+    <example os.product="Router 3041" os.version="V2.41" hw.product="Router 3041">3Com Router 3041 Software V2.41 (build V300R002B60D021)</example>
+    <example os.product="Router 5012" os.version="Extended_V2.20" hw.product="Router 5012">3Com Router 5012 Software Extended_V2.20 (build V300R002B13D004)</example>
+    <example os.product="Router 5012" os.version="V3.12" hw.product="Router 5012">3Com Router 5012 Software V3.12 (build V300R002B65D002SP01)</example>
+    <example os.product="Router 5231" os.version="Extended_V1.30" hw.product="Router 5231">3Com Router 5231 Software Extended_V1.30</example>
+    <example os.product="Router 5231" os.version="V1.20" hw.product="Router 5231">3Com Router 5231 Software V1.20</example>
+    <example os.product="Router 5232" os.version="Extended_V3.14p03" hw.product="Router 5232">3Com Router 5232 Software Extended_V3.14p03 (build V300R002B68D003)</example>
+    <example os.product="Router 5232" os.version="V2.10" hw.product="Router 5232">3Com Router 5232 Software V2.10 (build V300R003B01D008SP03)</example>
+    <example os.product="Router 5642" os.version="V3.01" hw.product="Router 5642">3Com Router 5642 Software V3.01 (build V300R002B62D014)</example>
+    <example os.product="Router 5682" os.version="Extended_V3.01p09" hw.product="Router 5682">3Com Router 5682 Software Extended_V3.01p09 (build V300R002B62D014)</example>
+    <example os.product="Router 6040" os.version="V3.12" hw.product="Router 6040">3Com Router 6040 Software V3.12 (build V300R002B65D002SP01)</example>
+    <example os.product="Router 6080" os.version="V2.31" hw.product="Router 6080">3Com Router 6080 Software V2.31 (build V300R002B13D004)</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -345,9 +345,9 @@
 
   <fingerprint pattern="^3Com (S\S+)$">
     <description>3COM Switch - bare</description>
-    <example>3Com S7902E</example>
-    <example>3Com S7906E</example>
-    <example>3Com S7910E</example>
+    <example os.product="S7902E">3Com S7902E</example>
+    <example os.product="S7906E">3Com S7906E</example>
+    <example os.product="S7910E">3Com S7910E</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -388,16 +388,16 @@
 
   <fingerprint pattern="^3Com (.*Switch \S+)(?: \d+-port)?$">
     <description>3COM Superstack Switch</description>
-    <example>3Com SuperStack 3 Switch 3226</example>
-    <example>3Com SuperStack 3 Switch 3250</example>
-    <example>3Com SuperStack 3 Switch 3812 12-port</example>
-    <example>3Com SuperStack 3 Switch 3824 24-port</example>
-    <example>3Com SuperStack 3 Switch 3848</example>
-    <example>3Com SuperStack 3 Switch 3870 24-port</example>
-    <example>3Com SuperStack 3 Switch 3870 48-port</example>
-    <example>3Com SuperStack 3 Switch 4300</example>
-    <example>3Com Switch 3812</example>
-    <example>3Com Switch 3824</example>
+    <example os.product="SuperStack 3 Switch 3226">3Com SuperStack 3 Switch 3226</example>
+    <example os.product="SuperStack 3 Switch 3250">3Com SuperStack 3 Switch 3250</example>
+    <example os.product="SuperStack 3 Switch 3812">3Com SuperStack 3 Switch 3812 12-port</example>
+    <example os.product="SuperStack 3 Switch 3824">3Com SuperStack 3 Switch 3824 24-port</example>
+    <example os.product="SuperStack 3 Switch 3848">3Com SuperStack 3 Switch 3848</example>
+    <example os.product="SuperStack 3 Switch 3870">3Com SuperStack 3 Switch 3870 24-port</example>
+    <example os.product="SuperStack 3 Switch 3870">3Com SuperStack 3 Switch 3870 48-port</example>
+    <example os.product="SuperStack 3 Switch 4300">3Com SuperStack 3 Switch 4300</example>
+    <example os.product="Switch 3812">3Com Switch 3812</example>
+    <example os.product="Switch 3824">3Com Switch 3824</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -405,23 +405,23 @@
 
   <fingerprint pattern="^3Com (.*Switch.*) \d+-Port.*Software Version 3Com OS V(\S+)$">
     <description>3COM Superstack Switch with port count and os version</description>
-    <example>3Com SuperStack 3 Switch 4500 26-Port Software Version 3Com OS V3.01.00s56</example>
-    <example>3Com SuperStack 4 Switch 5500G-EI 24-Port Software Version 3Com OS V3.03.02s56Mc02</example>
-    <example>3Com Switch 4200G 12-Port Software Version 3Com OS V3.01.00s56</example>
-    <example>3Com Switch 4200G PWR 24-Port Software Version 3Com OS V3.02.02s168</example>
-    <example>3Com Switch 4210 18-Port Software Version 3Com OS V3.01.02s56</example>
-    <example>3Com Switch 4210 52-Port Software Version 3Com OS V3.01.12s56</example>
-    <example>3Com Switch 4210 9-Port Software Version 3Com OS V3.01.03s56</example>
-    <example>3Com Switch 4210 9-Port Software Version 3Com OS V3.01.12s56</example>
-    <example>3Com Switch 4210 PWR 9-Port Software Version 3Com OS V3.01.12s56</example>
-    <example>3Com Switch 4500 26-Port Software Version 3Com OS V3.03.00s168</example>
-    <example>3Com Switch 4500 50-Port Software Version 3Com OS V3.03.02s168p09</example>
-    <example>3Com Switch 4500 50-Port Software Version 3Com OS V3.03.02s168p11</example>
-    <example>3Com Switch 4500 PWR 50-Port Software Version 3Com OS V3.03.02s168</example>
-    <example>3Com Switch 4500G 24-Port PWR Software Version 3Com OS V5.01.03s56</example>
-    <example>3Com Switch 4500G 24-Port Software Version 3Com OS V5.02.00s56p02</example>
-    <example>3Com Switch 4500G 48-Port PWR Software Version 3Com OS V5.01.02s56</example>
-    <example>3Com Switch 4500G PWR 48-Port Software Version 3Com OS V5.02.00s168p20</example>
+    <example os.product="SuperStack 3 Switch 4500" os.version="3.01.00s56">3Com SuperStack 3 Switch 4500 26-Port Software Version 3Com OS V3.01.00s56</example>
+    <example os.product="SuperStack 4 Switch 5500G-EI" os.version="3.03.02s56Mc02">3Com SuperStack 4 Switch 5500G-EI 24-Port Software Version 3Com OS V3.03.02s56Mc02</example>
+    <example os.product="Switch 4200G" os.version="3.01.00s56">3Com Switch 4200G 12-Port Software Version 3Com OS V3.01.00s56</example>
+    <example os.product="Switch 4200G PWR" os.version="3.02.02s168">3Com Switch 4200G PWR 24-Port Software Version 3Com OS V3.02.02s168</example>
+    <example os.product="Switch 4210" os.version="3.01.02s56">3Com Switch 4210 18-Port Software Version 3Com OS V3.01.02s56</example>
+    <example os.product="Switch 4210" os.version="3.01.12s56">3Com Switch 4210 52-Port Software Version 3Com OS V3.01.12s56</example>
+    <example os.product="Switch 4210" os.version="3.01.03s56">3Com Switch 4210 9-Port Software Version 3Com OS V3.01.03s56</example>
+    <example os.product="Switch 4210" os.version="3.01.12s56">3Com Switch 4210 9-Port Software Version 3Com OS V3.01.12s56</example>
+    <example os.product="Switch 4210 PWR" os.version="3.01.12s56">3Com Switch 4210 PWR 9-Port Software Version 3Com OS V3.01.12s56</example>
+    <example os.product="Switch 4500" os.version="3.03.00s168">3Com Switch 4500 26-Port Software Version 3Com OS V3.03.00s168</example>
+    <example os.product="Switch 4500" os.version="3.03.02s168p09">3Com Switch 4500 50-Port Software Version 3Com OS V3.03.02s168p09</example>
+    <example os.product="Switch 4500" os.version="3.03.02s168p11">3Com Switch 4500 50-Port Software Version 3Com OS V3.03.02s168p11</example>
+    <example os.product="Switch 4500 PWR" os.version="3.03.02s168">3Com Switch 4500 PWR 50-Port Software Version 3Com OS V3.03.02s168</example>
+    <example os.product="Switch 4500G" os.version="5.01.03s56">3Com Switch 4500G 24-Port PWR Software Version 3Com OS V5.01.03s56</example>
+    <example os.product="Switch 4500G" os.version="5.02.00s56p02">3Com Switch 4500G 24-Port Software Version 3Com OS V5.02.00s56p02</example>
+    <example os.product="Switch 4500G" os.version="5.01.02s56">3Com Switch 4500G 48-Port PWR Software Version 3Com OS V5.01.02s56</example>
+    <example os.product="Switch 4500G PWR" os.version="5.02.00s168p20">3Com Switch 4500G PWR 48-Port Software Version 3Com OS V5.02.00s168p20</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -430,14 +430,14 @@
 
   <fingerprint pattern="^3Com (.*Switch.*) \d+-Port.*Software Version (\d\..*(?:Release|Feature).*)$">
     <description>3COM Switch with release info</description>
-    <example>3Com Switch 4210 18-Port Software Version 3.10 Release 2212P01</example>
-    <example>3Com Switch 4210 26-Port Software Version 3.10 Release 2212</example>
-    <example>3Com Switch 4210 26-Port Software Version 3.10 Release 2212P01</example>
-    <example>3Com Switch 4210 52-Port Software Version 3.10 Release 2212</example>
-    <example>3Com Switch 4210 52-Port Software Version 3.10 Release 2212P01</example>
-    <example>3Com Switch 4210 9-Port Software Version 3.10 Release 2212</example>
-    <example>3Com Switch 4210 9-Port Software Version 3.10 Release 2212P01</example>
-    <example>3Com Switch 4800G 24-Port SFP Software Version 5.20 Feature 2210L03</example>
+    <example os.product="Switch 4210" os.version="3.10 Release 2212P01">3Com Switch 4210 18-Port Software Version 3.10 Release 2212P01</example>
+    <example os.product="Switch 4210" os.version="3.10 Release 2212">3Com Switch 4210 26-Port Software Version 3.10 Release 2212</example>
+    <example os.product="Switch 4210" os.version="3.10 Release 2212P01">3Com Switch 4210 26-Port Software Version 3.10 Release 2212P01</example>
+    <example os.product="Switch 4210" os.version="3.10 Release 2212">3Com Switch 4210 52-Port Software Version 3.10 Release 2212</example>
+    <example os.product="Switch 4210" os.version="3.10 Release 2212P01">3Com Switch 4210 52-Port Software Version 3.10 Release 2212P01</example>
+    <example os.product="Switch 4210" os.version="3.10 Release 2212">3Com Switch 4210 9-Port Software Version 3.10 Release 2212</example>
+    <example os.product="Switch 4210" os.version="3.10 Release 2212P01">3Com Switch 4210 9-Port Software Version 3.10 Release 2212P01</example>
+    <example os.product="Switch 4800G" os.version="5.20 Feature 2210L03">3Com Switch 4800G 24-Port SFP Software Version 5.20 Feature 2210L03</example>
     <param pos="0" name="os.vendor" value="3Com"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -478,10 +478,10 @@
 
   <fingerprint pattern="(?i)^ADTRAN (MX\d+(?: \S+)?(?: \S+)?)$">
     <description>ADTRAN Multiplexer</description>
-    <example>ADTRAN MX2820 Multiplexer</example>
-    <example>ADTRAN MX2800 DS3 Multiplexer</example>
-    <example>ADTRAN MX2800 STS-1</example>
-    <example>ADTRAN MX2800</example>
+    <example os.product="MX2820 Multiplexer">ADTRAN MX2820 Multiplexer</example>
+    <example os.product="MX2800 DS3 Multiplexer">ADTRAN MX2800 DS3 Multiplexer</example>
+    <example os.product="MX2800 STS-1">ADTRAN MX2800 STS-1</example>
+    <example os.product="MX2800">ADTRAN MX2800</example>
     <param pos="0" name="os.device" value="Multiplexer"/>
     <param pos="0" name="os.vendor" value="ADTRAN"/>
     <param pos="0" name="os.family" value="MX"/>
@@ -490,17 +490,17 @@
 
   <fingerprint pattern="(?i)^ADTRAN (NetVanta\S+)$">
     <description>ADTRAN Netvanta Router</description>
-    <example>ADTRAN NetVanta8044</example>
-    <example>ADTRAN NetVanta8044M</example>
-    <example>ADTRAN NetVanta814</example>
-    <example>ADTRAN NetVanta818</example>
-    <example>ADTRAN NetVanta832</example>
-    <example>ADTRAN NetVanta832T</example>
-    <example>ADTRAN NetVanta834</example>
-    <example>ADTRAN NetVanta834T</example>
-    <example>ADTRAN NetVanta838</example>
-    <example>ADTRAN NetVanta838T</example>
-    <example>ADTRAN NetVanta873</example>
+    <example os.product="NetVanta8044">ADTRAN NetVanta8044</example>
+    <example os.product="NetVanta8044M">ADTRAN NetVanta8044M</example>
+    <example os.product="NetVanta814">ADTRAN NetVanta814</example>
+    <example os.product="NetVanta818">ADTRAN NetVanta818</example>
+    <example os.product="NetVanta832">ADTRAN NetVanta832</example>
+    <example os.product="NetVanta832T">ADTRAN NetVanta832T</example>
+    <example os.product="NetVanta834">ADTRAN NetVanta834</example>
+    <example os.product="NetVanta834T">ADTRAN NetVanta834T</example>
+    <example os.product="NetVanta838">ADTRAN NetVanta838</example>
+    <example os.product="NetVanta838T">ADTRAN NetVanta838T</example>
+    <example os.product="NetVanta873">ADTRAN NetVanta873</example>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.vendor" value="ADTRAN"/>
     <param pos="0" name="os.family" value="NetVanta"/>
@@ -520,14 +520,14 @@
 
   <fingerprint pattern="^Total Access ([^,\s]+).*Version: ([^,]+), Date:">
     <description>ADTRAN TotalAccess - date variant</description>
-    <example>Total Access 924 (2nd Gen), Version: A1.08.00.E, Date: Tue Apr 28 10:54:58 2009</example>
-    <example>Total Access 904 (1st Gen), Version: A4.02.00.E, Date: Mon Aug 09 13:57:18 2010</example>
-    <example>Total Access 904, Version: 16.05.00.E, Date: Thu Feb 28 18:22:04 2008</example>
-    <example>Total Access 908 (1st Gen), Version: A1.02.00.E, Date: Mon Apr 14 13:59:03 2008</example>
-    <example>Total Access 908, ADSL (2nd Gen), Version: A2.06.00.E, Date: Mon Feb 15 10:36:45 2010</example>
-    <example>Total Access 908, Version: 12.06.00.E, Date: Mon Aug 28 13:49:40 2006</example>
-    <example>Total Access 924e (1st Gen), Version: A4.08.00.E, Date: Fri Jun 24 13:53:48 2011</example>
-    <example>Total Access 924e, Version: 14.06.00.E, Date: Tue Aug 14 22:38:20 2007</example>
+    <example os.product="924" os.version="A1.08.00.E">Total Access 924 (2nd Gen), Version: A1.08.00.E, Date: Tue Apr 28 10:54:58 2009</example>
+    <example os.product="904" os.version="A4.02.00.E">Total Access 904 (1st Gen), Version: A4.02.00.E, Date: Mon Aug 09 13:57:18 2010</example>
+    <example os.product="904" os.version="16.05.00.E">Total Access 904, Version: 16.05.00.E, Date: Thu Feb 28 18:22:04 2008</example>
+    <example os.product="908" os.version="A1.02.00.E">Total Access 908 (1st Gen), Version: A1.02.00.E, Date: Mon Apr 14 13:59:03 2008</example>
+    <example os.product="908" os.version="A2.06.00.E">Total Access 908, ADSL (2nd Gen), Version: A2.06.00.E, Date: Mon Feb 15 10:36:45 2010</example>
+    <example os.product="908" os.version="12.06.00.E">Total Access 908, Version: 12.06.00.E, Date: Mon Aug 28 13:49:40 2006</example>
+    <example os.product="924e" os.version="A4.08.00.E">Total Access 924e (1st Gen), Version: A4.08.00.E, Date: Fri Jun 24 13:53:48 2011</example>
+    <example os.product="924e" os.version="14.06.00.E">Total Access 924e, Version: 14.06.00.E, Date: Tue Aug 14 22:38:20 2007</example>
     <param pos="0" name="os.device" value="Media Gateway"/>
     <param pos="0" name="os.vendor" value="ADTRAN"/>
     <param pos="0" name="os.family" value="Total Access"/>
@@ -537,7 +537,7 @@
 
   <fingerprint pattern="^Total Access (\S+ SCU)$">
     <description>ADTRAN TotalAccess SCU</description>
-    <example>Total Access 1500 SCU</example>
+    <example os.product="1500 SCU">Total Access 1500 SCU</example>
     <param pos="0" name="os.device" value="Remote Terminal"/>
     <param pos="0" name="os.vendor" value="ADTRAN"/>
     <param pos="0" name="os.family" value="Total Access"/>
@@ -546,12 +546,12 @@
 
   <fingerprint pattern="^(TA\d\S+) (\d\S+ )?Total Access">
     <description>ADTRAN TotalAccess - model first variant</description>
-    <example>TA1100F 1179.760 Total Access SFP-Based System</example>
-    <example>TA1200F 1179.660L1 Total Access IP DSLAM System</example>
-    <example>TA1248 1179.641AL3 Total Access IP DSLAM System</example>
-    <example>TA1248E 1179.641AL3 Total Access IP DSLAM System</example>
-    <example>TA3011 1182.001L1 Total Access OMP-FC</example>
-    <example>TA3011 Total Access OMP-FC</example>
+    <example os.product="TA1100F" os.version="1179.760 ">TA1100F 1179.760 Total Access SFP-Based System</example>
+    <example os.product="TA1200F" os.version="1179.660L1 ">TA1200F 1179.660L1 Total Access IP DSLAM System</example>
+    <example os.product="TA1248" os.version="1179.641AL3 ">TA1248 1179.641AL3 Total Access IP DSLAM System</example>
+    <example os.product="TA1248E" os.version="1179.641AL3 ">TA1248E 1179.641AL3 Total Access IP DSLAM System</example>
+    <example os.product="TA3011" os.version="1182.001L1 ">TA3011 1182.001L1 Total Access OMP-FC</example>
+    <example os.product="TA3011">TA3011 Total Access OMP-FC</example>
     <param pos="0" name="os.device" value="DSLAM"/>
     <param pos="0" name="os.vendor" value="ADTRAN"/>
     <param pos="0" name="os.family" value="Total Access"/>
@@ -570,7 +570,7 @@
 
   <fingerprint pattern="(?i)^ADTRAN (T3SU-\S+)">
     <description>ADTRAN DSU/CSU</description>
-    <example>ADTRAN T3SU-300 (1200.217L1)</example>
+    <example os.product="T3SU-300">ADTRAN T3SU-300 (1200.217L1)</example>
     <param pos="0" name="os.device" value="DSU/CSU"/>
     <param pos="0" name="os.vendor" value="ADTRAN"/>
     <param pos="0" name="os.family" value="T3 Termination"/>
@@ -579,7 +579,7 @@
 
   <fingerprint pattern="^OPTI-MX (19 inch domestic shelf)$">
     <description>ADTRAN OPTI-MX Shelf</description>
-    <example>OPTI-MX 19 inch domestic shelf</example>
+    <example os.product="19 inch domestic shelf">OPTI-MX 19 inch domestic shelf</example>
     <param pos="0" name="os.device" value="Multiplexer"/>
     <param pos="0" name="os.vendor" value="ADTRAN"/>
     <param pos="0" name="os.family" value="OPTI-MX"/>
@@ -592,10 +592,10 @@
 
   <fingerprint pattern="^Allen-Bradley (\S+ (?:PLC|SLC)\S+) Series (\S+) Revision (\S+) \S+ (\S+) \S+$">
     <description>Allen-Bradley PLC/SLC</description>
-    <example>Allen-Bradley 1747-L551/C SLC-5/05 Series C Revision 11 1747_slc 3.46 13-Jan-06</example>
-    <example>Allen-Bradley 1747-L552/C SLC-5/05 Series C Revision 9 1747_slc 3.33 16-Nov-04</example>
-    <example>Allen-Bradley 1785-L20E PLC5-20/E Series E Revision B.2 np520e 1.67 13-Jan-98</example>
-    <example>Allen-Bradley 1785-L40E PLC5-40/E Series E Revision F.2 1785_np540e 2.39 03-Jul-02</example>
+    <example os.product="1747-L551/C SLC-5/05" os.version="C" os.version.version="11" os.version.version.version="3.46">Allen-Bradley 1747-L551/C SLC-5/05 Series C Revision 11 1747_slc 3.46 13-Jan-06</example>
+    <example os.product="1747-L552/C SLC-5/05" os.version="C" os.version.version="9" os.version.version.version="3.33">Allen-Bradley 1747-L552/C SLC-5/05 Series C Revision 9 1747_slc 3.33 16-Nov-04</example>
+    <example os.product="1785-L20E PLC5-20/E" os.version="E" os.version.version="B.2" os.version.version.version="1.67">Allen-Bradley 1785-L20E PLC5-20/E Series E Revision B.2 np520e 1.67 13-Jan-98</example>
+    <example os.product="1785-L40E PLC5-40/E" os.version="E" os.version.version="F.2" os.version.version.version="2.39">Allen-Bradley 1785-L40E PLC5-40/E Series E Revision F.2 1785_np540e 2.39 03-Jul-02</example>
     <param pos="0" name="os.device" value="PLC"/>
     <param pos="0" name="os.vendor" value="Rockwell Automation"/>
     <param pos="0" name="os.family" value="PLC"/>
@@ -607,13 +607,13 @@
 
   <fingerprint pattern="^Allen-Bradley (\S+) ([^/]+)/(\S+) MicroLogix1400 Series \S+ Revision \S+$">
     <description>Allen-Bradley MicroLogix PLC/SLC</description>
-    <example>Allen-Bradley 1766-L32AWA A/5.00 MicroLogix1400 Series A Revision 5.0</example>
-    <example>Allen-Bradley 1766-L32AWAA A/3.00 MicroLogix1400 Series A Revision 3.0</example>
-    <example>Allen-Bradley 1766-L32BWA A/5.00 MicroLogix1400 Series A Revision 5.0</example>
-    <example>Allen-Bradley 1766-L32BWA B/10.00 MicroLogix1400 Series B Revision 10.0</example>
-    <example>Allen-Bradley 1766-L32BXB A/5.00 MicroLogix1400 Series A Revision 5.0</example>
-    <example>Allen-Bradley 1766-L32BXB B/10.00 MicroLogix1400 Series B Revision 10.0</example>
-    <example>Allen-Bradley 1766-L32BXBA B/11.00 MicroLogix1400 Series B Revision 11.0</example>
+    <example os.product="1766-L32AWA" os.version="A" os.version.version="5.00">Allen-Bradley 1766-L32AWA A/5.00 MicroLogix1400 Series A Revision 5.0</example>
+    <example os.product="1766-L32AWAA" os.version="A" os.version.version="3.00">Allen-Bradley 1766-L32AWAA A/3.00 MicroLogix1400 Series A Revision 3.0</example>
+    <example os.product="1766-L32BWA" os.version="A" os.version.version="5.00">Allen-Bradley 1766-L32BWA A/5.00 MicroLogix1400 Series A Revision 5.0</example>
+    <example os.product="1766-L32BWA" os.version="B" os.version.version="10.00">Allen-Bradley 1766-L32BWA B/10.00 MicroLogix1400 Series B Revision 10.0</example>
+    <example os.product="1766-L32BXB" os.version="A" os.version.version="5.00">Allen-Bradley 1766-L32BXB A/5.00 MicroLogix1400 Series A Revision 5.0</example>
+    <example os.product="1766-L32BXB" os.version="B" os.version.version="10.00">Allen-Bradley 1766-L32BXB B/10.00 MicroLogix1400 Series B Revision 10.0</example>
+    <example os.product="1766-L32BXBA" os.version="B" os.version.version="11.00">Allen-Bradley 1766-L32BXBA B/11.00 MicroLogix1400 Series B Revision 11.0</example>
     <param pos="0" name="os.device" value="PLC"/>
     <param pos="0" name="os.vendor" value="Rockwell Automation"/>
     <param pos="0" name="os.family" value="PLC"/>
@@ -624,7 +624,7 @@
 
   <fingerprint pattern="^Allen-Bradley (\S+-ENET) Revision: (\S+) \S+ (\S+) \S+$">
     <description>Allen-Bradley PLC/SLC Ethernet Interface</description>
-    <example>Allen-Bradley 1756-ENET Revision: 2.7 icp_enet 1.135 12-Apr-02</example>
+    <example os.product="1756-ENET" os.version="2.7" os.version.version="1.135">Allen-Bradley 1756-ENET Revision: 2.7 icp_enet 1.135 12-Apr-02</example>
     <param pos="0" name="os.device" value="PLC"/>
     <param pos="0" name="os.vendor" value="Rockwell Automation"/>
     <param pos="0" name="os.family" value="Ethernet Interface"/>
@@ -635,7 +635,7 @@
 
   <fingerprint pattern="^Allen-Bradley (\S+-ENET) Ethernet Interface Series (\S+) Revision (\S+) \S+ (\S+) \S+$">
     <description>Allen-Bradley PLC/SLC Ethernet Interface - variant 1</description>
-    <example>Allen-Bradley 1785-ENET Ethernet Interface Series E Revision B.0 1785enet 1.35 06-Mar-98</example>
+    <example os.product="1785-ENET" os.version="E" os.version.version="B.0" os.version.version.version="1.35">Allen-Bradley 1785-ENET Ethernet Interface Series E Revision B.0 1785enet 1.35 06-Mar-98</example>
     <param pos="0" name="os.device" value="PLC"/>
     <param pos="0" name="os.vendor" value="Rockwell Automation"/>
     <param pos="0" name="os.family" value="Ethernet Interface"/>
@@ -647,13 +647,13 @@
 
   <fingerprint pattern="^Rockwell Automation (\S+)$">
     <description>Rockwell Automation PLC</description>
-    <example>Rockwell Automation 1756-EN2T/A</example>
-    <example>Rockwell Automation 1756-EN2T/C</example>
-    <example>Rockwell Automation 1756-EN2TR/B</example>
-    <example>Rockwell Automation 1756-ENBT</example>
-    <example>Rockwell Automation 1769-L3xE</example>
-    <example>Rockwell Automation 1769-LxxE</example>
-    <example>Rockwell Automation 1788-ENBT</example>
+    <example os.product="1756-EN2T/A">Rockwell Automation 1756-EN2T/A</example>
+    <example os.product="1756-EN2T/C">Rockwell Automation 1756-EN2T/C</example>
+    <example os.product="1756-EN2TR/B">Rockwell Automation 1756-EN2TR/B</example>
+    <example os.product="1756-ENBT">Rockwell Automation 1756-ENBT</example>
+    <example os.product="1769-L3xE">Rockwell Automation 1769-L3xE</example>
+    <example os.product="1769-LxxE">Rockwell Automation 1769-LxxE</example>
+    <example os.product="1788-ENBT">Rockwell Automation 1788-ENBT</example>
     <param pos="0" name="os.device" value="PLC"/>
     <param pos="0" name="os.vendor" value="Rockwell Automation"/>
     <param pos="0" name="os.family" value="PLC"/>
@@ -678,7 +678,7 @@
 
   <fingerprint pattern="^APC - (\d+-port IP KVM) - version: V_(\S+)">
     <description>APC KVM over IP</description>
-    <example>APC - 16-port IP KVM - version: V_2.0.0-2 (Oct/17/06)</example>
+    <example os.product="16-port IP KVM" os.version="2.0.0-2">APC - 16-port IP KVM - version: V_2.0.0-2 (Oct/17/06)</example>
     <param pos="0" name="os.vendor" value="APC"/>
     <param pos="0" name="os.family" value="IP KVM"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -688,8 +688,8 @@
 
   <fingerprint pattern="^APC Embedded PowerNet SNMP Agent \(.*SW v([^,]+),.*M[oO][dD]:\s*([^,]+),">
     <description>APC Embedded PowerNet</description>
-    <example>APC Embedded PowerNet SNMP Agent (FW v3.0.2 SW v2.2.4.a, HW ged~, MOD: AP9605, Mfg: 06/24/1998, SN: X)</example>
-    <example>APC Embedded PowerNet SNMP Agent (SW v2.0.3, HW v2.0B, Mod: AP9206, Mfg 06/22/94, SN: A94063028359)</example>
+    <example os.version="2.2.4.a" os.product="AP9605">APC Embedded PowerNet SNMP Agent (FW v3.0.2 SW v2.2.4.a, HW ged~, MOD: AP9605, Mfg: 06/24/1998, SN: X)</example>
+    <example os.version="2.0.3" os.product="AP9206">APC Embedded PowerNet SNMP Agent (SW v2.0.3, HW v2.0B, Mod: AP9206, Mfg 06/22/94, SN: A94063028359)</example>
     <param pos="0" name="os.vendor" value="APC"/>
     <param pos="0" name="os.device" value="UPS"/>
     <param pos="1" name="os.version"/>
@@ -698,18 +698,18 @@
 
   <fingerprint pattern="^APC (?:Environmental (?:Management System|Manager|Monitoring Unit)|InfraStruXure Manager|.* Rack PDU|NetBotz Rack Access|Web/SNMP Management Card).*AF1:\s*v?(\S+).*MN:\s*(\S+)">
     <description>APC UPS</description>
-    <example>APC Environmental Management System (MB:v3.6.9 PF:v2.6.4 PN:apc_hw02_aos_264.bin AF1:v2.6.7 AN1:apc_hw02_ems_267.bin MN:AP9320 HR:4 SN: ZA0747015277 MD:11/25/2007)</example>
-    <example>APC Environmental Manager (MB:v3.8.0 PF:v3.0.3 PN:apc_hw03_aos_303.bin AF1:v3.0.4 AN1:apc_hw03_mem_304.bin MN:AP9340 HR:05 SN: ZA0739002849 MD:09/25/2007)</example>
-    <example>APC Environmental Monitoring Unit (MB:v3.6.3 PF:v2.2.2 PN:apc_hw02_aos_222.bin AF1:v2.2.2 AN1:apc_hw02_ems_222.bin MN:AP9319 HR:3 SN:WA0339160711 MD:09/30/2003)</example>
-    <example>APC Web/SNMP Management Card (MB:v3.6.8 PF:v2.6.4 PN:apc_hw02_aos_264.bin AF1:v2.6.1 AN1:apc_hw02_sy_261.bin MN:AP9619 HR:A10 SN: ZA0624022354 MD:06/09/2006) (Embedded PowerNet SNMP Agent SW v2.2 compatible)</example>
-    <example>APC Web/SNMP Management Card (MB:v3.6.4 PF:v2.5.0 PN:apc_hw02_aos_250.bin AF1:v2.5.1 AN1:apc_hw02_sy_251.bin MN:AP9619 HR:A10 SN: ZA0435001769 MD:08/30/2004) (Embedded PowerNet SNMP Agent SW v2.2 compatible)</example>
-    <example>APC NetBotz Rack Access PX-HID (MB:v3.8.6 PF:v3.5.4 PN:apc_hw02_aos_354.bin AF1:v3.5.3 AN1:apc_hw02_pxhid_353.bin MN:AP9361 HR:04 SN: 5A0726V01013 MD:07/11/2007)</example>
-    <example>APC InfraStruXure Manager (MB:v3.6.0c AF1:v4.7.0.275 AN1:isx MN:AP92200 HR:1.0 SN:WA0532110212 MD:08/04/2005)</example>
-    <example>APC Metered Rack PDU (MB:v3.6.4 PF:v2.2.7 PN:apc_hw02_aos_227.bin AF1:v2.2.0 AN1:apc_hw02_rpdu_220.bin MN:AP7830 HR:B2 SN: JA0412013793 MD:03/18/2004)</example>
-    <example>APC Switched Rack PDU (MB:v3.6.4 PF:v2.2.7 PN:apc_hw02_aos_227.bin AF1:v2.2.0 AN1:apc_hw02_rpdu_220.bin MN:AP7900 HR:B2 SN: JA0410012030 MD:03/02/2004)</example>
-    <example>APC Web/SNMP Management Card (MB:v3.2.0 PF:v3.0.3 PN:aos303.bin AF1:v2.2.0 AN1:ms220.bin MN: AP9606 HR: G9 SN: JA0130009715 MD: 07/26/2001)</example>
-    <example>APC Web/SNMP Management Card (MB:v3.2.0 PF:v3.0.1 PN:aos301.bin AF1:v3.0.1 AN1:sumx301.bin MN: AP9606 HR: ] SN: 3A0105S05525 MD: 02/28/2001) (Embedded PowerNet SNMP Agent SW v2.2 compatible)</example>
-    <example>APC Web/SNMP Management Card (MB:v3.2.0 PF:v3.0.9.a PN:aos309a.bin AF1:v2.2.5.a AN1:ms225a.bin MN: AP9606 HR: J9 SN: WA0121006888 MD: 12/20/2002)</example>
+    <example os.version="2.6.7" os.product="AP9320">APC Environmental Management System (MB:v3.6.9 PF:v2.6.4 PN:apc_hw02_aos_264.bin AF1:v2.6.7 AN1:apc_hw02_ems_267.bin MN:AP9320 HR:4 SN: ZA0747015277 MD:11/25/2007)</example>
+    <example os.version="3.0.4" os.product="AP9340">APC Environmental Manager (MB:v3.8.0 PF:v3.0.3 PN:apc_hw03_aos_303.bin AF1:v3.0.4 AN1:apc_hw03_mem_304.bin MN:AP9340 HR:05 SN: ZA0739002849 MD:09/25/2007)</example>
+    <example os.version="2.2.2" os.product="AP9319">APC Environmental Monitoring Unit (MB:v3.6.3 PF:v2.2.2 PN:apc_hw02_aos_222.bin AF1:v2.2.2 AN1:apc_hw02_ems_222.bin MN:AP9319 HR:3 SN:WA0339160711 MD:09/30/2003)</example>
+    <example os.version="2.6.1" os.product="AP9619">APC Web/SNMP Management Card (MB:v3.6.8 PF:v2.6.4 PN:apc_hw02_aos_264.bin AF1:v2.6.1 AN1:apc_hw02_sy_261.bin MN:AP9619 HR:A10 SN: ZA0624022354 MD:06/09/2006) (Embedded PowerNet SNMP Agent SW v2.2 compatible)</example>
+    <example os.version="2.5.1" os.product="AP9619">APC Web/SNMP Management Card (MB:v3.6.4 PF:v2.5.0 PN:apc_hw02_aos_250.bin AF1:v2.5.1 AN1:apc_hw02_sy_251.bin MN:AP9619 HR:A10 SN: ZA0435001769 MD:08/30/2004) (Embedded PowerNet SNMP Agent SW v2.2 compatible)</example>
+    <example os.version="3.5.3" os.product="AP9361">APC NetBotz Rack Access PX-HID (MB:v3.8.6 PF:v3.5.4 PN:apc_hw02_aos_354.bin AF1:v3.5.3 AN1:apc_hw02_pxhid_353.bin MN:AP9361 HR:04 SN: 5A0726V01013 MD:07/11/2007)</example>
+    <example os.version="4.7.0.275" os.product="AP92200">APC InfraStruXure Manager (MB:v3.6.0c AF1:v4.7.0.275 AN1:isx MN:AP92200 HR:1.0 SN:WA0532110212 MD:08/04/2005)</example>
+    <example os.version="2.2.0" os.product="AP7830">APC Metered Rack PDU (MB:v3.6.4 PF:v2.2.7 PN:apc_hw02_aos_227.bin AF1:v2.2.0 AN1:apc_hw02_rpdu_220.bin MN:AP7830 HR:B2 SN: JA0412013793 MD:03/18/2004)</example>
+    <example os.version="2.2.0" os.product="AP7900">APC Switched Rack PDU (MB:v3.6.4 PF:v2.2.7 PN:apc_hw02_aos_227.bin AF1:v2.2.0 AN1:apc_hw02_rpdu_220.bin MN:AP7900 HR:B2 SN: JA0410012030 MD:03/02/2004)</example>
+    <example os.version="2.2.0" os.product="AP9606">APC Web/SNMP Management Card (MB:v3.2.0 PF:v3.0.3 PN:aos303.bin AF1:v2.2.0 AN1:ms220.bin MN: AP9606 HR: G9 SN: JA0130009715 MD: 07/26/2001)</example>
+    <example os.version="3.0.1" os.product="AP9606">APC Web/SNMP Management Card (MB:v3.2.0 PF:v3.0.1 PN:aos301.bin AF1:v3.0.1 AN1:sumx301.bin MN: AP9606 HR: ] SN: 3A0105S05525 MD: 02/28/2001) (Embedded PowerNet SNMP Agent SW v2.2 compatible)</example>
+    <example os.version="2.2.5.a" os.product="AP9606">APC Web/SNMP Management Card (MB:v3.2.0 PF:v3.0.9.a PN:aos309a.bin AF1:v2.2.5.a AN1:ms225a.bin MN: AP9606 HR: J9 SN: WA0121006888 MD: 12/20/2002)</example>
     <param pos="0" name="os.vendor" value="APC"/>
     <param pos="0" name="os.device" value="UPS"/>
     <param pos="1" name="os.version"/>
@@ -755,7 +755,7 @@
 
   <fingerprint pattern="^SNMP-Link (\S+)$">
     <description>Asentria SNMP-Link</description>
-    <example>SNMP-Link SL60</example>
+    <example os.product="SL60">SNMP-Link SL60</example>
     <param pos="0" name="os.vendor" value="Asentria"/>
     <param pos="0" name="os.family" value="SNMP-Link"/>
     <param pos="1" name="os.product"/>
@@ -763,8 +763,8 @@
 
   <fingerprint pattern="^SNMP-Link (\S+) (\S+) ST\S+$">
     <description>Asentria SNMP-Link - version variant</description>
-    <example>SNMP-Link SL61 1.10 STD</example>
-    <example>SNMP-Link SL81 1.11 STDF</example>
+    <example os.product="SL61" os.version="1.10">SNMP-Link SL61 1.10 STD</example>
+    <example os.product="SL81" os.version="1.11">SNMP-Link SL81 1.11 STDF</example>
     <param pos="0" name="os.vendor" value="Asentria"/>
     <param pos="0" name="os.family" value="SNMP-Link"/>
     <param pos="1" name="os.product"/>
@@ -798,7 +798,7 @@
 
   <fingerprint pattern="^DEFINITY ONE Release (\S+) Agent$">
     <description>Avaya Definity One media, voicemail, VoIP server</description>
-    <example>DEFINITY ONE Release 3 Agent</example>
+    <example os.version="3">DEFINITY ONE Release 3 Agent</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.product" value="Definity One"/>
     <param pos="0" name="os.device" value="VoIP"/>
@@ -807,14 +807,14 @@
 
   <fingerprint pattern="^Avaya (AP-\d+|AP4\-AP5\-AP6|Wireless Outdoor Router|Wireless AP\-3)\s*[vV](\S+)">
     <description>Avaya WAP</description>
-    <example>Avaya AP-3 v2.5.3(914) SN-02UT44560476 v2.0.10</example>
-    <example>Avaya AP-8 v2.6.0(914) SN-06UT27560151 v3.1.0</example>
-    <example>Avaya AP4-AP5-AP6 v2.2.4(534) SN-03AT33590076 v3.0.4</example>
-    <example>Avaya AP4-AP5-AP6 v2.4.5(758) SN-04AT07580112 v3.0.4</example>
-    <example>Avaya Wireless AP-3v2.2.4(534) SN-02UT21560880 v2.0.10</example>
-    <example>Avaya Wireless AP-3v2.4.5(758) SN-01UT47560491 v2.0.10</example>
-    <example>Avaya Wireless Outdoor Router V3.87 SN-00UT42270773 V3.70</example>
-    <example>Avaya Wireless Outdoor Router v4.15 SN-03UT28230440 V3.73</example>
+    <example os.product="AP-3" os.version="2.5.3(914)">Avaya AP-3 v2.5.3(914) SN-02UT44560476 v2.0.10</example>
+    <example os.product="AP-8" os.version="2.6.0(914)">Avaya AP-8 v2.6.0(914) SN-06UT27560151 v3.1.0</example>
+    <example os.product="AP4-AP5-AP6" os.version="2.2.4(534)">Avaya AP4-AP5-AP6 v2.2.4(534) SN-03AT33590076 v3.0.4</example>
+    <example os.product="AP4-AP5-AP6" os.version="2.4.5(758)">Avaya AP4-AP5-AP6 v2.4.5(758) SN-04AT07580112 v3.0.4</example>
+    <example os.product="Wireless AP-3" os.version="2.2.4(534)">Avaya Wireless AP-3v2.2.4(534) SN-02UT21560880 v2.0.10</example>
+    <example os.product="Wireless AP-3" os.version="2.4.5(758)">Avaya Wireless AP-3v2.4.5(758) SN-01UT47560491 v2.0.10</example>
+    <example os.product="Wireless Outdoor Router" os.version="3.87">Avaya Wireless Outdoor Router V3.87 SN-00UT42270773 V3.70</example>
+    <example os.product="Wireless Outdoor Router" os.version="4.15">Avaya Wireless Outdoor Router v4.15 SN-03UT28230440 V3.73</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.product"/>
@@ -834,10 +834,10 @@
 
   <fingerprint pattern="^Avaya Inc\., (.* Media Gateway), SW Version (\S+)">
     <description>Avaya Media Gateway</description>
-    <example>Avaya Inc., G250 Media Gateway, SW Version 25.28.0</example>
-    <example>Avaya Inc., G250-BRI Media Gateway, SW Version 25.28.0</example>
-    <example>Avaya Inc., G350 Converged Media Gateway, SW Version 24.21.1</example>
-    <example>Avaya Inc., G450 Media Gateway, SW Version 31.22.0</example>
+    <example os.product="G250 Media Gateway" os.version="25.28.0">Avaya Inc., G250 Media Gateway, SW Version 25.28.0</example>
+    <example os.product="G250-BRI Media Gateway" os.version="25.28.0">Avaya Inc., G250-BRI Media Gateway, SW Version 25.28.0</example>
+    <example os.product="G350 Converged Media Gateway" os.version="24.21.1">Avaya Inc., G350 Converged Media Gateway, SW Version 24.21.1</example>
+    <example os.product="G450 Media Gateway" os.version="31.22.0">Avaya Inc., G450 Media Gateway, SW Version 31.22.0</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.device" value="Media Gateway"/>
     <param pos="1" name="os.product"/>
@@ -846,7 +846,7 @@
 
   <fingerprint pattern="Avaya (\S+) Telephony Media Gateway$">
     <description>Avaya Telephony Media Gateway</description>
-    <example>Avaya G700 Telephony Media Gateway</example>
+    <example os.product="G700">Avaya G700 Telephony Media Gateway</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.device" value="Media Gateway"/>
     <param pos="1" name="os.product"/>
@@ -855,7 +855,7 @@
   <fingerprint pattern="^Avaya Cajun Switch Agent v(\S+)$">
     <description>Avaya Cajun Switch</description>
     <example os.version="5.2.10">Avaya Cajun Switch Agent v5.2.10</example>
-    <example>Avaya Cajun Switch Agent v5.4.2</example>
+    <example os.version="5.4.2">Avaya Cajun Switch Agent v5.4.2</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.product" value="Cajun Switch"/>
@@ -864,21 +864,21 @@
 
   <fingerprint pattern="^(Ethernet Routing Switch.*)\s+HW:.*SW:\s*v?(\S+).*Avaya Networks$">
     <description>Avaya Routing Switch</description>
-    <example>Ethernet Routing Switch 2526T HW:04 FW:1.0.0.15 SW:v4.4.0.010 BN:10 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 3524GT HW:01 FW:1.0.0.4 SW:v5.0.0.060 BN:60 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 4550T-PWR HW:01 FW:5.3.0.3 SW:v5.6.0.008 BN:08 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5510-24T HW:01 FW:6.0.0.10 SW:v6.2.1.003 BN:03 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5510-24T HW:32 FW:6.0.0.14 SW:v6.2.3.011 BN:11 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5510-24T HW:37 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5520-24T-PWR HW:36 FW:6.0.0.10 SW:v6.2.0.200 BN:200 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5520-24T-PWR HW:37 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5530-24TFD HW:34 FW:6.0.0.13 SW:v6.2.2.022 BN:22 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5530-24TFD HW:37 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5530-24TFD HW:37 FW:6.0.0.15 SW:v6.2.4.010 BN:10 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5530-24TFD HW:B.99 FW:6.0.0.15 SW:v6.2.4.011 BN:11 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5632FD HW:03 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5650TD HW:04 FW:6.0.0.13 SW:v6.2.2.023 BN:23 (c) Avaya Networks</example>
-    <example>Ethernet Routing Switch 5650TD-PWR HW:03 FW:6.0.0.15 SW:v6.2.4.010 BN:10 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 2526T" os.version="4.4.0.010">Ethernet Routing Switch 2526T HW:04 FW:1.0.0.15 SW:v4.4.0.010 BN:10 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 3524GT" os.version="5.0.0.060">Ethernet Routing Switch 3524GT HW:01 FW:1.0.0.4 SW:v5.0.0.060 BN:60 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 4550T-PWR" os.version="5.6.0.008">Ethernet Routing Switch 4550T-PWR HW:01 FW:5.3.0.3 SW:v5.6.0.008 BN:08 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5510-24T" os.version="6.2.1.003">Ethernet Routing Switch 5510-24T HW:01 FW:6.0.0.10 SW:v6.2.1.003 BN:03 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5510-24T" os.version="6.2.3.011">Ethernet Routing Switch 5510-24T HW:32 FW:6.0.0.14 SW:v6.2.3.011 BN:11 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5510-24T" os.version="6.2.0.008">Ethernet Routing Switch 5510-24T HW:37 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5520-24T-PWR" os.version="6.2.0.200">Ethernet Routing Switch 5520-24T-PWR HW:36 FW:6.0.0.10 SW:v6.2.0.200 BN:200 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5520-24T-PWR" os.version="6.2.0.008">Ethernet Routing Switch 5520-24T-PWR HW:37 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5530-24TFD" os.version="6.2.2.022">Ethernet Routing Switch 5530-24TFD HW:34 FW:6.0.0.13 SW:v6.2.2.022 BN:22 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5530-24TFD" os.version="6.2.0.008">Ethernet Routing Switch 5530-24TFD HW:37 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5530-24TFD" os.version="6.2.4.010">Ethernet Routing Switch 5530-24TFD HW:37 FW:6.0.0.15 SW:v6.2.4.010 BN:10 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5530-24TFD" os.version="6.2.4.011">Ethernet Routing Switch 5530-24TFD HW:B.99 FW:6.0.0.15 SW:v6.2.4.011 BN:11 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5632FD" os.version="6.2.0.008">Ethernet Routing Switch 5632FD HW:03 FW:6.0.0.10 SW:v6.2.0.008 BN:08 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5650TD" os.version="6.2.2.023">Ethernet Routing Switch 5650TD HW:04 FW:6.0.0.13 SW:v6.2.2.023 BN:23 (c) Avaya Networks</example>
+    <example os.product="Ethernet Routing Switch 5650TD-PWR" os.version="6.2.4.010">Ethernet Routing Switch 5650TD-PWR HW:03 FW:6.0.0.15 SW:v6.2.4.010 BN:10 (c) Avaya Networks</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -887,13 +887,13 @@
 
   <fingerprint pattern="^PR:CS 1000.*BN:(\S+).*Avaya Inc\.$">
     <description>Avaya Call Server</description>
-    <example>PR:CS 1000 SW:MGC BN:MGCCCD01 HW:MGC (c) Avaya Inc.</example>
-    <example>PR:CS 1000 SW:NRS+SS_EM, Backup Server BN:7.50.17-00 HW:Avaya CPPMv1 (c) Avaya Inc.</example>
-    <example>PR:CS 1000 SW:NRS+SS_EM, Backup Server BN:7.50.17-00 HW:HP DL360G7 (c) Avaya Inc.</example>
-    <example>PR:CS 1000 SW:NRS+SS_EM_SubM, Primary Security Server BN:7.50.17-00 HW:Avaya CPPMv1 (c) Avaya Inc.</example>
-    <example>PR:CS 1000 SW:NRS+SS_EM_SubM, Primary Security Server BN:7.50.17-00 HW:HP DL360G7 (c) Avaya Inc.</example>
-    <example>PR:CS 1000 SW:NRS+SS_EM_SubM, Primary Security Server BN:7.50.17-00 HW:IBM X3350 (c) Avaya Inc.</example>
-    <example>PR:CS 1000, 2010 E SW:Call Server, Sys 4021 BN:7.50Q HW:CP-PM (c) Avaya Inc.</example>
+    <example os.version="MGCCCD01">PR:CS 1000 SW:MGC BN:MGCCCD01 HW:MGC (c) Avaya Inc.</example>
+    <example os.version="7.50.17-00">PR:CS 1000 SW:NRS+SS_EM, Backup Server BN:7.50.17-00 HW:Avaya CPPMv1 (c) Avaya Inc.</example>
+    <example os.version="7.50.17-00">PR:CS 1000 SW:NRS+SS_EM, Backup Server BN:7.50.17-00 HW:HP DL360G7 (c) Avaya Inc.</example>
+    <example os.version="7.50.17-00">PR:CS 1000 SW:NRS+SS_EM_SubM, Primary Security Server BN:7.50.17-00 HW:Avaya CPPMv1 (c) Avaya Inc.</example>
+    <example os.version="7.50.17-00">PR:CS 1000 SW:NRS+SS_EM_SubM, Primary Security Server BN:7.50.17-00 HW:HP DL360G7 (c) Avaya Inc.</example>
+    <example os.version="7.50.17-00">PR:CS 1000 SW:NRS+SS_EM_SubM, Primary Security Server BN:7.50.17-00 HW:IBM X3350 (c) Avaya Inc.</example>
+    <example os.version="7.50Q">PR:CS 1000, 2010 E SW:Call Server, Sys 4021 BN:7.50Q HW:CP-PM (c) Avaya Inc.</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="os.product" value="Call Server"/>
@@ -902,17 +902,17 @@
 
   <fingerprint pattern="^(ERS-\S+) \(([^\)]+)\)$">
     <description>Avaya (Nortel) Switch</description>
-    <example>ERS-1612 (2.1.0.0)</example>
-    <example>ERS-1612 (2.1.7.0)</example>
-    <example>ERS-8306 (4.2.0.1)</example>
-    <example>ERS-8310 (4.2.0.1)</example>
-    <example>ERS-8610co (5.1.0.0)</example>
-    <example>ERS-8610co (5.1.1.10)</example>
-    <example>ERS-8610co (5.1.6.0)</example>
-    <example>ERS-8610co (5.1.7.1)</example>
-    <example>ERS-8806 (7.1.0.0)</example>
-    <example>ERS-8810 (7.0.0.2)</example>
-    <example>ERS-8810 (7.1.0.1)</example>
+    <example os.product="ERS-1612" os.version="2.1.0.0">ERS-1612 (2.1.0.0)</example>
+    <example os.product="ERS-1612" os.version="2.1.7.0">ERS-1612 (2.1.7.0)</example>
+    <example os.product="ERS-8306" os.version="4.2.0.1">ERS-8306 (4.2.0.1)</example>
+    <example os.product="ERS-8310" os.version="4.2.0.1">ERS-8310 (4.2.0.1)</example>
+    <example os.product="ERS-8610co" os.version="5.1.0.0">ERS-8610co (5.1.0.0)</example>
+    <example os.product="ERS-8610co" os.version="5.1.1.10">ERS-8610co (5.1.1.10)</example>
+    <example os.product="ERS-8610co" os.version="5.1.6.0">ERS-8610co (5.1.6.0)</example>
+    <example os.product="ERS-8610co" os.version="5.1.7.1">ERS-8610co (5.1.7.1)</example>
+    <example os.product="ERS-8806" os.version="7.1.0.0">ERS-8806 (7.1.0.0)</example>
+    <example os.product="ERS-8810" os.version="7.0.0.2">ERS-8810 (7.0.0.2)</example>
+    <example os.product="ERS-8810" os.version="7.1.0.1">ERS-8810 (7.1.0.1)</example>
     <param pos="0" name="os.vendor" value="Avaya"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="ERS"/>
@@ -939,10 +939,10 @@
 
   <fingerprint pattern="^Monarch (?:M\d+ FW Ver \d+\.\d / )?(\d+) (?:Print|Network) Adapter">
     <description>Avery Dennison Monarch barcode printers</description>
-    <example>Monarch 7411 Print Adapter</example>
-    <example>Monarch 7410 Print Adapter compatible with an HP JETDIRECT EX</example>
-    <example>Monarch M09855 FW Ver 6.2 / 7411 Network Adapter FW Ver CAMO-7.60, 802.11b-g WiFi FW Ver</example>
-    <example>Monarch M09855 FW Ver 6.2 / 7411 Network Adapter FW Ver CAMO-7.60, 802.11b-g WiFi FW Ver / Verifier</example>
+    <example os.product="7411">Monarch 7411 Print Adapter</example>
+    <example os.product="7410">Monarch 7410 Print Adapter compatible with an HP JETDIRECT EX</example>
+    <example os.product="7411">Monarch M09855 FW Ver 6.2 / 7411 Network Adapter FW Ver CAMO-7.60, 802.11b-g WiFi FW Ver</example>
+    <example os.product="7411">Monarch M09855 FW Ver 6.2 / 7411 Network Adapter FW Ver CAMO-7.60, 802.11b-g WiFi FW Ver / Verifier</example>
     <param pos="0" name="os.vendor" value="Avery Dennison"/>
     <param pos="0" name="os.device" value="Print Server"/>
     <param pos="1" name="os.product"/>
@@ -954,12 +954,12 @@
 
   <fingerprint pattern="^(DSR\d+) (\S+)$">
     <description>Avocent DSR series KVM-over-IP</description>
-    <example>DSR1010 03.00.01.00</example>
-    <example>DSR2030 03.04.00.07</example>
-    <example>DSR2161 03.00.01.00</example>
-    <example>DSR4010 03.00.00.02</example>
-    <example>DSR4020 03.06.01.07</example>
-    <example>DSR800 03.00.01.00</example>
+    <example os.product="DSR1010" os.version="03.00.01.00">DSR1010 03.00.01.00</example>
+    <example os.product="DSR2030" os.version="03.04.00.07">DSR2030 03.04.00.07</example>
+    <example os.product="DSR2161" os.version="03.00.01.00">DSR2161 03.00.01.00</example>
+    <example os.product="DSR4010" os.version="03.00.00.02">DSR4010 03.00.00.02</example>
+    <example os.product="DSR4020" os.version="03.06.01.07">DSR4020 03.06.01.07</example>
+    <example os.product="DSR800" os.version="03.00.01.00">DSR800 03.00.01.00</example>
     <param pos="0" name="os.vendor" value="Avocent"/>
     <param pos="0" name="os.device" value="KVM"/>
     <param pos="1" name="os.product"/>
@@ -968,14 +968,14 @@
 
   <fingerprint pattern="^(ESP-\d+) MI V(\S+)$">
     <description>Avocent ESP Serial Port</description>
-    <example>ESP-16 MI V3.13</example>
-    <example>ESP-16 MI V3.14b</example>
-    <example>ESP-2 MI V2.99</example>
-    <example>ESP-2 MI V3.08</example>
-    <example>ESP-4 MI V3.04</example>
-    <example>ESP-8 MI V3.12b</example>
-    <example>ESP-8 MI V3.13</example>
-    <example>ESP-8 MI V3.14b</example>
+    <example os.product="ESP-16" os.version="3.13">ESP-16 MI V3.13</example>
+    <example os.product="ESP-16" os.version="3.14b">ESP-16 MI V3.14b</example>
+    <example os.product="ESP-2" os.version="2.99">ESP-2 MI V2.99</example>
+    <example os.product="ESP-2" os.version="3.08">ESP-2 MI V3.08</example>
+    <example os.product="ESP-4" os.version="3.04">ESP-4 MI V3.04</example>
+    <example os.product="ESP-8" os.version="3.12b">ESP-8 MI V3.12b</example>
+    <example os.product="ESP-8" os.version="3.13">ESP-8 MI V3.13</example>
+    <example os.product="ESP-8" os.version="3.14b">ESP-8 MI V3.14b</example>
     <param pos="0" name="os.vendor" value="Avocent"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -1031,9 +1031,9 @@
 
   <fingerprint pattern="^Blue Coat PacketShaper (\S+)$">
     <description>Blue Coat PacketShaper</description>
-    <example>Blue Coat PacketShaper 8.4.1</example>
-    <example>Blue Coat PacketShaper 8.7.2_B174625_b65</example>
-    <example>Blue Coat PacketShaper 9.1.3</example>
+    <example os.version="8.4.1">Blue Coat PacketShaper 8.4.1</example>
+    <example os.version="8.7.2_B174625_b65">Blue Coat PacketShaper 8.7.2_B174625_b65</example>
+    <example os.version="9.1.3">Blue Coat PacketShaper 9.1.3</example>
     <param pos="0" name="os.vendor" value="Blue Coat"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
     <param pos="0" name="os.product" value="PacketShaper"/>
@@ -1058,9 +1058,9 @@
 
   <fingerprint pattern="^Brocade ((?:\S+ )?SAN Switch) Module for IBM eServer BladeCenter$">
     <description>Brocade SAN switch</description>
-    <example>Brocade 4Gb SAN Switch Module for IBM eServer BladeCenter</example>
-    <example>Brocade 8Gb SAN Switch Module for IBM eServer BladeCenter</example>
-    <example>Brocade SAN Switch Module for IBM eServer BladeCenter</example>
+    <example os.product="4Gb SAN Switch">Brocade 4Gb SAN Switch Module for IBM eServer BladeCenter</example>
+    <example os.product="8Gb SAN Switch">Brocade 8Gb SAN Switch Module for IBM eServer BladeCenter</example>
+    <example os.product="SAN Switch">Brocade SAN Switch Module for IBM eServer BladeCenter</example>
     <param pos="0" name="os.vendor" value="Brocade"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1069,10 +1069,10 @@
 
   <fingerprint pattern="^Brocade (?:Communications? Systems, Inc\. )?([^,\(]+)(?: \([^\)]+\))?,(?: Extended route scalability,)? IronWare Version V?(\S+)">
     <description>Brocade IronWare</description>
-    <example>Brocade Communications Systems, Inc. BigIron RX, IronWare Version V2.7.3aT143 Compiled on Jan 07 2011 at 19:37:41 labeled as V2.7.03a</example>
-    <example>Brocade Communications Systems, Inc. FESX424-PREM, IronWare Version 07.0.01bT3e3 Compiled on Mar 17 2010 at 23:02:11 labeled as SXR07001b</example>
-    <example>Brocade NetIron CER, IronWare Version V5.2.0dT183 Compiled on Mar 02 2012 at 19:15:05 labeled as V5.2.00d</example>
-    <example>Brocade Backbone (System Mode: MLX), IronWare Version V5.1.0dT163 Compiled on Aug 19 2011 at 19:00:39 labeled as V5.1.00d</example>
+    <example os.product="BigIron RX" os.version="2.7.3aT143">Brocade Communications Systems, Inc. BigIron RX, IronWare Version V2.7.3aT143 Compiled on Jan 07 2011 at 19:37:41 labeled as V2.7.03a</example>
+    <example os.product="FESX424-PREM" os.version="07.0.01bT3e3">Brocade Communications Systems, Inc. FESX424-PREM, IronWare Version 07.0.01bT3e3 Compiled on Mar 17 2010 at 23:02:11 labeled as SXR07001b</example>
+    <example os.product="NetIron CER" os.version="5.2.0dT183">Brocade NetIron CER, IronWare Version V5.2.0dT183 Compiled on Mar 02 2012 at 19:15:05 labeled as V5.2.00d</example>
+    <example os.product="Backbone" os.version="5.1.0dT163">Brocade Backbone (System Mode: MLX), IronWare Version V5.1.0dT163 Compiled on Aug 19 2011 at 19:00:39 labeled as V5.1.00d</example>
     <param pos="0" name="os.vendor" value="Brocade"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="IronWare"/>
@@ -1082,11 +1082,11 @@
 
   <fingerprint pattern="^Brocade (?:Communications? Systems, Inc\. )?([^,\(]+)(?: \([^\)]+\))?,(?: Extended route scalability,)? TrafficWork Version V?(\S+)$">
     <description>Brocade TrafficWare</description>
-    <example>Brocade Communications Systems, Inc. ServerIron ADX 1008-1-PREM, TrafficWork Version 12.4.00T401</example>
-    <example>Brocade Communications Systems, Inc. ServerIron ADX 1008F-1, TrafficWork Version 12.3.03T401</example>
-    <example>Brocade Communications Systems, Inc. ServerIron ADX 4000, TrafficWork Version 12.3.01T403</example>
-    <example>Brocade Communications Systems, Inc. ServerIron ADX 4000, TrafficWork Version 12.3.01dT401</example>
-    <example>Brocade Communications Systems, Inc. ServerIron ADX 4000, TrafficWork Version 12.4.00bT403</example>
+    <example os.product="ServerIron ADX 1008-1-PREM" os.version="12.4.00T401">Brocade Communications Systems, Inc. ServerIron ADX 1008-1-PREM, TrafficWork Version 12.4.00T401</example>
+    <example os.product="ServerIron ADX 1008F-1" os.version="12.3.03T401">Brocade Communications Systems, Inc. ServerIron ADX 1008F-1, TrafficWork Version 12.3.03T401</example>
+    <example os.product="ServerIron ADX 4000" os.version="12.3.01T403">Brocade Communications Systems, Inc. ServerIron ADX 4000, TrafficWork Version 12.3.01T403</example>
+    <example os.product="ServerIron ADX 4000" os.version="12.3.01dT401">Brocade Communications Systems, Inc. ServerIron ADX 4000, TrafficWork Version 12.3.01dT401</example>
+    <example os.product="ServerIron ADX 4000" os.version="12.4.00bT403">Brocade Communications Systems, Inc. ServerIron ADX 4000, TrafficWork Version 12.4.00bT403</example>
     <param pos="0" name="os.vendor" value="Brocade"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="TrafficWare"/>
@@ -1141,8 +1141,8 @@
 
   <fingerprint pattern="^SP NC-[^,]+, Firmware Ver\.(\S+)">
     <description>Brother multifunction device</description>
-    <example>SP NC-6300h, Firmware Ver.B  ,MID 5CS-157</example>
-    <example>SP NC-6300h, Firmware Ver.C  ,MID 5CS-157</example>
+    <example os.version="B">SP NC-6300h, Firmware Ver.B  ,MID 5CS-157</example>
+    <example os.version="C">SP NC-6300h, Firmware Ver.C  ,MID 5CS-157</example>
     <param pos="0" name="os.certainty" value="0.7"/>
     <param pos="0" name="os.vendor" value="Brother"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1151,22 +1151,22 @@
 
   <fingerprint pattern="^Brother (NC-\d+\S+),\s*Firmware Ver\.\s?([^\s,]+)">
     <description>Brother multifunction device - variant 1</description>
-    <example>Brother NC-130h, Firmware Ver.0.09  ,MID 8CA-A17-001</example>
-    <example>Brother NC-6800h, Firmware Ver.1.04  (09.05.08),MID 8C5-D61,FID 2</example>
-    <example>Brother NC-6400h, Firmware Ver.1.11 (06.12.20),MID 84UZ92</example>
-    <example>Brother NC-170h, Firmware Ver.0.09 ,MID 8CA-H11-001</example>
-    <example>Brother NC-8200h, Firmware Ver.1.03 (10.05.20),MID 84UC07</example>
-    <example>Brother NC-110h, Firmware Ver.A ,MID 8CA-814-201</example>
-    <example>Brother NC-140w, Firmware Ver.0.09 ,MID 8CA-A17-001</example>
-    <example>Brother NC-2010p, Firmware Ver. 3.62 (99.02.19</example>
-    <example>Brother NC-220w, Firmware Ver.0.09 ,MID 8CA-K13-001</example>
-    <example>Brother NC-220w, Firmware Ver.0.09 ,MID 8CA-K13-101</example>
-    <example>Brother NC-270w, Firmware Ver.0.01 (11.05.24),MID 8CA-P01-001</example>
-    <example>Brother NC-3100s,Firmware Ver.4.69,MID 54S601</example>
-    <example>Brother NC-6200h, Firmware Ver.A ,MID 8C5-A15,FID 2</example>
-    <example>Brother NC-6300h, Firmware Ver.K ,MID 5CS-101</example>
-    <example>Brother NC-7200w, Firmware Ver.1.03 (06.04.11),MID 8C5-B17,FID 2</example>
-    <example>Brother NC-7900w, Firmware Ver.1.04 (12.02.15),MID 84U-D05</example>
+    <example os.product="NC-130h" os.version="0.09">Brother NC-130h, Firmware Ver.0.09  ,MID 8CA-A17-001</example>
+    <example os.product="NC-6800h" os.version="1.04">Brother NC-6800h, Firmware Ver.1.04  (09.05.08),MID 8C5-D61,FID 2</example>
+    <example os.product="NC-6400h" os.version="1.11">Brother NC-6400h, Firmware Ver.1.11 (06.12.20),MID 84UZ92</example>
+    <example os.product="NC-170h" os.version="0.09">Brother NC-170h, Firmware Ver.0.09 ,MID 8CA-H11-001</example>
+    <example os.product="NC-8200h" os.version="1.03">Brother NC-8200h, Firmware Ver.1.03 (10.05.20),MID 84UC07</example>
+    <example os.product="NC-110h" os.version="A">Brother NC-110h, Firmware Ver.A ,MID 8CA-814-201</example>
+    <example os.product="NC-140w" os.version="0.09">Brother NC-140w, Firmware Ver.0.09 ,MID 8CA-A17-001</example>
+    <example os.product="NC-2010p" os.version="3.62">Brother NC-2010p, Firmware Ver. 3.62 (99.02.19</example>
+    <example os.product="NC-220w" os.version="0.09">Brother NC-220w, Firmware Ver.0.09 ,MID 8CA-K13-001</example>
+    <example os.product="NC-220w" os.version="0.09">Brother NC-220w, Firmware Ver.0.09 ,MID 8CA-K13-101</example>
+    <example os.product="NC-270w" os.version="0.01">Brother NC-270w, Firmware Ver.0.01 (11.05.24),MID 8CA-P01-001</example>
+    <example os.product="NC-3100s" os.version="4.69">Brother NC-3100s,Firmware Ver.4.69,MID 54S601</example>
+    <example os.product="NC-6200h" os.version="A">Brother NC-6200h, Firmware Ver.A ,MID 8C5-A15,FID 2</example>
+    <example os.product="NC-6300h" os.version="K">Brother NC-6300h, Firmware Ver.K ,MID 5CS-101</example>
+    <example os.product="NC-7200w" os.version="1.03">Brother NC-7200w, Firmware Ver.1.03 (06.04.11),MID 8C5-B17,FID 2</example>
+    <example os.product="NC-7900w" os.version="1.04">Brother NC-7900w, Firmware Ver.1.04 (12.02.15),MID 84U-D05</example>
     <param pos="0" name="os.certainty" value="0.7"/>
     <param pos="0" name="os.vendor" value="Brother"/>
     <param pos="1" name="os.product"/>
@@ -1180,8 +1180,8 @@
 
   <fingerprint pattern="^C&amp;D Technologies SageNET (\S+) V(\S+)$">
     <description>C&amp;D Technologies SafeNET</description>
-    <example>C&amp;D Technologies SageNET 169-414 V1.15</example>
-    <example>C&amp;D Technologies SageNET 169-414 V1.28</example>
+    <example os.product="169-414" os.version="1.15">C&amp;D Technologies SageNET 169-414 V1.15</example>
+    <example os.product="169-414" os.version="1.28">C&amp;D Technologies SageNET 169-414 V1.28</example>
     <param pos="0" name="os.vendor" value="C&amp;D Technologies"/>
     <param pos="0" name="os.family" value="SageNET"/>
     <param pos="1" name="os.product"/>
@@ -1194,11 +1194,11 @@
 
   <fingerprint pattern="^Cabletron(?: Systems(?:, Inc\.)?)? (\S+) Rev (\S+) .* ofc$">
     <description>Cabletron Switch</description>
-    <example>Cabletron 2E42-27 Rev 04.09.08 08/25/99--02:09 ofc</example>
-    <example>Cabletron Systems HSIM-W6 Rev 02.01.09 IFO Based Switch 04/30/99--12:39 ofc</example>
-    <example>Cabletron Systems, Inc. 2E42-27R Rev 04.07.07 10/26/98--19:36 ofc</example>
-    <example>Cabletron Systems, Inc. 2H252-25R Rev 02.00.17 10/30/98--15:00 ofc</example>
-    <example>Cabletron Systems, Inc. 6H252-17 Rev 05.08.30 03/31/08--17:14 ofc</example>
+    <example os.product="2E42-27" os.version="04.09.08">Cabletron 2E42-27 Rev 04.09.08 08/25/99--02:09 ofc</example>
+    <example os.product="HSIM-W6" os.version="02.01.09">Cabletron Systems HSIM-W6 Rev 02.01.09 IFO Based Switch 04/30/99--12:39 ofc</example>
+    <example os.product="2E42-27R" os.version="04.07.07">Cabletron Systems, Inc. 2E42-27R Rev 04.07.07 10/26/98--19:36 ofc</example>
+    <example os.product="2H252-25R" os.version="02.00.17">Cabletron Systems, Inc. 2H252-25R Rev 02.00.17 10/30/98--15:00 ofc</example>
+    <example os.product="6H252-17" os.version="05.08.30">Cabletron Systems, Inc. 6H252-17 Rev 05.08.30 03/31/08--17:14 ofc</example>
     <param pos="0" name="os.vendor" value="Cabletron"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1207,8 +1207,8 @@
 
   <fingerprint pattern="^Cabletron (\S+) Version (\S+) \S+$">
     <description>Cabletron Switch - time variant</description>
-    <example>Cabletron ELS10-26 Version 1.01.02 06/09/98--12:51:12</example>
-    <example>Cabletron ELS10-26 Version 1.02.00 04/05/99--14:27:16</example>
+    <example os.product="ELS10-26" os.version="1.01.02">Cabletron ELS10-26 Version 1.01.02 06/09/98--12:51:12</example>
+    <example os.product="ELS10-26" os.version="1.02.00">Cabletron ELS10-26 Version 1.02.00 04/05/99--14:27:16</example>
     <param pos="0" name="os.vendor" value="Cabletron"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1217,11 +1217,11 @@
 
   <fingerprint pattern="^Cabletron (\S+) (?:Rev\.|SW:)(\S+)$">
     <description>Cabletron Switch - software variant</description>
-    <example>Cabletron ELS100-16TX Rev.1.02.00</example>
-    <example>Cabletron ELS100-24TXG SW:2.01.00</example>
-    <example>Cabletron ELS100-24TXG SW:2.2.0.1</example>
-    <example>Cabletron ELS100-24TXM SW:2.00.02</example>
-    <example>Cabletron ELS100-24TXM SW:2.1.2.4</example>
+    <example os.product="ELS100-16TX" os.version="1.02.00">Cabletron ELS100-16TX Rev.1.02.00</example>
+    <example os.product="ELS100-24TXG" os.version="2.01.00">Cabletron ELS100-24TXG SW:2.01.00</example>
+    <example os.product="ELS100-24TXG" os.version="2.2.0.1">Cabletron ELS100-24TXG SW:2.2.0.1</example>
+    <example os.product="ELS100-24TXM" os.version="2.00.02">Cabletron ELS100-24TXM SW:2.00.02</example>
+    <example os.product="ELS100-24TXM" os.version="2.1.2.4">Cabletron ELS100-24TXM SW:2.1.2.4</example>
     <param pos="0" name="os.vendor" value="Cabletron"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1247,8 +1247,8 @@
 
   <fingerprint pattern="^(SSR \S+) - Cabletron Systems, Inc. Firmware Version: (\S+) PROM Version: \S+$">
     <description>Cabletron Switch - firmware variant</description>
-    <example>SSR 2000 - Cabletron Systems, Inc. Firmware Version: 2.2.0.1 PROM Version: prom-1.1.0.5</example>
-    <example>SSR 8000 - Cabletron Systems, Inc. Firmware Version: 3.1.0.0 PROM Version: prom-2.0.1.1</example>
+    <example os.product="SSR 2000" os.version="2.2.0.1">SSR 2000 - Cabletron Systems, Inc. Firmware Version: 2.2.0.1 PROM Version: prom-1.1.0.5</example>
+    <example os.product="SSR 8000" os.version="3.1.0.0">SSR 8000 - Cabletron Systems, Inc. Firmware Version: 3.1.0.0 PROM Version: prom-2.0.1.1</example>
     <param pos="0" name="os.vendor" value="Cabletron"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1257,7 +1257,7 @@
 
   <fingerprint pattern="^SmartSwitch Router (\S+) v(\S+) Copyright \(c\) 1996-1999 Cabletron Systems, Inc\. All Rights Reserved$">
     <description>Cabletron Router</description>
-    <example>SmartSwitch Router 245 v3.7.1 Copyright (c) 1996-1999 Cabletron Systems, Inc. All Rights Reserved</example>
+    <example os.product="245" os.version="3.7.1">SmartSwitch Router 245 v3.7.1 Copyright (c) 1996-1999 Cabletron Systems, Inc. All Rights Reserved</example>
     <param pos="0" name="os.vendor" value="Cabletron"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -1266,9 +1266,9 @@
 
   <fingerprint pattern="^Enterasys Networks, Inc\. (.*?) Rev (\S+) .* ofc$">
     <description>Enterasys Switch - date variant</description>
-    <example>Enterasys Networks, Inc. 1H582-51 Rev 03.05.09.1 07/28/2005--17:47 ofc</example>
-    <example>Enterasys Networks, Inc. Matrix N3 Platinum Rev 05.42.04 06/07/2007--17:19 ofc</example>
-    <example>Enterasys Networks, Inc. NSA Chassis Rev 07.41.03.0009 01/05/2012--10:33 ofc</example>
+    <example os.product="1H582-51" os.version="03.05.09.1">Enterasys Networks, Inc. 1H582-51 Rev 03.05.09.1 07/28/2005--17:47 ofc</example>
+    <example os.product="Matrix N3 Platinum" os.version="05.42.04">Enterasys Networks, Inc. Matrix N3 Platinum Rev 05.42.04 06/07/2007--17:19 ofc</example>
+    <example os.product="NSA Chassis" os.version="07.41.03.0009">Enterasys Networks, Inc. NSA Chassis Rev 07.41.03.0009 01/05/2012--10:33 ofc</example>
     <param pos="0" name="os.vendor" value="Enterasys"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1277,7 +1277,7 @@
 
   <fingerprint pattern="^Enterasys Networks, Inc\. (\S+) Rev (\S+)$">
     <description>Enterasys Switch</description>
-    <example>Enterasys Networks, Inc. B3G124-24 Rev 01.02.01.0004</example>
+    <example os.product="B3G124-24" os.version="01.02.01.0004">Enterasys Networks, Inc. B3G124-24 Rev 01.02.01.0004</example>
     <param pos="0" name="os.vendor" value="Enterasys"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1290,9 +1290,9 @@
 
   <fingerprint pattern="^Canon (iR ?\S+(?: [A-Z0-9]\S+)?)(?: /P)?(?: EEPROM \S+)?$">
     <description>Canon iR multifunction device</description>
-    <example>Canon iR C3220-C1 /P</example>
-    <example>Canon iR105PLUS-M3 /P</example>
-    <example>Canon iR6570 /P</example>
+    <example os.product="iR C3220-C1">Canon iR C3220-C1 /P</example>
+    <example os.product="iR105PLUS-M3">Canon iR105PLUS-M3 /P</example>
+    <example os.product="iR6570">Canon iR6570 /P</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.family" value="iR Series"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -1301,13 +1301,13 @@
 
   <fingerprint pattern="^Canon (iPR ?\S+(?: [A-Z0-9]\S+)?)(?: /P)?(?: EEPROM \S+)?$">
     <description>Canon iPR multifunction device</description>
-    <example>Canon iPR C1 /P</example>
-    <example>Canon iPR C1-Q1 /P</example>
-    <example>Canon iPR C1-Q2 /P</example>
-    <example>Canon iPR C1-T1 /P</example>
-    <example>Canon iPR C1PLUS-T1 /P</example>
-    <example>Canon iPR C7000VP-A3100 /P</example>
-    <example>Canon iPR C7010VP-A3200 /P</example>
+    <example os.product="iPR C1">Canon iPR C1 /P</example>
+    <example os.product="iPR C1-Q1">Canon iPR C1-Q1 /P</example>
+    <example os.product="iPR C1-Q2">Canon iPR C1-Q2 /P</example>
+    <example os.product="iPR C1-T1">Canon iPR C1-T1 /P</example>
+    <example os.product="iPR C1PLUS-T1">Canon iPR C1PLUS-T1 /P</example>
+    <example os.product="iPR C7000VP-A3100">Canon iPR C7000VP-A3100 /P</example>
+    <example os.product="iPR C7010VP-A3200">Canon iPR C7010VP-A3200 /P</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.family" value="iPR Series"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -1316,15 +1316,15 @@
 
   <fingerprint pattern="^Canon LASER SHOT (\S+)(?: /P)?(?: EEPROM \S+)?$">
     <description>Canon Laser Shot multifunction device</description>
-    <example>Canon LASER SHOT LBP-1310 /P</example>
-    <example>Canon LASER SHOT LBP-1310 /P EEPROM 1104</example>
-    <example>Canon LASER SHOT LBP-1310 /P EEPROM 1200</example>
-    <example>Canon LASER SHOT LBP-1910 /P</example>
-    <example>Canon LASER SHOT LBP-2510 /P EEPROM 1204</example>
-    <example>Canon LASER SHOT LBP-2710 /P EEPROM 1206</example>
-    <example>Canon LASER SHOT LBP-2810 /P</example>
-    <example>Canon LASER SHOT LBP-910 /P</example>
-    <example>Canon LASER SHOT LBP-950 /P</example>
+    <example os.product="LBP-1310">Canon LASER SHOT LBP-1310 /P</example>
+    <example os.product="LBP-1310">Canon LASER SHOT LBP-1310 /P EEPROM 1104</example>
+    <example os.product="LBP-1310">Canon LASER SHOT LBP-1310 /P EEPROM 1200</example>
+    <example os.product="LBP-1910">Canon LASER SHOT LBP-1910 /P</example>
+    <example os.product="LBP-2510">Canon LASER SHOT LBP-2510 /P EEPROM 1204</example>
+    <example os.product="LBP-2710">Canon LASER SHOT LBP-2710 /P EEPROM 1206</example>
+    <example os.product="LBP-2810">Canon LASER SHOT LBP-2810 /P</example>
+    <example os.product="LBP-910">Canon LASER SHOT LBP-910 /P</example>
+    <example os.product="LBP-950">Canon LASER SHOT LBP-950 /P</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.family" value="Laser Shot"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -1333,8 +1333,8 @@
 
   <fingerprint pattern="^Canon imageCLASS (\S+)(?: /P)?(?: EEPROM \S+)?$">
     <description>Canon imageCLASS multifunction device</description>
-    <example>Canon imageCLASS C2500 /P</example>
-    <example>Canon imageCLASS C3500 /P</example>
+    <example os.product="C2500">Canon imageCLASS C2500 /P</example>
+    <example os.product="C3500">Canon imageCLASS C3500 /P</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.family" value="imageCLASS"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -1343,9 +1343,9 @@
 
   <fingerprint pattern="^Canon Inc\., (\S+) Printer(?: /P)?(?: EEPROM \S+)?$">
     <description>Canon printer - Inc variant</description>
-    <example>Canon Inc., LBP-1760e Printer /P</example>
-    <example>Canon Inc., LBP-1760e Printer</example>
-    <example>Canon Inc., LBP-3260 Printer /P</example>
+    <example os.product="LBP-1760e">Canon Inc., LBP-1760e Printer /P</example>
+    <example os.product="LBP-1760e">Canon Inc., LBP-1760e Printer</example>
+    <example os.product="LBP-3260">Canon Inc., LBP-3260 Printer /P</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -1355,18 +1355,18 @@
 
   <fingerprint pattern="(?i)^Canon(?: Inc\.)? (?:Color )?(?:Large Format )?(?:LASER CLASS )?(?:LASER SHOT )?(\S+(?: [A-Z0-9]\S+)?)(?: Series)?(?: \([^\)]+\))?(?: /P)?(?: EEPROM \S+)?$">
     <description>Canon printer</description>
-    <example>Canon MF8170 /P</example>
-    <example>Canon MF5900 Series /P</example>
-    <example>Canon CLC-iR C2620-C2 /P</example>
-    <example>Canon CLC4040-iR C4580-H1 /P</example>
-    <example>Canon CLC5151-iR C5180-H1 /P</example>
-    <example>Canon COLOR LASER SHOT LBP-2360 /P</example>
-    <example>Canon Inc. LASER CLASS 3170 /P</example>
-    <example>Canon LASER CLASS 700</example>
-    <example>Canon LBP5500 /P EEPROM 1100</example>
-    <example>Canon Large Format W6200PG /P</example>
-    <example>Canon MF6500 Series (FAX)</example>
-    <example>Canon MF6500 Series (UFRII LT)</example>
+    <example os.product="MF8170">Canon MF8170 /P</example>
+    <example os.product="MF5900 Series">Canon MF5900 Series /P</example>
+    <example os.product="CLC-iR C2620-C2">Canon CLC-iR C2620-C2 /P</example>
+    <example os.product="CLC4040-iR C4580-H1">Canon CLC4040-iR C4580-H1 /P</example>
+    <example os.product="CLC5151-iR C5180-H1">Canon CLC5151-iR C5180-H1 /P</example>
+    <example os.product="LBP-2360">Canon COLOR LASER SHOT LBP-2360 /P</example>
+    <example os.product="3170">Canon Inc. LASER CLASS 3170 /P</example>
+    <example os.product="700">Canon LASER CLASS 700</example>
+    <example os.product="LBP5500">Canon LBP5500 /P EEPROM 1100</example>
+    <example os.product="W6200PG">Canon Large Format W6200PG /P</example>
+    <example os.product="MF6500 Series">Canon MF6500 Series (FAX)</example>
+    <example os.product="MF6500 Series">Canon MF6500 Series (UFRII LT)</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="1" name="os.product"/>
@@ -1374,7 +1374,7 @@
 
   <fingerprint pattern="^Canon Network Camera (\S+)$">
     <description>Canon Camera</description>
-    <example>Canon Network Camera VB-C60</example>
+    <example os.product="VB-C60">Canon Network Camera VB-C60</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.device" value="IP Camera"/>
     <param pos="1" name="os.product"/>
@@ -1382,11 +1382,11 @@
 
   <fingerprint pattern="^Canon Network .* Board-(\S+)$">
     <description>Canon Network Printer Board</description>
-    <example>Canon Network Interface Board-C1</example>
-    <example>Canon Network Multi-PDL Printer Board-H1</example>
-    <example>Canon Network Printer Board-E1</example>
-    <example>Canon Network Printer Board-F1</example>
-    <example>Canon Network Printer Board-K1</example>
+    <example os.version="C1">Canon Network Interface Board-C1</example>
+    <example os.version="H1">Canon Network Multi-PDL Printer Board-H1</example>
+    <example os.version="E1">Canon Network Printer Board-E1</example>
+    <example os.version="F1">Canon Network Printer Board-F1</example>
+    <example os.version="K1">Canon Network Printer Board-K1</example>
     <param pos="0" name="os.vendor" value="Canon"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.product" value="Printer Board"/>
@@ -1437,9 +1437,9 @@
 
   <fingerprint pattern="^(?:IP\S+ rev\s*[^,]*,\s)?IPSO (\S+) (\S+)-(?:BUILD|GA|FCS)0?(\S+) (?:releng|root) (\S+).*i386$">
     <description>Check Point IPSO firewall</description>
-    <example>IPSO hostname 4.1-BUILD022 releng 1515  11.15.2006-180244 i386</example>
-    <example>IP300 rev A02, IPSO b7dc-cimip350-02 3.7.1-BUILD004 releng 1227 11.06.2003-010000 i386</example>
-    <example>IP650 rev AA729002-408, IPSO semalfw05 3.7.1-BUILD020 releng 1299 02.09.2005-020308 i386</example>
+    <example os.version="4.1" host.name="hostname" os.version.version="22" os.version.version.version="1515">IPSO hostname 4.1-BUILD022 releng 1515  11.15.2006-180244 i386</example>
+    <example os.version="3.7.1" host.name="b7dc-cimip350-02" os.version.version="04" os.version.version.version="1227">IP300 rev A02, IPSO b7dc-cimip350-02 3.7.1-BUILD004 releng 1227 11.06.2003-010000 i386</example>
+    <example os.version="3.7.1" host.name="semalfw05" os.version.version="20" os.version.version.version="1299">IP650 rev AA729002-408, IPSO semalfw05 3.7.1-BUILD020 releng 1299 02.09.2005-020308 i386</example>
     <param pos="0" name="os.certainty" value="0.95"/>
     <param pos="0" name="os.vendor" value="Check Point"/>
     <param pos="0" name="os.family" value="IPSO"/>
@@ -1467,7 +1467,7 @@
 
   <fingerprint pattern="^(\S{1,32}) OPTICAL SW:(\S+) .* Ciena \(R\) Corporation$">
     <description>Ciena Optical - software version variant</description>
-    <example>6500 OPTICAL SW:0810 BN:HD (c) Ciena (R) Corporation</example>
+    <example os.product="6500" os.version="0810">6500 OPTICAL SW:0810 BN:HD (c) Ciena (R) Corporation</example>
     <param pos="0" name="os.vendor" value="Ciena"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="Packet-Optical"/>
@@ -1485,7 +1485,7 @@
 
   <fingerprint pattern="^Ciena CN (\S+) V(\S+) \(MIBs \S+\)$">
     <description>Ciena CN</description>
-    <example>Ciena CN 3106 V1.0.4(04) (MIBs V1.6.8)</example>
+    <example os.product="3106" os.version="1.0.4(04)">Ciena CN 3106 V1.0.4(04) (MIBs V1.6.8)</example>
     <param pos="0" name="os.vendor" value="Ciena"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -1605,7 +1605,7 @@
 
   <fingerprint pattern="^Cisco 761 Software Version (.*) -">
     <description>Cisco 761</description>
-    <example>Cisco 761 Software Version c760-i.b.NET3 4.2(3) - Aug 21 1998 17:05:41 ISDN Stack Revision NET3 2.10</example>
+    <example os.version="c760-i.b.NET3 4.2(3)">Cisco 761 Software Version c760-i.b.NET3 4.2(3) - Aug 21 1998 17:05:41 ISDN Stack Revision NET3 2.10</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="760 Series"/>
@@ -1616,9 +1616,9 @@
 
   <fingerprint pattern="^Cisco Systems, Inc\./VPN 3000 Concentrator(?: Series)? Version (\S+) built">
     <description>Cisco VPN 3000 Concentrator</description>
-    <example>Cisco Systems, Inc./VPN 3000 Concentrator Series Version 3.0.2.Rel built by vmurphy on Apr 05 2001 21:41:33</example>
-    <example>Cisco Systems, Inc./VPN 3000 Concentrator Version 4.1.3.Rel built by vmurphy on Apr 12 2004 04:06:15</example>
-    <example>Cisco Systems, Inc./VPN 3000 Concentrator Version 4.1.7.H built by vmurphy on Oct 03 2005 23:20:53</example>
+    <example os.version="3.0.2.Rel">Cisco Systems, Inc./VPN 3000 Concentrator Series Version 3.0.2.Rel built by vmurphy on Apr 05 2001 21:41:33</example>
+    <example os.version="4.1.3.Rel">Cisco Systems, Inc./VPN 3000 Concentrator Version 4.1.3.Rel built by vmurphy on Apr 12 2004 04:06:15</example>
+    <example os.version="4.1.7.H">Cisco Systems, Inc./VPN 3000 Concentrator Version 4.1.7.H built by vmurphy on Oct 03 2005 23:20:53</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="VPN 3000 Concentrator"/>
@@ -1629,15 +1629,15 @@
 
   <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-[^\)]+\), Version ([^, ]+)[,\s]?">
     <description>Cisco Catalyst Network Analysis Module - version variant</description>
-    <example>Network Analysis Module (WS-SVC-NAM-1), Version 3.1(1)
+    <example os.version="3.1(1)&#10;Copyright">Network Analysis Module (WS-SVC-NAM-1), Version 3.1(1)
 Copyright (c) 1999-2003 by cisco Systems, Inc.</example>
-    <example>Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.3(0.9)
+    <example os.version="3.3(0.9)&#10;Copyright">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.3(0.9)
 Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
-    <example>Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.4(0.9)
+    <example os.version="3.4(0.9)&#10;Copyright">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.4(0.9)
 Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
-    <example>Cisco Network Analysis Module (WS-SVC-NAM-2), Version 5.0(1) RELEASE SOFTWARE [fc4]</example>
-    <example>Cisco Network Analysis Module (WS-SVC-NAM-2-250S), Version 4.1(1) RELEASE SOFTWARE [fc2]</example>
-    <example>Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.6(1b)</example>
+    <example os.version="5.0(1)">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 5.0(1) RELEASE SOFTWARE [fc4]</example>
+    <example os.version="4.1(1)">Cisco Network Analysis Module (WS-SVC-NAM-2-250S), Version 4.1(1) RELEASE SOFTWARE [fc2]</example>
+    <example os.version="3.6(1b)">Cisco Network Analysis Module (WS-SVC-NAM-2), Version 3.6(1b)</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="NAM"/>
@@ -1652,7 +1652,7 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
 
   <fingerprint pattern="^(?:Cisco )?Network Analysis Module \(WS-([^\-]+)-NAM\)$">
     <description>Cisco Catalyst Network Analysis Module</description>
-    <example>Network Analysis Module (WS-X6380-NAM)</example>
+    <example hw.product="X6380">Network Analysis Module (WS-X6380-NAM)</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.product" value="NAM"/>
@@ -1667,7 +1667,7 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     <description>Cisco IOS</description>
     <!-- Cisco Internetwork Operating System Software \r\nIOS (tm) C1700 Software (C1700-Y-M), Version 12.2(4)YB, EARLY DEPLOYMENT RELEASE SOFTWARE (fc1)\r\nSynched to technology version 12.2(6.8)T2\r\nTAC Support: http://www.cisco.com/tac\r\nCopyright (c) 1986-2002 by ci -->
 
-    <example _encoding="base64">
+    <example _encoding="base64" os.version="12.2(4)YB">
       Q2lzY28gSW50ZXJuZXR3b3JrIE9wZXJhdGluZyBTeXN0ZW0gU29mdHdhcmUgDQpJT1MgKHRtK
       SBDMTcwMCBTb2Z0d2FyZSAoQzE3MDAtWS1NKSwgVmVyc2lvbiAxMi4yKDQpWUIsIEVBUkxZIE
       RFUExPWU1FTlQgUkVMRUFTRSBTT0ZUV0FSRSAoZmMxKQ0KU3luY2hlZCB0byB0ZWNobm9sb2d
@@ -1676,7 +1676,7 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     </example>
     <!-- Cisco Internetwork Operating System Software \r\nIOS (tm) C2600 Software (C2600-I-M), Version 12.0(3)T3,  RELEASE SOFTWARE (fc1)\r\nCopyright (c) 1986-1999 by cisco Systems, Inc\r\n\nCompiled Thu 15-Apr-99 15:41 by kpma -->
 
-    <example _encoding="base64">
+    <example _encoding="base64" os.version="12.0(3)T3">
       Q2lzY28gSW50ZXJuZXR3b3JrIE9wZXJhdGluZyBTeXN0ZW0gU29mdHdhcmUgDQpJT1MgKHRtK
       SBDMjYwMCBTb2Z0d2FyZSAoQzI2MDAtSS1NKSwgVmVyc2lvbiAxMi4wKDMpVDMsICBSRUxFQV
       NFIFNPRlRXQVJFIChmYzEpDQpDb3B5cmlnaHQgKGMpIDE5ODYtMTk5OSBieSBjaXNjbyBTeXN
@@ -1684,7 +1684,7 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
     </example>
     <!-- Cisco IOS Software, C1700 Software (C1700-ADVSECURITYK9-M), Version 12.3(11)YZ2, RELEASE SOFTWARE (fc2)\r\nTechnical Support: http://www.cisco.com/techsupport\r\nCopyright (c) 1986-2007 by Cisco Systems, Inc\r\nCompiled Wed 08-Aug-07 19:22 by dchih -->
 
-    <example _encoding="base64">
+    <example _encoding="base64" os.version="12.3(11)YZ2">
       Q2lzY28gSU9TIFNvZnR3YXJlLCBDMTcwMCBTb2Z0d2FyZSAoQzE3MDAtQURWU0VDVVJJVFlLO
       S1NKSwgVmVyc2lvbiAxMi4zKDExKVlaMiwgUkVMRUFTRSBTT0ZUV0FSRSAoZmMyKQ0KVGVjaG
       5pY2FsIFN1cHBvcnQ6IGh0dHA6Ly93d3cuY2lzY28uY29tL3RlY2hzdXBwb3J0DQpDb3B5cml
@@ -1702,23 +1702,23 @@ Copyright (c) 1999-2004 by cisco Systems, Inc.</example>
 
   <fingerprint pattern="^Cisco Systems, Inc\. \S+[\r\n]+Cisco Catalyst Operating System Software, Version (\S+)[\r\n]+Copyright \(c\)">
     <description>Cisco Catalyst - Inc variant</description>
-    <example>Cisco Systems, Inc. WS-C2948
+    <example os.version="6.3(5)">Cisco Systems, Inc. WS-C2948
 Cisco Catalyst Operating System Software, Version 6.3(5)
 Copyright (c) 1995-2002 by Cisco Systems, Inc.
 </example>
-    <example>Cisco Systems, Inc. WS-C2948
+    <example os.version="8.1(3)">Cisco Systems, Inc. WS-C2948
 Cisco Catalyst Operating System Software, Version 8.1(3)
 Copyright (c) 1995-2003 by Cisco Systems, Inc.
 </example>
-    <example>Cisco Systems, Inc. WS-C2948
+    <example os.version="5.5(10)">Cisco Systems, Inc. WS-C2948
 Cisco Catalyst Operating System Software, Version 5.5(10)
 Copyright (c) 1995-2001 by Cisco Systems, Inc.
 </example>
-    <example>Cisco Systems, Inc. WS-C2980G-A
+    <example os.version="6.3(7)">Cisco Systems, Inc. WS-C2980G-A
 Cisco Catalyst Operating System Software, Version 6.3(7)
 Copyright (c) 1995-2002 by Cisco Systems, Inc.
 </example>
-    <example>Cisco Systems, Inc. WS-C2948
+    <example os.version="5.5(16)">Cisco Systems, Inc. WS-C2948
 Cisco Catalyst Operating System Software, Version 5.5(16)
 Copyright (c) 1995-2002 by Cisco Systems, Inc.
 </example>
@@ -1733,7 +1733,7 @@ Copyright (c) 1995-2002 by Cisco Systems, Inc.
 
   <fingerprint pattern="^Cisco Systems \S+[\r\n]+Cisco Catalyst Operating System Software, Version (\S+)[\r\n]+Copyright \(c\)">
     <description>Cisco Catalyst</description>
-    <example>Cisco Systems WS-C6009
+    <example os.version="8.3(7)">Cisco Systems WS-C6009
 Cisco Catalyst Operating System Software, Version 8.3(7)
 Copyright (c) 1995-2005 by Cisco Systems
 </example>
@@ -1748,7 +1748,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Hardware:(\S+),.*Software:UCOS (\S+)$">
     <description>Cisco UCOS</description>
-    <example>Hardware:7845H2, 2 Intel(R) Xeon(R) CPU 5140 @ 2.33GHz, 4096 MB Memory: Software:UCOS 3.0.0.0-54</example>
+    <example os.product="7845H2" os.version="3.0.0.0-54">Hardware:7845H2, 2 Intel(R) Xeon(R) CPU 5140 @ 2.33GHz, 4096 MB Memory: Software:UCOS 3.0.0.0-54</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="UCOS"/>
@@ -1760,7 +1760,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Cisco (VG2\S+) version (\S+)$">
     <description>Cisco VG200 series analog voice gateway</description>
-    <example>Cisco VG248 version 1.3(1)</example>
+    <example os.product="VG248" os.version="1.3(1)">Cisco VG248 version 1.3(1)</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="VG200"/>
@@ -1771,9 +1771,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(WLSE(?: \d+)?) Release (\S+) .* \(C\) Copyright .*Cisco Systems Inc.$">
     <description>Cisco Wireless LAN Solution Engine</description>
-    <example>WLSE Release 2.5FCS Wed Oct 22 21:31:11 UTC 2003 (C) Copyright 2003 by Cisco Systems Inc.</example>
-    <example>WLSE 1030 Release 2.13FCS Wed Feb 22 02:00:55 UTC 2006 (C) Copyright 2006 by Cisco Systems Inc.</example>
-    <example>WLSE 1133 Release 2.15.4 Mon Dec 6 15:19:46 UTC 2010 (C) Copyright 2010 by Cisco Systems Inc.</example>
+    <example os.product="WLSE" os.version="2.5FCS">WLSE Release 2.5FCS Wed Oct 22 21:31:11 UTC 2003 (C) Copyright 2003 by Cisco Systems Inc.</example>
+    <example os.product="WLSE 1030" os.version="2.13FCS">WLSE 1030 Release 2.13FCS Wed Feb 22 02:00:55 UTC 2006 (C) Copyright 2006 by Cisco Systems Inc.</example>
+    <example os.product="WLSE 1133" os.version="2.15.4">WLSE 1133 Release 2.15.4 Mon Dec 6 15:19:46 UTC 2010 (C) Copyright 2010 by Cisco Systems Inc.</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="WLSE"/>
@@ -1784,10 +1784,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Cisco (NX-OS|SAN-OS)\(tm\) ([^,]+), Software \([^\)]+\), Version ([^\,]+), .* Cisco Systems">
     <description>Cisco NX-OS/SAN-OS</description>
-    <example>Cisco NX-OS(tm) cgr1000, Software (cgr1000-uk9), Version 5.2(1)CG2(1), Interim version 5.2(1)CG2(0.167, RELEASE SOFTWARE Copyright (c) 2002-2011 by Cisco Systems, Inc. Compiled 1/1/2012 1:00:00</example>
-    <example>Cisco NX-OS(tm) m9100, Software (m9100-s2ek9-mz), Version 5.0(4), RELEASE SOFTWARE Copyright (c) 2002-2010 by Cisco Systems, Inc. Compiled 7/26/2010 15:00:00</example>
-    <example>Cisco NX-OS(tm) ucs, Software (ucs-6100-k9-system), Version 5.0(3)N2(2.1s), RELEASE SOFTWARE Copyright (c) 2002-2011 by Cisco Systems, Inc. Compiled 11/1/2011 13:00:00</example>
-    <example>Cisco NX-OS(tm) ucs, Software (ucs-6100-k9-system), Version 5.0(3)N2(2.1t), RELEASE SOFTWARE Copyright (c) 2002-2011 by Cisco Systems, Inc. Compiled 11/14/2011 17:00:00</example>
+    <example os.family="NX-OS" os.product="NX-OS" hw.series="cgr1000" os.version="5.2(1)CG2(1)">Cisco NX-OS(tm) cgr1000, Software (cgr1000-uk9), Version 5.2(1)CG2(1), Interim version 5.2(1)CG2(0.167, RELEASE SOFTWARE Copyright (c) 2002-2011 by Cisco Systems, Inc. Compiled 1/1/2012 1:00:00</example>
+    <example os.family="NX-OS" os.product="NX-OS" hw.series="m9100" os.version="5.0(4)">Cisco NX-OS(tm) m9100, Software (m9100-s2ek9-mz), Version 5.0(4), RELEASE SOFTWARE Copyright (c) 2002-2010 by Cisco Systems, Inc. Compiled 7/26/2010 15:00:00</example>
+    <example os.family="NX-OS" os.product="NX-OS" hw.series="ucs" os.version="5.0(3)N2(2.1s)">Cisco NX-OS(tm) ucs, Software (ucs-6100-k9-system), Version 5.0(3)N2(2.1s), RELEASE SOFTWARE Copyright (c) 2002-2011 by Cisco Systems, Inc. Compiled 11/1/2011 13:00:00</example>
+    <example os.family="NX-OS" os.product="NX-OS" hw.series="ucs" os.version="5.0(3)N2(2.1t)">Cisco NX-OS(tm) ucs, Software (ucs-6100-k9-system), Version 5.0(3)N2(2.1t), RELEASE SOFTWARE Copyright (c) 2002-2011 by Cisco Systems, Inc. Compiled 11/14/2011 17:00:00</example>
     <param pos="0" name="os.certainty" value="0.85"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -1830,9 +1830,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^ACOLA CoBox Snr \S+ V?(\S+)(?: \(\d+\))?$">
     <description>aCola CoBox</description>
-    <example>ACOLA CoBox Snr 238-204 V3.40</example>
-    <example>ACOLA CoBox Snr 6818376 04.5b5 (010430)</example>
-    <example>ACOLA CoBox Snr 784-208 V3.6</example>
+    <example os.version="3.40">ACOLA CoBox Snr 238-204 V3.40</example>
+    <example os.version="04.5b5">ACOLA CoBox Snr 6818376 04.5b5 (010430)</example>
+    <example os.version="3.6">ACOLA CoBox Snr 784-208 V3.6</example>
     <param pos="0" name="os.vendor" value="aCola"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="0" name="os.product" value="CoBox"/>
@@ -1841,12 +1841,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^CoBox for Recognition Systems, Snr\s*\S+ V?(\S+)(?: \(\d+\))?$">
     <description>ProNet CoBox for Recognition Systems</description>
-    <example>CoBox for Recognition Systems, Snr 0621630 05.6b1 (080305)</example>
-    <example>CoBox for Recognition Systems, Snr 0622033 05.6 (040825)</example>
-    <example>CoBox for Recognition Systems, Snr 220-146 V3.40</example>
-    <example>CoBox for Recognition Systems, Snr1039-191 3.8b4</example>
-    <example>CoBox for Recognition Systems, Snr  6925226 05.6 (040825)</example>
-    <example>CoBox for Recognition Systems, Snr  7107590 04.5 (011218)</example>
+    <example os.version="05.6b1">CoBox for Recognition Systems, Snr 0621630 05.6b1 (080305)</example>
+    <example os.version="05.6">CoBox for Recognition Systems, Snr 0622033 05.6 (040825)</example>
+    <example os.version="3.40">CoBox for Recognition Systems, Snr 220-146 V3.40</example>
+    <example os.version="3.8b4">CoBox for Recognition Systems, Snr1039-191 3.8b4</example>
+    <example os.version="05.6">CoBox for Recognition Systems, Snr  6925226 05.6 (040825)</example>
+    <example os.version="04.5">CoBox for Recognition Systems, Snr  7107590 04.5 (011218)</example>
     <param pos="0" name="os.vendor" value="Pronet"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="0" name="os.product" value="CoBox"/>
@@ -1859,7 +1859,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(SP\d+)\s">
     <description>Compuprint SP series printers</description>
-    <example>SP40       </example>
+    <example os.product="SP40">SP40       </example>
     <param pos="0" name="os.vendor" value="Compuprint"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -1871,7 +1871,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Compuware AMD, ver. ndw.(\S+)$">
     <description>Compuware advanced monitoring device</description>
-    <example>Compuware AMD, ver. ndw.11.0.731</example>
+    <example os.version="11.0.731">Compuware AMD, ver. ndw.11.0.731</example>
     <param pos="0" name="os.vendor" value="Compuware"/>
     <param pos="0" name="os.family" value="Vantage"/>
     <param pos="0" name="os.product" value="AMD"/>
@@ -1899,7 +1899,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Data Domain OS (\S+)$">
     <description>Data Domain OS</description>
-    <example>Data Domain OS 4.3.3.0-53506</example>
+    <example os.version="4.3.3.0-53506">Data Domain OS 4.3.3.0-53506</example>
     <param pos="0" name="os.vendor" value="Data Domain"/>
     <param pos="0" name="os.product" value="DD OS"/>
     <param pos="0" name="os.device" value="Storage"/>
@@ -1913,9 +1913,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Datamax Corporation I-Class (\S+) Ver:(\S+)">
     <description>Datamax I-Class printer</description>
-    <example>Datamax Corporation I-Class 4208 Ver:08.01 01/14/2004 PN:83-2297-08B</example>
-    <example>Datamax Corporation I-Class 4208 Ver:08.038 11/16/2004 PN:83-2297-08D8</example>
-    <example>Datamax Corporation I-Class 4208 Ver:08.03R2 08/30/2007 PN:83-2297-08DR2</example>
+    <example os.product="4208" os.version="08.01">Datamax Corporation I-Class 4208 Ver:08.01 01/14/2004 PN:83-2297-08B</example>
+    <example os.product="4208" os.version="08.038">Datamax Corporation I-Class 4208 Ver:08.038 11/16/2004 PN:83-2297-08D8</example>
+    <example os.product="4208" os.version="08.03R2">Datamax Corporation I-Class 4208 Ver:08.03R2 08/30/2007 PN:83-2297-08DR2</example>
     <param pos="0" name="os.vendor" value="Datamax"/>
     <param pos="0" name="os.family" value="I-Class"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1948,7 +1948,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^DELL PowerVault (\S+)$">
     <description>Dell PowerVault Tape Library</description>
-    <example>DELL PowerVault 136T</example>
+    <example os.product="136T">DELL PowerVault 136T</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="PowerVault"/>
     <param pos="0" name="os.device" value="Tape library"/>
@@ -1957,7 +1957,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^PowerEdge (\S+) Integrated Switch$">
     <description>Dell PowerEdge Switch</description>
-    <example>PowerEdge 1655MC Integrated Switch</example>
+    <example os.product="1655MC">PowerEdge 1655MC Integrated Switch</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="PowerEdge Integrated"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -1966,9 +1966,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Dell (\d{4}[cd]?n) (?:Laser )?MFP">
     <description>Dell MFP Laser Printer</description>
-    <example>Dell 2135cn MFP; Net 12.10, Controller 200903191302, Engine 03.00.10</example>
-    <example>Dell 2335dn MFP; 2.70.03.02;Engine 1.10.65;NIC V4.01.30(2335dn MFP) 02-05-2010;S/N JQF9FG1</example>
-    <example>Dell 2355dn Laser MFP; V2.70.45.30 May-20-2013;Engine 1.20.25;NIC V4.01.42(2355dn MFP) 4-23-2013;S/N 3DKCJM1</example>
+    <example os.product="2135cn">Dell 2135cn MFP; Net 12.10, Controller 200903191302, Engine 03.00.10</example>
+    <example os.product="2335dn">Dell 2335dn MFP; 2.70.03.02;Engine 1.10.65;NIC V4.01.30(2335dn MFP) 02-05-2010;S/N JQF9FG1</example>
+    <example os.product="2355dn">Dell 2355dn Laser MFP; V2.70.45.30 May-20-2013;Engine 1.20.25;NIC V4.01.42(2355dn MFP) 4-23-2013;S/N 3DKCJM1</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="Laser Printer"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
@@ -1977,11 +1977,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Dell(?:.*Laser.*)? (\w*\d{4}cn)(?:.*Net |; V)(\S+)(?:,| )">
     <description>Dell Color Laser Printer</description>
-    <example>Dell Laser Printer 5100cn (Net 6.26, Controller 200408201123, Engine 01.00.04)</example>
-    <example>Dell Color Laser 3110cn; Net 8.29, Controller 200604102121, Engine 05.03.00</example>
-    <example>Dell Color Laser 5110cn; Net 11.33, Controller 200612011020, Engine 01.03.00</example>
-    <example>Dell 1235cn; V1.70.01.06 Nov-14-2008;Engine 1.77.74;NIC V4.00.54 10-31-2008;S/N GJ8TJH1</example>
-    <example>Dell 1235cn; V1.70.01.08 Jan-29-2009;Engine 1.77.77;NIC V4.00.54 10-31-2008;S/N 9SMWJH1</example>
+    <example os.product="5100cn" os.version="6.26,">Dell Laser Printer 5100cn (Net 6.26, Controller 200408201123, Engine 01.00.04)</example>
+    <example os.product="3110cn" os.version="8.29,">Dell Color Laser 3110cn; Net 8.29, Controller 200604102121, Engine 05.03.00</example>
+    <example os.product="5110cn" os.version="11.33,">Dell Color Laser 5110cn; Net 11.33, Controller 200612011020, Engine 01.03.00</example>
+    <example os.product="1235cn" os.version="1.70.01.06">Dell 1235cn; V1.70.01.06 Nov-14-2008;Engine 1.77.74;NIC V4.00.54 10-31-2008;S/N GJ8TJH1</example>
+    <example os.product="1235cn" os.version="1.70.01.08">Dell 1235cn; V1.70.01.08 Jan-29-2009;Engine 1.77.77;NIC V4.00.54 10-31-2008;S/N 9SMWJH1</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="Color Laser Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -1991,9 +1991,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Dell Laser Printer (\S+) version (\S+)">
     <description>Dell Laser Printer</description>
-    <example>Dell Laser Printer 1720dn version NM.NA.N099 kernel 2.6.10 All-N-1</example>
-    <example>Dell Laser Printer 5210n version NS.NP.N212 kernel 2.6.6 All-N-1</example>
-    <example>Dell Laser Printer W5300 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="1720dn" os.version="NM.NA.N099">Dell Laser Printer 1720dn version NM.NA.N099 kernel 2.6.10 All-N-1</example>
+    <example os.product="5210n" os.version="NS.NP.N212">Dell Laser Printer 5210n version NS.NP.N212 kernel 2.6.6 All-N-1</example>
+    <example os.product="W5300" os.version="55.10.19">Dell Laser Printer W5300 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="Laser Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -2003,10 +2003,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Dell (\S+)(?: Mono)? Laser Printer(?:;| version) \S+;?">
     <description>Dell Laser Printer - variant 1</description>
-    <example>Dell 2330dn Laser Printer version NR.APS.N449 kernel 2.6.18.5 All-N-1</example>
-    <example>Dell 2350dn Laser Printer version NR.APS.N449 kernel 2.6.18.5 All-N-1</example>
-    <example>Dell 3330dn Laser Printer version NR.APS.N447b2 kernel 2.6.18.5 All-N-1</example>
-    <example>Dell 5330dn Mono Laser Printer; 2.70.00.49 06-30-2010;Engine 1.01.83;NIC V4.01.18(5330dn) 06-19-2010;S/N 73P2FG1</example>
+    <example os.product="2330dn">Dell 2330dn Laser Printer version NR.APS.N449 kernel 2.6.18.5 All-N-1</example>
+    <example os.product="2350dn">Dell 2350dn Laser Printer version NR.APS.N449 kernel 2.6.18.5 All-N-1</example>
+    <example os.product="3330dn">Dell 3330dn Laser Printer version NR.APS.N447b2 kernel 2.6.18.5 All-N-1</example>
+    <example os.product="5330dn">Dell 5330dn Mono Laser Printer; 2.70.00.49 06-30-2010;Engine 1.01.83;NIC V4.01.18(5330dn) 06-19-2010;S/N 73P2FG1</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="Laser Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -2015,7 +2015,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Dell (\d{4}d?n) Series$">
     <description>Dell Laser Printer - model only variant</description>
-    <example>Dell 1815n Series</example>
+    <example os.product="1815n">Dell 1815n Series</example>
     <param pos="0" name="os.vendor" value="Dell"/>
     <param pos="0" name="os.family" value="Laser Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -2037,9 +2037,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:Digi )?(?: International)?((?:ConnectPort|Connect|PortServer|One) .*?) Version (\S+) \d+/\d+\/\d+(?: \S+)?(?: \S+)?$">
     <description>Digi Serial Port Servers</description>
-    <example>ConnectPort TS1 W RJ Version 82001772_B1 02/13/2008</example>
-    <example>Digi Connect ES serie 800 SB Version 82002147_A 02/09/2009</example>
-    <example>Digi One TS Version 82000747_N2 02/25/2005</example>
+    <example os.product="ConnectPort TS1 W RJ" os.version="82001772_B1">ConnectPort TS1 W RJ Version 82001772_B1 02/13/2008</example>
+    <example os.product="Connect ES serie 800 SB" os.version="82002147_A">Digi Connect ES serie 800 SB Version 82002147_A 02/09/2009</example>
+    <example os.product="One TS" os.version="82000747_N2">Digi One TS Version 82000747_N2 02/25/2005</example>
     <param pos="0" name="os.vendor" value="Digi"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -2048,7 +2048,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Digi International (PortServer II) v(\S+)">
     <description>Digi Serial PortServer II</description>
-    <example>Digi International PortServer II v3.1.12 Jan 21 2003</example>
+    <example os.product="PortServer II" os.version="3.1.12">Digi International PortServer II v3.1.12 Jan 21 2003</example>
     <param pos="0" name="os.vendor" value="Digi"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -2057,7 +2057,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Digi (Connect) Device, Version Unknown$">
     <description>Digi Connect Unknown</description>
-    <example>Digi Connect Device, Version Unknown</example>
+    <example os.product="Connect">Digi Connect Device, Version Unknown</example>
     <param pos="0" name="os.vendor" value="Digi"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -2065,12 +2065,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Digi (TransPort \S+) Ser#:\S+ Software Build Ver([^\.]+). .* MAC:(\S+)$">
     <description>Digi TransPort</description>
-    <example>Digi TransPort VC74-00S2-DE5-XX Ser#:127485 Software Build Ver5099. Apr 16 2010 16:54:47 C6 ARM Bios Ver 5.85 v38 667MHz B511-M512-F80-O1,0 MAC:00042d01f1fd</example>
-    <example>Digi TransPort WR21-HX1B-DE1-XX Ser#:211555 Software Build Ver5142. Nov 28 2011 11:25:34 WW ARM Bios Ver 6.45 v43 454MHz B987-M995-F80-O1,0 MAC:00042d033a63</example>
-    <example>Digi TransPort WR41-CX00-DA1-XX(WR41v2) Ser#:178329 Software Build Ver5129. May 20 2011 10:51:03 MW ARM Bios Ver 6.02 v41 399MHz B256-M256-F80-O100000,0 MAC:00042d02b899</example>
-    <example>Digi TransPort WR41-CXS1-DE1-XX(WR41v2) Ser#:187037 Software Build Ver5141. Nov 02 2011 00:17:59 MW ARM Bios Ver 6.37 v41 399MHz B256-M256-F80-O140,0 MAC:00042d02da9d</example>
-    <example>Digi TransPort WR44-HXA3-DE1-XX Ser#:176625 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02b1f1</example>
-    <example>Digi TransPort WR44-HXA3-DE1-XX Ser#:182788 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02ca04</example>
+    <example os.product="TransPort VC74-00S2-DE5-XX" os.version="5099" host.mac="00042d01f1fd">Digi TransPort VC74-00S2-DE5-XX Ser#:127485 Software Build Ver5099. Apr 16 2010 16:54:47 C6 ARM Bios Ver 5.85 v38 667MHz B511-M512-F80-O1,0 MAC:00042d01f1fd</example>
+    <example os.product="TransPort WR21-HX1B-DE1-XX" os.version="5142" host.mac="00042d033a63">Digi TransPort WR21-HX1B-DE1-XX Ser#:211555 Software Build Ver5142. Nov 28 2011 11:25:34 WW ARM Bios Ver 6.45 v43 454MHz B987-M995-F80-O1,0 MAC:00042d033a63</example>
+    <example os.product="TransPort WR41-CX00-DA1-XX(WR41v2)" os.version="5129" host.mac="00042d02b899">Digi TransPort WR41-CX00-DA1-XX(WR41v2) Ser#:178329 Software Build Ver5129. May 20 2011 10:51:03 MW ARM Bios Ver 6.02 v41 399MHz B256-M256-F80-O100000,0 MAC:00042d02b899</example>
+    <example os.product="TransPort WR41-CXS1-DE1-XX(WR41v2)" os.version="5141" host.mac="00042d02da9d">Digi TransPort WR41-CXS1-DE1-XX(WR41v2) Ser#:187037 Software Build Ver5141. Nov 02 2011 00:17:59 MW ARM Bios Ver 6.37 v41 399MHz B256-M256-F80-O140,0 MAC:00042d02da9d</example>
+    <example os.product="TransPort WR44-HXA3-DE1-XX" os.version="5142" host.mac="00042d02b1f1">Digi TransPort WR44-HXA3-DE1-XX Ser#:176625 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02b1f1</example>
+    <example os.product="TransPort WR44-HXA3-DE1-XX" os.version="5142" host.mac="00042d02ca04">Digi TransPort WR44-HXA3-DE1-XX Ser#:182788 Software Build Ver5142. Nov 28 2011 11:33:21 SW ARM Bios Ver 6.45 v39 400MHz B512-M512-F80-O1,0 MAC:00042d02ca04</example>
     <param pos="0" name="os.vendor" value="Digi"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -2080,9 +2080,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(AnywhereUSB)/\d+$">
     <description>Digi AnywhereUSB</description>
-    <example>AnywhereUSB/2</example>
-    <example>AnywhereUSB/14</example>
-    <example>AnywhereUSB/5</example>
+    <example os.product="AnywhereUSB">AnywhereUSB/2</example>
+    <example os.product="AnywhereUSB">AnywhereUSB/14</example>
+    <example os.product="AnywhereUSB">AnywhereUSB/5</example>
     <param pos="0" name="os.vendor" value="Digi"/>
     <param pos="0" name="os.device" value="USB Server"/>
     <param pos="1" name="os.product"/>
@@ -2101,7 +2101,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^D-Link (\S+) Print Server$">
     <description>D-link Print Server</description>
-    <example>D-Link DP-301P+ Print Server</example>
+    <example os.product="DP-301P+">D-Link DP-301P+ Print Server</example>
     <param pos="0" name="os.vendor" value="D-Link"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -2113,22 +2113,22 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(Evolution(?: S )?(?:\s*\d+)?)">
     <description>Eaton Evolution UPS</description>
-    <example>Evolution 1100</example>
-    <example>Evolution 1500</example>
-    <example>Evolution 1550</example>
-    <example>Evolution 2200</example>
-    <example>Evolution 3000</example>
-    <example>Evolution 650</example>
-    <example>Evolution 800</example>
-    <example>Evolution 850</example>
-    <example>Evolution S 1750</example>
-    <example>Evolution S 2500</example>
-    <example>Evolution S 3000</example>
-    <example>Evolution Series - IP</example>
-    <example>Evolution Series - METRO</example>
-    <example>Evolution Series - XPAND</example>
-    <example>Evolution Series - XPAND IP</example>
-    <example>Evolution Series EDGE - EDGE</example>
+    <example os.product="Evolution 1100">Evolution 1100</example>
+    <example os.product="Evolution 1500">Evolution 1500</example>
+    <example os.product="Evolution 1550">Evolution 1550</example>
+    <example os.product="Evolution 2200">Evolution 2200</example>
+    <example os.product="Evolution 3000">Evolution 3000</example>
+    <example os.product="Evolution 650">Evolution 650</example>
+    <example os.product="Evolution 800">Evolution 800</example>
+    <example os.product="Evolution 850">Evolution 850</example>
+    <example os.product="Evolution S 1750">Evolution S 1750</example>
+    <example os.product="Evolution S 2500">Evolution S 2500</example>
+    <example os.product="Evolution S 3000">Evolution S 3000</example>
+    <example os.product="Evolution">Evolution Series - IP</example>
+    <example os.product="Evolution">Evolution Series - METRO</example>
+    <example os.product="Evolution">Evolution Series - XPAND</example>
+    <example os.product="Evolution">Evolution Series - XPAND IP</example>
+    <example os.product="Evolution">Evolution Series EDGE - EDGE</example>
     <param pos="0" name="os.vendor" value="Eaton"/>
     <param pos="0" name="os.device" value="UPS"/>
     <param pos="1" name="os.product"/>
@@ -2140,10 +2140,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:Connectrix )?(DS[-_]\d\d\d\d\S)$">
     <description>EMC Connectrix SAN switch</description>
-    <example>Connectrix DS_4100B</example>
-    <example>Connectrix DS_5000B</example>
-    <example>DS_4100B</example>
-    <example>DS-5000B</example>
+    <example os.product="DS_4100B">Connectrix DS_4100B</example>
+    <example os.product="DS_5000B">Connectrix DS_5000B</example>
+    <example os.product="DS_4100B">DS_4100B</example>
+    <example os.product="DS-5000B">DS-5000B</example>
     <param pos="0" name="os.vendor" value="EMC"/>
     <param pos="0" name="os.family" value="Connectrix"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -2152,11 +2152,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(CX\S+) - Flare (\d\S+)$">
     <description>EMC Clariion NAS</description>
-    <example>CX3-10c - Flare 3.26.0.10.5.032</example>
-    <example>CX300 - Flare 2.16.0.300.5.012</example>
-    <example>CX400 - Flare 2.19.0.400.5.040</example>
-    <example>CX500 - Flare 2.07.0.500.5.020</example>
-    <example>CX700 - Flare 2.24.0.700.5.022</example>
+    <example os.product="CX3-10c" os.version="3.26.0.10.5.032">CX3-10c - Flare 3.26.0.10.5.032</example>
+    <example os.product="CX300" os.version="2.16.0.300.5.012">CX300 - Flare 2.16.0.300.5.012</example>
+    <example os.product="CX400" os.version="2.19.0.400.5.040">CX400 - Flare 2.19.0.400.5.040</example>
+    <example os.product="CX500" os.version="2.07.0.500.5.020">CX500 - Flare 2.07.0.500.5.020</example>
+    <example os.product="CX700" os.version="2.24.0.700.5.022">CX700 - Flare 2.24.0.700.5.022</example>
     <param pos="0" name="os.vendor" value="EMC"/>
     <param pos="0" name="os.family" value="Clariion"/>
     <param pos="0" name="os.device" value="Storage"/>
@@ -2170,7 +2170,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^NetQue Version (\S+)$">
     <description>Emulex NetQue print server</description>
-    <example>NetQue Version 4.0</example>
+    <example os.version="4.0">NetQue Version 4.0</example>
     <param pos="0" name="os.vendor" value="Emulex"/>
     <param pos="0" name="os.family" value="NetQue"/>
     <param pos="0" name="os.product" value="NetQue"/>
@@ -2199,15 +2199,15 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^EPSON ([A-Z]\S+) (\d+\.\S+)$">
     <description>Epson Printer - model and version</description>
-    <example>EPSON AL-C2000 01.00</example>
-    <example>EPSON AL-C8500 01.00</example>
-    <example>EPSON EPL-N2050+ 01.00</example>
-    <example>EPSON EPL-N2700 01.00</example>
-    <example>EPSON EPL-N2750 01.00</example>
-    <example>EPSON EPL-N4000+ 01.00</example>
-    <example>EPSON LP-8700PS3 01.00</example>
-    <example>EPSON LP-9600 01.00</example>
-    <example>EPSON LP-9600S 01.00</example>
+    <example os.product="AL-C2000" os.version="01.00">EPSON AL-C2000 01.00</example>
+    <example os.product="AL-C8500" os.version="01.00">EPSON AL-C8500 01.00</example>
+    <example os.product="EPL-N2050+" os.version="01.00">EPSON EPL-N2050+ 01.00</example>
+    <example os.product="EPL-N2700" os.version="01.00">EPSON EPL-N2700 01.00</example>
+    <example os.product="EPL-N2750" os.version="01.00">EPSON EPL-N2750 01.00</example>
+    <example os.product="EPL-N4000+" os.version="01.00">EPSON EPL-N4000+ 01.00</example>
+    <example os.product="LP-8700PS3" os.version="01.00">EPSON LP-8700PS3 01.00</example>
+    <example os.product="LP-9600" os.version="01.00">EPSON LP-9600 01.00</example>
+    <example os.product="LP-9600S" os.version="01.00">EPSON LP-9600S 01.00</example>
     <param pos="0" name="os.vendor" value="Epson"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -2216,11 +2216,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^EPSON ([A-Z]\S+)$">
     <description>Epson Printer - model only</description>
-    <example>EPSON LP-M720</example>
-    <example>EPSON LP-S820</example>
-    <example>EPSON AL-CX28</example>
-    <example>EPSON AL-CX37</example>
-    <example>EPSON AL-C3900</example>
+    <example os.product="LP-M720">EPSON LP-M720</example>
+    <example os.product="LP-S820">EPSON LP-S820</example>
+    <example os.product="AL-CX28">EPSON AL-CX28</example>
+    <example os.product="AL-CX37">EPSON AL-CX37</example>
+    <example os.product="AL-C3900">EPSON AL-C3900</example>
     <param pos="0" name="os.vendor" value="Epson"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -2228,18 +2228,18 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:EPSON|EpsonNet)(?: Built-in)? (.* Print Server)$">
     <description>Epson Print Server</description>
-    <example>EPSON 11b/g &amp; 10/100 USB Ext. Print Server</example>
-    <example>EPSON Type B 10Base-T Print Server</example>
-    <example>EPSON Type B 10Base-T/100Base-TX Print Server</example>
-    <example>EPSON Type B 10Base-T/2 Print Server</example>
-    <example>EPSON Wireless 802.11b Print Server</example>
-    <example>EpsonNet 11b/g &amp; 10/100 USB Ext. Print Server</example>
-    <example>EPSON Built-in 10Base-T/100Base-TX Print Server</example>
-    <example>EPSON Built-in 11b/g &amp; 10/100 Print Server</example>
-    <example>EPSON Built-in 11b/g/n &amp; 10/100 Print Server</example>
-    <example>EPSON Built-in 11b/g/n Print Server</example>
-    <example>EPSON Built-in Gigabit Ether Print Server</example>
-    <example>EPSON External 10Base-T/100Base-TX Print Server</example>
+    <example os.product="11b/g &amp; 10/100 USB Ext. Print Server">EPSON 11b/g &amp; 10/100 USB Ext. Print Server</example>
+    <example os.product="Type B 10Base-T Print Server">EPSON Type B 10Base-T Print Server</example>
+    <example os.product="Type B 10Base-T/100Base-TX Print Server">EPSON Type B 10Base-T/100Base-TX Print Server</example>
+    <example os.product="Type B 10Base-T/2 Print Server">EPSON Type B 10Base-T/2 Print Server</example>
+    <example os.product="Wireless 802.11b Print Server">EPSON Wireless 802.11b Print Server</example>
+    <example os.product="11b/g &amp; 10/100 USB Ext. Print Server">EpsonNet 11b/g &amp; 10/100 USB Ext. Print Server</example>
+    <example os.product="10Base-T/100Base-TX Print Server">EPSON Built-in 10Base-T/100Base-TX Print Server</example>
+    <example os.product="11b/g &amp; 10/100 Print Server">EPSON Built-in 11b/g &amp; 10/100 Print Server</example>
+    <example os.product="11b/g/n &amp; 10/100 Print Server">EPSON Built-in 11b/g/n &amp; 10/100 Print Server</example>
+    <example os.product="11b/g/n Print Server">EPSON Built-in 11b/g/n Print Server</example>
+    <example os.product="Gigabit Ether Print Server">EPSON Built-in Gigabit Ether Print Server</example>
+    <example os.product="External 10Base-T/100Base-TX Print Server">EPSON External 10Base-T/100Base-TX Print Server</example>
     <param pos="0" name="os.vendor" value="Epson"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -2266,16 +2266,16 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Epson ([A-Z][^;]+); ESS (\S+)$">
     <description>Epson Printer - ess variant</description>
-    <example>Epson AL-CX17NF; ESS 01.00.07</example>
-    <example>Epson AL-CX17NF; ESS 01.00.08</example>
-    <example>Epson AL-CX17NF; ESS 01.00.13</example>
-    <example>Epson AL-CX17NF; ESS 01.00.18</example>
-    <example>Epson AL-CX17WF; ESS 01.00.07</example>
-    <example>Epson AL-MX14NF; ESS SG4_SEC_1.08</example>
-    <example>Epson AL-MX14NF; ESS SG4_SEC_1.16</example>
-    <example>Epson AL-MX14NF; ESS SG4_SEC_1.22b</example>
-    <example>Epson AL-MX14NF; ESS SG4_SEC_1.22c</example>
-    <example>Epson LP-M120F; ESS SG4_SEC_1.23a</example>
+    <example os.product="AL-CX17NF" os.version="01.00.07">Epson AL-CX17NF; ESS 01.00.07</example>
+    <example os.product="AL-CX17NF" os.version="01.00.08">Epson AL-CX17NF; ESS 01.00.08</example>
+    <example os.product="AL-CX17NF" os.version="01.00.13">Epson AL-CX17NF; ESS 01.00.13</example>
+    <example os.product="AL-CX17NF" os.version="01.00.18">Epson AL-CX17NF; ESS 01.00.18</example>
+    <example os.product="AL-CX17WF" os.version="01.00.07">Epson AL-CX17WF; ESS 01.00.07</example>
+    <example os.product="AL-MX14NF" os.version="SG4_SEC_1.08">Epson AL-MX14NF; ESS SG4_SEC_1.08</example>
+    <example os.product="AL-MX14NF" os.version="SG4_SEC_1.16">Epson AL-MX14NF; ESS SG4_SEC_1.16</example>
+    <example os.product="AL-MX14NF" os.version="SG4_SEC_1.22b">Epson AL-MX14NF; ESS SG4_SEC_1.22b</example>
+    <example os.product="AL-MX14NF" os.version="SG4_SEC_1.22c">Epson AL-MX14NF; ESS SG4_SEC_1.22c</example>
+    <example os.product="LP-M120F" os.version="SG4_SEC_1.23a">Epson LP-M120F; ESS SG4_SEC_1.23a</example>
     <param pos="0" name="os.vendor" value="Epson"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -2298,9 +2298,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="Extreme(?:X[0O]S|Ware X[0O]S) (?:\S+ )?version (\S+) \S+ by \S+ on">
     <description>Extreme Networks Switches</description>
-    <example>ExtremeWare X0S version 11.2.0.15 v1120b15 by release-manager on Fri Apr 1 18:40:23 PST 2005</example>
-    <example>ExtremeXOS version 11.6.3.5 v1163b5 by release-manager on Sun Sep 9 10:46:16 PDT 2007</example>
-    <example>ExtremeXOS (X460-24x) version 15.6.1.4 v1561b4 by release-manager on Tue Sep 30 14:06:19 EDT 2014</example>
+    <example os.version="11.2.0.15">ExtremeWare X0S version 11.2.0.15 v1120b15 by release-manager on Fri Apr 1 18:40:23 PST 2005</example>
+    <example os.version="11.6.3.5">ExtremeXOS version 11.6.3.5 v1163b5 by release-manager on Sun Sep 9 10:46:16 PDT 2007</example>
+    <example os.version="15.6.1.4">ExtremeXOS (X460-24x) version 15.6.1.4 v1561b4 by release-manager on Tue Sep 30 14:06:19 EDT 2014</example>
     <param pos="0" name="os.vendor" value="Extreme Networks"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.product" value="XOS"/>
@@ -2313,11 +2313,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Foundry Networks, Inc\. ([^,]+), (?:IronWare|Iron Software) Version V?(\S+) Compiled">
     <description>Foundry Networks IronWare Switches</description>
-    <example>Foundry Networks, Inc. Backbone, IronWare Version 06.6.36T41 Compiled on Jul 20 2001 at 21:38:29 labeled as BIS06636</example>
-    <example>Foundry Networks, Inc. BigIron 15000 Router, IronWare Version 08.0.01vT53 Compiled on Feb 26 2010 at 20:07:21 labeled as B2P08001v</example>
-    <example>Foundry Networks, Inc. BigIron 4000 Router, IronWare Version 07.8.02fT53 Compiled on Jan 16 2007 at 19:51:36 labeled as B2R07802f</example>
-    <example>Foundry Networks, Inc. BigIron 8000 Router, IronWare Version 08.0.01tT53 Compiled on Mar 04 2009 at 22:12:06 labeled as B2R08001t</example>
-    <example>Foundry Networks, Inc. Switch, IronWare Version 11.0.00gTI2 Compiled on Feb 18 2011 at 17:14:50 labeled as WJM11000g</example>
+    <example os.product="Backbone" os.version="06.6.36T41">Foundry Networks, Inc. Backbone, IronWare Version 06.6.36T41 Compiled on Jul 20 2001 at 21:38:29 labeled as BIS06636</example>
+    <example os.product="BigIron 15000 Router" os.version="08.0.01vT53">Foundry Networks, Inc. BigIron 15000 Router, IronWare Version 08.0.01vT53 Compiled on Feb 26 2010 at 20:07:21 labeled as B2P08001v</example>
+    <example os.product="BigIron 4000 Router" os.version="07.8.02fT53">Foundry Networks, Inc. BigIron 4000 Router, IronWare Version 07.8.02fT53 Compiled on Jan 16 2007 at 19:51:36 labeled as B2R07802f</example>
+    <example os.product="BigIron 8000 Router" os.version="08.0.01tT53">Foundry Networks, Inc. BigIron 8000 Router, IronWare Version 08.0.01tT53 Compiled on Mar 04 2009 at 22:12:06 labeled as B2R08001t</example>
+    <example os.product="Switch" os.version="11.0.00gTI2">Foundry Networks, Inc. Switch, IronWare Version 11.0.00gTI2 Compiled on Feb 18 2011 at 17:14:50 labeled as WJM11000g</example>
     <param pos="0" name="os.vendor" value="Foundry Networks"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="IronWare"/>
@@ -2327,9 +2327,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Foundry AP: \S+ v(\S+)$">
     <description>Foundry Networks AP</description>
-    <example>Foundry AP: 01.03.04Tw8 v2.0.0</example>
-    <example>Foundry AP: 01.03.05Tw8 v3.0.4</example>
-    <example>Foundry AP: 02.02.00Tw8 v4.0.0</example>
+    <example os.version="2.0.0">Foundry AP: 01.03.04Tw8 v2.0.0</example>
+    <example os.version="3.0.4">Foundry AP: 01.03.05Tw8 v3.0.4</example>
+    <example os.version="4.0.0">Foundry AP: 02.02.00Tw8 v4.0.0</example>
     <param pos="0" name="os.vendor" value="Foundry Networks"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="0" name="os.product" value="WAP"/>
@@ -2346,12 +2346,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Foundry Networks (EdgeIron \S+)$">
     <description>Foundry Edge Iron</description>
-    <example>Foundry Networks EdgeIron 2402CF</example>
-    <example>Foundry Networks EdgeIron 24G</example>
-    <example>Foundry Networks EdgeIron 24G-A</example>
-    <example>Foundry Networks EdgeIron 4802CF</example>
-    <example>Foundry Networks EdgeIron 48G</example>
-    <example>Foundry Networks EdgeIron 48G1X10G</example>
+    <example os.product="EdgeIron 2402CF">Foundry Networks EdgeIron 2402CF</example>
+    <example os.product="EdgeIron 24G">Foundry Networks EdgeIron 24G</example>
+    <example os.product="EdgeIron 24G-A">Foundry Networks EdgeIron 24G-A</example>
+    <example os.product="EdgeIron 4802CF">Foundry Networks EdgeIron 4802CF</example>
+    <example os.product="EdgeIron 48G">Foundry Networks EdgeIron 48G</example>
+    <example os.product="EdgeIron 48G1X10G">Foundry Networks EdgeIron 48G1X10G</example>
     <param pos="0" name="os.vendor" value="Foundry Networks"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -2383,10 +2383,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^FUJI XEROX ((?:Document Centre|DocuCentre-\S+) [^\s;]+)">
     <description>Xerox Document Centre Multi-function System - Fuji variant</description>
-    <example>FUJI XEROX Document Centre C360;ESS 1.131.11,IOT 6.6.5,IIT 12.7.0,IIT D12.0.0,ADF 10.3.0,FAX 11.20.50</example>
-    <example>FUJI XEROX Document Centre C400 v 2. 0. 6</example>
-    <example>FUJI XEROX Document Centre 405</example>
-    <example>FUJI XEROX DocuCentre-III C2200 ;ESS1.120.4,IOT 20.6.0,IIT 22.9.0,ADF 20.0.0,FAX 11.20.55,SJFI3.0.10,SSMI1.9.0</example>
+    <example os.product="Document Centre C360">FUJI XEROX Document Centre C360;ESS 1.131.11,IOT 6.6.5,IIT 12.7.0,IIT D12.0.0,ADF 10.3.0,FAX 11.20.50</example>
+    <example os.product="Document Centre C400">FUJI XEROX Document Centre C400 v 2. 0. 6</example>
+    <example os.product="Document Centre 405">FUJI XEROX Document Centre 405</example>
+    <example os.product="DocuCentre-III C2200">FUJI XEROX DocuCentre-III C2200 ;ESS1.120.4,IOT 20.6.0,IIT 22.9.0,ADF 20.0.0,FAX 11.20.55,SJFI3.0.10,SSMI1.9.0</example>
     <param pos="0" name="os.vendor" value="Fuji Xerox"/>
     <param pos="0" name="os.family" value="Document Centre"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -2395,7 +2395,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^FUJI XEROX (\S+ [^\s;]+)">
     <description>FUJI Xerox default</description>
-    <example>FUJI XEROX ApeosPort-II C4300 ;ESS 1.121.8,IOT 3.8.2,IIT 7.6.0,ADF 11.6.3,FAX 11.20.53</example>
+    <example os.product="ApeosPort-II C4300">FUJI XEROX ApeosPort-II C4300 ;ESS 1.121.8,IOT 3.8.2,IIT 7.6.0,ADF 11.6.3,FAX 11.20.53</example>
     <param pos="0" name="os.vendor" value="Fuji Xerox"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -2407,8 +2407,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(DynaStar \d+)$">
     <description>Garrett DynaStar Industrial Router</description>
-    <example>DynaStar 2000</example>
-    <example>DynaStar 1500</example>
+    <example os.product="DynaStar 2000">DynaStar 2000</example>
+    <example os.product="DynaStar 1500">DynaStar 1500</example>
     <param pos="0" name="os.vendor" value="GarrettCom"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -2420,8 +2420,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) .*GigaVUE-H-Series ([\d\.]+) .* (\S+)$">
     <description>Gigamon GigaVUE HD</description>
-    <example>Linux giga1-hd1-wax 2.6.34-GIGAMONuni-gvhd GigaVUE-H-Series 3.0.06 #1681 2013-11-06 07:42:52 ppc</example>
-    <example>Linux GigaVUE-HB1-2 2.6.34-GIGAMONuni-gvhb1 GigaVUE-H-Series 3.0.02 #13 2013-08-22 09:58:43 ppc</example>
+    <example os.version="3.0.06" os.arch="ppc" host.name="giga1-hd1-wax">Linux giga1-hd1-wax 2.6.34-GIGAMONuni-gvhd GigaVUE-H-Series 3.0.06 #1681 2013-11-06 07:42:52 ppc</example>
+    <example os.version="3.0.02" os.arch="ppc" host.name="GigaVUE-HB1-2">Linux GigaVUE-HB1-2 2.6.34-GIGAMONuni-gvhb1 GigaVUE-H-Series 3.0.02 #13 2013-08-22 09:58:43 ppc</example>
     <param pos="0" name="os.vendor" value="Gigamon"/>
     <param pos="0" name="os.device" value="Monitoring"/>
     <param pos="0" name="os.product" value="GigaVUE HD"/>
@@ -2433,7 +2433,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) .*GigaVUE-TA1 ([\d\.]+) .* (\S+)$">
     <description>Gigamon GigaVUE TA</description>
-    <example>Linux GigaVUE-TA1 2.6.34-GIGAMONsmp-gvag GigaVUE-TA1 2.5.02 #5 2013-03-15 18:08:44 SMP ppc</example>
+    <example os.version="2.5.02" os.arch="ppc" host.name="GigaVUE-TA1">Linux GigaVUE-TA1 2.6.34-GIGAMONsmp-gvag GigaVUE-TA1 2.5.02 #5 2013-03-15 18:08:44 SMP ppc</example>
     <param pos="0" name="os.vendor" value="Gigamon"/>
     <param pos="0" name="os.device" value="Monitoring"/>
     <param pos="0" name="os.product" value="GigaVUE TA1"/>
@@ -2449,9 +2449,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^IP-Console-Switch-(\S+) (\S+)$">
     <description>Compaq IP Console Switch</description>
-    <example>IP-Console-Switch-1x1x16 03.00.01</example>
-    <example>IP-Console-Switch-3x1x16 03.00.13</example>
-    <example>IP-Console-Switch-3x1x16 03.00.11</example>
+    <example os.product="1x1x16" os.version="03.00.01">IP-Console-Switch-1x1x16 03.00.01</example>
+    <example os.product="3x1x16" os.version="03.00.13">IP-Console-Switch-3x1x16 03.00.13</example>
+    <example os.product="3x1x16" os.version="03.00.11">IP-Console-Switch-3x1x16 03.00.11</example>
     <param pos="0" name="os.vendor" value="Compaq"/>
     <param pos="0" name="os.family" value="IP Console Switch"/>
     <param pos="0" name="os.device" value="KVM"/>
@@ -2471,7 +2471,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP-UX (\S+) (\S+)">
     <description>HP-UX</description>
-    <example>HP-UX hostname B.10.20 A 9000/820 2006447661</example>
+    <example host.name="hostname" os.version="B.10.20">HP-UX hostname B.10.20 A 9000/820 2006447661</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="HP-UX"/>
     <param pos="0" name="os.product" value="HP-UX"/>
@@ -2482,7 +2482,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(\S{1,512}) .*OpenVMS V(\S+)">
     <description>OpenVMS</description>
-    <example host.name="hostname">hostname VAX 4000-200 OpenVMS V7.2 Compaq TCP/IP Services for OpenVMS</example>
+    <example host.name="hostname" os.version="7.2">hostname VAX 4000-200 OpenVMS V7.2 Compaq TCP/IP Services for OpenVMS</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="OpenVMS"/>
     <param pos="0" name="os.product" value="OpenVMS"/>
@@ -2519,15 +2519,15 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^DECserver\s*(\S+)(?:\s*, Network Access SW)? V(\S+) .* LAT V5\.1,? LOAD IMAGE: \S+$">
     <description>DECserver</description>
-    <example>DECserver 700-08 V1.1 BL44-11 ROM V3.4-9 LAT V5.1 LOAD IMAGE: WWENG1</example>
-    <example>DECserver 90TL V1.1A BL45-11 ROM 2.0.0 LAT V5.1 LOAD IMAGE: MNENG1</example>
-    <example>DECserver900TM , Network Access SW V2.3A , HW=V1.6 , RO=V7.1-0, SW=BL47-60, LAT V5.1, LOAD IMAGE: WWENG2</example>
-    <example>DECserver90M , Network Access SW V2.2 , HW=V4.0 , RO=4.1, SW=BL29-52, LAT V5.1, LOAD IMAGE: MNENG2</example>
-    <example>DECserver90M , Network Access SW V2.3A , HW=V4.0 , RO=5.1, SW=BL47-60, LAT V5.1, LOAD IMAGE: MNENG3</example>
-    <example>DECserver90M , Network Access SW V2.4 BL50 , HW=V4.0 , RO=4.1, SW=V2.4 BL50, LAT V5.1, LOAD IMAGE: MNENG2</example>
-    <example>DECserver90M , Network Access SW V2.4 BL50 , HW=V4.0 , RO=5.1, SW=V2.4 BL50, LAT V5.1, LOAD IMAGE: MNENG3</example>
-    <example>DECserver90M , Network Access SW V2.5 BL51 , HW=V4.0 , RO=5.1, SW=V2.5 BL51, LAT V5.1, LOAD IMAGE: MNENG3</example>
-    <example>DECserver716, Network Access SW V3.2 BL01 , HW=V1.2 , RO=V7.3-0, LAT V5.1, LOAD IMAGE: WWENG2</example>
+    <example hw.product="700-08" os.version="1.1">DECserver 700-08 V1.1 BL44-11 ROM V3.4-9 LAT V5.1 LOAD IMAGE: WWENG1</example>
+    <example hw.product="90TL" os.version="1.1A">DECserver 90TL V1.1A BL45-11 ROM 2.0.0 LAT V5.1 LOAD IMAGE: MNENG1</example>
+    <example hw.product="900TM" os.version="2.3A">DECserver900TM , Network Access SW V2.3A , HW=V1.6 , RO=V7.1-0, SW=BL47-60, LAT V5.1, LOAD IMAGE: WWENG2</example>
+    <example hw.product="90M" os.version="2.2">DECserver90M , Network Access SW V2.2 , HW=V4.0 , RO=4.1, SW=BL29-52, LAT V5.1, LOAD IMAGE: MNENG2</example>
+    <example hw.product="90M" os.version="2.3A">DECserver90M , Network Access SW V2.3A , HW=V4.0 , RO=5.1, SW=BL47-60, LAT V5.1, LOAD IMAGE: MNENG3</example>
+    <example hw.product="90M" os.version="2.4">DECserver90M , Network Access SW V2.4 BL50 , HW=V4.0 , RO=4.1, SW=V2.4 BL50, LAT V5.1, LOAD IMAGE: MNENG2</example>
+    <example hw.product="90M" os.version="2.4">DECserver90M , Network Access SW V2.4 BL50 , HW=V4.0 , RO=5.1, SW=V2.4 BL50, LAT V5.1, LOAD IMAGE: MNENG3</example>
+    <example hw.product="90M" os.version="2.5">DECserver90M , Network Access SW V2.5 BL51 , HW=V4.0 , RO=5.1, SW=V2.5 BL51, LAT V5.1, LOAD IMAGE: MNENG3</example>
+    <example hw.product="716" os.version="3.2">DECserver716, Network Access SW V3.2 BL01 , HW=V1.2 , RO=V7.3-0, LAT V5.1, LOAD IMAGE: WWENG2</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.product" value="DECserver"/>
     <param pos="1" name="hw.product"/>
@@ -2536,25 +2536,25 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP3000 SERIES ([^,]+), MPE XL version (\S+) NS Transport">
     <description>HP3000 MPEi/X</description>
-    <example>HP3000 SERIES 918RX, MPE XL version C.75.00 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES 928RX, MPE XL version C.60.00 NS Transport version B.06.00</example>
-    <example>HP3000 SERIES 939, MPE XL version C.70.02 NS Transport version B.07.00</example>
-    <example>HP3000 SERIES 969-200, MPE XL version C.75.00 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES 969-220, MPE XL version C.70.00 NS Transport version B.07.00</example>
-    <example>HP3000 SERIES 969-400, MPE XL version C.75.04 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES 977SX, MPE XL version C.55.00 NS Transport version B.05.09</example>
-    <example>HP3000 SERIES 979-400, MPE XL version C.75.00 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES 988RX, MPE XL version C.55.00 NS Transport version B.05.09</example>
-    <example>HP3000 SERIES 989-400, MPE XL version C.75.00 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES 989-650, MPE XL version C.70.02 NS Transport version B.07.00</example>
-    <example>HP3000 SERIES GREB/3000-A400-44, MPE XL version C.75.00 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES U988RX, MPE XL version C.70.01 NS Transport version B.07.00</example>
-    <example>HP3000 SERIES e3000/A400-100-11, MPE XL version C.75.00 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES e3000/A500-200-14, MPE XL version C.75.02 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES e3000/N4000-400-44, MPE XL version C.75.03 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES e3000/N4000-400-50, MPE XL version C.75.05 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES e3000/N4000-400-75, MPE XL version C.75.00 NS Transport version B.07.05</example>
-    <example>HP3000 SERIES e3000/N4000-400-75, MPE XL version C.75.05 NS Transport version B.07.05</example>
+    <example hw.product="918RX" os.version="C.75.00">HP3000 SERIES 918RX, MPE XL version C.75.00 NS Transport version B.07.05</example>
+    <example hw.product="928RX" os.version="C.60.00">HP3000 SERIES 928RX, MPE XL version C.60.00 NS Transport version B.06.00</example>
+    <example hw.product="939" os.version="C.70.02">HP3000 SERIES 939, MPE XL version C.70.02 NS Transport version B.07.00</example>
+    <example hw.product="969-200" os.version="C.75.00">HP3000 SERIES 969-200, MPE XL version C.75.00 NS Transport version B.07.05</example>
+    <example hw.product="969-220" os.version="C.70.00">HP3000 SERIES 969-220, MPE XL version C.70.00 NS Transport version B.07.00</example>
+    <example hw.product="969-400" os.version="C.75.04">HP3000 SERIES 969-400, MPE XL version C.75.04 NS Transport version B.07.05</example>
+    <example hw.product="977SX" os.version="C.55.00">HP3000 SERIES 977SX, MPE XL version C.55.00 NS Transport version B.05.09</example>
+    <example hw.product="979-400" os.version="C.75.00">HP3000 SERIES 979-400, MPE XL version C.75.00 NS Transport version B.07.05</example>
+    <example hw.product="988RX" os.version="C.55.00">HP3000 SERIES 988RX, MPE XL version C.55.00 NS Transport version B.05.09</example>
+    <example hw.product="989-400" os.version="C.75.00">HP3000 SERIES 989-400, MPE XL version C.75.00 NS Transport version B.07.05</example>
+    <example hw.product="989-650" os.version="C.70.02">HP3000 SERIES 989-650, MPE XL version C.70.02 NS Transport version B.07.00</example>
+    <example hw.product="GREB/3000-A400-44" os.version="C.75.00">HP3000 SERIES GREB/3000-A400-44, MPE XL version C.75.00 NS Transport version B.07.05</example>
+    <example hw.product="U988RX" os.version="C.70.01">HP3000 SERIES U988RX, MPE XL version C.70.01 NS Transport version B.07.00</example>
+    <example hw.product="e3000/A400-100-11" os.version="C.75.00">HP3000 SERIES e3000/A400-100-11, MPE XL version C.75.00 NS Transport version B.07.05</example>
+    <example hw.product="e3000/A500-200-14" os.version="C.75.02">HP3000 SERIES e3000/A500-200-14, MPE XL version C.75.02 NS Transport version B.07.05</example>
+    <example hw.product="e3000/N4000-400-44" os.version="C.75.03">HP3000 SERIES e3000/N4000-400-44, MPE XL version C.75.03 NS Transport version B.07.05</example>
+    <example hw.product="e3000/N4000-400-50" os.version="C.75.05">HP3000 SERIES e3000/N4000-400-50, MPE XL version C.75.05 NS Transport version B.07.05</example>
+    <example hw.product="e3000/N4000-400-75" os.version="C.75.00">HP3000 SERIES e3000/N4000-400-75, MPE XL version C.75.00 NS Transport version B.07.05</example>
+    <example hw.product="e3000/N4000-400-75" os.version="C.75.05">HP3000 SERIES e3000/N4000-400-75, MPE XL version C.75.05 NS Transport version B.07.05</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="HP3000"/>
     <param pos="0" name="os.product" value="MPE XL"/>
@@ -2564,8 +2564,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP Comware Platform Software Comware Software Version ([^\s,]+)[,\s]\s*(?:Release|Alpha|Beta)\s*(\S+) HP (\S+) Router">
     <description>HP Comware</description>
-    <example>HP Comware Platform Software Comware Software Version 5.20,Release 2603P08 HP A6602 Router Copyright(c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software Comware Software Version 5.20,Release 2603P08 HP A6608 Router Copyright(c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A6602" os.version.version="2603P08">HP Comware Platform Software Comware Software Version 5.20,Release 2603P08 HP A6602 Router Copyright(c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A6608" os.version.version="2603P08">HP Comware Platform Software Comware Software Version 5.20,Release 2603P08 HP A6608 Router Copyright(c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="Comware"/>
@@ -2578,8 +2578,8 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^HP Series Router (\S+) HP Comware Platform Software Comware Software Version ([^\s,]+)[,\s]\s*Release ([^,\s]+)?[,\s].*Copyright">
     <description>HP Comware - variant 1</description>
     <example hw.product="A-MSR20-40" os.version="5.20" os.version.version="2209P15">HP Series Router A-MSR20-40 HP Comware Platform Software Comware Software Version 5.20, Release 2209P15, Standard Copyright(c) 2010-2012 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Series Router A-MSR30-20 HP Comware Platform Software Comware Software Version 5.20, Release 2207P41, Standard Copyright(c) 2010 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Series Router A-MSR900 HP Comware Platform Software Comware Software Version 5.20, Release 2207P41 Copyright(c) 2010 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A-MSR30-20" os.version.version="2207P41">HP Series Router A-MSR30-20 HP Comware Platform Software Comware Software Version 5.20, Release 2207P41, Standard Copyright(c) 2010 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A-MSR900" os.version.version="2207P41">HP Series Router A-MSR900 HP Comware Platform Software Comware Software Version 5.20, Release 2207P41 Copyright(c) 2010 Hewlett-Packard Development Company, L.P.</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="Comware"/>
@@ -2603,17 +2603,17 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP Comware Platform Software, Software Version ([^\s,]+)[,\s]\s*(?:Release|Alpha|Beta)\s*(\S+) HP (\S+) (?:SI|EI|Switch|Copyright|v\d)">
     <description>HP Comware - variant 3</description>
-    <example>HP Comware Platform Software, Software Version 5.20 Release 2208 HP A5500-24G SI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20 Release 2208 HP A5500-48G EI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20 Release 2208P01 HP A5500-24G EI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20 Release 2210 HP A5500-48G SI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20 Release 5103P01 HP A3100-16 v2 EI Switch Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20, Release 1211P04 HP A5800-24G Switch Copyright (c) 2010-2012 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20, Release 6616P05 HP A7506 Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20, Release 6616P05 HP A7510 Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20, Release 6635 HP A7506 Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 5.20.99, Release 2101P01 HP A3600-48 v2 EI Switch Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP Comware Platform Software, Software Version 7.1.033, Alpha 0002 HP MSR36-60 Copyright (c) 2010-2012 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A5500-24G" os.version.version="2208">HP Comware Platform Software, Software Version 5.20 Release 2208 HP A5500-24G SI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A5500-48G" os.version.version="2208">HP Comware Platform Software, Software Version 5.20 Release 2208 HP A5500-48G EI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A5500-24G" os.version.version="2208P01">HP Comware Platform Software, Software Version 5.20 Release 2208P01 HP A5500-24G EI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A5500-48G" os.version.version="2210">HP Comware Platform Software, Software Version 5.20 Release 2210 HP A5500-48G SI Switch with 2 Interface Slots Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A3100-16" os.version.version="5103P01">HP Comware Platform Software, Software Version 5.20 Release 5103P01 HP A3100-16 v2 EI Switch Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A5800-24G" os.version.version="1211P04">HP Comware Platform Software, Software Version 5.20, Release 1211P04 HP A5800-24G Switch Copyright (c) 2010-2012 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A7506" os.version.version="6616P05">HP Comware Platform Software, Software Version 5.20, Release 6616P05 HP A7506 Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A7510" os.version.version="6616P05">HP Comware Platform Software, Software Version 5.20, Release 6616P05 HP A7510 Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" hw.product="A7506" os.version.version="6635">HP Comware Platform Software, Software Version 5.20, Release 6635 HP A7506 Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20.99" hw.product="A3600-48" os.version.version="2101P01">HP Comware Platform Software, Software Version 5.20.99, Release 2101P01 HP A3600-48 v2 EI Switch Copyright (c) 2010-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="7.1.033" hw.product="MSR36-60" os.version.version="0002">HP Comware Platform Software, Software Version 7.1.033, Alpha 0002 HP MSR36-60 Copyright (c) 2010-2012 Hewlett-Packard Development Company, L.P.</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="Comware"/>
@@ -2627,7 +2627,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>H3C Comware, generic, pre-HP acquisition</description>
     <!-- H3C Comware Platform Software, Software Version 5.20 Release 2208\r\nH3C S5500-28C-EI\r\nCopyright (c) 2004-2010 Hangzhou H3C Tech. Co., Ltd. All rights reserved. -->
 
-    <example _encoding="base64">
+    <example _encoding="base64" os.version="5.20" hw.product="S5500-28C-EI">
       SDNDIENvbXdhcmUgUGxhdGZvcm0gU29mdHdhcmUsIFNvZnR3YXJlIFZlcnNpb24gNS4yMCBSZ
       WxlYXNlIDIyMDgNCkgzQyBTNTUwMC0yOEMtRUkNCkNvcHlyaWdodCAoYykgMjAwNC0yMDEwIE
       hhbmd6aG91IEgzQyBUZWNoLiBDby4sIEx0ZC4gQWxsIHJpZ2h0cyByZXNlcnZlZC4K
@@ -2654,16 +2654,16 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP (V1910\S+) (?:\(.*?\) )?Switch Software Version (\S+).? Release (\S+) Copyright">
     <description>HP Switch</description>
-    <example>HP V1910-16G Switch Software Version 5.20 Release 1108 Copyright (c) 2004-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP V1910-16G Switch Software Version 5.20, Release 1511 Copyright(c) 2010-2012 HP Tech. Co., Ltd. All rights reserved.</example>
-    <example>HP V1910-24G Switch Software Version 5.20 Release 1111 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP V1910-24G Switch Software Version 5.20 Release 1111P01 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP V1910-24G Switch Software Version 5.20, Release 1511 Copyright(c) 2010-2012 HP Tech. Co., Ltd. All rights reserved.</example>
-    <example>HP V1910-24G-PoE (170W) Switch Software Version 5.20 Release 1108P01 Copyright (c) 2004-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP V1910-24G-PoE (170W) Switch Software Version 5.20 Release 1111P01 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP V1910-24G-PoE (365W) Switch Software Version 5.20 Release 1108 Copyright (c) 2004-2011 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP V1910-48G Switch Software Version 5.20 Release 1111P01 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
-    <example>HP V1910-48G Switch Software Version 5.20, Release 1511 Copyright(c) 2010-2012 HP Tech. Co., Ltd. All rights reserved.</example>
+    <example os.version="5.20" os.product="V1910-16G" hw.product="V1910-16G" os.version.version="1108">HP V1910-16G Switch Software Version 5.20 Release 1108 Copyright (c) 2004-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20," os.product="V1910-16G" hw.product="V1910-16G" os.version.version="1511">HP V1910-16G Switch Software Version 5.20, Release 1511 Copyright(c) 2010-2012 HP Tech. Co., Ltd. All rights reserved.</example>
+    <example os.version="5.20" os.product="V1910-24G" hw.product="V1910-24G" os.version.version="1111">HP V1910-24G Switch Software Version 5.20 Release 1111 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" os.product="V1910-24G" hw.product="V1910-24G" os.version.version="1111P01">HP V1910-24G Switch Software Version 5.20 Release 1111P01 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20," os.product="V1910-24G" hw.product="V1910-24G" os.version.version="1511">HP V1910-24G Switch Software Version 5.20, Release 1511 Copyright(c) 2010-2012 HP Tech. Co., Ltd. All rights reserved.</example>
+    <example os.version="5.20" os.product="V1910-24G-PoE" hw.product="V1910-24G-PoE" os.version.version="1108P01">HP V1910-24G-PoE (170W) Switch Software Version 5.20 Release 1108P01 Copyright (c) 2004-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" os.product="V1910-24G-PoE" hw.product="V1910-24G-PoE" os.version.version="1111P01">HP V1910-24G-PoE (170W) Switch Software Version 5.20 Release 1111P01 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" os.product="V1910-24G-PoE" hw.product="V1910-24G-PoE" os.version.version="1108">HP V1910-24G-PoE (365W) Switch Software Version 5.20 Release 1108 Copyright (c) 2004-2011 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20" os.product="V1910-48G" hw.product="V1910-48G" os.version.version="1111P01">HP V1910-48G Switch Software Version 5.20 Release 1111P01 Copyright (c) 2004-2012 Hewlett-Packard Development Company, L.P.</example>
+    <example os.version="5.20," os.product="V1910-48G" hw.product="V1910-48G" os.version.version="1511">HP V1910-48G Switch Software Version 5.20, Release 1511 Copyright(c) 2010-2012 HP Tech. Co., Ltd. All rights reserved.</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="V1910"/>
@@ -2675,9 +2675,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP (V1905\S+) Switch Product Version (\S+) Copyright">
     <description>HP Switch - product version variant</description>
-    <example>HP V1905-24 Switch Product Version 02.00.01 Copyright (c) 2011 Hewlett-Packard Development Company, L.P All rights Reserved.</example>
-    <example>HP V1905-24-PoE Switch Product Version 02.00.01 Copyright (c) 2011 Hewlett-Packard Development Company, L.P All rights Reserved.</example>
-    <example>HP V1905-48 Switch Product Version 02.00.01 Copyright (c) 2011 Hewlett-Packard Development Company, L.P All rights Reserved.</example>
+    <example os.version="02.00.01" os.product="V1905-24" hw.product="V1905-24">HP V1905-24 Switch Product Version 02.00.01 Copyright (c) 2011 Hewlett-Packard Development Company, L.P All rights Reserved.</example>
+    <example os.version="02.00.01" os.product="V1905-24-PoE" hw.product="V1905-24-PoE">HP V1905-24-PoE Switch Product Version 02.00.01 Copyright (c) 2011 Hewlett-Packard Development Company, L.P All rights Reserved.</example>
+    <example os.version="02.00.01" os.product="V1905-48" hw.product="V1905-48">HP V1905-48 Switch Product Version 02.00.01 Copyright (c) 2011 Hewlett-Packard Development Company, L.P All rights Reserved.</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.family" value="V1905"/>
@@ -2688,7 +2688,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Hewlett-Packard Company (\S+) HP ProCurve Routing Switch.*Software Version (\S+)">
     <description>HP ProCurve Routing Switch - build data variant</description>
-    <example>Hewlett-Packard Company J4139A HP ProCurve Routing Switch 9304M, Software Version 08.0.01kT53 Compiled on Apr 27 2007 at 18:55:59 labeled as H2R08001k</example>
+    <example os.product="J4139A" os.version="08.0.01kT53">Hewlett-Packard Company J4139A HP ProCurve Routing Switch 9304M, Software Version 08.0.01kT53 Compiled on Apr 27 2007 at 18:55:59 labeled as H2R08001k</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -2698,8 +2698,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP (J\S+) ProCurve Switch.*, revision (\S+),">
     <description>HP ProCurve Routing Switch</description>
-    <example>HP J4813A ProCurve Switch 2524, revision F.05.34, ROM F.02.01  (/sw/code/build/info(s02))</example>
-    <example>HP J4121A ProCurve Switch 4000M, revision C.09.28, ROM C.06.01 (/sw/code/build/vgro(c09))</example>
+    <example os.product="J4813A" os.version="F.05.34">HP J4813A ProCurve Switch 2524, revision F.05.34, ROM F.02.01  (/sw/code/build/info(s02))</example>
+    <example os.product="J4121A" os.version="C.09.28">HP J4121A ProCurve Switch 4000M, revision C.09.28, ROM C.06.01 (/sw/code/build/vgro(c09))</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -2709,7 +2709,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^ProCurve (J\S+) Switch.*, revision (\S+),">
     <description>HP ProCurve Switch - HP prefix and build path variant</description>
-    <example>ProCurve J4900B Switch 2626, revision H.08.98, ROM H.08.02 (/sw/code/build/fish(ts_08_5))</example>
+    <example os.product="J4900B" os.version="H.08.98">ProCurve J4900B Switch 2626, revision H.08.98, ROM H.08.02 (/sw/code/build/fish(ts_08_5))</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -2720,9 +2720,9 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^HP ProCurve (\S+) - \d+ GE, ([A-Z]{1,2}\.[^,]+),">
     <description>HP ProCurve Switch - HP prefix variant</description>
     <example os.product="1810G" os.version="H.1.2">HP ProCurve 1810G - 8 GE, H.1.2, eCos-2.0</example>
-    <example>HP ProCurve 1810G - 24 GE, P.1.14, eCos-2.0</example>
-    <example>HP ProCurve 1810G - 8 GE, P.1.8, eCos-2.0</example>
-    <example>HP ProCurve 1810G - 8 GE, P.2.2, eCos-2.0, CFE-2.1</example>
+    <example os.product="1810G" os.version="P.1.14">HP ProCurve 1810G - 24 GE, P.1.14, eCos-2.0</example>
+    <example os.product="1810G" os.version="P.1.8">HP ProCurve 1810G - 8 GE, P.1.8, eCos-2.0</example>
+    <example os.product="1810G" os.version="P.2.2">HP ProCurve 1810G - 8 GE, P.2.2, eCos-2.0, CFE-2.1</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -2741,9 +2741,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^ProCurve (\S+) (.*?) Switch, revision ([^,]+),">
     <description>HP ProCurve Switch - extended model variant</description>
-    <example>ProCurve J9145A 2910al-24G Switch, revision W.14.03, ROM W.14.04 (/sw/code/build/sbm(t4a_RC3))</example>
-    <example>ProCurve J9145A 2910al-24G Switch, revision W.14.30, ROM W.14.04 (/sw/code/build/sbm(t4a))</example>
-    <example>ProCurve 516733-B21 6120XG Blade Switch, revision Z.14.26, ROM Z.14.09 (/sw/code/build/vern(Z_14_zinfip_t4b))</example>
+    <example os.product="2910al-24G" os.version="W.14.03" hw.product="J9145A">ProCurve J9145A 2910al-24G Switch, revision W.14.03, ROM W.14.04 (/sw/code/build/sbm(t4a_RC3))</example>
+    <example os.product="2910al-24G" os.version="W.14.30" hw.product="J9145A">ProCurve J9145A 2910al-24G Switch, revision W.14.30, ROM W.14.04 (/sw/code/build/sbm(t4a))</example>
+    <example os.product="6120XG Blade" os.version="Z.14.26" hw.product="516733-B21">ProCurve 516733-B21 6120XG Blade Switch, revision Z.14.26, ROM Z.14.09 (/sw/code/build/vern(Z_14_zinfip_t4b))</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="2" name="os.product"/>
@@ -2753,10 +2753,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^ProCurve (\S+) Switch ([^,]+), revision ([^,]+),">
     <description>HP Switch - build path variant</description>
-    <example>ProCurve j9020a Switch 2510-48, revision U.11.04, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
-    <example>ProCurve j9020a Switch 2510-48, revision U.11.08, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
-    <example>ProCurve j9020a Switch 2510-48, revision U.11.11, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
-    <example>ProCurve j9020a Switch 2510-48, revision U.11.17, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
+    <example os.product="2510-48" os.version="U.11.04" hw.product="j9020a">ProCurve j9020a Switch 2510-48, revision U.11.04, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
+    <example os.product="2510-48" os.version="U.11.08" hw.product="j9020a">ProCurve j9020a Switch 2510-48, revision U.11.08, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
+    <example os.product="2510-48" os.version="U.11.11" hw.product="j9020a">ProCurve j9020a Switch 2510-48, revision U.11.11, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
+    <example os.product="2510-48" os.version="U.11.17" hw.product="j9020a">ProCurve j9020a Switch 2510-48, revision U.11.17, ROM R.10.06 (/sw/code/build/dosx(ndx))</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="2" name="os.product"/>
@@ -2766,9 +2766,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP(\S+) HP ProCurve Switch ([^,]+), revision ([^,]+),">
     <description>HP ProCurve Switch - model first variant</description>
-    <example>HPJ3298A HP ProCurve Switch 212M, revision D.05.04, ROM D.05.01 (/sw/code/build/srao(f98))</example>
-    <example>HPJ4121A HP ProCurve Switch 4000M, revision C.05.04, ROM C.05.02 (/sw/code/build/vgro(f98))</example>
-    <example>HPJ4122A HP ProCurve Switch 2400M, revision C.05.04, ROM C.05.02 (/sw/code/build/vgro(f98))</example>
+    <example os.product="212M" os.version="D.05.04" hw.product="J3298A">HPJ3298A HP ProCurve Switch 212M, revision D.05.04, ROM D.05.01 (/sw/code/build/srao(f98))</example>
+    <example os.product="4000M" os.version="C.05.04" hw.product="J4121A">HPJ4121A HP ProCurve Switch 4000M, revision C.05.04, ROM C.05.02 (/sw/code/build/vgro(f98))</example>
+    <example os.product="2400M" os.version="C.05.04" hw.product="J4122A">HPJ4122A HP ProCurve Switch 2400M, revision C.05.04, ROM C.05.02 (/sw/code/build/vgro(f98))</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="2" name="os.product"/>
@@ -2778,10 +2778,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP (\S+) (\S+) Switch, revision ([^,]+),">
     <description>HP Switch - rom variant</description>
-    <example>HP J9145A E2910al-24G Switch, revision W.15.08.0007, ROM W.14.06 (/ws/swbuildm/rel_galt_qaoff/code/build/sbm(rel_galt_qaoff)) (Formerly ProCurve)</example>
-    <example>HP J9623A E2620-24 Switch, revision RA.15.05.0006, ROM RA.15.10 (/sw/code/build/xform(RA_15_05)) (Formerly ProCurve)</example>
-    <example>HP J9625A E2620-24-PoEP Switch, revision RA.15.05.0006, ROM RA.15.10 (/sw/code/build/xform(RA_15_05)) (Formerly ProCurve)</example>
-    <example>HP J9626A E2620-48 Switch, revision RA.15.05.0006, ROM RA.15.10 (/sw/code/build/xform(RA_15_05)) (Formerly ProCurve)</example>
+    <example os.product="E2910al-24G" os.version="W.15.08.0007" hw.product="J9145A">HP J9145A E2910al-24G Switch, revision W.15.08.0007, ROM W.14.06 (/ws/swbuildm/rel_galt_qaoff/code/build/sbm(rel_galt_qaoff)) (Formerly ProCurve)</example>
+    <example os.product="E2620-24" os.version="RA.15.05.0006" hw.product="J9623A">HP J9623A E2620-24 Switch, revision RA.15.05.0006, ROM RA.15.10 (/sw/code/build/xform(RA_15_05)) (Formerly ProCurve)</example>
+    <example os.product="E2620-24-PoEP" os.version="RA.15.05.0006" hw.product="J9625A">HP J9625A E2620-24-PoEP Switch, revision RA.15.05.0006, ROM RA.15.10 (/sw/code/build/xform(RA_15_05)) (Formerly ProCurve)</example>
+    <example os.product="E2620-48" os.version="RA.15.05.0006" hw.product="J9626A">HP J9626A E2620-48 Switch, revision RA.15.05.0006, ROM RA.15.10 (/sw/code/build/xform(RA_15_05)) (Formerly ProCurve)</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="2" name="os.product"/>
@@ -2791,10 +2791,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP (\S+) Switch ([^,]+), revision ([^,]+),">
     <description>HP Switch - extended model variant</description>
-    <example>HP J8692A Switch E3500yl-24G, revision K.15.05.0002, ROM K.15.13 (/sw/code/build/btm(K_15_05)) (Formerly ProCurve)</example>
-    <example>HP J8697A Switch E5406zl, revision K.15.06.0006, ROM K.15.19 (/sw/code/build/btm(K_15_06)) (Formerly ProCurve)</example>
-    <example>HP J8698A Switch E5412zl, revision K.15.08.0007, ROM K.15.28 (/ws/swbuildm/rel_galt_qaoff/code/build/btm(rel_galt_qaoff)) (Formerly ProCurve)</example>
-    <example>HP J9477A Switch E8206zl, revision K.15.07.0008, ROM K.15.28 (/ws/swbuildm/ec_rel_ftcollins_qaoff/code/build/btm(ec_rel_ftcollins_qaoff)) (Formerly ProCurve)</example>
+    <example os.product="E3500yl-24G" os.version="K.15.05.0002" hw.product="J8692A">HP J8692A Switch E3500yl-24G, revision K.15.05.0002, ROM K.15.13 (/sw/code/build/btm(K_15_05)) (Formerly ProCurve)</example>
+    <example os.product="E5406zl" os.version="K.15.06.0006" hw.product="J8697A">HP J8697A Switch E5406zl, revision K.15.06.0006, ROM K.15.19 (/sw/code/build/btm(K_15_06)) (Formerly ProCurve)</example>
+    <example os.product="E5412zl" os.version="K.15.08.0007" hw.product="J8698A">HP J8698A Switch E5412zl, revision K.15.08.0007, ROM K.15.28 (/ws/swbuildm/rel_galt_qaoff/code/build/btm(rel_galt_qaoff)) (Formerly ProCurve)</example>
+    <example os.product="E8206zl" os.version="K.15.07.0008" hw.product="J9477A">HP J9477A Switch E8206zl, revision K.15.07.0008, ROM K.15.28 (/ws/swbuildm/ec_rel_ftcollins_qaoff/code/build/btm(ec_rel_ftcollins_qaoff)) (Formerly ProCurve)</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="2" name="os.product"/>
@@ -2804,8 +2804,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP(\S+) ProCurve \S+ Hub \d+M+, ROM ([^,]+),">
     <description>HP ProCurve Hub</description>
-    <example>HPJ3288A ProCurve 10/100 Hub 12M, ROM A.01.00, EEPROM A.01.00, HW A.02.00</example>
-    <example>HPJ3289A ProCurve 10/100 Hub 24M, ROM A.01.00, EEPROM A.01.00, HW A.02.00</example>
+    <example os.product="J3288A" os.version="A.01.00">HPJ3288A ProCurve 10/100 Hub 12M, ROM A.01.00, EEPROM A.01.00, HW A.02.00</example>
+    <example os.product="J3289A" os.version="A.01.00">HPJ3289A ProCurve 10/100 Hub 24M, ROM A.01.00, EEPROM A.01.00, HW A.02.00</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Hub"/>
     <param pos="1" name="os.product"/>
@@ -2814,14 +2814,14 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^PROCURVE (\S+) - (\S+)$">
     <description>HP ProCurve Switch</description>
-    <example>PROCURVE J9028A - PB.02.01</example>
-    <example>PROCURVE J9028A - PB.02.03</example>
-    <example>PROCURVE J9028A - PB.03.02</example>
-    <example>PROCURVE J9028A - PB.03.04</example>
-    <example>PROCURVE J9079A - VA.02.02</example>
-    <example>PROCURVE J9080A - VB.02.01</example>
-    <example>PROCURVE J9080A - VB.02.02</example>
-    <example>PROCURVE J9080A - VB.02.04</example>
+    <example os.product="J9028A" os.version="PB.02.01">PROCURVE J9028A - PB.02.01</example>
+    <example os.product="J9028A" os.version="PB.02.03">PROCURVE J9028A - PB.02.03</example>
+    <example os.product="J9028A" os.version="PB.03.02">PROCURVE J9028A - PB.03.02</example>
+    <example os.product="J9028A" os.version="PB.03.04">PROCURVE J9028A - PB.03.04</example>
+    <example os.product="J9079A" os.version="VA.02.02">PROCURVE J9079A - VA.02.02</example>
+    <example os.product="J9080A" os.version="VB.02.01">PROCURVE J9080A - VB.02.01</example>
+    <example os.product="J9080A" os.version="VB.02.02">PROCURVE J9080A - VB.02.02</example>
+    <example os.product="J9080A" os.version="VB.02.04">PROCURVE J9080A - VB.02.04</example>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -2830,10 +2830,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP Pro[cC]urve Access Point (\S+): v(\S+)">
     <description>HP ProCurve Wireless Access Point - serial number variant</description>
-    <example>HP ProCurve Access Point 420: v2.1.5 v3.0.6</example>
-    <example>HP Procurve Access Point 420: v2.0.38 v1.1.8 SN:TW517QB0VM</example>
-    <example>HP Procurve Access Point 420: v2.0.38 v1.1.8 SN:TW525QB1T8</example>
-    <example>HP Procurve Access Point 420: v2.0.39 v1.1.8 SN:TW439QB0JJ</example>
+    <example os.product="420" os.version="2.1.5">HP ProCurve Access Point 420: v2.1.5 v3.0.6</example>
+    <example os.product="420" os.version="2.0.38">HP Procurve Access Point 420: v2.0.38 v1.1.8 SN:TW517QB0VM</example>
+    <example os.product="420" os.version="2.0.38">HP Procurve Access Point 420: v2.0.38 v1.1.8 SN:TW525QB1T8</example>
+    <example os.product="420" os.version="2.0.39">HP Procurve Access Point 420: v2.0.39 v1.1.8 SN:TW439QB0JJ</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -2843,7 +2843,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP ProCurve AP (.*?)v(\d[0-9\.]+)\(.*SN-">
     <description>HP ProCurve Wireless Access Point</description>
-    <example>HP ProCurve AP 520wlv2.4.5(758) SN-PG44JL9CWY23 v2.0.10</example>
+    <example os.product="520wl" os.version="2.4.5">HP ProCurve AP 520wlv2.4.5(758) SN-PG44JL9CWY23 v2.0.10</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -2853,13 +2853,13 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^ProCurve Access Point (\S+(?: \S+)) ([^,]+), revision ([^,]+),">
     <description>HP ProCurve Wireless Access Point - boot variant</description>
-    <example>ProCurve Access Point 10ag WW J9141A, revision WM.01.11, boot version WAB.01.00</example>
-    <example>ProCurve Access Point 530 NA J8986A, revision WA.02.15, boot version WAB.01.00</example>
-    <example>ProCurve Access Point 530 NA J8986A, revision WA.02.19, boot version WAB.01.00</example>
-    <example>ProCurve Access Point 530 NA J8986A, revision WA.02.27.0003, boot version WAB.01.00</example>
-    <example>ProCurve Access Point 530 WW J8987A, revision WA.01.05, boot version WAB.01.00</example>
-    <example>ProCurve Access Point 530 WW J8987A, revision WA.02.15, boot version</example>
-    <example>ProCurve Access Point 530 WW J8987A, revision WA.02.19, boot version WAB.01.00</example>
+    <example os.product="10ag WW" os.version="WM.01.11" hw.product="J9141A">ProCurve Access Point 10ag WW J9141A, revision WM.01.11, boot version WAB.01.00</example>
+    <example os.product="530 NA" os.version="WA.02.15" hw.product="J8986A">ProCurve Access Point 530 NA J8986A, revision WA.02.15, boot version WAB.01.00</example>
+    <example os.product="530 NA" os.version="WA.02.19" hw.product="J8986A">ProCurve Access Point 530 NA J8986A, revision WA.02.19, boot version WAB.01.00</example>
+    <example os.product="530 NA" os.version="WA.02.27.0003" hw.product="J8986A">ProCurve Access Point 530 NA J8986A, revision WA.02.27.0003, boot version WAB.01.00</example>
+    <example os.product="530 WW" os.version="WA.01.05" hw.product="J8987A">ProCurve Access Point 530 WW J8987A, revision WA.01.05, boot version WAB.01.00</example>
+    <example os.product="530 WW" os.version="WA.02.15" hw.product="J8987A">ProCurve Access Point 530 WW J8987A, revision WA.02.15, boot version</example>
+    <example os.product="530 WW" os.version="WA.02.19" hw.product="J8987A">ProCurve Access Point 530 WW J8987A, revision WA.02.19, boot version WAB.01.00</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -2870,12 +2870,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^ProCurve Secure Router ([^,]+), Version: ([^,]+),">
     <description>HP ProCurve Secure Router</description>
-    <example>ProCurve Secure Router 7102dl, Version: 03.01, Date: Fri Aug 12 08:41:29 2005</example>
-    <example>ProCurve Secure Router 7102dl, Version: 05.02, Date: Mon May 15 09:32:11 2006</example>
-    <example>ProCurve Secure Router 7203dl, Version: 05.02, Date: Mon May 15 09:32:11 2006</example>
-    <example>ProCurve Secure Router 7203dl, Version: 08.03, Date: Fri Jul 20 09:41:03 2007</example>
-    <example>ProCurve Secure Router 7203dl, Version: 14.04, Date: Wed Oct 14 11:33:27 2009</example>
-    <example>ProCurve Secure Router 7203dl, Version: 17.02.00, Date: Thu Jun 24 11:04:36 2010</example>
+    <example os.product="7102dl" os.version="03.01">ProCurve Secure Router 7102dl, Version: 03.01, Date: Fri Aug 12 08:41:29 2005</example>
+    <example os.product="7102dl" os.version="05.02">ProCurve Secure Router 7102dl, Version: 05.02, Date: Mon May 15 09:32:11 2006</example>
+    <example os.product="7203dl" os.version="05.02">ProCurve Secure Router 7203dl, Version: 05.02, Date: Mon May 15 09:32:11 2006</example>
+    <example os.product="7203dl" os.version="08.03">ProCurve Secure Router 7203dl, Version: 08.03, Date: Fri Jul 20 09:41:03 2007</example>
+    <example os.product="7203dl" os.version="14.04">ProCurve Secure Router 7203dl, Version: 14.04, Date: Wed Oct 14 11:33:27 2009</example>
+    <example os.product="7203dl" os.version="17.02.00">ProCurve Secure Router 7203dl, Version: 17.02.00, Date: Thu Jun 24 11:04:36 2010</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="ProCurve"/>
     <param pos="0" name="os.device" value="Router"/>
@@ -2895,8 +2895,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP (?:Color )?LaserJet (\S+)$">
     <description>HP Color LaserJet</description>
-    <example>HP Color LaserJet 2840</example>
-    <example>HP LaserJet 2840</example>
+    <example os.product="2840">HP Color LaserJet 2840</example>
+    <example os.product="2840">HP LaserJet 2840</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="LaserJet"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -2905,7 +2905,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^MSA (Fabric Switch \d+)$">
     <description>HP MSA Fabric Switch</description>
-    <example>MSA Fabric Switch 6</example>
+    <example os.product="Fabric Switch 6">MSA Fabric Switch 6</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="MSA"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -2935,16 +2935,16 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP StorageWorks (MSA\S+)$">
     <description>HP StorageWorks Modular Smart Array</description>
-    <example>HP StorageWorks MSA2012fc</example>
-    <example>HP StorageWorks MSA2012i</example>
-    <example>HP StorageWorks MSA2012sa</example>
-    <example>HP StorageWorks MSA2212fc</example>
-    <example>HP StorageWorks MSA2312fc</example>
-    <example>HP StorageWorks MSA2312i</example>
-    <example>HP StorageWorks MSA2312sa</example>
-    <example>HP StorageWorks MSA2324fc</example>
-    <example>HP StorageWorks MSA2324i</example>
-    <example>HP StorageWorks MSA2324sa</example>
+    <example os.product="MSA2012fc">HP StorageWorks MSA2012fc</example>
+    <example os.product="MSA2012i">HP StorageWorks MSA2012i</example>
+    <example os.product="MSA2012sa">HP StorageWorks MSA2012sa</example>
+    <example os.product="MSA2212fc">HP StorageWorks MSA2212fc</example>
+    <example os.product="MSA2312fc">HP StorageWorks MSA2312fc</example>
+    <example os.product="MSA2312i">HP StorageWorks MSA2312i</example>
+    <example os.product="MSA2312sa">HP StorageWorks MSA2312sa</example>
+    <example os.product="MSA2324fc">HP StorageWorks MSA2324fc</example>
+    <example os.product="MSA2324i">HP StorageWorks MSA2324i</example>
+    <example os.product="MSA2324sa">HP StorageWorks MSA2324sa</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="StorageWorks"/>
     <param pos="1" name="os.product"/>
@@ -2953,10 +2953,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP StorageWorks (P2000.*)$">
     <description>HP StorageWorks Modular Smart Array - connection type variant</description>
-    <example>HP StorageWorks P2000 G3 FC</example>
-    <example>HP StorageWorks P2000 G3 SAS</example>
-    <example>HP StorageWorks P2000 G3 iSCSI</example>
-    <example>HP StorageWorks P2000G3 FC/iSCSI</example>
+    <example os.product="P2000 G3 FC">HP StorageWorks P2000 G3 FC</example>
+    <example os.product="P2000 G3 SAS">HP StorageWorks P2000 G3 SAS</example>
+    <example os.product="P2000 G3 iSCSI">HP StorageWorks P2000 G3 iSCSI</example>
+    <example os.product="P2000G3 FC/iSCSI">HP StorageWorks P2000G3 FC/iSCSI</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="StorageWorks"/>
     <param pos="1" name="os.product"/>
@@ -2965,7 +2965,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP StorageWorks (\S+) Stackable Single Power Supply Fibre Channel Switch$">
     <description>HP StorageWorks Stackable FC Switch</description>
-    <example>HP StorageWorks SN6000 Stackable Single Power Supply Fibre Channel Switch</example>
+    <example os.product="SN6000">HP StorageWorks SN6000 Stackable Single Power Supply Fibre Channel Switch</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="StorageWorks"/>
     <param pos="1" name="os.product"/>
@@ -2974,7 +2974,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP StorageWorks (\S+) Fibre Channel Switch$">
     <description>HP StorageWorks FC Switch</description>
-    <example>HP StorageWorks 8/20q Fibre Channel Switch</example>
+    <example os.product="8/20q">HP StorageWorks 8/20q Fibre Channel Switch</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="StorageWorks"/>
     <param pos="1" name="os.product"/>
@@ -3073,10 +3073,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP ETHERNET MULTI-ENVIRONMENT,ROM (\S+?),JETDIRECT(?: EX)?,(\w+),EEPROM">
     <description>HP JetDirect printer</description>
-    <example>HP ETHERNET MULTI-ENVIRONMENT,ROM A.03.15,JETDIRECT,JD24,EEPROM A.04.09</example>
-    <example>HP ETHERNET MULTI-ENVIRONMENT,ROM A.05.03,JETDIRECT,JD24,EEPROM A.05.05</example>
-    <example>HP ETHERNET MULTI-ENVIRONMENT,ROM A.05.03,JETDIRECT,JD24,EEPROM A.08.49</example>
-    <example>HP ETHERNET MULTI-ENVIRONMENT,ROM B.25.01,JETDIRECT,JD118,EEPROM D.27.02,CIDATE 03/23/2004</example>
+    <example os.version="A.03.15" os.product="JD24">HP ETHERNET MULTI-ENVIRONMENT,ROM A.03.15,JETDIRECT,JD24,EEPROM A.04.09</example>
+    <example os.version="A.05.03" os.product="JD24">HP ETHERNET MULTI-ENVIRONMENT,ROM A.05.03,JETDIRECT,JD24,EEPROM A.05.05</example>
+    <example os.version="A.05.03" os.product="JD24">HP ETHERNET MULTI-ENVIRONMENT,ROM A.05.03,JETDIRECT,JD24,EEPROM A.08.49</example>
+    <example os.version="B.25.01" os.product="JD118">HP ETHERNET MULTI-ENVIRONMENT,ROM B.25.01,JETDIRECT,JD118,EEPROM D.27.02,CIDATE 03/23/2004</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="JetDirect"/>
     <param pos="0" name="os.device" value="Print Server"/>
@@ -3086,9 +3086,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HP ETHERNET MULTI-ENVIRONMENT,SN:\w+,FN:\w+,SVCID:\d+,PID:HP (?:Color )?LaserJet (.*)$">
     <description>HP JetDirect-based printer</description>
-    <example>HP ETHERNET MULTI-ENVIRONMENT,SN:CNBJL00199,FN:JK0086J,SVCID:17036,PID:HP LaserJet P2015 Series</example>
-    <example>HP ETHERNET MULTI-ENVIRONMENT,SN:CNBJL53447,FN:JK35P6Y,SVCID:00000,PID:HP LaserJet P2015 Series</example>
-    <example>HP ETHERNET MULTI-ENVIRONMENT,SN:CNF9B1HNBY,FN:PT50G6X,SVCID:20132,PID:HP Color LaserJet CM2320nf MFP</example>
+    <example os.product="P2015 Series">HP ETHERNET MULTI-ENVIRONMENT,SN:CNBJL00199,FN:JK0086J,SVCID:17036,PID:HP LaserJet P2015 Series</example>
+    <example os.product="P2015 Series">HP ETHERNET MULTI-ENVIRONMENT,SN:CNBJL53447,FN:JK35P6Y,SVCID:00000,PID:HP LaserJet P2015 Series</example>
+    <example os.product="CM2320nf MFP">HP ETHERNET MULTI-ENVIRONMENT,SN:CNF9B1HNBY,FN:PT50G6X,SVCID:20132,PID:HP Color LaserJet CM2320nf MFP</example>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.family" value="LaserJet"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -3142,7 +3142,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^MAS 1\.0 \(Intel X86\) Copyright.*Huawei Technologies Co\., Ltd on SUSE LINUX ([\d\.]+)$">
     <description>Huawei device on SuSE Linux</description>
-    <example>MAS 1.0 (Intel X86) Copyright (c) 1998-2006 Huawei Technologies Co., Ltd on SUSE LINUX 9.0</example>
+    <example os.version="9.0">MAS 1.0 (Intel X86) Copyright (c) 1998-2006 Huawei Technologies Co., Ltd on SUSE LINUX 9.0</example>
     <param pos="0" name="os.vendor" value="SuSE"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -3423,8 +3423,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^IBM Network Printer (\S+)$">
     <description>IBM Network Printer</description>
-    <example>IBM Network Printer 12</example>
-    <example>IBM Network Printer 24</example>
+    <example os.product="12">IBM Network Printer 12</example>
+    <example os.product="24">IBM Network Printer 24</example>
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.family" value="Network Printer"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -3433,11 +3433,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^IBM 6400 Version (\S+)">
     <description>IBM 6400 Matrix Printer</description>
-    <example>IBM 6400 Version 1.1.41 3-3-3</example>
-    <example>IBM 6400 Version 1.1.38.11 3-3-3</example>
-    <example>IBM 6400 Version 1.1.5</example>
-    <example>IBM 6400 Version 7.0.9.6</example>
-    <example>IBM 6400 Version 7.1</example>
+    <example os.version="1.1.41">IBM 6400 Version 1.1.41 3-3-3</example>
+    <example os.version="1.1.38.11">IBM 6400 Version 1.1.38.11 3-3-3</example>
+    <example os.version="1.1.5">IBM 6400 Version 1.1.5</example>
+    <example os.version="7.0.9.6">IBM 6400 Version 7.0.9.6</example>
+    <example os.version="7.1">IBM 6400 Version 7.1</example>
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="0" name="os.product" value="6400 Matrix Printer"/>
@@ -3504,7 +3504,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Thermal Label Printer Intermec (\S+)$">
     <description>Intermec Thermal Label Printer</description>
-    <example os.product="Thermal Label Printer PM43" hw.product="Thermal Label Printer PM43">Thermal Label Printer Intermec PM43</example>
+    <example os.product="Thermal Label Printer PM43" hw.product="Thermal Label Printer PM43" hw.model="PM43">Thermal Label Printer Intermec PM43</example>
     <param pos="0" name="hw.vendor" value="Intermec"/>
     <param pos="1" name="hw.model"/>
     <param pos="0" name="hw.product" value="Thermal Label Printer {hw.model}"/>
@@ -3516,7 +3516,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Honeywell (PM\d+);P([\d\.]+)$">
     <description>Honeywell Thermal Label Printer (Previously Intermec)</description>
-    <example os.product="Thermal Label Printer PM43" hw.product="Thermal Label Printer PM43">Honeywell PM43;P10.14.014620</example>
+    <example os.product="Thermal Label Printer PM43" hw.product="Thermal Label Printer PM43" hw.model="PM43" hw.version="10.14.014620">Honeywell PM43;P10.14.014620</example>
     <param pos="0" name="hw.vendor" value="Honeywell"/>
     <param pos="1" name="hw.model"/>
     <param pos="2" name="hw.version"/>
@@ -3549,13 +3549,13 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper (\S+) : (\d+\S+)$">
     <description>Juniper Router</description>
-    <example>Juniper WXC-1800 : 5.6.4.0</example>
-    <example>Juniper WXC-1800 : 5.7.7.0</example>
-    <example>Juniper WXC-250 : 5.7.7.0</example>
-    <example>Juniper WXC-3400 : 5.6.4.0</example>
-    <example>Juniper WXC-500 : 5.5.2.0</example>
-    <example>Juniper WXC-500 : 5.7.5.0</example>
-    <example>Juniper WXC-500 : 5.7.7.0_PD1</example>
+    <example os.product="WXC-1800" os.version="5.6.4.0">Juniper WXC-1800 : 5.6.4.0</example>
+    <example os.product="WXC-1800" os.version="5.7.7.0">Juniper WXC-1800 : 5.7.7.0</example>
+    <example os.product="WXC-250" os.version="5.7.7.0">Juniper WXC-250 : 5.7.7.0</example>
+    <example os.product="WXC-3400" os.version="5.6.4.0">Juniper WXC-3400 : 5.6.4.0</example>
+    <example os.product="WXC-500" os.version="5.5.2.0">Juniper WXC-500 : 5.5.2.0</example>
+    <example os.product="WXC-500" os.version="5.7.5.0">Juniper WXC-500 : 5.7.5.0</example>
+    <example os.product="WXC-500" os.version="5.7.7.0_PD1">Juniper WXC-500 : 5.7.7.0_PD1</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -3564,22 +3564,22 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper Networks,Inc,([^,]+),([^,]+) \(build (\d+)\)$">
     <description>Juniper Router - build variant</description>
-    <example>Juniper Networks,Inc,MAG-4610,7.1R6 (build 20169)</example>
-    <example>Juniper Networks,Inc,MAG-4610,7.1R7:HF2 (build 21415)</example>
-    <example>Juniper Networks,Inc,MAG-4610,7.3R1:B2 (build 21317)</example>
-    <example>Juniper Networks,Inc,MAG-SM160,7.3R1:B2 (build 21317)</example>
-    <example>Juniper Networks,Inc,SA-2000,7.1R1.1 (build 17943)</example>
-    <example>Juniper Networks,Inc,SA-2000,7.1R2 (build 18193)</example>
-    <example>Juniper Networks,Inc,SA-2000,7.1R4 (build 19243)</example>
-    <example>Juniper Networks,Inc,SA-2500,7.1R1 (build 17675)</example>
-    <example>Juniper Networks,Inc,SA-2500,7.1R2 (build 18193)</example>
-    <example>Juniper Networks,Inc,SA-2500,7.1R6 (build 20169)</example>
-    <example>Juniper Networks,Inc,SA-2500,7.1R9 (build 20893)</example>
-    <example>Juniper Networks,Inc,SA-2500,7.2R1.1 (build 20761)</example>
-    <example>Juniper Networks,Inc,SA-4000,7.1R7 (build 20581)</example>
-    <example>Juniper Networks,Inc,SA-4500,7.1R10 (build 21187)</example>
-    <example>Juniper Networks,Inc,SA-4500,7.1R8 (build 20737)</example>
-    <example>Juniper Networks,Inc,SA-6000,7.1R7:HF2 (build 21415)</example>
+    <example os.product="MAG-4610" os.version="7.1R6" os.version.version="20169">Juniper Networks,Inc,MAG-4610,7.1R6 (build 20169)</example>
+    <example os.product="MAG-4610" os.version="7.1R7:HF2" os.version.version="21415">Juniper Networks,Inc,MAG-4610,7.1R7:HF2 (build 21415)</example>
+    <example os.product="MAG-4610" os.version="7.3R1:B2" os.version.version="21317">Juniper Networks,Inc,MAG-4610,7.3R1:B2 (build 21317)</example>
+    <example os.product="MAG-SM160" os.version="7.3R1:B2" os.version.version="21317">Juniper Networks,Inc,MAG-SM160,7.3R1:B2 (build 21317)</example>
+    <example os.product="SA-2000" os.version="7.1R1.1" os.version.version="17943">Juniper Networks,Inc,SA-2000,7.1R1.1 (build 17943)</example>
+    <example os.product="SA-2000" os.version="7.1R2" os.version.version="18193">Juniper Networks,Inc,SA-2000,7.1R2 (build 18193)</example>
+    <example os.product="SA-2000" os.version="7.1R4" os.version.version="19243">Juniper Networks,Inc,SA-2000,7.1R4 (build 19243)</example>
+    <example os.product="SA-2500" os.version="7.1R1" os.version.version="17675">Juniper Networks,Inc,SA-2500,7.1R1 (build 17675)</example>
+    <example os.product="SA-2500" os.version="7.1R2" os.version.version="18193">Juniper Networks,Inc,SA-2500,7.1R2 (build 18193)</example>
+    <example os.product="SA-2500" os.version="7.1R6" os.version.version="20169">Juniper Networks,Inc,SA-2500,7.1R6 (build 20169)</example>
+    <example os.product="SA-2500" os.version="7.1R9" os.version.version="20893">Juniper Networks,Inc,SA-2500,7.1R9 (build 20893)</example>
+    <example os.product="SA-2500" os.version="7.2R1.1" os.version.version="20761">Juniper Networks,Inc,SA-2500,7.2R1.1 (build 20761)</example>
+    <example os.product="SA-4000" os.version="7.1R7" os.version.version="20581">Juniper Networks,Inc,SA-4000,7.1R7 (build 20581)</example>
+    <example os.product="SA-4500" os.version="7.1R10" os.version.version="21187">Juniper Networks,Inc,SA-4500,7.1R10 (build 21187)</example>
+    <example os.product="SA-4500" os.version="7.1R8" os.version.version="20737">Juniper Networks,Inc,SA-4500,7.1R8 (build 20737)</example>
+    <example os.product="SA-6000" os.version="7.1R7:HF2" os.version.version="21415">Juniper Networks,Inc,SA-6000,7.1R7:HF2 (build 21415)</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -3597,17 +3597,17 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper (SRX\S*(?: \S+)?)$">
     <description>Juniper SRX</description>
-    <example>Juniper SRX</example>
-    <example>Juniper SRX 210H</example>
-    <example>Juniper SRX 240</example>
-    <example>Juniper SRX 650</example>
-    <example>Juniper SRX100H</example>
-    <example>Juniper SRX210</example>
-    <example>Juniper SRX210H</example>
-    <example>Juniper SRX240</example>
-    <example>Juniper SRX240 Cluster</example>
-    <example>Juniper SRX240 Firewall</example>
-    <example>Juniper SRX240H</example>
+    <example os.product="SRX">Juniper SRX</example>
+    <example os.product="SRX 210H">Juniper SRX 210H</example>
+    <example os.product="SRX 240">Juniper SRX 240</example>
+    <example os.product="SRX 650">Juniper SRX 650</example>
+    <example os.product="SRX100H">Juniper SRX100H</example>
+    <example os.product="SRX210">Juniper SRX210</example>
+    <example os.product="SRX210H">Juniper SRX210H</example>
+    <example os.product="SRX240">Juniper SRX240</example>
+    <example os.product="SRX240 Cluster">Juniper SRX240 Cluster</example>
+    <example os.product="SRX240 Firewall">Juniper SRX240 Firewall</example>
+    <example os.product="SRX240H">Juniper SRX240H</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="1" name="os.product"/>
@@ -3616,8 +3616,8 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^Juniper Networks, Inc\. (?:(?:Dell|DELL) )?(\S+) internet router, kernel JUNOS (\S+?),? ">
     <description>Juniper Router - build path variant</description>
     <example hw.model="J-EX4200-24T" os.version="11.1R3.5">Juniper Networks, Inc. DELL J-EX4200-24T internet router, kernel JUNOS 11.1R3.5 #0: 2011-06-25 01:18:46 UTC builder@briath.juniper.net:/volume/build/junos/11.1/release/11.1R3.5/obj-powerpc/bsd/kernels/JUNIPER-EX/kernel Build date: 2011-06-25 01:01:37</example>
-    <example os.version="11.4R1.6">Juniper Networks, Inc. ex4200-48p internet router, kernel JUNOS 11.4R1.6 #0: 2011-11-15 11:14:01 UTC builder@evenath.juniper.net:/volume/build/junos/11.4/release/11.4R1.6/obj-powerpc/bsd/kernels/JUNIPER-EX/kernel Build date: 2011-11-15 10:35:08 UTC C</example>
-    <example os.version="9.2R4.4">Juniper Networks, Inc. t640 internet router, kernel JUNOS 9.2R4.4 #0: 2009-05-27 07:54:10 UTC builder@amalath.juniper.net:/volume/build/junos/9.2/release/9.2R4.4/obj-i386/sys/compile/JUNIPER Build date: 2009-05-27 08:11:51 UTC Copyright (c) 1996-2009</example>
+    <example os.version="11.4R1.6" hw.model="ex4200-48p">Juniper Networks, Inc. ex4200-48p internet router, kernel JUNOS 11.4R1.6 #0: 2011-11-15 11:14:01 UTC builder@evenath.juniper.net:/volume/build/junos/11.4/release/11.4R1.6/obj-powerpc/bsd/kernels/JUNIPER-EX/kernel Build date: 2011-11-15 10:35:08 UTC C</example>
+    <example os.version="9.2R4.4" hw.model="t640">Juniper Networks, Inc. t640 internet router, kernel JUNOS 9.2R4.4 #0: 2009-05-27 07:54:10 UTC builder@amalath.juniper.net:/volume/build/junos/9.2/release/9.2R4.4/obj-i386/sys/compile/JUNIPER Build date: 2009-05-27 08:11:51 UTC Copyright (c) 1996-2009</example>
     <example hw.model="srx3400" os.version="12.3X48-D60.2">Juniper Networks, Inc. srx3400 internet router, kernel JUNOS 12.3X48-D60.2, Build date: 2017-12-11 19:52:52 UTC Copyright (c) 1996-2017 Juniper Networks, Inc.</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.family" value="Junos"/>
@@ -3645,9 +3645,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper Networks, Inc\. (\S+) Edge Routing Switch SW Version : \((\S+) (\S+) \[BuildId (\d+)\]\)">
     <description>Juniper Edge Routing Switch</description>
-    <example>Juniper Networks, Inc. E120 Edge Routing Switch SW Version : (10.1.0 release-0.0 [BuildId 10854]) Build Date : April 22, 2009 02:27 Copyright (c) 1999-2009 Juniper Networks, Inc. All rights reserved.</example>
-    <example>Juniper Networks, Inc. E120 Edge Routing Switch SW Version : (10.1.3 release-0.0 [BuildId 12315]) Build Date : July 7, 2010 13:31 Copyright (c) 1999-2010 Juniper Networks, Inc. All rights reserved.</example>
-    <example>Juniper Networks, Inc. ERX-700 Edge Routing Switch SW Version : (8.2.4 patch-0.4 [BuildId 10192]) Build Date : October 24, 2008 00:24 Copyright (c) 1999, 2001 Juniper Networks, Inc.</example>
+    <example os.product="E120" os.version="10.1.0" os.version.version="release-0.0" os.version.version.version="10854">Juniper Networks, Inc. E120 Edge Routing Switch SW Version : (10.1.0 release-0.0 [BuildId 10854]) Build Date : April 22, 2009 02:27 Copyright (c) 1999-2009 Juniper Networks, Inc. All rights reserved.</example>
+    <example os.product="E120" os.version="10.1.3" os.version.version="release-0.0" os.version.version.version="12315">Juniper Networks, Inc. E120 Edge Routing Switch SW Version : (10.1.3 release-0.0 [BuildId 12315]) Build Date : July 7, 2010 13:31 Copyright (c) 1999-2010 Juniper Networks, Inc. All rights reserved.</example>
+    <example os.product="ERX-700" os.version="8.2.4" os.version.version="patch-0.4" os.version.version.version="10192">Juniper Networks, Inc. ERX-700 Edge Routing Switch SW Version : (8.2.4 patch-0.4 [BuildId 10192]) Build Date : October 24, 2008 00:24 Copyright (c) 1999, 2001 Juniper Networks, Inc.</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -3658,7 +3658,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper Networks (\S+(?: \S+)?) Switch, SW Version (\S+)$">
     <description>Juniper Switch</description>
-    <example>Juniper Networks EX2500 10GbE Switch, SW Version 3.1R1.0</example>
+    <example os.product="EX2500 10GbE" os.version="3.1R1.0">Juniper Networks EX2500 10GbE Switch, SW Version 3.1R1.0</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -3667,7 +3667,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper Networks, Inc\. (\S+) Edge Switch Router SW Version : \((\S+) (\S+) \[BuildId (\d+)\]\)">
     <description>Juniper Edge Routing Switch - variant 1</description>
-    <example>Juniper Networks, Inc. RX1400 Edge Switch Router SW Version : (10.3.2 patch-0.2 [BuildId 12841]) Build Date : February 3, 2011 16:26 Copyright (c) 1999, 2001 Juniper Networks, Inc.</example>
+    <example os.product="RX1400" os.version="10.3.2" os.version.version="patch-0.2" os.version.version.version="12841">Juniper Networks, Inc. RX1400 Edge Switch Router SW Version : (10.3.2 patch-0.2 [BuildId 12841]) Build Date : February 3, 2011 16:26 Copyright (c) 1999, 2001 Juniper Networks, Inc.</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -3678,7 +3678,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper Networks, Inc (MX-\d+) (\S+) REL$">
     <description>Juniper WLC</description>
-    <example>Juniper Networks, Inc MX-8 7.6.2.3 REL</example>
+    <example os.product="MX-8" os.version="7.6.2.3">Juniper Networks, Inc MX-8 7.6.2.3 REL</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="1" name="os.product"/>
@@ -3687,8 +3687,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Juniper Networks, Inc. SRC-PE (C\d+)$">
     <description>Juniper Edge Routing Switch - SRC-PE</description>
-    <example>Juniper Networks, Inc. SRC-PE C2000</example>
-    <example>Juniper Networks, Inc. SRC-PE C4000</example>
+    <example os.product="C2000">Juniper Networks, Inc. SRC-PE C2000</example>
+    <example os.product="C4000">Juniper Networks, Inc. SRC-PE C4000</example>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -3713,10 +3713,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^LANIER (.*) ([0-9.]+) / LANIER">
     <description>Lanier multifunction device</description>
-    <example>LANIER LD145 2.40 / LANIER Network Printer C model / LANIER Network Scanner C model / LANIER Network Facsimile C model</example>
-    <example>LANIER LD335c 1.27 / LANIER Network Printer C model / LANIER Network Scanner C model</example>
-    <example>LANIER LP226c/SP C410 1.05 / LANIER Network Printer C model</example>
-    <example>LANIER LD120d 0.40.12 / LANIER Network Printer C model / LANIER Network Scanner C model / LANIER Network Facsimile C model</example>
+    <example os.product="LD145" os.version="2.40">LANIER LD145 2.40 / LANIER Network Printer C model / LANIER Network Scanner C model / LANIER Network Facsimile C model</example>
+    <example os.product="LD335c" os.version="1.27">LANIER LD335c 1.27 / LANIER Network Printer C model / LANIER Network Scanner C model</example>
+    <example os.product="LP226c/SP C410" os.version="1.05">LANIER LP226c/SP C410 1.05 / LANIER Network Printer C model</example>
+    <example os.product="LD120d" os.version="0.40.12">LANIER LD120d 0.40.12 / LANIER Network Printer C model / LANIER Network Scanner C model / LANIER Network Facsimile C model</example>
     <param pos="0" name="os.vendor" value="Lanier"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -3729,26 +3729,26 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix ((?:LPS|EPS|MPS)\S+) Version [VB]?([^/\(\s]+)[/\(\s]?">
     <description>Lantronix print server</description>
-    <example>Lantronix EPS2 Version V3.3/4(950530)</example>
-    <example>Lantronix EPS2 Version V3.4/1(960401)</example>
-    <example>Lantronix EPS1 Version V3.3/2(941216)</example>
-    <example>Lantronix EPS1 Version V3.3/4(950530)</example>
-    <example>Lantronix EPS1 Version V3.4/1(960401)</example>
-    <example>Lantronix EPS1 Version V3.5/10(990820)</example>
-    <example>Lantronix EPS1 Version V3.5/3(971202)</example>
-    <example>Lantronix EPS1 Version V3.5/5(980529)</example>
-    <example>Lantronix EPS1 Version V3.5/7(981112)</example>
-    <example>Lantronix EPS1 Version V3.6/4(000712)</example>
-    <example>Lantronix EPS1 Version V3.6/5(010208)</example>
-    <example>Lantronix EPS2 Version V3.5/2(970721)</example>
-    <example>Lantronix EPS2 Version V3.5/5(980529)</example>
-    <example>Lantronix EPS2-100 Version V3.5/7(981112)</example>
-    <example>Lantronix EPS2-100 Version V3.6/4(000712)</example>
-    <example>Lantronix EPS2-100 Version V3.7/1(031017)</example>
-    <example>Lantronix EPS4-100 Version B3.7/109(030909)</example>
-    <example>Lantronix EPS4-100 Version V3.5/7(981112)</example>
-    <example>Lantronix EPS4-100 Version V3.6/4(000712)</example>
-    <example>Lantronix EPS4-100 Version V3.7/1(031017)</example>
+    <example os.version="3.3" os.product="EPS2">Lantronix EPS2 Version V3.3/4(950530)</example>
+    <example os.version="3.4" os.product="EPS2">Lantronix EPS2 Version V3.4/1(960401)</example>
+    <example os.version="3.3" os.product="EPS1">Lantronix EPS1 Version V3.3/2(941216)</example>
+    <example os.version="3.3" os.product="EPS1">Lantronix EPS1 Version V3.3/4(950530)</example>
+    <example os.version="3.4" os.product="EPS1">Lantronix EPS1 Version V3.4/1(960401)</example>
+    <example os.version="3.5" os.product="EPS1">Lantronix EPS1 Version V3.5/10(990820)</example>
+    <example os.version="3.5" os.product="EPS1">Lantronix EPS1 Version V3.5/3(971202)</example>
+    <example os.version="3.5" os.product="EPS1">Lantronix EPS1 Version V3.5/5(980529)</example>
+    <example os.version="3.5" os.product="EPS1">Lantronix EPS1 Version V3.5/7(981112)</example>
+    <example os.version="3.6" os.product="EPS1">Lantronix EPS1 Version V3.6/4(000712)</example>
+    <example os.version="3.6" os.product="EPS1">Lantronix EPS1 Version V3.6/5(010208)</example>
+    <example os.version="3.5" os.product="EPS2">Lantronix EPS2 Version V3.5/2(970721)</example>
+    <example os.version="3.5" os.product="EPS2">Lantronix EPS2 Version V3.5/5(980529)</example>
+    <example os.version="3.5" os.product="EPS2-100">Lantronix EPS2-100 Version V3.5/7(981112)</example>
+    <example os.version="3.6" os.product="EPS2-100">Lantronix EPS2-100 Version V3.6/4(000712)</example>
+    <example os.version="3.7" os.product="EPS2-100">Lantronix EPS2-100 Version V3.7/1(031017)</example>
+    <example os.version="3.7" os.product="EPS4-100">Lantronix EPS4-100 Version B3.7/109(030909)</example>
+    <example os.version="3.5" os.product="EPS4-100">Lantronix EPS4-100 Version V3.5/7(981112)</example>
+    <example os.version="3.6" os.product="EPS4-100">Lantronix EPS4-100 Version V3.6/4(000712)</example>
+    <example os.version="3.7" os.product="EPS4-100">Lantronix EPS4-100 Version V3.7/1(031017)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="2" name="os.version"/>
@@ -3759,12 +3759,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?i:Lantronix) ((MSS|SCS|LRS|ETS|EDS)\S+) (?:Version |[VB])?([^/\(\s]+)[/\(\s]?">
     <description>Lantronix terminal server</description>
-    <example>Lantronix MSS100 Version V3.6/9(030114)</example>
-    <example>Lantronix EDS8PS V4.1.0.2R17 (03111515KK9H)</example>
-    <example>Lantronix ETS8P Version V3.6/4(000712)</example>
-    <example>Lantronix SCS400 Version B2.0/504(040415)</example>
-    <example>Lantronix LRS2 Version V1.3/4(980529)</example>
-    <example>LANTRONIX ETS-16 Version V2.2/45(940822)</example>
+    <example os.product="MSS100" os.family="MSS" os.version="V3.6">Lantronix MSS100 Version V3.6/9(030114)</example>
+    <example os.product="EDS8PS" os.family="EDS" os.version="4.1.0.2R17">Lantronix EDS8PS V4.1.0.2R17 (03111515KK9H)</example>
+    <example os.product="ETS8P" os.family="ETS" os.version="V3.6">Lantronix ETS8P Version V3.6/4(000712)</example>
+    <example os.product="SCS400" os.family="SCS" os.version="B2.0">Lantronix SCS400 Version B2.0/504(040415)</example>
+    <example os.product="LRS2" os.family="LRS" os.version="V1.3">Lantronix LRS2 Version V1.3/4(980529)</example>
+    <example os.product="ETS-16" os.family="ETS" os.version="V2.2">LANTRONIX ETS-16 Version V2.2/45(940822)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -3774,7 +3774,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix ((EDS)\S+)$">
     <description>Lantronix terminal server - model only variant</description>
-    <example>Lantronix EDS16PR</example>
+    <example os.product="EDS16PR" os.family="EDS">Lantronix EDS16PR</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -3783,7 +3783,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix Inc\. - (Modbus Bridge)$">
     <description>Lantronix modbus bridge</description>
-    <example>Lantronix Inc. - Modbus Bridge</example>
+    <example os.product="Modbus Bridge">Lantronix Inc. - Modbus Bridge</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -3791,10 +3791,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix (U[TD]S\S*) (?:Snr )?(?:[\-\dA-Za-z]+\s+)?V?(\S+)(?: \d+\.\S+)?(?: \(.*\))?\s*$">
     <description>Lantronix UDS/UTS serial to ethernet adapter</description>
-    <example>Lantronix UDS1100 V6.1.0.3 (060811)</example>
-    <example>Lantronix UDS 2132805 V5.8.0.1 (041102)</example>
-    <example>Lantronix UDS V5.9.0.0 (091013)</example>
-    <example>Lantronix UDS V6.6.21.0RC3 (080919)</example>
+    <example os.product="UDS1100" os.version="6.1.0.3">Lantronix UDS1100 V6.1.0.3 (060811)</example>
+    <example os.product="UDS" os.version="5.8.0.1">Lantronix UDS 2132805 V5.8.0.1 (041102)</example>
+    <example os.product="UDS" os.version="5.9.0.0">Lantronix UDS V5.9.0.0 (091013)</example>
+    <example os.product="UDS" os.version="6.6.21.0RC3">Lantronix UDS V6.6.21.0RC3 (080919)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="UDS"/>
     <param pos="0" name="os.device" value="Device Server"/>
@@ -3804,7 +3804,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix (UDS)$">
     <description>Lantronix UDS serial to ethernet adapter</description>
-    <example>Lantronix UDS</example>
+    <example os.product="UDS">Lantronix UDS</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="UDS"/>
     <param pos="0" name="os.device" value="Device Server"/>
@@ -3813,15 +3813,15 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix (X[pP]ort \S+) V(\S+) \(.*\)\s*$">
     <description>Lantronix XPort serial to ethernet adapter - version and serial variant</description>
-    <example>Lantronix XPort AR V4.0.0.0R16 (0)</example>
-    <example>Lantronix XPort AR V4.0.0.0R16 (064907012804)</example>
-    <example>Lantronix XPort AR V4.0.0.0R16 (070407018581)</example>
-    <example>Lantronix XPort AR V4.0.0.0R16 (07103607I8BAOD)</example>
-    <example>Lantronix XPort AR V5.1.0.0R4 (065207015235)</example>
-    <example>Lantronix Xport Pro V5.0.0.0R14 (07112947T9ETLD)</example>
-    <example>Lantronix Xport Pro V5.0.0.0R14 (07121257T5O4CJ)</example>
-    <example>Lantronix Xport Pro V5.2.0.0R20 (07110707T8O60M)</example>
-    <example>Lantronix Xport Pro V5.2.0.0R20 (07112097T8TOVI)</example>
+    <example os.product="XPort AR" os.version="4.0.0.0R16">Lantronix XPort AR V4.0.0.0R16 (0)</example>
+    <example os.product="XPort AR" os.version="4.0.0.0R16">Lantronix XPort AR V4.0.0.0R16 (064907012804)</example>
+    <example os.product="XPort AR" os.version="4.0.0.0R16">Lantronix XPort AR V4.0.0.0R16 (070407018581)</example>
+    <example os.product="XPort AR" os.version="4.0.0.0R16">Lantronix XPort AR V4.0.0.0R16 (07103607I8BAOD)</example>
+    <example os.product="XPort AR" os.version="5.1.0.0R4">Lantronix XPort AR V5.1.0.0R4 (065207015235)</example>
+    <example os.product="Xport Pro" os.version="5.0.0.0R14">Lantronix Xport Pro V5.0.0.0R14 (07112947T9ETLD)</example>
+    <example os.product="Xport Pro" os.version="5.0.0.0R14">Lantronix Xport Pro V5.0.0.0R14 (07121257T5O4CJ)</example>
+    <example os.product="Xport Pro" os.version="5.2.0.0R20">Lantronix Xport Pro V5.2.0.0R20 (07110707T8O60M)</example>
+    <example os.product="Xport Pro" os.version="5.2.0.0R20">Lantronix Xport Pro V5.2.0.0R20 (07112097T8TOVI)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPort"/>
     <param pos="0" name="os.device" value="Device Server"/>
@@ -3831,7 +3831,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix (XPort \S+)$">
     <description>Lantronix XPort serial to ethernet adapter</description>
-    <example>Lantronix XPort AR</example>
+    <example os.product="XPort AR">Lantronix XPort AR</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPort"/>
     <param pos="0" name="os.device" value="Device Server"/>
@@ -3840,7 +3840,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix (XPress \S+) V(\S+) \(.*\)\s*$">
     <description>Lantronix XPress serial to ethernet adapter</description>
-    <example>Lantronix XPress DR+ V6.1.0.1 (060404)</example>
+    <example os.product="XPress DR+" os.version="6.1.0.1">Lantronix XPress DR+ V6.1.0.1 (060404)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="XPress"/>
     <param pos="0" name="os.device" value="Device Server"/>
@@ -3850,17 +3850,17 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix (MatchPort \S+(?: \S+)?) V(\S+) \(">
     <description>Lantronix MatchPort serial to ethernet adapter</description>
-    <example>Lantronix MatchPort AR V1.1.0.0R1 (07101497G7IJFA)</example>
-    <example>Lantronix MatchPort AR V1.1.0.0R6.MC_V3.5 (07100747G7I1DT)</example>
-    <example>Lantronix MatchPort AR V1.1.0.0R7 (07110947G8CY77)</example>
-    <example>Lantronix MatchPort AR V1.1.0.0R7 (07111167G8D044)</example>
-    <example>Lantronix MatchPort AR V1.1.0.0R7 (77092507G6O3TO)</example>
-    <example>Lantronix MatchPort AR V1.3.0.0B3 (07093487G7HSYS)</example>
-    <example>Lantronix MatchPort b/g Pro V1.1.0.0R6.MC_WIFI_V3 (07082157J6MXD</example>
-    <example>Lantronix MatchPort b/g Pro V1.1.0.1R1.1.1.2 (07110177J8CO4V)</example>
-    <example>Lantronix MatchPort b/g Pro V1.1.0.1R1.1.3.07 (07101877J6MZ0D)</example>
-    <example>Lantronix MatchPort b/g Pro V1.3.0.0R9 (07090117J6NHS9)</example>
-    <example>Lantronix MatchPort b/g Pro V1.3.0.0R9 (07102327J7IUK5)</example>
+    <example os.product="MatchPort AR" os.version="1.1.0.0R1">Lantronix MatchPort AR V1.1.0.0R1 (07101497G7IJFA)</example>
+    <example os.product="MatchPort AR" os.version="1.1.0.0R6.MC_V3.5">Lantronix MatchPort AR V1.1.0.0R6.MC_V3.5 (07100747G7I1DT)</example>
+    <example os.product="MatchPort AR" os.version="1.1.0.0R7">Lantronix MatchPort AR V1.1.0.0R7 (07110947G8CY77)</example>
+    <example os.product="MatchPort AR" os.version="1.1.0.0R7">Lantronix MatchPort AR V1.1.0.0R7 (07111167G8D044)</example>
+    <example os.product="MatchPort AR" os.version="1.1.0.0R7">Lantronix MatchPort AR V1.1.0.0R7 (77092507G6O3TO)</example>
+    <example os.product="MatchPort AR" os.version="1.3.0.0B3">Lantronix MatchPort AR V1.3.0.0B3 (07093487G7HSYS)</example>
+    <example os.product="MatchPort b/g Pro" os.version="1.1.0.0R6.MC_WIFI_V3">Lantronix MatchPort b/g Pro V1.1.0.0R6.MC_WIFI_V3 (07082157J6MXD</example>
+    <example os.product="MatchPort b/g Pro" os.version="1.1.0.1R1.1.1.2">Lantronix MatchPort b/g Pro V1.1.0.1R1.1.1.2 (07110177J8CO4V)</example>
+    <example os.product="MatchPort b/g Pro" os.version="1.1.0.1R1.1.3.07">Lantronix MatchPort b/g Pro V1.1.0.1R1.1.3.07 (07101877J6MZ0D)</example>
+    <example os.product="MatchPort b/g Pro" os.version="1.3.0.0R9">Lantronix MatchPort b/g Pro V1.3.0.0R9 (07090117J6NHS9)</example>
+    <example os.product="MatchPort b/g Pro" os.version="1.3.0.0R9">Lantronix MatchPort b/g Pro V1.3.0.0R9 (07102327J7IUK5)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="MatchPort"/>
     <param pos="0" name="os.device" value="Device Server"/>
@@ -3870,12 +3870,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix (WiBox) V(\S+) \(.*\)\s*$">
     <description>Lantronix WiBox</description>
-    <example>Lantronix WiBox V5.8.0.1 (041013)</example>
-    <example>Lantronix WiBox V6.0.0.1 (050413)</example>
-    <example>Lantronix WiBox V6.4.0.0 (061024)</example>
-    <example>Lantronix WiBox V6.5.0.0 (070402)</example>
-    <example>Lantronix WiBox V6.6.0.0 (080116)</example>
-    <example>Lantronix WiBox V6.7.0.0 (100118)</example>
+    <example os.product="WiBox" os.version="5.8.0.1">Lantronix WiBox V5.8.0.1 (041013)</example>
+    <example os.product="WiBox" os.version="6.0.0.1">Lantronix WiBox V6.0.0.1 (050413)</example>
+    <example os.product="WiBox" os.version="6.4.0.0">Lantronix WiBox V6.4.0.0 (061024)</example>
+    <example os.product="WiBox" os.version="6.5.0.0">Lantronix WiBox V6.5.0.0 (070402)</example>
+    <example os.product="WiBox" os.version="6.6.0.0">Lantronix WiBox V6.6.0.0 (080116)</example>
+    <example os.product="WiBox" os.version="6.7.0.0">Lantronix WiBox V6.7.0.0 (100118)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.family" value="WiBox"/>
     <param pos="0" name="os.device" value="Device Server"/>
@@ -3885,11 +3885,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix ((SDS)\S*) V(\S+) \(.*\)\s*$">
     <description>Lantronix SDS</description>
-    <example>Lantronix SDS V5.8.0.1 (041014)</example>
-    <example>Lantronix SDS V5.8.0.7 (061010)</example>
-    <example>Lantronix SDS1101 V6.1.0.3 (060811)</example>
-    <example>Lantronix SDS1101 V6.5.0.0 (070402)</example>
-    <example>Lantronix SDS2101 V6.5.0.0 (070402)</example>
+    <example os.product="SDS" os.family="SDS" os.version="5.8.0.1">Lantronix SDS V5.8.0.1 (041014)</example>
+    <example os.product="SDS" os.family="SDS" os.version="5.8.0.7">Lantronix SDS V5.8.0.7 (061010)</example>
+    <example os.product="SDS1101" os.family="SDS" os.version="6.1.0.3">Lantronix SDS1101 V6.1.0.3 (060811)</example>
+    <example os.product="SDS1101" os.family="SDS" os.version="6.5.0.0">Lantronix SDS1101 V6.5.0.0 (070402)</example>
+    <example os.product="SDS2101" os.family="SDS" os.version="6.5.0.0">Lantronix SDS2101 V6.5.0.0 (070402)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -3899,9 +3899,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix ((SLS)\S*) (\S+)$">
     <description>Lantronix SLS</description>
-    <example>Lantronix SLS 010100</example>
-    <example>Lantronix SLSLP 030001</example>
-    <example>Lantronix SLSLP 030005</example>
+    <example os.product="SLS" os.family="SLS" os.version="010100">Lantronix SLS 010100</example>
+    <example os.product="SLSLP" os.family="SLS" os.version="030001">Lantronix SLSLP 030001</example>
+    <example os.product="SLSLP" os.family="SLS" os.version="030005">Lantronix SLSLP 030005</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -3911,8 +3911,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix ((NTS)\S*) \S+ (\S+) \(">
     <description>Lantronix NTS</description>
-    <example>Lantronix NTS 0239032 04.4 (010817)</example>
-    <example>Lantronix NTS 1145416 04.4 (010817)</example>
+    <example os.product="NTS" os.family="NTS" os.version="04.4">Lantronix NTS 0239032 04.4 (010817)</example>
+    <example os.product="NTS" os.family="NTS" os.version="04.4">Lantronix NTS 1145416 04.4 (010817)</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -3922,7 +3922,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lantronix ((NTS)\S*) V(\S+)$">
     <description>Lantronix NTS - variant 1</description>
-    <example>Lantronix NTS1536-076 V3.8</example>
+    <example os.product="NTS1536-076" os.family="NTS" os.version="3.8">Lantronix NTS1536-076 V3.8</example>
     <param pos="0" name="os.vendor" value="Lantronix"/>
     <param pos="0" name="os.device" value="Device Server"/>
     <param pos="1" name="os.product"/>
@@ -3945,16 +3945,16 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lexmark (\S+) version (\S+)">
     <description>Lexmark Laser Printer</description>
-    <example>Lexmark C524 version NS.NP.N212 kernel 2.6.6 All-N-1</example>
-    <example>Lexmark T522 version 54.30.06 kernel 2.4.0-test6 All-N-1</example>
-    <example>Lexmark T522 version 54.10.33 kernel 2.4.0-test6 All-N-1</example>
-    <example>Lexmark T622 version 54.10.37 kernel 2.4.0-test6 All-N-1</example>
-    <example>Lexmark T630 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
-    <example>Lexmark T632 version 55.10.87 kernel 2.4.0-test6 All-N-1</example>
-    <example>Lexmark T634 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
-    <example>Lexmark T642 version NS.NP.N118 kernel 2.6.6 All-N-1</example>
-    <example>Lexmark T644 version NS.NP.N118 kernel 2.6.6 All-N-1</example>
-    <example>Lexmark T644 version NS.NP.N219 kernel 2.6.6 All-N-1</example>
+    <example os.product="C524" os.version="NS.NP.N212">Lexmark C524 version NS.NP.N212 kernel 2.6.6 All-N-1</example>
+    <example os.product="T522" os.version="54.30.06">Lexmark T522 version 54.30.06 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="T522" os.version="54.10.33">Lexmark T522 version 54.10.33 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="T622" os.version="54.10.37">Lexmark T622 version 54.10.37 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="T630" os.version="55.10.19">Lexmark T630 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="T632" os.version="55.10.87">Lexmark T632 version 55.10.87 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="T634" os.version="55.10.19">Lexmark T634 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="T642" os.version="NS.NP.N118">Lexmark T642 version NS.NP.N118 kernel 2.6.6 All-N-1</example>
+    <example os.product="T644" os.version="NS.NP.N118">Lexmark T644 version NS.NP.N118 kernel 2.6.6 All-N-1</example>
+    <example os.product="T644" os.version="NS.NP.N219">Lexmark T644 version NS.NP.N219 kernel 2.6.6 All-N-1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -3964,13 +3964,13 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:Lexmark )?MarkNet (.*) Version (\S+) Ethernet">
     <description>Lexmark MarkNet Printer Server</description>
-    <example>MarkNet Pro 1 Version 2.10.192 Ethernet 10T.</example>
-    <example>MarkNet Pro 1 Version 2.10.192 Ethernet Combo.</example>
-    <example>MarkNet Pro 1 Version 2.10.17 Ethernet 10/100.</example>
-    <example>MarkNet Pro 1 Version 2.10.196 Ethernet Combo.</example>
-    <example>MarkNet X2011e Version 4.20.21 Ethernet 10/100.</example>
-    <example>Lexmark MarkNet XLe 202 Version 4.117.1 Ethernet.</example>
-    <example>Lexmark MarkNet XLe 202 Version 4.133.1 Ethernet.</example>
+    <example os.product="Pro 1" os.version="2.10.192">MarkNet Pro 1 Version 2.10.192 Ethernet 10T.</example>
+    <example os.product="Pro 1" os.version="2.10.192">MarkNet Pro 1 Version 2.10.192 Ethernet Combo.</example>
+    <example os.product="Pro 1" os.version="2.10.17">MarkNet Pro 1 Version 2.10.17 Ethernet 10/100.</example>
+    <example os.product="Pro 1" os.version="2.10.196">MarkNet Pro 1 Version 2.10.196 Ethernet Combo.</example>
+    <example os.product="X2011e" os.version="4.20.21">MarkNet X2011e Version 4.20.21 Ethernet 10/100.</example>
+    <example os.product="XLe 202" os.version="4.117.1">Lexmark MarkNet XLe 202 Version 4.117.1 Ethernet.</example>
+    <example os.product="XLe 202" os.version="4.133.1">Lexmark MarkNet XLe 202 Version 4.133.1 Ethernet.</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="MarkNet"/>
@@ -3981,12 +3981,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lexmark Optra (\S+(?: \S+)?(?: \S+)?) +Version (\S+)">
     <description>Lexmark Optra Laser Printer</description>
-    <example>Lexmark Optra T610  Version 5.15.18  FaxSCSI-Ethernet.</example>
-    <example>Lexmark Optra K 1220 Version 1.9.14 Ethernet 10/100.</example>
-    <example>Lexmark Optra K 1220 Version 3.11.17 Ethernet 10/100.</example>
-    <example>Lexmark Optra N Laser Printer Version 79.133.1 Ethernet.</example>
-    <example>Lexmark Optra SC 1275 Version 1.10.10 Ethernet 10/100.</example>
-    <example>Lexmark Optra SC 1275 Version 1.10.196 Ethernet 10/100.</example>
+    <example os.product="T610" os.version="5.15.18">Lexmark Optra T610  Version 5.15.18  FaxSCSI-Ethernet.</example>
+    <example os.product="K 1220" os.version="1.9.14">Lexmark Optra K 1220 Version 1.9.14 Ethernet 10/100.</example>
+    <example os.product="K 1220" os.version="3.11.17">Lexmark Optra K 1220 Version 3.11.17 Ethernet 10/100.</example>
+    <example os.product="N Laser Printer" os.version="79.133.1">Lexmark Optra N Laser Printer Version 79.133.1 Ethernet.</example>
+    <example os.product="SC 1275" os.version="1.10.10">Lexmark Optra SC 1275 Version 1.10.10 Ethernet 10/100.</example>
+    <example os.product="SC 1275" os.version="1.10.196">Lexmark Optra SC 1275 Version 1.10.196 Ethernet 10/100.</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="Optra"/>
@@ -3997,14 +3997,14 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lexmark Forms Printer (\S+(?: plus)?) +version (\S+)">
     <description>Lexmark Forms Printer</description>
-    <example>Lexmark Forms Printer 2580 version LC.CO.N061 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 2580 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 2581 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 2590 version LC.CO.N061 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 2590 version LCL.CU.P103 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 2590 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 2591 version LCL.CU.P103 kernel 2.6.10 All-N-1</example>
-    <example>Lexmark Forms Printer 4227 plus version LC.CO.N061 kernel 2.6.10 All-N-1</example>
+    <example os.product="2580" os.version="LC.CO.N061">Lexmark Forms Printer 2580 version LC.CO.N061 kernel 2.6.10 All-N-1</example>
+    <example os.product="2580" os.version="LCL.CU.P105">Lexmark Forms Printer 2580 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
+    <example os.product="2581" os.version="LCL.CU.P105">Lexmark Forms Printer 2581 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
+    <example os.product="2590" os.version="LC.CO.N061">Lexmark Forms Printer 2590 version LC.CO.N061 kernel 2.6.10 All-N-1</example>
+    <example os.product="2590" os.version="LCL.CU.P103">Lexmark Forms Printer 2590 version LCL.CU.P103 kernel 2.6.10 All-N-1</example>
+    <example os.product="2590" os.version="LCL.CU.P105">Lexmark Forms Printer 2590 version LCL.CU.P105 kernel 2.6.10 All-N-1</example>
+    <example os.product="2591" os.version="LCL.CU.P103">Lexmark Forms Printer 2591 version LCL.CU.P103 kernel 2.6.10 All-N-1</example>
+    <example os.product="4227 plus" os.version="LC.CO.N061">Lexmark Forms Printer 4227 plus version LC.CO.N061 kernel 2.6.10 All-N-1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.family" value="Forms Printer"/>
@@ -4015,9 +4015,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lexmark (\S+) Series version (\S+)">
     <description>Lexmark Printer</description>
-    <example>Lexmark Pro5500 Series version FHN.RB.P1.111006z kernel 2.6.28.10.1 All-N-1</example>
-    <example>Lexmark Pro910 Series version FQN.QNL.P1.111026 kernel 2.6.28.10.1 All-N-1</example>
-    <example>Lexmark S510 Series version FHN.EA3.P1.111006z kernel 2.6.28.10.1 All-N-1</example>
+    <example os.product="Pro5500" os.version="FHN.RB.P1.111006z">Lexmark Pro5500 Series version FHN.RB.P1.111006z kernel 2.6.28.10.1 All-N-1</example>
+    <example os.product="Pro910" os.version="FQN.QNL.P1.111026">Lexmark Pro910 Series version FQN.QNL.P1.111026 kernel 2.6.28.10.1 All-N-1</example>
+    <example os.product="S510" os.version="FHN.EA3.P1.111006z">Lexmark S510 Series version FHN.EA3.P1.111006z kernel 2.6.28.10.1 All-N-1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -4027,17 +4027,17 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:Lexmark|LEXMARK) (\S+) [vV]ersion (\S+)">
     <description>Lexmark Printer - no kernel variant</description>
-    <example>LEXMARK X204 version NM.APS.N058 kernel 2.6.18.5 All-N-1</example>
-    <example>Lexmark C720 Version 3.19.12 Ethernet 10/100.</example>
-    <example>Lexmark C720 Version 3.20.11 Ethernet 10/100.</example>
-    <example>Lexmark C720 Version 3.20.20 Ethernet 10/100.</example>
-    <example>Lexmark C720 Version 3.20.30 Ethernet 10/100.</example>
-    <example>Lexmark T520 Version 5.201.26 FaxSCSI-Ethernet.</example>
-    <example>Lexmark T620 Version 1.10.192 Ethernet 10/100.</example>
-    <example>Lexmark T620 Version 1.10.196 Ethernet 10/100.</example>
-    <example>Lexmark T620 Version 3.20.20 Ethernet 10/100.</example>
-    <example>Lexmark T630 Version 6.22.26 MFP-Ethernet 10/100.</example>
-    <example>Lexmark T632 Version 6.22.26 MFP-Ethernet 10/100.</example>
+    <example os.product="X204" os.version="NM.APS.N058">LEXMARK X204 version NM.APS.N058 kernel 2.6.18.5 All-N-1</example>
+    <example os.product="C720" os.version="3.19.12">Lexmark C720 Version 3.19.12 Ethernet 10/100.</example>
+    <example os.product="C720" os.version="3.20.11">Lexmark C720 Version 3.20.11 Ethernet 10/100.</example>
+    <example os.product="C720" os.version="3.20.20">Lexmark C720 Version 3.20.20 Ethernet 10/100.</example>
+    <example os.product="C720" os.version="3.20.30">Lexmark C720 Version 3.20.30 Ethernet 10/100.</example>
+    <example os.product="T520" os.version="5.201.26">Lexmark T520 Version 5.201.26 FaxSCSI-Ethernet.</example>
+    <example os.product="T620" os.version="1.10.192">Lexmark T620 Version 1.10.192 Ethernet 10/100.</example>
+    <example os.product="T620" os.version="1.10.196">Lexmark T620 Version 1.10.196 Ethernet 10/100.</example>
+    <example os.product="T620" os.version="3.20.20">Lexmark T620 Version 3.20.20 Ethernet 10/100.</example>
+    <example os.product="T630" os.version="6.22.26">Lexmark T630 Version 6.22.26 MFP-Ethernet 10/100.</example>
+    <example os.product="T632" os.version="6.22.26">Lexmark T632 Version 6.22.26 MFP-Ethernet 10/100.</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -4046,8 +4046,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lexmark ([^;]+); Net.*ESS ([^,]+),IOT (\S+)$">
     <description>Lexmark Printer - net variant</description>
-    <example>Lexmark X560n; Net 11.73,ESS 200709260947,IOT 05.10.00</example>
-    <example>Lexmark X560n; Net 11.77,ESS 200805220849,IOT 05.10.00</example>
+    <example os.product="X560n" os.version="05.10.00" os.version.version="200709260947">Lexmark X560n; Net 11.73,ESS 200709260947,IOT 05.10.00</example>
+    <example os.product="X560n" os.version="05.10.00" os.version.version="200805220849">Lexmark X560n; Net 11.77,ESS 200805220849,IOT 05.10.00</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -4057,7 +4057,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lexmark (\S+(?: \S+)?) Print Server$">
     <description>Lexmark Printer - print server variant</description>
-    <example>Lexmark C500 PS Print Server</example>
+    <example os.product="C500 PS">Lexmark C500 PS Print Server</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Print Server"/>
     <param pos="1" name="os.product"/>
@@ -4065,7 +4065,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Lexmark (\S+) Series$">
     <description>Lexmark Printer - no software version variant</description>
-    <example>Lexmark X500 Series</example>
+    <example os.product="X500">Lexmark X500 Series</example>
     <param pos="0" name="os.vendor" value="Lexmark"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -4077,12 +4077,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^KONICA MINOLTA (?:bizhub )?(\S+)">
     <description>Konica Minolta bizhub multifunction device</description>
-    <example>KONICA MINOLTA bizhub C252</example>
-    <example>KONICA MINOLTA bizhub C351</example>
-    <example>KONICA MINOLTA bizhub 500</example>
-    <example>KONICA MINOLTA 200</example>
-    <example>KONICA MINOLTA 350</example>
-    <example>KONICA MINOLTA 362</example>
+    <example os.product="C252">KONICA MINOLTA bizhub C252</example>
+    <example os.product="C351">KONICA MINOLTA bizhub C351</example>
+    <example os.product="500">KONICA MINOLTA bizhub 500</example>
+    <example os.product="200">KONICA MINOLTA 200</example>
+    <example os.product="350">KONICA MINOLTA 350</example>
+    <example os.product="362">KONICA MINOLTA 362</example>
     <param pos="0" name="os.vendor" value="Konica Minolta"/>
     <param pos="0" name="os.family" value="bizhub"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -4112,8 +4112,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^KYOCERA Printer I/F (IB-.*) Ver">
     <description>KYOCERA MITA printer - version variant</description>
-    <example>KYOCERA Printer I/F IB-23 Ver 1.1.0</example>
-    <example>KYOCERA Printer I/F IB-20/21 Ver 1.1.1</example>
+    <example os.product="IB-23">KYOCERA Printer I/F IB-23 Ver 1.1.0</example>
+    <example os.product="IB-20/21">KYOCERA Printer I/F IB-20/21 Ver 1.1.1</example>
     <param pos="0" name="os.certainty" value="0.5"/>
     <param pos="0" name="os.vendor" value="Kyocera Mita"/>
     <param pos="1" name="os.product"/>
@@ -4169,7 +4169,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.4\.21-27.*EL(?:smp)?) .* (\S+)$">
     <description>Red Hat Enterprise Linux 3 Update 4</description>
-    <example>Linux hostname 2.4.21-27.0.2.ELsmp #1 SMP Wed Jan 12 23:35:44 EST 2005 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.4.21-27.0.2.ELsmp" os.arch="i686">Linux hostname 2.4.21-27.0.2.ELsmp #1 SMP Wed Jan 12 23:35:44 EST 2005 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4183,7 +4183,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.6\.9-22\.EL(?:smp)?) .* (\S+)$">
     <description>Red Hat Enterprise Linux 4 Update 2</description>
-    <example>Linux hostname 2.6.9-22.ELsmp #1 SMP Mon Sep 19 18:32:14 EDT 2005 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.9-22.ELsmp" os.arch="i686">Linux hostname 2.6.9-22.ELsmp #1 SMP Mon Sep 19 18:32:14 EDT 2005 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4210,8 +4210,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.6\.18-53.*el5) .* (\S+)$">
     <description>Red Hat Enterprise Linux 5</description>
-    <example>Linux hostname 2.6.18-53.1.4.el5 #1 SMP Fri Nov 30 00:45:16 EST 2007 i686</example>
-    <example>Linux hostname 2.6.18-53.1.4.el5 #1 SMP Fri Nov 30 00:45:55 EST 2007 x86_64</example>
+    <example host.name="hostname" linux.kernel.version="2.6.18-53.1.4.el5" os.arch="i686">Linux hostname 2.6.18-53.1.4.el5 #1 SMP Fri Nov 30 00:45:16 EST 2007 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.18-53.1.4.el5" os.arch="x86_64">Linux hostname 2.6.18-53.1.4.el5 #1 SMP Fri Nov 30 00:45:55 EST 2007 x86_64</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4225,7 +4225,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.4\.9-e\.\S+).* (\S+)$">
     <description>Red Hat Enterprise Linux 2.1</description>
-    <example>Linux hostname 2.4.9-e.40smp #1 SMP Thu Apr 8 16:53:29 EDT 2004 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.4.9-e.40smp" os.arch="i686">Linux hostname 2.4.9-e.40smp #1 SMP Thu Apr 8 16:53:29 EDT 2004 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4239,7 +4239,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.4\.18-3) .* (\S+)$">
     <description>Red Hat Linux 7.3</description>
-    <example>Linux hostname 2.4.18-3 #1 Thu Apr 18 07:37:53 EDT 2002 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.4.18-3" os.arch="i686">Linux hostname 2.4.18-3 #1 Thu Apr 18 07:37:53 EDT 2002 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4253,7 +4253,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^CentOS release ([\d.]*)">
     <description>CentOS Linux</description>
-    <example>CentOS release 4.9 (Final)</example>
+    <example os.version="4.9">CentOS release 4.9 (Final)</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="CentOS"/>
@@ -4264,7 +4264,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.6\.9-55[\d.]*EL(?:smp)?) .* (\S+)$">
     <description>CentOS Linux 4.5</description>
-    <example>Linux hostname 2.6.9-55.0.9.ELsmp #1 SMP Thu Sep 27 18:27:41 EDT 2007 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.9-55.0.9.ELsmp" os.arch="i686">Linux hostname 2.6.9-55.0.9.ELsmp #1 SMP Thu Sep 27 18:27:41 EDT 2007 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="CentOS"/>
@@ -4278,9 +4278,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.6\.18-53[\d\.]*el5xen) .* (\S+)$">
     <description>CentOS Linux 5</description>
-    <example>Linux hostname 2.6.18-53.1.4.el5xen #1 SMP Fri Nov 30 01:21:23 EST 2007 x86_64</example>
-    <example>Linux hostname 2.6.18-53.1.6.el5xen #1 SMP Wed Jan 23 11:59:21 EST 2008 x86_64</example>
-    <example>Linux hostname 2.6.18-53.1.13.el5xen #1 SMP Tue Feb 12 13:33:07 EST 2008 x86_64</example>
+    <example host.name="hostname" linux.kernel.version="2.6.18-53.1.4.el5xen" os.arch="x86_64">Linux hostname 2.6.18-53.1.4.el5xen #1 SMP Fri Nov 30 01:21:23 EST 2007 x86_64</example>
+    <example host.name="hostname" linux.kernel.version="2.6.18-53.1.6.el5xen" os.arch="x86_64">Linux hostname 2.6.18-53.1.6.el5xen #1 SMP Wed Jan 23 11:59:21 EST 2008 x86_64</example>
+    <example host.name="hostname" linux.kernel.version="2.6.18-53.1.13.el5xen" os.arch="x86_64">Linux hostname 2.6.18-53.1.13.el5xen #1 SMP Tue Feb 12 13:33:07 EST 2008 x86_64</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="CentOS"/>
@@ -4294,7 +4294,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\S+.FC4) .* (\S+)$">
     <description>Fedora Core Linux 4</description>
-    <example>Linux hostname 2.6.11-1.1369_FC4 #1 Thu Jun 2 22:55:56 EDT 2005 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.11-1.1369_FC4" os.arch="i686">Linux hostname 2.6.11-1.1369_FC4 #1 Thu Jun 2 22:55:56 EDT 2005 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4308,7 +4308,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\S+.fc6) .* (\S+)$">
     <description>Fedora Core Linux 6</description>
-    <example>Linux hostname 2.6.20-1.2948.fc6 #1 SMP Fri Apr 27 19:48:40 EDT 2007 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.20-1.2948.fc6" os.arch="i686">Linux hostname 2.6.20-1.2948.fc6 #1 SMP Fri Apr 27 19:48:40 EDT 2007 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4322,7 +4322,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\S+.fc7) .* (\S+)$">
     <description>Fedora Core Linux 7</description>
-    <example>Linux hostname 2.6.22.9-91.fc7 #1 SMP Thu Sep 27 23:10:59 EDT 2007 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.22.9-91.fc7" os.arch="i686">Linux hostname 2.6.22.9-91.fc7 #1 SMP Thu Sep 27 23:10:59 EDT 2007 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
@@ -4336,7 +4336,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.6\.4-52(?:-smp)) .* (\S+)$">
     <description>SuSE Linux 9.1</description>
-    <example>Linux hostname 2.6.4-52-smp #1 SMP Wed Apr 7 02:11:20 UTC 2004 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.4-52-smp" os.arch="i686">Linux hostname 2.6.4-52-smp #1 SMP Wed Apr 7 02:11:20 UTC 2004 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="SuSE"/>
@@ -4350,7 +4350,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.4\.32-ow1) (\S+)$">
     <description>OpenWall Linux</description>
-    <example>Linux hostname 2.4.32-ow1 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.4.32-ow1" os.version="i686">Linux hostname 2.4.32-ow1 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="OpenWall"/>
@@ -4362,7 +4362,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+) (2\.6\.20-16-\S+).* (\S+)$">
     <description>Ubuntu Linux 7.04</description>
-    <example>Linux hostname 2.6.20-16-server #2 SMP Thu Jun 7 20:26:23 UTC 2007 i686</example>
+    <example host.name="hostname" linux.kernel.version="2.6.20-16-server" os.arch="i686">Linux hostname 2.6.20-16-server #2 SMP Thu Jun 7 20:26:23 UTC 2007 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
@@ -4395,7 +4395,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Silver Peak Systems, Inc\. (\S+) Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*).* (?:[0-9]{4}|[A-Z][A-Z][A-Z]{1,2}|\+[0-9]+|Local time.*(?:manual|zic|m\S*)) (\S+)">
     <description>Silver Peak Systems</description>
-    <example os.product="NX7600" host.name="foo" os.version="2.6.22.14" os.arch="x86_64">Silver Peak Systems, Inc. NX7600 Linux foo 2.6.22.14 hidalgo 3.3.0.0_32549 #1 2010-07-20 04:25:08 SMP x86_64</example>
+    <example os.product="NX7600" host.name="foo" os.version="2.6.22.14" os.arch="x86_64" linux.kernel.version="2.6.22.14">Silver Peak Systems, Inc. NX7600 Linux foo 2.6.22.14 hidalgo 3.3.0.0_32549 #1 2010-07-20 04:25:08 SMP x86_64</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.device" value="WAN Accelerator"/>
@@ -4437,7 +4437,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*) (\S+)$">
     <description>Linux Generic - hostname/kernel/arch variant</description>
-    <example>Linux hostname 2.6.9 x86_64</example>
+    <example os.version="2.6.9" host.name="hostname" linux.kernel.version="2.6.9" os.arch="x86_64">Linux hostname 2.6.9 x86_64</example>
     <param pos="0" name="os.certainty" value="0.5"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -4449,7 +4449,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux ([0-9]+\.[0-9]+\.[0-9]+\S*) (\S+)$">
     <description>Linux Generic - kernel/arch variant</description>
-    <example>Linux 2.6.9 x86_64</example>
+    <example os.version="2.6.9" linux.kernel.version="2.6.9" os.arch="x86_64">Linux 2.6.9 x86_64</example>
     <param pos="0" name="os.certainty" value="0.5"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -4460,7 +4460,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (.*?) ([0-9]+\.[0-9]+\.[0-9]+\S*)$">
     <description>Linux Generic - hostname/kernel variant</description>
-    <example>Linux hostname 2.6.9</example>
+    <example os.version="2.6.9" host.name="hostname" linux.kernel.version="2.6.9">Linux hostname 2.6.9</example>
     <param pos="0" name="os.certainty" value="0.5"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -4471,7 +4471,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux ([0-9]+\.[0-9]+\.[0-9]+\S*)$">
     <description>Linux Generic - kernel variant</description>
-    <example>Linux 2.6.9</example>
+    <example os.version="2.6.9" linux.kernel.version="2.6.9">Linux 2.6.9</example>
     <param pos="0" name="os.certainty" value="0.5"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -4481,7 +4481,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Linux (\S+)$">
     <description>Linux Generic - hostname variant</description>
-    <example>Linux hostname</example>
+    <example host.name="hostname">Linux hostname</example>
     <param pos="0" name="os.certainty" value="0.5"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
@@ -4687,8 +4687,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Microsoft Windows CE Version ([\d.]+)">
     <description>Windows CE</description>
-    <example>Microsoft Windows CE Version 4.20 (Build 0)</example>
-    <example>Microsoft Windows CE Version 4.20 (Build 1088)</example>
+    <example os.version="4.20">Microsoft Windows CE Version 4.20 (Build 0)</example>
+    <example os.version="4.20">Microsoft Windows CE Version 4.20 (Build 1088)</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows CE"/>
@@ -4848,7 +4848,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="Windows\s\S+\s(6\.2\.\d+)\s+Server\s[\d\.]+\s(\w+)">
     <description>Windows Server 2012</description>
-    <example>Windows w12-srv-snmp 6.2.9200   Server 4.0 Intel64 Family 6 Model 26 Stepping 4</example>
+    <example os.version="6.2.9200" os.arch="Intel64">Windows w12-srv-snmp 6.2.9200   Server 4.0 Intel64 Family 6 Model 26 Stepping 4</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="1" name="os.version"/>
@@ -4863,7 +4863,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^LX Console Manager, s/w version=(\S+)$">
     <description>MRV LX console servers</description>
-    <example>LX Console Manager, s/w version=5.3.9</example>
+    <example os.version="5.3.9">LX Console Manager, s/w version=5.3.9</example>
     <param pos="0" name="os.vendor" value="MRV Communications"/>
     <param pos="0" name="os.product" value="LX"/>
     <param pos="0" name="os.device" value="Remote Access Server"/>
@@ -4876,7 +4876,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RASExpress Server Version (\S+)$">
     <description>MultiTech RASExpress remote access server</description>
-    <example>RASExpress Server Version 5.63</example>
+    <example os.version="5.63">RASExpress Server Version 5.63</example>
     <param pos="0" name="os.vendor" value="MultiTech"/>
     <param pos="0" name="os.product" value="RASExpress"/>
     <param pos="0" name="os.device" value="Remote Access Server"/>
@@ -4889,8 +4889,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Neoscale CryptoStore\(TM\) (\S+)$">
     <description>Neoscale CryptoStore</description>
-    <example>Neoscale CryptoStore(TM) neoaht2</example>
-    <example>Neoscale CryptoStore(TM) neoaht3</example>
+    <example os.product="neoaht2">Neoscale CryptoStore(TM) neoaht2</example>
+    <example os.product="neoaht3">Neoscale CryptoStore(TM) neoaht3</example>
     <param pos="0" name="os.vendor" value="Neoscale"/>
     <param pos="0" name="os.family" value="CryptoStore"/>
     <param pos="0" name="os.device" value="Storage"/>
@@ -4903,9 +4903,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:NetApp|Data ONTAP) Release (\S+):?">
     <description>NetApp filer</description>
-    <example>Data ONTAP Release 7.2.3: Thu Jul  5 10:42:49 PDT 2007 (IBM)</example>
-    <example>NetApp Release 7.2.4: Fri Nov 16 00:34:57 PST 2007</example>
-    <example>NetApp Release 8.1RC2 7-Mode: Thu Oct 27 19:26:06 PDT 2011</example>
+    <example os.version="7.2.3:">Data ONTAP Release 7.2.3: Thu Jul  5 10:42:49 PDT 2007 (IBM)</example>
+    <example os.version="7.2.4:">NetApp Release 7.2.4: Fri Nov 16 00:34:57 PST 2007</example>
+    <example os.version="8.1RC2">NetApp Release 8.1RC2 7-Mode: Thu Oct 27 19:26:06 PDT 2011</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="NetApp"/>
     <param pos="0" name="os.family" value="Data ONTAP"/>
@@ -4921,8 +4921,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^NetBotz RackBotz (\S+) Appliance; FV: ([^,]+), HR:">
     <description>NetBotz RackBotz monitoring device</description>
-    <example>NetBotz RackBotz 400C Appliance; FV: A1_3_71_136-20021216P, HR: REV A13, MD: 11/04/2003; MC: TEX</example>
-    <example>NetBotz RackBotz 400C Appliance; FV: A1_3_90_168-20040908P, HR: REV A13, MD: 11/03/2003; MC: TEX</example>
+    <example os.product="400C" os.version="A1_3_71_136-20021216P">NetBotz RackBotz 400C Appliance; FV: A1_3_71_136-20021216P, HR: REV A13, MD: 11/04/2003; MC: TEX</example>
+    <example os.product="400C" os.version="A1_3_90_168-20040908P">NetBotz RackBotz 400C Appliance; FV: A1_3_90_168-20040908P, HR: REV A13, MD: 11/03/2003; MC: TEX</example>
     <param pos="0" name="os.vendor" value="NetBotz"/>
     <param pos="0" name="os.family" value="RackBotz"/>
     <param pos="0" name="os.device" value="Monitoring"/>
@@ -4938,11 +4938,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Netopia (\d{4}(?:W|NWG|NWG-ENT)) v(\S+)$">
     <description>Netopia Wireless ADSL Router</description>
-    <example>Netopia 3347NWG v7.5.1r8</example>
-    <example>Netopia 3347NWG v7.7.4r0</example>
-    <example>Netopia 3347NWG-ENT v8.5</example>
-    <example>Netopia 3347NWG-ENT v8.6.1r4</example>
-    <example>Netopia 3347W v8.4r2</example>
+    <example os.product="3347NWG" os.version="7.5.1r8">Netopia 3347NWG v7.5.1r8</example>
+    <example os.product="3347NWG" os.version="7.7.4r0">Netopia 3347NWG v7.7.4r0</example>
+    <example os.product="3347NWG-ENT" os.version="8.5">Netopia 3347NWG-ENT v8.5</example>
+    <example os.product="3347NWG-ENT" os.version="8.6.1r4">Netopia 3347NWG-ENT v8.6.1r4</example>
+    <example os.product="3347W" os.version="8.4r2">Netopia 3347W v8.4r2</example>
     <param pos="0" name="os.vendor" value="Netopia"/>
     <param pos="0" name="os.family" value="Netopia"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -4954,9 +4954,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Netopia (\S+) v(\S+)$">
     <description>Netopia Router</description>
-    <example>Netopia 2241N-VGx v7.7.0b4</example>
-    <example>Netopia 2241N-VGx v7.7.0r1</example>
-    <example>Netopia R9100 v4.8.2</example>
+    <example os.product="2241N-VGx" os.version="7.7.0b4">Netopia 2241N-VGx v7.7.0b4</example>
+    <example os.product="2241N-VGx" os.version="7.7.0r1">Netopia 2241N-VGx v7.7.0r1</example>
+    <example os.product="R9100" os.version="4.8.2">Netopia R9100 v4.8.2</example>
     <param pos="0" name="os.vendor" value="Netopia"/>
     <param pos="0" name="os.family" value="Netopia"/>
     <param pos="0" name="os.device" value="Broadband Router"/>
@@ -4971,7 +4971,7 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^NetScaler NS([^:]+): Build ([^,]+), Date:">
     <description>Netscaler Appliance</description>
     <example os.version="10.0" os.version.version="54.6.nc">NetScaler NS10.0: Build 54.6.nc, Date: Apr 6 2012, 08:00:41 </example>
-    <example>NetScaler NS9.3: Build 57.5.nc, Date: Jun 27 2012, 19:37:56 </example>
+    <example os.version="9.3" os.version.version="57.5.nc">NetScaler NS9.3: Build 57.5.nc, Date: Jun 27 2012, 19:37:56 </example>
     <param pos="0" name="os.vendor" value="Citrix"/>
     <param pos="0" name="os.family" value="Netscaler"/>
     <param pos="0" name="os.device" value="Network Management Device"/>
@@ -4987,7 +4987,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Business Policy Switch 2000.* SW:v([\d.]+)">
     <description>Nortel Business Policy Switch 2000</description>
-    <example>Business Policy Switch 2000 HW:10 FW:3.6.0.1 SW:v3.1.6.02 ISVN:2</example>
+    <example os.version="3.1.6.02">Business Policy Switch 2000 HW:10 FW:3.6.0.1 SW:v3.1.6.02 ISVN:2</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="BOSS"/>
@@ -4998,10 +4998,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^BayStack (\S+).*SW:[vV](\S+)">
     <description>Nortel BayStack switch</description>
-    <example>BayStack 420     HW:#02      FW:3.0.0.3   SW:v3.0.0.46</example>
-    <example>BayStack 450-24T HW:RevB  FW:V1.02 SW:V1.0.0.8</example>
-    <example>BayStack 350-24T HW:RevD  FW:V1.44 SW:v2.0.0.28</example>
-    <example>BayStack 450-24T HW:RevL  FW:V1.47 SW:v3.1.0.22  ISVN:1</example>
+    <example os.product="420" os.version="3.0.0.46">BayStack 420     HW:#02      FW:3.0.0.3   SW:v3.0.0.46</example>
+    <example os.product="450-24T" os.version="1.0.0.8">BayStack 450-24T HW:RevB  FW:V1.02 SW:V1.0.0.8</example>
+    <example os.product="350-24T" os.version="2.0.0.28">BayStack 350-24T HW:RevD  FW:V1.44 SW:v2.0.0.28</example>
+    <example os.product="450-24T" os.version="3.1.0.22">BayStack 450-24T HW:RevL  FW:V1.47 SW:v3.1.0.22  ISVN:1</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="BayStack"/>
@@ -5012,7 +5012,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Ethernet Switch (\S+).*SW:v([\d.]+)">
     <description>Nortel BayStack switch - variant 1</description>
-    <example>Ethernet Switch 470-48T      HW:#05      FW:3.6.0.6   SW:v3.6.2.04 BN:4 ISVN:2 (c) Nortel Networks</example>
+    <example os.product="470-48T" os.version="3.6.2.04">Ethernet Switch 470-48T      HW:#05      FW:3.6.0.6   SW:v3.6.2.04 BN:4 ISVN:2 (c) Nortel Networks</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="BayStack"/>
@@ -5023,7 +5023,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Bay Networks, Inc\. BayStack (\S+) Ethernet Switch Rev: (.+)$">
     <description>Nortel BayStack switch - variant 2</description>
-    <example>Bay Networks, Inc. BayStack 303 Ethernet Switch Rev: 2.2.32.19-2.1.4.16</example>
+    <example os.product="303" os.version="2.2.32.19-2.1.4.16">Bay Networks, Inc. BayStack 303 Ethernet Switch Rev: 2.2.32.19-2.1.4.16</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="BayStack"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -5033,7 +5033,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^BayStack (\S+), version (\S+) \(.*\)$">
     <description>Nortel BayStack switch - variant 3</description>
-    <example>BayStack 301, version 1.0.0 (96120629)</example>
+    <example os.product="301" os.version="1.0.0">BayStack 301, version 1.0.0 (96120629)</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="BayStack"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -5043,7 +5043,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Accelar-(\S+) \(([^\)]+)\)$">
     <description>Nortel Accelar switch</description>
-    <example>Accelar-8106 (3.0.1)</example>
+    <example os.product="8106" os.version="3.0.1">Accelar-8106 (3.0.1)</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="Accelar"/>
     <param pos="0" name="os.device" value="Switch"/>
@@ -5053,7 +5053,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Alteon iSD NSNAS HW:4050 SW:(\S+)$">
     <description>Nortel Secure Network Access Switch 4050</description>
-    <example>Alteon iSD NSNAS HW:4050 SW:1.6.1.3</example>
+    <example os.version="1.6.1.3">Alteon iSD NSNAS HW:4050 SW:1.6.1.3</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="Secure Network Access Switch"/>
     <param pos="0" name="os.device" value="NAC"/>
@@ -5074,7 +5074,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Nortel, CS 1000 VGMC, Software Release (\S+)$">
     <description>Nortel CS 1000 Voice Gateway Media Card</description>
-    <example>Nortel, CS 1000 VGMC, Software Release IPL-4.50.88</example>
+    <example os.version="IPL-4.50.88">Nortel, CS 1000 VGMC, Software Release IPL-4.50.88</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="CS 1000"/>
     <param pos="0" name="os.device" value="VoIP"/>
@@ -5084,7 +5084,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Nortel, CS 1000S/M Call Server, System (\S+), Release (\S+), Issue (\S+)$">
     <description>Nortel CS 1000 Call Server</description>
-    <example>Nortel, CS 1000S/M Call Server, System 2121, Release 4, Issue 50</example>
+    <example os.version="4" os.version.version="50" os.version.version.version="2121">Nortel, CS 1000S/M Call Server, System 2121, Release 4, Issue 50</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="CS 1000"/>
     <param pos="0" name="os.device" value="VoIP"/>
@@ -5096,7 +5096,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^NORTEL, Succession 1000/M Call Server, System (\S+), Release (\S+), Issue (\S+)$">
     <description>NORTEL, Succession 1000/M Call Server</description>
-    <example>NORTEL, Succession 1000/M Call Server, System 2121, Release 3, Issue 0</example>
+    <example os.version="3" os.version.version="0" os.version.version.version="2121">NORTEL, Succession 1000/M Call Server, System 2121, Release 3, Issue 0</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="Succession 1000/M"/>
     <param pos="0" name="os.device" value="VoIP"/>
@@ -5141,10 +5141,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Nortel SR ([^,\s]+).*Software Version = ([^,]+),">
     <description>Nortel Secure Router</description>
-    <example>Nortel SR 1001, Software Version = r8.3.5, Boot Version = J1100_031805</example>
-    <example>Nortel SR 1004, Software Version = r8.4.4, Boot Version = T1k031605</example>
-    <example>Nortel SR 3120, Software Version = r9.2, Boot Version = r9.2</example>
-    <example>Nortel SR 4134 SNMP Agent, Software Version = 10.2.0.211, Boot Version = 0.0.0.45</example>
+    <example os.product="1001" os.version="r8.3.5">Nortel SR 1001, Software Version = r8.3.5, Boot Version = J1100_031805</example>
+    <example os.product="1004" os.version="r8.4.4">Nortel SR 1004, Software Version = r8.4.4, Boot Version = T1k031605</example>
+    <example os.product="3120" os.version="r9.2">Nortel SR 3120, Software Version = r9.2, Boot Version = r9.2</example>
+    <example os.product="4134" os.version="10.2.0.211">Nortel SR 4134 SNMP Agent, Software Version = 10.2.0.211, Boot Version = 0.0.0.45</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="Secure Router"/>
     <param pos="0" name="os.device" value="Router"/>
@@ -5154,14 +5154,14 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Image: rel/([^/\s]+)/? Created on">
     <description>Bay Networks Router</description>
-    <example>Image: rel/10.00 Created on Fri Mar 1 23:18:04 EST 1996.</example>
-    <example>Image: rel/10.01 Created on Thu Jul 18 11:31:53 EDT 1996.</example>
-    <example>Image: rel/11.02 Created on Fri May 30 22:23:06 EDT 1997.</example>
-    <example>Image: rel/11.02 Created on Fri May 30 22:54:42 EDT 1997.</example>
-    <example>Image: rel/15.6.0.0/ Created on Thu Mar 31 18:08:57 EST 2005.</example>
-    <example>Image: rel/15.6.0.0/ Created on Thu Mar 31 19:41:07 EST 2005.</example>
-    <example>Image: rel/15.7.0.0/ Created on Fri Jul 7 12:49:01 EDT 2006.</example>
-    <example>Image: rel/15.7.1.0/ Created on Wed Jun 13 12:03:05 EDT 2007.</example>
+    <example os.version="10.00">Image: rel/10.00 Created on Fri Mar 1 23:18:04 EST 1996.</example>
+    <example os.version="10.01">Image: rel/10.01 Created on Thu Jul 18 11:31:53 EDT 1996.</example>
+    <example os.version="11.02">Image: rel/11.02 Created on Fri May 30 22:23:06 EDT 1997.</example>
+    <example os.version="11.02">Image: rel/11.02 Created on Fri May 30 22:54:42 EDT 1997.</example>
+    <example os.version="15.6.0.0">Image: rel/15.6.0.0/ Created on Thu Mar 31 18:08:57 EST 2005.</example>
+    <example os.version="15.6.0.0">Image: rel/15.6.0.0/ Created on Thu Mar 31 19:41:07 EST 2005.</example>
+    <example os.version="15.7.0.0">Image: rel/15.7.0.0/ Created on Fri Jul 7 12:49:01 EDT 2006.</example>
+    <example os.version="15.7.1.0">Image: rel/15.7.1.0/ Created on Wed Jun 13 12:03:05 EDT 2007.</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.family" value="BayRS"/>
     <param pos="0" name="os.device" value="Router"/>
@@ -5171,7 +5171,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Nortel (Layer2-3 GbE Switch Module)">
     <description>Nortel Switch Module</description>
-    <example>Nortel Layer2-3 GbE Switch Module(Copper)</example>
+    <example os.product="Layer2-3 GbE Switch Module">Nortel Layer2-3 GbE Switch Module(Copper)</example>
     <param pos="0" name="os.vendor" value="Nortel"/>
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="1" name="os.product"/>
@@ -5379,8 +5379,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce (NC-\d+h), Firmware Ver.(\d+.\d+)\s+\(\d{1,2}.\d{1,2}.\d{1,2}\),">
     <description>Oce NC Series of Print Servers</description>
-    <example>Oce NC-6800h, Firmware Ver.1.01  (10.01.08),MID 8C5-D92,FID 2</example>
-    <example>Oce NC-6400h, Firmware Ver.1.03  (07.02.27),MID 8C5-B29,FID 2</example>
+    <example os.product="NC-6800h" os.version="1.01">Oce NC-6800h, Firmware Ver.1.01  (10.01.08),MID 8C5-D92,FID 2</example>
+    <example os.product="NC-6400h" os.version="1.03">Oce NC-6400h, Firmware Ver.1.03  (07.02.27),MID 8C5-B29,FID 2</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="NC Series"/>
     <param pos="1" name="os.product"/>
@@ -5390,8 +5390,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce (im\d+)$">
     <description>Oce IM series multifunction device</description>
-    <example>Oce im2330</example>
-    <example>Oce im4512</example>
+    <example os.product="im2330">Oce im2330</example>
+    <example os.product="im4512">Oce im4512</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="IM Series"/>
     <param pos="1" name="os.product"/>
@@ -5400,7 +5400,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce (cm\d+)$">
     <description>Oce CM series multifunction device</description>
-    <example>Oce cm4010</example>
+    <example os.product="cm4010">Oce cm4010</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="CM Series"/>
     <param pos="1" name="os.product"/>
@@ -5409,7 +5409,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce digital 3155 (R\S+)$">
     <description>Oce 3165 multifunction device</description>
-    <example>Oce digital 3155 R5.3</example>
+    <example os.version="R5.3">Oce digital 3155 R5.3</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="3155 Series"/>
     <param pos="0" name="os.product" value="3155"/>
@@ -5419,7 +5419,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce digital 3165 (R\S+)$">
     <description>Oce 3165 multifunction device - variant 1</description>
-    <example>Oce digital 3165 R5.3</example>
+    <example os.version="R5.3">Oce digital 3165 R5.3</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="3165 Series"/>
     <param pos="0" name="os.product" value="3165"/>
@@ -5429,7 +5429,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce, 3165 ([^,]+), Controller \S+$">
     <description>Oce 3165 multifunction device - variant 2</description>
-    <example>Oce, 3165 R8.2, Controller R10.2.8</example>
+    <example os.version="R8.2">Oce, 3165 R8.2, Controller R10.2.8</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="3165 Series"/>
     <param pos="0" name="os.product" value="3165"/>
@@ -5439,7 +5439,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce, DS60 ([^,]+),">
     <description>Oce DS60 multifunction device</description>
-    <example>Oce, DS60 R1.2.0, Smart Imager R8.5.3.22</example>
+    <example os.version="R1.2.0">Oce, DS60 R1.2.0, Smart Imager R8.5.3.22</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="DS60 Series"/>
     <param pos="0" name="os.product" value="DS60"/>
@@ -5449,7 +5449,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce, TDS750 ([^,]+),">
     <description>Oce TDS750 multifunction device</description>
-    <example>Oce, TDS750 R1.1, Power Logic Controller R14.8.1.0_12010481</example>
+    <example os.version="R1.1">Oce, TDS750 R1.1, Power Logic Controller R14.8.1.0_12010481</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="TDS750 Series"/>
     <param pos="0" name="os.product" value="750"/>
@@ -5459,7 +5459,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce, (ColorWave\S+) ([^,]+),">
     <description>Oce ColorWave multifunction device</description>
-    <example>Oce, ColorWave650 R2.0, EmCon R2.0, Network interface</example>
+    <example os.product="ColorWave650" os.version="R2.0">Oce, ColorWave650 R2.0, EmCon R2.0, Network interface</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="ColorWave"/>
     <param pos="1" name="os.product"/>
@@ -5469,8 +5469,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce, (VarioPrint \S+) ([^,]+),">
     <description>Oce VarioPrint multifunction device - detailed variant</description>
-    <example>Oce, VarioPrint 135 R2.1.0.0, PRISMAsync R13.4.42.7</example>
-    <example>Oce, VarioPrint 2045 R3.2, Controller R8.2.15</example>
+    <example os.product="VarioPrint 135" os.version="R2.1.0.0">Oce, VarioPrint 135 R2.1.0.0, PRISMAsync R13.4.42.7</example>
+    <example os.product="VarioPrint 2045" os.version="R3.2">Oce, VarioPrint 2045 R3.2, Controller R8.2.15</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="VarioPrint"/>
     <param pos="1" name="os.product"/>
@@ -5480,7 +5480,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce (VarioPrint \S+) (R\S+)$">
     <description>Oce VarioPrint multifunction device</description>
-    <example>Oce VarioPrint 2070 R2</example>
+    <example os.product="VarioPrint 2070" os.version="R2">Oce VarioPrint 2070 R2</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="VarioPrint"/>
     <param pos="1" name="os.product"/>
@@ -5490,7 +5490,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce (CS\S+)">
     <description>Oce CS Series</description>
-    <example>Oce CS2344 /P</example>
+    <example os.product="CS2344">Oce CS2344 /P</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="0" name="os.family" value="CS Series"/>
     <param pos="1" name="os.product"/>
@@ -5499,7 +5499,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Oce (\d+\S*)">
     <description>Oce Device</description>
-    <example>Oce 1000C</example>
+    <example os.family="1000C" os.product="1000C">Oce 1000C</example>
     <param pos="0" name="os.vendor" value="Oce"/>
     <param pos="1" name="os.family"/>
     <param pos="1" name="os.product"/>
@@ -5521,23 +5521,23 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^NRG ((?:MP|SP )?\S+|DSm\d+) (?:V|v)?\.?(\S+)">
     <description>Ricoh NRG network multifunction device</description>
-    <example hw.product="SP C312DN" os.version="1.03">NRG SP C312DN V1.03 / NRG Network Printer C model</example>
-    <example>NRG MP 3350 1.10 / NRG Network Printer C model / NRG Network Scanner C model</example>
-    <example>NRG MP C3500 1.67 / NRG Network Printer C model / NRG Network Scanner C model</example>
-    <example>NRG DSm415 0.29.01 / NRG Network Printer C model / NRG Network Scanner C model</example>
-    <example>NRG MP 171 1.00.1 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
-    <example>NRG SP C231SF v1.14a / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
-    <example>NRG DSm622 1.05 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
-    <example>NRG MP C2550 1.14 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
-    <example>NRG MP C3500 1.70 / NRG Network Printer C model / NRG Network Scanner C model</example>
-    <example>NRG MP C4000 1.24 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
-    <example>NRG MP C4500 1.65 / NRG Network Printer C model / NRG Network Scanner C model</example>
-    <example>NRG 4525/4508/4502 5.25 / NRG Network Printer C model / NRG Network Scanner C model</example>
-    <example>NRG 6002/6005/6008 1.12.3 / NRG Network Printer C model / NRG Network Scanner C model</example>
-    <example>NRG C7417 1.00 / NRG Network Printer C model</example>
-    <example>NRG C7425dn 1.10 / NRG Network Printer C model</example>
-    <example>NRG C7435n 1.05 / NRG Network Printer C model</example>
-    <example hw.product="DSc38" os.version="2.13">NRG DSc38 V.2.13 / NRG Network Printer C model</example>
+    <example hw.product="SP C312DN" os.version="1.03" os.product="SP C312DN">NRG SP C312DN V1.03 / NRG Network Printer C model</example>
+    <example os.product="MP" os.version="3350" hw.product="MP">NRG MP 3350 1.10 / NRG Network Printer C model / NRG Network Scanner C model</example>
+    <example os.product="MP" os.version="C3500" hw.product="MP">NRG MP C3500 1.67 / NRG Network Printer C model / NRG Network Scanner C model</example>
+    <example os.product="DSm415" os.version="0.29.01" hw.product="DSm415">NRG DSm415 0.29.01 / NRG Network Printer C model / NRG Network Scanner C model</example>
+    <example os.product="MP" os.version="171" hw.product="MP">NRG MP 171 1.00.1 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
+    <example os.product="SP C231SF" os.version="1.14a" hw.product="SP C231SF">NRG SP C231SF v1.14a / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
+    <example os.product="DSm622" os.version="1.05" hw.product="DSm622">NRG DSm622 1.05 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
+    <example os.product="MP" os.version="C2550" hw.product="MP">NRG MP C2550 1.14 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
+    <example os.product="MP" os.version="C3500" hw.product="MP">NRG MP C3500 1.70 / NRG Network Printer C model / NRG Network Scanner C model</example>
+    <example os.product="MP" os.version="C4000" hw.product="MP">NRG MP C4000 1.24 / NRG Network Printer C model / NRG Network Scanner C model / NRG Network Facsimile C model</example>
+    <example os.product="MP" os.version="C4500" hw.product="MP">NRG MP C4500 1.65 / NRG Network Printer C model / NRG Network Scanner C model</example>
+    <example os.product="4525/4508/4502" os.version="5.25" hw.product="4525/4508/4502">NRG 4525/4508/4502 5.25 / NRG Network Printer C model / NRG Network Scanner C model</example>
+    <example os.product="6002/6005/6008" os.version="1.12.3" hw.product="6002/6005/6008">NRG 6002/6005/6008 1.12.3 / NRG Network Printer C model / NRG Network Scanner C model</example>
+    <example os.product="C7417" os.version="1.00" hw.product="C7417">NRG C7417 1.00 / NRG Network Printer C model</example>
+    <example os.product="C7425dn" os.version="1.10" hw.product="C7425dn">NRG C7425dn 1.10 / NRG Network Printer C model</example>
+    <example os.product="C7435n" os.version="1.05" hw.product="C7435n">NRG C7435n 1.05 / NRG Network Printer C model</example>
+    <example hw.product="DSc38" os.version="2.13" os.product="DSc38">NRG DSc38 V.2.13 / NRG Network Printer C model</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -5567,10 +5567,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^OKI (\S+(?: \S+)?(?: \S+)?) Rev\. \S+ .*Print\s*Server">
     <description>OKI Print Server - rev space variant</description>
-    <example>OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B6250 Rev.8.1: (C)2005 OKI DATA CORP</example>
-    <example>OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B6500 Rev.2.19 C1: (C)2005 OKI DATA CORP</example>
-    <example>OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B720n Rev.7.1b1: (C)2005 OKI DATA CORP</example>
-    <example>OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B930 Rev.3.6: (C)2005 OKI DATA CORP</example>
+    <example os.product="OkiLAN 6400e">OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B6250 Rev.8.1: (C)2005 OKI DATA CORP</example>
+    <example os.product="OkiLAN 6400e">OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B6500 Rev.2.19 C1: (C)2005 OKI DATA CORP</example>
+    <example os.product="OkiLAN 6400e">OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B720n Rev.7.1b1: (C)2005 OKI DATA CORP</example>
+    <example os.product="OkiLAN 6400e">OKI OkiLAN 6400e Rev. 10/100BASE Ethernet PrintServer: Attached to B930 Rev.3.6: (C)2005 OKI DATA CORP</example>
     <param pos="0" name="os.vendor" value="Oki"/>
     <param pos="0" name="os.device" value="Print Server"/>
     <param pos="1" name="os.product"/>
@@ -5578,8 +5578,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^OKI (\S+(?: \S+)?(?: \S+)?) Rev\.(\S+) .*Print\s*Server">
     <description>OKI Print Server</description>
-    <example>OKI FastEther8450e Rev.01.08 10/100BASE Ethernet PrintServer: Attached to B430 Rev.C2.00 : Copyright (c) 2008 Oki Data Corporation. All rights reserved.</example>
-    <example>OKI FastEther8450e Rev.08.01 10/100BASE Ethernet PrintServer: Attached to C5650 Rev.M1.02 : Copyright (c) 2007 Oki Data Corporation. All rights reserved.</example>
+    <example os.product="FastEther8450e" os.version="01.08">OKI FastEther8450e Rev.01.08 10/100BASE Ethernet PrintServer: Attached to B430 Rev.C2.00 : Copyright (c) 2008 Oki Data Corporation. All rights reserved.</example>
+    <example os.product="FastEther8450e" os.version="08.01">OKI FastEther8450e Rev.08.01 10/100BASE Ethernet PrintServer: Attached to C5650 Rev.M1.02 : Copyright (c) 2007 Oki Data Corporation. All rights reserved.</example>
     <param pos="0" name="os.vendor" value="Oki"/>
     <param pos="0" name="os.device" value="Print Server"/>
     <param pos="1" name="os.product"/>
@@ -5601,7 +5601,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Overland Agent Version (\S+)$">
     <description>Overland NEO tape library - agent variant</description>
-    <example>Overland Agent Version 1.1</example>
+    <example os.version="1.1">Overland Agent Version 1.1</example>
     <param pos="0" name="os.vendor" value="Overland"/>
     <param pos="0" name="os.family" value="NEO"/>
     <param pos="0" name="os.product" value="NEO Tape Library"/>
@@ -5617,9 +5617,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Palo Alto Networks (\S+) series firewall$">
     <description>Palo Alto firewall</description>
-    <example>Palo Alto Networks PA-2000 series firewall</example>
-    <example>Palo Alto Networks PA-500 series firewall</example>
-    <example>Palo Alto Networks PA-4000 series firewall</example>
+    <example hw.product="PA-2000">Palo Alto Networks PA-2000 series firewall</example>
+    <example hw.product="PA-500">Palo Alto Networks PA-500 series firewall</example>
+    <example hw.product="PA-4000">Palo Alto Networks PA-4000 series firewall</example>
     <param pos="0" name="os.vendor" value="Palo Alto Networks"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.product" value="PAN-OS"/>
@@ -5652,7 +5652,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(WJ-HD\d+) SWVer(\S+)$">
     <description>Panasonic digital disk recorder</description>
-    <example>WJ-HD300 SWVer1.53</example>
+    <example os.product="WJ-HD300" os.version="1.53">WJ-HD300 SWVer1.53</example>
     <param pos="0" name="os.vendor" value="Panasonic"/>
     <param pos="0" name="os.device" value="Storage"/>
     <param pos="1" name="os.product"/>
@@ -5661,7 +5661,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Panasonic ([A-Z][A-Z]-\S+)$">
     <description>Panasonic Printer</description>
-    <example>Panasonic DP-1520P</example>
+    <example os.product="DP-1520P">Panasonic DP-1520P</example>
     <param pos="0" name="os.vendor" value="Panasonic"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -5673,7 +5673,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^PARADYNE T1 DSU/CSU; model: ([^;]+); S/W Release: ([^;]+);">
     <description>Paradyne CSU/DSU</description>
-    <example>PARADYNE T1 DSU/CSU; model: 3165-A4-210; S/W Release: 05.01.16; H/W CCA1: 3996-82C; Serial number: 5796841</example>
+    <example os.product="3165-A4-210" os.version="05.01.16">PARADYNE T1 DSU/CSU; model: 3165-A4-210; S/W Release: 05.01.16; H/W CCA1: 3996-82C; Serial number: 5796841</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Paradyne"/>
     <param pos="0" name="os.device" value="CSU/DSU"/>
@@ -5683,8 +5683,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^PARADYNE (BitStorm \S+);.*S/W Release: ([^;]+);">
     <description>Paradyne BitStorm DSLAM</description>
-    <example>PARADYNE BitStorm 2600; S/W Release: 02.05.07;</example>
-    <example>PARADYNE BitStorm 4800; S/W Release: 01.00.09;</example>
+    <example os.product="BitStorm 2600" os.version="02.05.07">PARADYNE BitStorm 2600; S/W Release: 02.05.07;</example>
+    <example os.product="BitStorm 4800" os.version="01.00.09">PARADYNE BitStorm 4800; S/W Release: 01.00.09;</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Paradyne"/>
     <param pos="0" name="os.family" value="BitStorm"/>
@@ -5695,7 +5695,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^PARADYNE (GranDSLAM \S+);.*S/W Release: ([^;]+);">
     <description>Paradyne GranDSLAM</description>
-    <example>PARADYNE GranDSLAM 4200; S/W Release: 02.05.23;</example>
+    <example os.product="GranDSLAM 4200" os.version="02.05.23">PARADYNE GranDSLAM 4200; S/W Release: 02.05.23;</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Paradyne"/>
     <param pos="0" name="os.family" value="GranDSLAM"/>
@@ -5706,7 +5706,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^PARADYNE SHDSL FrameSaver DSL; Model: ([^;]+); S/W Release: ([^;]+);">
     <description>Paradyne Frame Relay</description>
-    <example>PARADYNE SHDSL FrameSaver DSL; Model: 9788; S/W Release: 02.00.06; NAM CCA number: 4814-80C; Serial number: 6658952</example>
+    <example os.product="9788" os.version="02.00.06">PARADYNE SHDSL FrameSaver DSL; Model: 9788; S/W Release: 02.00.06; NAM CCA number: 4814-80C; Serial number: 6658952</example>
     <param pos="0" name="os.certainty" value="1.0"/>
     <param pos="0" name="os.vendor" value="Paradyne"/>
     <param pos="0" name="os.device" value="Frame Relay"/>
@@ -5781,9 +5781,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Rectifier Technologies Pacific (WebCSU \S+) V(\S+)$">
     <description>Rectifier Technologies Pacific WebCSU - version variant</description>
-    <example>Rectifier Technologies Pacific WebCSU 169-412 V1.15</example>
-    <example>Rectifier Technologies Pacific WebCSU 169-412 V1.28</example>
-    <example>Rectifier Technologies Pacific WebCSU 169-412 V1.30</example>
+    <example os.product="WebCSU 169-412" os.version="1.15">Rectifier Technologies Pacific WebCSU 169-412 V1.15</example>
+    <example os.product="WebCSU 169-412" os.version="1.28">Rectifier Technologies Pacific WebCSU 169-412 V1.28</example>
+    <example os.product="WebCSU 169-412" os.version="1.30">Rectifier Technologies Pacific WebCSU 169-412 V1.30</example>
     <param pos="0" name="os.vendor" value="Rectifier Technologies"/>
     <param pos="0" name="os.family" value="RTP Power Controller"/>
     <param pos="0" name="os.device" value="Power Device"/>
@@ -5831,12 +5831,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Raritan Computer; (CommandCenter Secure Gateway); Version ([^;]+); (\S+) HW\s*$">
     <description>Redback CommandCenter Secure Gateway</description>
-    <example>Raritan Computer; CommandCenter Secure Gateway; Version 3.1.1.5.2; CC-SG-G1 HW</example>
-    <example>Raritan Computer; CommandCenter Secure Gateway; Version 3.1.1.5.2; CC-SG-V1 HW</example>
-    <example>Raritan Computer; CommandCenter Secure Gateway; Version 3.2.1.5.1; CC-SG-E1 HW</example>
-    <example>Raritan Computer; CommandCenter Secure Gateway; Version 3.2.1.5.1; CC-SG-V1 HW</example>
-    <example>Raritan Computer; CommandCenter Secure Gateway; Version 4.3.0.5.13; CC-SG-V1-A HW</example>
-    <example>Raritan Computer; CommandCenter Secure Gateway; Version 5.3.0.5.8; CCSG128-VA HW</example>
+    <example os.product="CommandCenter Secure Gateway" os.version="3.1.1.5.2" hw.product="CC-SG-G1">Raritan Computer; CommandCenter Secure Gateway; Version 3.1.1.5.2; CC-SG-G1 HW</example>
+    <example os.product="CommandCenter Secure Gateway" os.version="3.1.1.5.2" hw.product="CC-SG-V1">Raritan Computer; CommandCenter Secure Gateway; Version 3.1.1.5.2; CC-SG-V1 HW</example>
+    <example os.product="CommandCenter Secure Gateway" os.version="3.2.1.5.1" hw.product="CC-SG-E1">Raritan Computer; CommandCenter Secure Gateway; Version 3.2.1.5.1; CC-SG-E1 HW</example>
+    <example os.product="CommandCenter Secure Gateway" os.version="3.2.1.5.1" hw.product="CC-SG-V1">Raritan Computer; CommandCenter Secure Gateway; Version 3.2.1.5.1; CC-SG-V1 HW</example>
+    <example os.product="CommandCenter Secure Gateway" os.version="4.3.0.5.13" hw.product="CC-SG-V1-A">Raritan Computer; CommandCenter Secure Gateway; Version 4.3.0.5.13; CC-SG-V1-A HW</example>
+    <example os.product="CommandCenter Secure Gateway" os.version="5.3.0.5.8" hw.product="CCSG128-VA">Raritan Computer; CommandCenter Secure Gateway; Version 5.3.0.5.8; CCSG128-VA HW</example>
     <param pos="0" name="os.vendor" value="Raritan"/>
     <param pos="1" name="os.product"/>
     <param pos="2" name="os.version"/>
@@ -5845,11 +5845,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Raritan (Dominion PX) - Firmware Version (\S+)$">
     <description>Raritan Dominion PX</description>
-    <example>Raritan Dominion PX - Firmware Version 010200</example>
-    <example>Raritan Dominion PX - Firmware Version 010300</example>
-    <example>Raritan Dominion PX - Firmware Version 010502-10441</example>
-    <example>Raritan Dominion PX - Firmware Version 010505-10603</example>
-    <example>Raritan Dominion PX - Firmware Version 010600-10544</example>
+    <example os.product="Dominion PX" os.version="010200">Raritan Dominion PX - Firmware Version 010200</example>
+    <example os.product="Dominion PX" os.version="010300">Raritan Dominion PX - Firmware Version 010300</example>
+    <example os.product="Dominion PX" os.version="010502-10441">Raritan Dominion PX - Firmware Version 010502-10441</example>
+    <example os.product="Dominion PX" os.version="010505-10603">Raritan Dominion PX - Firmware Version 010505-10603</example>
+    <example os.product="Dominion PX" os.version="010600-10544">Raritan Dominion PX - Firmware Version 010600-10544</example>
     <param pos="0" name="os.vendor" value="Raritan"/>
     <param pos="0" name="os.device" value="PDU"/>
     <param pos="1" name="os.product"/>
@@ -5862,16 +5862,16 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Red[bB]ack Networks AOS Release (\S+) .* Copyright">
     <description>Redback networks AOS</description>
-    <example>RedBack Networks AOS Release 3.1.6.18 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2001 by RedBack Networks, Inc. Compiled 2001-Oct-24 19:56:11 GMT by wheatley</example>
-    <example>Redback Networks AOS Release 5.0.6.10 MAINTENANCE RELEASE Copyright (c) 1997-2002 by Redback Networks, Inc. Compiled 2002-Sep-20 20:53:18 GMT by wheatley</example>
-    <example>Redback Networks AOS Release 5.0.6.33 MAINTENANCE RELEASE Copyright (c) 1997-2003 by Redback Networks, Inc. Compiled 2003-Nov-09 19:21:42 GMT by wheatley</example>
-    <example>Redback Networks AOS Release 6.0.8.0 PRODUCTION RELEASE Copyright (c) 1997-2003 by Redback Networks, Inc. Compiled 2003-Nov-26 02:22:01 GMT by wheatley</example>
-    <example>Redback Networks AOS Release 6.0.8.5 MAINTENANCE RELEASE Copyright (c) 1997-2004 by Redback Networks, Inc. Compiled 2004-Feb-18 09:28:31 GMT by wheatley</example>
-    <example>Redback Networks AOS Release 6.0.9.12 MAINTENANCE RELEASE Copyright (c) 1997-2004 by Redback Networks, Inc. Compiled 2004-Jul-28 23:58:03 GMT by wheatley</example>
-    <example>Redback Networks AOS Release 6.1.4.13 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2006 by Redback Networks, Inc. Compiled 2006-Oct-06 16:26:44 GMT by relsms</example>
-    <example>Redback Networks AOS Release 6.1.4.14 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2006 by Redback Networks, Inc. Compiled 2007-Jan-03 03:15:24 GMT by relsms</example>
-    <example>Redback Networks AOS Release 6.1.4.16 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2006 by Redback Networks, Inc. Compiled 2007-Aug-10 21:42:14 GMT by relsms</example>
-    <example>Redback Networks AOS Release 6.2.5.0 PRODUCTION RELEASE Copyright (c) 1997-2007 by Redback Networks, Inc. Compiled 2007-Nov-28 02:48:44 GMT by relsms</example>
+    <example os.version="3.1.6.18">RedBack Networks AOS Release 3.1.6.18 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2001 by RedBack Networks, Inc. Compiled 2001-Oct-24 19:56:11 GMT by wheatley</example>
+    <example os.version="5.0.6.10">Redback Networks AOS Release 5.0.6.10 MAINTENANCE RELEASE Copyright (c) 1997-2002 by Redback Networks, Inc. Compiled 2002-Sep-20 20:53:18 GMT by wheatley</example>
+    <example os.version="5.0.6.33">Redback Networks AOS Release 5.0.6.33 MAINTENANCE RELEASE Copyright (c) 1997-2003 by Redback Networks, Inc. Compiled 2003-Nov-09 19:21:42 GMT by wheatley</example>
+    <example os.version="6.0.8.0">Redback Networks AOS Release 6.0.8.0 PRODUCTION RELEASE Copyright (c) 1997-2003 by Redback Networks, Inc. Compiled 2003-Nov-26 02:22:01 GMT by wheatley</example>
+    <example os.version="6.0.8.5">Redback Networks AOS Release 6.0.8.5 MAINTENANCE RELEASE Copyright (c) 1997-2004 by Redback Networks, Inc. Compiled 2004-Feb-18 09:28:31 GMT by wheatley</example>
+    <example os.version="6.0.9.12">Redback Networks AOS Release 6.0.9.12 MAINTENANCE RELEASE Copyright (c) 1997-2004 by Redback Networks, Inc. Compiled 2004-Jul-28 23:58:03 GMT by wheatley</example>
+    <example os.version="6.1.4.13">Redback Networks AOS Release 6.1.4.13 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2006 by Redback Networks, Inc. Compiled 2006-Oct-06 16:26:44 GMT by relsms</example>
+    <example os.version="6.1.4.14">Redback Networks AOS Release 6.1.4.14 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2006 by Redback Networks, Inc. Compiled 2007-Jan-03 03:15:24 GMT by relsms</example>
+    <example os.version="6.1.4.16">Redback Networks AOS Release 6.1.4.16 PRODUCTION MAINTENANCE RELEASE Copyright (c) 1997-2006 by Redback Networks, Inc. Compiled 2007-Aug-10 21:42:14 GMT by relsms</example>
+    <example os.version="6.2.5.0">Redback Networks AOS Release 6.2.5.0 PRODUCTION RELEASE Copyright (c) 1997-2007 by Redback Networks, Inc. Compiled 2007-Nov-28 02:48:44 GMT by relsms</example>
     <param pos="0" name="os.vendor" value="Redback Networks"/>
     <param pos="0" name="os.product" value="AOS"/>
     <param pos="1" name="os.version"/>
@@ -5879,11 +5879,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Redback Networks SmartEdge OS Version SEOS-(.*?) Built by">
     <description>Redback SmartEdge</description>
-    <example>Redback Networks SmartEdge OS Version SEOS-11.1.2.3p1-Release Built by sysbuild@SWB-node04 Fri Dec 23 11:47:30 PST 2011 Copyright (C) 1998-2011, Redback Networks Inc. All rights reserved.</example>
-    <example>Redback Networks SmartEdge OS Version SEOS-11.1.2.3p3-Release Built by sysbuild@SWB-node06 Thu Feb 16 16:39:21 PST 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
-    <example>Redback Networks SmartEdge OS Version SEOS-11.1.2.4-Release Built by sysbuild@SWB-node01 Sat Mar 3 16:15:16 PST 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
-    <example>Redback Networks SmartEdge OS Version SEOS-11.1.2.4-Release Built by sysbuild@SWB-node03 Sat Mar 3 16:15:16 PST 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
-    <example>Redback Networks SmartEdge OS Version SEOS-11.1.2.4p3-Release Built by sysbuild@SWB-node01 Sat Apr 28 07:58:16 PDT 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
+    <example os.version="11.1.2.3p1-Release">Redback Networks SmartEdge OS Version SEOS-11.1.2.3p1-Release Built by sysbuild@SWB-node04 Fri Dec 23 11:47:30 PST 2011 Copyright (C) 1998-2011, Redback Networks Inc. All rights reserved.</example>
+    <example os.version="11.1.2.3p3-Release">Redback Networks SmartEdge OS Version SEOS-11.1.2.3p3-Release Built by sysbuild@SWB-node06 Thu Feb 16 16:39:21 PST 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
+    <example os.version="11.1.2.4-Release">Redback Networks SmartEdge OS Version SEOS-11.1.2.4-Release Built by sysbuild@SWB-node01 Sat Mar 3 16:15:16 PST 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
+    <example os.version="11.1.2.4-Release">Redback Networks SmartEdge OS Version SEOS-11.1.2.4-Release Built by sysbuild@SWB-node03 Sat Mar 3 16:15:16 PST 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
+    <example os.version="11.1.2.4p3-Release">Redback Networks SmartEdge OS Version SEOS-11.1.2.4p3-Release Built by sysbuild@SWB-node01 Sat Apr 28 07:58:16 PDT 2012 Copyright (C) 1998-2012, Redback Networks Inc. All rights reserved.</example>
     <param pos="0" name="os.vendor" value="Redback Networks"/>
     <param pos="0" name="os.product" value="SmartEdge OS"/>
     <param pos="1" name="os.version"/>
@@ -5895,23 +5895,23 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RICOH Aficio ((?:[MS]P )?\S+) ([0-9\.a-zA-Z]+) ">
     <description>Ricoh Aficio multifunction device</description>
-    <example>RICOH Aficio 1022 5.20 / RICOH Network Printer C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 1232C 2.07.2 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 1515 0.29.03 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 1515 0.29.04 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 2015 0.40.07 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 2027 1.04 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 2035 1.05.1 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
-    <example>RICOH Aficio 2035e 2.40 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio MP 1600 1.00.1 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio MP 161 1.03 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio MP 5500 2.06 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio MP 5500 2.04 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio MP C2500 1.62.1 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio MP C2500 1.66 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio MP C3000 1.70 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH Aficio 2045 1.06s / RICOH Network Printer C model / RICOH Network Scanner C model</example>
-    <example>RICOH Aficio SP C411DN 1.01 / RICOH Network Printer C model</example>
+    <example os.product="1022" os.version="5.20">RICOH Aficio 1022 5.20 / RICOH Network Printer C model / RICOH Network Facsimile C model</example>
+    <example os.product="1232C" os.version="2.07.2">RICOH Aficio 1232C 2.07.2 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="1515" os.version="0.29.03">RICOH Aficio 1515 0.29.03 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="1515" os.version="0.29.04">RICOH Aficio 1515 0.29.04 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="2015" os.version="0.40.07">RICOH Aficio 2015 0.40.07 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="2027" os.version="1.04">RICOH Aficio 2027 1.04 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="2035" os.version="1.05.1">RICOH Aficio 2035 1.05.1 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
+    <example os.product="2035e" os.version="2.40">RICOH Aficio 2035e 2.40 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP 1600" os.version="1.00.1">RICOH Aficio MP 1600 1.00.1 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP 161" os.version="1.03">RICOH Aficio MP 161 1.03 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP 5500" os.version="2.06">RICOH Aficio MP 5500 2.06 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP 5500" os.version="2.04">RICOH Aficio MP 5500 2.04 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP C2500" os.version="1.62.1">RICOH Aficio MP C2500 1.62.1 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP C2500" os.version="1.66">RICOH Aficio MP C2500 1.66 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP C3000" os.version="1.70">RICOH Aficio MP C3000 1.70 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="2045" os.version="1.06s">RICOH Aficio 2045 1.06s / RICOH Network Printer C model / RICOH Network Scanner C model</example>
+    <example os.product="SP C411DN" os.version="1.01">RICOH Aficio SP C411DN 1.01 / RICOH Network Printer C model</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Aficio"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -5921,8 +5921,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RICOH Aficio (\S+)$">
     <description>Generic Ricoh Aficio multifunction device</description>
-    <example>RICOH Aficio 350e/355e</example>
-    <example>RICOH Aficio 551</example>
+    <example os.product="350e/355e">RICOH Aficio 350e/355e</example>
+    <example os.product="551">RICOH Aficio 551</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Aficio"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -5931,7 +5931,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RICOH Aficio (\S+ \S+)$">
     <description>Generic Ricoh Aficio multifunction device - variant 1</description>
-    <example>RICOH Aficio MP C2500</example>
+    <example os.product="MP C2500">RICOH Aficio MP C2500</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Aficio"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -5940,7 +5940,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RICOH Aficio (\S+) /">
     <description>Generic Ricoh Aficio multifunction device - variant 2</description>
-    <example>RICOH Aficio 1013 / RICOH Network Printer D model</example>
+    <example os.product="1013">RICOH Aficio 1013 / RICOH Network Printer D model</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Aficio"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -5949,11 +5949,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RICOH imagio (\S+ \S+|\S+) (\d+\S+) /">
     <description>Generic Ricoh Imagio multifunction device</description>
-    <example>RICOH imagio MP C6001 1.04 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
-    <example>RICOH imagio MP C6001 1.05.1 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
-    <example>RICOH imagio MP6001 1.14 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH imagio MP6001 1.19 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
-    <example>RICOH imagio Neo 135 0.60.01 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP C6001" os.version="1.04">RICOH imagio MP C6001 1.04 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
+    <example os.product="MP C6001" os.version="1.05.1">RICOH imagio MP C6001 1.05.1 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
+    <example os.product="MP6001" os.version="1.14">RICOH imagio MP6001 1.14 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="MP6001" os.version="1.19">RICOH imagio MP6001 1.19 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
+    <example os.product="Neo 135" os.version="0.60.01">RICOH imagio Neo 135 0.60.01 / RICOH Network Printer C model / RICOH Network Scanner C model / RICOH Network Facsimile C model</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Imagio"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -5963,7 +5963,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RICOH IPS[Ii]O (\S+) (\S+) /">
     <description>Generic Ricoh IPSIO multifunction device</description>
-    <example>RICOH IPSiO NX96e 1.01 / RICOH Network Printer C model</example>
+    <example os.product="NX96e" os.version="1.01">RICOH IPSiO NX96e 1.01 / RICOH Network Printer C model</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="IPSIO"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -5985,7 +5985,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RICOH Pro (\S+) (\S+) /">
     <description>Generic Ricoh Pro multifunction device</description>
-    <example>RICOH Pro 907EX 1.02 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
+    <example os.product="907EX" os.version="1.02">RICOH Pro 907EX 1.02 / RICOH Network Printer C model / RICOH Network Scanner C model</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Pro"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -6077,7 +6077,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Gestetner (\S+) (\S+) / Gestetner Network Printer">
     <description>Gestetner Network Printer</description>
-    <example>Gestetner C7640nD 1.01 / Gestetner Network Printer C model</example>
+    <example os.product="C7640nD" os.version="1.01">Gestetner C7640nD 1.01 / Gestetner Network Printer C model</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -6090,15 +6090,15 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="(?i)^(?:IBM )?InfoPrint(?: Color)? (\S+)(?: MFP)? Version (\S+)">
     <description>IBM Infoprint Printer - verbose variant</description>
-    <example>IBM Infoprint 1332 version 55.00.39 kernel 2.4.0-test6 All-N-1</example>
-    <example>IBM Infoprint 1372 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
-    <example>IBM Infoprint Color 1354 version 86.01.01 kernel 2.4.0-test6 All-N-1</example>
-    <example>InfoPrint 6500 Version 1.4.40.6 3-3-3</example>
-    <example>IBM Infoprint 1352 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
-    <example>InfoPrint 1832 version NR.APS.N447b2 kernel 2.6.18.5 All-N-1</example>
-    <example>IBM Infoprint 1410 MFP version NGN1.NM.N112 kernel 2.4.0-test6 All-N-1</example>
-    <example>InfoPrint Color 1826 MFP version NR.APS.N469 kernel 2.6.18.5 All-N-1</example>
-    <example>IBM Infoprint 1226 Version 3.20.30 Ethernet 10/100.</example>
+    <example os.product="1332" os.version="55.00.39">IBM Infoprint 1332 version 55.00.39 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="1372" os.version="55.10.19">IBM Infoprint 1372 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="1354" os.version="86.01.01">IBM Infoprint Color 1354 version 86.01.01 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="6500" os.version="1.4.40.6">InfoPrint 6500 Version 1.4.40.6 3-3-3</example>
+    <example os.product="1352" os.version="55.10.19">IBM Infoprint 1352 version 55.10.19 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="1832" os.version="NR.APS.N447b2">InfoPrint 1832 version NR.APS.N447b2 kernel 2.6.18.5 All-N-1</example>
+    <example os.product="1410" os.version="NGN1.NM.N112">IBM Infoprint 1410 MFP version NGN1.NM.N112 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="1826" os.version="NR.APS.N469">InfoPrint Color 1826 MFP version NR.APS.N469 kernel 2.6.18.5 All-N-1</example>
+    <example os.product="1226" os.version="3.20.30">IBM Infoprint 1226 Version 3.20.30 Ethernet 10/100.</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Infoprint"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -6108,7 +6108,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:IBM )InfoPrint (\d+)\s*$">
     <description>IBM Infoprint Printer - simple variant</description>
-    <example>IBM InfoPrint 40 </example>
+    <example os.product="40">IBM InfoPrint 40 </example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Infoprint"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -6117,8 +6117,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(?:IBM )?InfoPrint (?:\(v\d+\) )?(\d+\S+)">
     <description>IBM Infoprint Printer</description>
-    <example>IBM InfoPrint (v1) 21</example>
-    <example>InfoPrint 4247-Z03</example>
+    <example os.product="21">IBM InfoPrint (v1) 21</example>
+    <example os.product="4247-Z03">InfoPrint 4247-Z03</example>
     <param pos="0" name="os.vendor" value="Ricoh"/>
     <param pos="0" name="os.family" value="Infoprint"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -6131,22 +6131,22 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^RouterOS (RB.*)$">
     <description>Miktorik RouterOS - model variant</description>
-    <example>RouterOS RB Crossroads</example>
-    <example>RouterOS RB Groove A-5Hn</example>
-    <example>RouterOS RB MetaROUTER</example>
-    <example>RouterOS RB Metal 5SHPn</example>
-    <example>RouterOS RB OmniTIK UPA-5HnD</example>
-    <example>RouterOS RB SXT-5D</example>
-    <example>RouterOS RB miniROUTER</example>
-    <example>RouterOS RB1100</example>
-    <example>RouterOS RB1100AHx2</example>
-    <example>RouterOS RB112</example>
-    <example>RouterOS RB1200</example>
-    <example>RouterOS RB600A</example>
-    <example>RouterOS RB711-2Hn</example>
-    <example>RouterOS RB751G-2HnD</example>
-    <example>RouterOS RB800</example>
-    <example>RouterOS RB951-2n</example>
+    <example os.product="RB Crossroads">RouterOS RB Crossroads</example>
+    <example os.product="RB Groove A-5Hn">RouterOS RB Groove A-5Hn</example>
+    <example os.product="RB MetaROUTER">RouterOS RB MetaROUTER</example>
+    <example os.product="RB Metal 5SHPn">RouterOS RB Metal 5SHPn</example>
+    <example os.product="RB OmniTIK UPA-5HnD">RouterOS RB OmniTIK UPA-5HnD</example>
+    <example os.product="RB SXT-5D">RouterOS RB SXT-5D</example>
+    <example os.product="RB miniROUTER">RouterOS RB miniROUTER</example>
+    <example os.product="RB1100">RouterOS RB1100</example>
+    <example os.product="RB1100AHx2">RouterOS RB1100AHx2</example>
+    <example os.product="RB112">RouterOS RB112</example>
+    <example os.product="RB1200">RouterOS RB1200</example>
+    <example os.product="RB600A">RouterOS RB600A</example>
+    <example os.product="RB711-2Hn">RouterOS RB711-2Hn</example>
+    <example os.product="RB751G-2HnD">RouterOS RB751G-2HnD</example>
+    <example os.product="RB800">RouterOS RB800</example>
+    <example os.product="RB951-2n">RouterOS RB951-2n</example>
     <param pos="0" name="os.vendor" value="MikroTik"/>
     <param pos="0" name="os.family" value="RouterOS"/>
     <param pos="0" name="os.device" value="Router"/>
@@ -6197,9 +6197,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="(?i)^SAVIN (\S+)(?: / .*)?$">
     <description>Savin Printer</description>
-    <example>SAVIN 2400WD</example>
-    <example>Savin 9965DP</example>
-    <example>SAVIN 2555 / RICOH Network Printer D model</example>
+    <example os.product="2400WD">SAVIN 2400WD</example>
+    <example os.product="9965DP">Savin 9965DP</example>
+    <example os.product="2555">SAVIN 2555 / RICOH Network Printer D model</example>
     <param pos="0" name="os.vendor" value="Savin"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -6207,10 +6207,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SAVIN ((?:\S+ )?\S+) (\d\S+) /">
     <description>Savin Printer - version variant</description>
-    <example>SAVIN 2522 5.20 / SAVIN Network Printer C model / SAVIN Network Scanner C model / SAVIN Network Facsimile C model</example>
-    <example>SAVIN 9922DP 1.4.9 / RICOH Network Printer C model</example>
-    <example>SAVIN SLP38c 2.22 / SAVIN Network Printer C model</example>
-    <example>SAVIN SP C400DN 1.01 / SAVIN Network Printer C model</example>
+    <example os.product="2522" os.version="5.20">SAVIN 2522 5.20 / SAVIN Network Printer C model / SAVIN Network Scanner C model / SAVIN Network Facsimile C model</example>
+    <example os.product="9922DP" os.version="1.4.9">SAVIN 9922DP 1.4.9 / RICOH Network Printer C model</example>
+    <example os.product="SLP38c" os.version="2.22">SAVIN SLP38c 2.22 / SAVIN Network Printer C model</example>
+    <example os.product="SP C400DN" os.version="1.01">SAVIN SP C400DN 1.01 / SAVIN Network Printer C model</example>
     <param pos="0" name="os.vendor" value="Savin"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -6223,8 +6223,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Samsung(?: Samsung)? ([^;\s]+)(?: \d\S+)?(?: Series)?(?: Series)?;?\s*(?:OS )?V?([^\;\s]+)\s?.*?;.*Engine">
     <description>Samsung Printer</description>
-    <example>Samsung CLP-300; CLP300N_V1.01.02.01 11-15-2006;Engine 1.01.57;NIC V4.01.06(CLP-300) 11-03-2006;S/N XXXXXXXXXXXXXXXX</example>
-    <example>Samsung Samsung SCX-470x Series; V3.00.01.04 SEP-16-2011;Engine V1.02.05 09-02-2011;NIC V6.01.00;S/N XXXXXXXXXXXXXXXX</example>
+    <example os.product="CLP-300" os.version="CLP300N_V1.01.02.01">Samsung CLP-300; CLP300N_V1.01.02.01 11-15-2006;Engine 1.01.57;NIC V4.01.06(CLP-300) 11-03-2006;S/N XXXXXXXXXXXXXXXX</example>
+    <example os.product="SCX-470x" os.version="3.00.01.04">Samsung Samsung SCX-470x Series; V3.00.01.04 SEP-16-2011;Engine V1.02.05 09-02-2011;NIC V6.01.00;S/N XXXXXXXXXXXXXXXX</example>
     <param pos="0" name="os.vendor" value="Samsung"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -6233,9 +6233,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Samsung (CLX-\S+)$">
     <description>Samsung Printer - model only variant</description>
-    <example>Samsung CLX-7285</example>
-    <example>Samsung CLX-7355</example>
-    <example>Samsung CLX-7455</example>
+    <example os.product="CLX-7285">Samsung CLX-7285</example>
+    <example os.product="CLX-7355">Samsung CLX-7355</example>
+    <example os.product="CLX-7455">Samsung CLX-7455</example>
     <param pos="0" name="os.vendor" value="Samsung"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -6243,7 +6243,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Samsung (CLP-705) Series; ; S/N">
     <description>Samsung Printer - serial number variant</description>
-    <example>Samsung CLP-705 Series; ; S/N XXXXXXXXXXXXXXXX</example>
+    <example os.product="CLP-705">Samsung CLP-705 Series; ; S/N XXXXXXXXXXXXXXXX</example>
     <param pos="0" name="os.vendor" value="Samsung"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -6257,7 +6257,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <description>SonicWall - SonicOS Enhanced variant</description>
     <example hw.product="NSA" hw.model="220" os.version="5.8.1.2-20o">SonicWALL NSA 220 (SonicOS Enhanced 5.8.1.2-20o)</example>
     <example hw.product="TZ" hw.model="215" os.version="5.8.1.2-6o">SonicWALL TZ 215 wireless-N (SonicOS Enhanced 5.8.1.2-6o)</example>
-    <example>SonicWALL TZ190 Enhanced (SonicOS Enhanced 3.6.0.4-30e)</example>
+    <example hw.product="TZ19" hw.model="0" os.version="3.6.0.4-30e">SonicWALL TZ190 Enhanced (SonicOS Enhanced 3.6.0.4-30e)</example>
     <example hw.product="SuperMassive" hw.model="9200" os.version="6.2.5.3-35n">SonicWALL SuperMassive 9200 (SonicOS Enhanced 6.2.5.3-35n)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
@@ -6284,14 +6284,14 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SonicWALL (.*?)\s+\(([^\)]+)\)\s*$">
     <description>SonicWall</description>
-    <example>SonicWALL StrongARM / 233 Mhz (PRO 200)</example>
-    <example>SonicWALL StrongARM / 233 Mhz (PRO 230)</example>
-    <example>SonicWALL StrongARM / 233 Mhz (PRO 300)</example>
-    <example>SonicWALL StrongARM / 233 Mhz (PRO 330)</example>
-    <example>SonicWALL Toshiba / 133 Mhz (SOHO2)</example>
-    <example>SonicWALL Toshiba / 133 Mhz (SOHO3)</example>
-    <example>SonicWALL Toshiba / 133 Mhz (TELE3 SP)</example>
-    <example>SonicWALL I80X86 / 800 Mhz (PRO 2040 Standa)</example>
+    <example hw.family="StrongARM / 233 Mhz" hw.product="PRO 200">SonicWALL StrongARM / 233 Mhz (PRO 200)</example>
+    <example hw.family="StrongARM / 233 Mhz" hw.product="PRO 230">SonicWALL StrongARM / 233 Mhz (PRO 230)</example>
+    <example hw.family="StrongARM / 233 Mhz" hw.product="PRO 300">SonicWALL StrongARM / 233 Mhz (PRO 300)</example>
+    <example hw.family="StrongARM / 233 Mhz" hw.product="PRO 330">SonicWALL StrongARM / 233 Mhz (PRO 330)</example>
+    <example hw.family="Toshiba / 133 Mhz" hw.product="SOHO2">SonicWALL Toshiba / 133 Mhz (SOHO2)</example>
+    <example hw.family="Toshiba / 133 Mhz" hw.product="SOHO3">SonicWALL Toshiba / 133 Mhz (SOHO3)</example>
+    <example hw.family="Toshiba / 133 Mhz" hw.product="TELE3 SP">SonicWALL Toshiba / 133 Mhz (TELE3 SP)</example>
+    <example hw.family="I80X86 / 800 Mhz" hw.product="PRO 2040 Standa">SonicWALL I80X86 / 800 Mhz (PRO 2040 Standa)</example>
     <param pos="0" name="os.vendor" value="SonicWall"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.product" value="SonicOS"/>
@@ -6314,7 +6314,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SCO UnixWare (\S+)$">
     <description>SCO UnixWare</description>
-    <example>SCO UnixWare 7.1.0</example>
+    <example os.version="7.1.0">SCO UnixWare 7.1.0</example>
     <param pos="0" name="os.vendor" value="SCO"/>
     <param pos="0" name="os.family" value="UnixWare"/>
     <param pos="0" name="os.product" value="UnixWare"/>
@@ -6323,7 +6323,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SCO OpenServer Release (\S+)$">
     <description>SCO OpenServer</description>
-    <example>SCO OpenServer Release 6</example>
+    <example os.version="6">SCO OpenServer Release 6</example>
     <param pos="0" name="os.vendor" value="SCO"/>
     <param pos="0" name="os.family" value="OpenServer"/>
     <param pos="0" name="os.product" value="OpenServer"/>
@@ -6336,8 +6336,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^ShoreGear (\S+)$">
     <description>Shoretel ShoreGear VoIP Switch</description>
-    <example>ShoreGear 60/12</example>
-    <example>ShoreGear T1</example>
+    <example os.product="60/12">ShoreGear 60/12</example>
+    <example os.product="T1">ShoreGear T1</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="ShoreTel"/>
     <param pos="0" name="os.family" value="ShoreGear"/>
@@ -6389,7 +6389,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SHARP (AR-\S+)$">
     <description>Sharp AR Series multifunction device</description>
-    <example>SHARP AR-M450</example>
+    <example os.product="AR-M450">SHARP AR-M450</example>
     <param pos="0" name="os.vendor" value="Sharp"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.family" value="AR Series"/>
@@ -6398,10 +6398,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SHARP (MX-\S+)$">
     <description>Sharp MX Series multifunction device</description>
-    <example>SHARP MX-M350N</example>
-    <example>SHARP MX-M453N</example>
-    <example>SHARP MX-M503N</example>
-    <example>SHARP MX-M620U</example>
+    <example os.product="MX-M350N">SHARP MX-M350N</example>
+    <example os.product="MX-M453N">SHARP MX-M453N</example>
+    <example os.product="MX-M503N">SHARP MX-M503N</example>
+    <example os.product="MX-M620U">SHARP MX-M620U</example>
     <param pos="0" name="os.vendor" value="Sharp"/>
     <param pos="0" name="os.device" value="Multifunction Device"/>
     <param pos="0" name="os.family" value="MX Series"/>
@@ -6414,9 +6414,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SNMP agent for HiPath 3000.*V(\S+)$">
     <description>Siemens HiPath 3000 VoIP system</description>
-    <example>SNMP agent for HiPath 3000 V3/V4</example>
-    <example>SNMP agent for HiPath 3000/5000 V5.x</example>
-    <example>SNMP agent for HiPath 3000 V3.x</example>
+    <example os.version="4">SNMP agent for HiPath 3000 V3/V4</example>
+    <example os.version="5.x">SNMP agent for HiPath 3000/5000 V5.x</example>
+    <example os.version="3.x">SNMP agent for HiPath 3000 V3.x</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="os.product" value="HiPath 3000"/>
@@ -6425,8 +6425,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SCALANCE (W\d\d\d-\S\S\S)$">
     <description>Siemens Scalance Industrial Wireless Access Point</description>
-    <example>SCALANCE W747-1RR</example>
-    <example>SCALANCE W788-1RR</example>
+    <example os.product="W747-1RR">SCALANCE W747-1RR</example>
+    <example os.product="W788-1RR">SCALANCE W788-1RR</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.family" value="Scalance"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -6436,15 +6436,15 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^HiPath Wireless Access Controller - ([^,]+)\s*, System Version ((?:V\d+ )?\S+)$">
     <description>Siemens HiPath Wireless Access Point</description>
     <example os.product="C20 Office" os.version="V6R1.10507.0">HiPath Wireless Access Controller - C20 Office, System Version V6R1.10507.0</example>
-    <example>HiPath Wireless Access Controller - C2400 Enterprise, System Version 07.41.01.0192</example>
-    <example>HiPath Wireless Access Controller - C2400 Enterprise, System Version 07.41.03.0006</example>
-    <example>HiPath Wireless Access Controller - C25, System Version 07.41.02.0009</example>
-    <example>HiPath Wireless Access Controller - C25, System Version 08.01.01.0247</example>
-    <example>HiPath Wireless Access Controller - C25, System Version 08.01.02.0030</example>
-    <example>HiPath Wireless Access Controller - C5110-2, System Version 07.41.01.0192</example>
-    <example>HiPath Wireless Access Controller - FE Series , System Version V5 R1.10034.0</example>
-    <example>HiPath Wireless Access Controller - GE Series , System Version V5 R3.10404.0</example>
-    <example>HiPath Wireless Access Controller - V2110, System Version 08.01.01.0251</example>
+    <example os.product="C2400 Enterprise" os.version="07.41.01.0192">HiPath Wireless Access Controller - C2400 Enterprise, System Version 07.41.01.0192</example>
+    <example os.product="C2400 Enterprise" os.version="07.41.03.0006">HiPath Wireless Access Controller - C2400 Enterprise, System Version 07.41.03.0006</example>
+    <example os.product="C25" os.version="07.41.02.0009">HiPath Wireless Access Controller - C25, System Version 07.41.02.0009</example>
+    <example os.product="C25" os.version="08.01.01.0247">HiPath Wireless Access Controller - C25, System Version 08.01.01.0247</example>
+    <example os.product="C25" os.version="08.01.02.0030">HiPath Wireless Access Controller - C25, System Version 08.01.02.0030</example>
+    <example os.product="C5110-2" os.version="07.41.01.0192">HiPath Wireless Access Controller - C5110-2, System Version 07.41.01.0192</example>
+    <example os.product="FE Series " os.version="V5 R1.10034.0">HiPath Wireless Access Controller - FE Series , System Version V5 R1.10034.0</example>
+    <example os.product="GE Series " os.version="V5 R3.10404.0">HiPath Wireless Access Controller - GE Series , System Version V5 R3.10404.0</example>
+    <example os.product="V2110" os.version="08.01.01.0251">HiPath Wireless Access Controller - V2110, System Version 08.01.01.0251</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="HiPath"/>
     <param pos="0" name="os.family" value="WAP"/>
@@ -6454,8 +6454,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^HiPath (optiPoint \S+ \S+) HFA$">
     <description>Siemens HiPath optiPoint</description>
-    <example>HiPath optiPoint 400 Economy HFA</example>
-    <example>HiPath optiPoint 400 Standard HFA</example>
+    <example os.product="optiPoint 400 Economy">HiPath optiPoint 400 Economy HFA</example>
+    <example os.product="optiPoint 400 Standard">HiPath optiPoint 400 Standard HFA</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="os.family" value="HFA"/>
@@ -6464,8 +6464,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^optiPoint (\S+ \S+)$">
     <description>Siemens VoIP Phone</description>
-    <example>optiPoint 410 phone</example>
-    <example>optiPoint 600 office</example>
+    <example os.product="410 phone">optiPoint 410 phone</example>
+    <example os.product="600 office">optiPoint 600 office</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="os.family" value="optiPoint"/>
@@ -6474,9 +6474,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Siemens (\S+)\s+(.*?Router) \(([^\)]+)\) v?(\S+)\s*">
     <description>Siemens Router</description>
-    <example>Siemens 5830 DMT Router (5830-001) v6.1.120 Copyright (C) 2004 Siemens Subscriber Networks, Inc. All Rights Reserved</example>
-    <example>Siemens 5851 SDSL [ATM] Router (5851-648) v6.1.140 Copyright (C) 2004 Siemens Subscriber Networks, Inc. All Rights Reserved</example>
-    <example>Siemens 5940 T1E1 [COMBO] Router (5940-005) v6.3.050</example>
+    <example os.family="DMT Router" os.product="5830" os.version="6.1.120" siemens.model="5830-001">Siemens 5830 DMT Router (5830-001) v6.1.120 Copyright (C) 2004 Siemens Subscriber Networks, Inc. All Rights Reserved</example>
+    <example os.family="SDSL [ATM] Router" os.product="5851" os.version="6.1.140" siemens.model="5851-648">Siemens 5851 SDSL [ATM] Router (5851-648) v6.1.140 Copyright (C) 2004 Siemens Subscriber Networks, Inc. All Rights Reserved</example>
+    <example os.family="T1E1 [COMBO] Router" os.product="5940" os.version="6.3.050" siemens.model="5940-005">Siemens 5940 T1E1 [COMBO] Router (5940-005) v6.3.050</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="2" name="os.family"/>
@@ -6487,7 +6487,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Siemens (\S+)\s+(.*?)\s+\(([^\)]+)\) Router .*?v(\d+\S+)\s+">
     <description>Siemens Router - variant 1</description>
-    <example>Siemens 7950 G.SHDSL [ATM] (7950-001) Router with ISDN Voice v6.1.077 All Rights Reserved</example>
+    <example os.family="G.SHDSL [ATM]" os.product="7950" os.version="6.1.077" siemens.model="7950-001">Siemens 7950 G.SHDSL [ATM] (7950-001) Router with ISDN Voice v6.1.077 All Rights Reserved</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="2" name="os.family"/>
@@ -6498,9 +6498,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Siemens, SIMATIC HMI, ([^,]+),.*FW:\s*V([^,]+)">
     <description>Siemens HMI - firmware variant</description>
-    <example hw.product="KTP1000 Basic PN">Siemens, SIMATIC HMI, KTP1000 Basic PN, 6AV6 647-0AF11-3AX0, HW: 1, FW: V01.06.00, Revision: 1</example>
-    <example hw.version="01.06.00">Siemens, SIMATIC HMI, KTP600 Basic Mono PN, 6AV6647-0AB11-3AX0, HW:1, FW:V01.06.00</example>
-    <example>Siemens, SIMATIC HMI, KTP600 Basic color PN, 6AV6 647-0AD11-3AX0, HW:1, FW:V11.00.02.00</example>
+    <example hw.product="KTP1000 Basic PN" hw.version="01.06.00">Siemens, SIMATIC HMI, KTP1000 Basic PN, 6AV6 647-0AF11-3AX0, HW: 1, FW: V01.06.00, Revision: 1</example>
+    <example hw.version="01.06.00" hw.product="KTP600 Basic Mono PN">Siemens, SIMATIC HMI, KTP600 Basic Mono PN, 6AV6647-0AB11-3AX0, HW:1, FW:V01.06.00</example>
+    <example hw.product="KTP600 Basic color PN" hw.version="11.00.02.00">Siemens, SIMATIC HMI, KTP600 Basic color PN, 6AV6 647-0AD11-3AX0, HW:1, FW:V11.00.02.00</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.device" value="HMI Controller"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -6515,11 +6515,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Siemens, SIMATIC HMI, ([^,]+),.*SW:\s*V\s*(\d+ \d+ \d+)">
     <description>Siemens HMI</description>
-    <example hw.product="MP177">Siemens, SIMATIC HMI, MP177, 6AV6 642-0EA01-3AX0, HW: 0, SW: V 1 0 0</example>
-    <example hw.version="1 0 2">Siemens, SIMATIC HMI, TP177B, 6AV6 642-0BD01-3AX0, HW: 0, SW: V 1 0 2</example>
-    <example>Siemens, SIMATIC HMI, XP277, 6AV6 643-0CB01-1AX0, HW: 0, SW: V 1 1 2</example>
-    <example>Siemens, SIMATIC HMI, unknown, 6AV2 124-0GC01-0AX0, HW: 0, SW: V 11 0 2</example>
-    <example>Siemens, SIMATIC HMI, unknown, 6AV2 124-0JC01-0AX0, HW: 0, SW: V 11 0 0</example>
+    <example hw.product="MP177" hw.version="1 0 0">Siemens, SIMATIC HMI, MP177, 6AV6 642-0EA01-3AX0, HW: 0, SW: V 1 0 0</example>
+    <example hw.version="1 0 2" hw.product="TP177B">Siemens, SIMATIC HMI, TP177B, 6AV6 642-0BD01-3AX0, HW: 0, SW: V 1 0 2</example>
+    <example hw.product="XP277" hw.version="1 1 2">Siemens, SIMATIC HMI, XP277, 6AV6 643-0CB01-1AX0, HW: 0, SW: V 1 1 2</example>
+    <example hw.product="unknown" hw.version="11 0 2">Siemens, SIMATIC HMI, unknown, 6AV2 124-0GC01-0AX0, HW: 0, SW: V 11 0 2</example>
+    <example hw.product="unknown" hw.version="11 0 0">Siemens, SIMATIC HMI, unknown, 6AV2 124-0JC01-0AX0, HW: 0, SW: V 11 0 0</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.device" value="HMI Controller"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -6579,9 +6579,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Siemens, SIMATIC S7, ([^,]+), .*?, V\.([^,]+)">
     <description>Siemens S7 - variant 1</description>
-    <example hw.product="CPU-1200">Siemens, SIMATIC S7, CPU-1200, 6ES7 212-1BD30-0XB0 SZVA1YU6008610 , 1, V.1.0.1, SZVA1YU6008610</example>
-    <example hw.version="1.0.1">Siemens, SIMATIC S7, CPU-1200, 6ES7 212-1HD30-0XB0 SZVA3YU7002312 , 1, V.1.0.1, SZVA3YU7002312</example>
-    <example>Siemens, SIMATIC S7, CPU-1200, 6ES7 214-1BE30-0XB0 SZVA2YYY007305 , 1, V.1.0.2, SZVA2YYY007305</example>
+    <example hw.product="CPU-1200" hw.version="1.0.1">Siemens, SIMATIC S7, CPU-1200, 6ES7 212-1BD30-0XB0 SZVA1YU6008610 , 1, V.1.0.1, SZVA1YU6008610</example>
+    <example hw.version="1.0.1" hw.product="CPU-1200">Siemens, SIMATIC S7, CPU-1200, 6ES7 212-1HD30-0XB0 SZVA3YU7002312 , 1, V.1.0.1, SZVA3YU7002312</example>
+    <example hw.product="CPU-1200" hw.version="1.0.2">Siemens, SIMATIC S7, CPU-1200, 6ES7 214-1BE30-0XB0 SZVA2YYY007305 , 1, V.1.0.2, SZVA2YYY007305</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
@@ -6602,8 +6602,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Siemens, SINUMERIK, solution line ([^,]+),.*?FW:V([^,]+)">
     <description>Siemens Sinumerik Solution Line</description>
-    <example hw.product="PCU50">Siemens, SINUMERIK, solution line PCU50, , HW:1, FW:V00.00.00,</example>
-    <example hw.version="00.00.00">Siemens, SINUMERIK, solution line PCU50.3B-P 1GB XP, 6FC5210-0DF33-2AB0, HW:A, FW:V00.00.00, ST-BN2040231</example>
+    <example hw.product="PCU50" hw.version="00.00.00">Siemens, SINUMERIK, solution line PCU50, , HW:1, FW:V00.00.00,</example>
+    <example hw.version="00.00.00" hw.product="PCU50.3B-P 1GB XP">Siemens, SINUMERIK, solution line PCU50.3B-P 1GB XP, 6FC5210-0DF33-2AB0, HW:A, FW:V00.00.00, ST-BN2040231</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.device" value="Monitoring"/>
     <param pos="0" name="os.family" value="Windows"/>
@@ -6617,10 +6617,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Name:(ReliantUNIX)-. release:(\S+) version:(\S+) machine:(\S+)$">
     <description>Siemens Reliant Unix (SINIX)</description>
-    <example>Name:ReliantUNIX-N release:5.45 version:B0032 machine:RM400</example>
-    <example>Name:ReliantUNIX-N release:5.45 version:B2005 machine:RM400</example>
-    <example>Name:ReliantUNIX-Y release:5.45 version:A1023 machine:RM600</example>
-    <example>Name:ReliantUNIX-Y release:5.45 version:B2005 machine:RM600</example>
+    <example os.product="ReliantUNIX" os.version="5.45" os.version.version="B0032" hw.product="RM400">Name:ReliantUNIX-N release:5.45 version:B0032 machine:RM400</example>
+    <example os.product="ReliantUNIX" os.version="5.45" os.version.version="B2005" hw.product="RM400">Name:ReliantUNIX-N release:5.45 version:B2005 machine:RM400</example>
+    <example os.product="ReliantUNIX" os.version="5.45" os.version.version="A1023" hw.product="RM600">Name:ReliantUNIX-Y release:5.45 version:A1023 machine:RM600</example>
+    <example os.product="ReliantUNIX" os.version="5.45" os.version.version="B2005" hw.product="RM600">Name:ReliantUNIX-Y release:5.45 version:B2005 machine:RM600</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="Monitoring"/>
     <param pos="0" name="os.family" value="Unix"/>
@@ -6632,14 +6632,14 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Siemens Subscriber Networks (\S+) \((\S+)\)$">
     <description>Siemens DSL Modems</description>
-    <example>Siemens Subscriber Networks 4100-Series (D240)</example>
-    <example>Siemens Subscriber Networks 4100-Series (D241)</example>
-    <example>Siemens Subscriber Networks 4100/4200-Series (D240)</example>
-    <example>Siemens Subscriber Networks 4100/4200-Series (D245)</example>
-    <example>Siemens Subscriber Networks 6200/6300-Series (E771)</example>
-    <example>Siemens Subscriber Networks 6300-Series (E771)</example>
-    <example>Siemens Subscriber Networks 6500-Series (E652)</example>
-    <example>Siemens Subscriber Networks SE567/8-Series (E652)</example>
+    <example os.product="4100-Series" os.version="D240">Siemens Subscriber Networks 4100-Series (D240)</example>
+    <example os.product="4100-Series" os.version="D241">Siemens Subscriber Networks 4100-Series (D241)</example>
+    <example os.product="4100/4200-Series" os.version="D240">Siemens Subscriber Networks 4100/4200-Series (D240)</example>
+    <example os.product="4100/4200-Series" os.version="D245">Siemens Subscriber Networks 4100/4200-Series (D245)</example>
+    <example os.product="6200/6300-Series" os.version="E771">Siemens Subscriber Networks 6200/6300-Series (E771)</example>
+    <example os.product="6300-Series" os.version="E771">Siemens Subscriber Networks 6300-Series (E771)</example>
+    <example os.product="6500-Series" os.version="E652">Siemens Subscriber Networks 6500-Series (E652)</example>
+    <example os.product="SE567/8-Series" os.version="E652">Siemens Subscriber Networks SE567/8-Series (E652)</example>
     <param pos="0" name="os.vendor" value="Siemens"/>
     <param pos="0" name="os.device" value="ADSL Router"/>
     <param pos="0" name="os.family" value="Subscriber Networks"/>
@@ -6653,10 +6653,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Source Technologies (ST-9\S+) version (\S+) kernel \S+">
     <description>Source Technologies ST9600 Series Secure Printer</description>
-    <example>Source Technologies ST-9620 version NJ.APS.N254e kernel 2.6.18.5 All-N-1</example>
-    <example>Source Technologies ST-9620 version NR.APS.N447b2 kernel 2.6.18.5 All-N-1</example>
-    <example>Source Technologies ST-9445 version 61.60.06 kernel 2.4.0-test6 All-N-1</example>
-    <example>Source Technologies ST-9512 version NM.NA.N099 kernel 2.6.10 All-N-1</example>
+    <example os.product="ST-9620" os.version="NJ.APS.N254e">Source Technologies ST-9620 version NJ.APS.N254e kernel 2.6.18.5 All-N-1</example>
+    <example os.product="ST-9620" os.version="NR.APS.N447b2">Source Technologies ST-9620 version NR.APS.N447b2 kernel 2.6.18.5 All-N-1</example>
+    <example os.product="ST-9445" os.version="61.60.06">Source Technologies ST-9445 version 61.60.06 kernel 2.4.0-test6 All-N-1</example>
+    <example os.product="ST-9512" os.version="NM.NA.N099">Source Technologies ST-9512 version NM.NA.N099 kernel 2.6.10 All-N-1</example>
     <param pos="0" name="os.vendor" value="Source Technologies"/>
     <param pos="0" name="os.family" value="ST9000 Series"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -6697,7 +6697,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^SunOS (\S+) (\S+) \S+ (\S+)$">
     <description>SunOS/Solaris</description>
-    <example>SunOS zeus.net.cmu.edu 4.1.3_U1 1 sun4m</example>
+    <example host.name="zeus.net.cmu.edu" os.version="4.1.3_U1" os.arch="sun4m">SunOS zeus.net.cmu.edu 4.1.3_U1 1 sun4m</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="Solaris"/>
     <param pos="0" name="os.product" value="Solaris"/>
@@ -6856,7 +6856,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Sun StorEdge (\S+)$">
     <description>Sun StorEdge disk array</description>
-    <example>Sun StorEdge 3511</example>
+    <example os.product="3511">Sun StorEdge 3511</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.family" value="StorEdge"/>
     <param pos="1" name="os.product"/>
@@ -6866,15 +6866,15 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^SunOS 5\.([789]|10) (\S+) sparc SUNW,([^,]+),">
     <description>SunOS/Solaris 5.7-5.10 - Call Manager variant</description>
     <example os.version="10" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V210, Class 4 Call Manager</example>
-    <example>SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V210, Class 5 Call Manager</example>
-    <example>SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V215, CommandCenter</example>
-    <example>SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V240, Class 5 Call Manager</example>
-    <example>SunOS 5.10 sun4u sparc SUNW,Ultra-250, Class 5 Call Manager</example>
-    <example>SunOS 5.10 sun4u sparc SUNW,UltraAX-i2, Class 5 Call Manager</example>
+    <example os.version="10" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V210, Class 5 Call Manager</example>
+    <example os.version="10" os.arch="sun4u" hw.product="Sun-Fire-V215">SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V215, CommandCenter</example>
+    <example os.version="10" os.arch="sun4u" hw.product="Sun-Fire-V240">SunOS 5.10 sun4u sparc SUNW,Sun-Fire-V240, Class 5 Call Manager</example>
+    <example os.version="10" os.arch="sun4u" hw.product="Ultra-250">SunOS 5.10 sun4u sparc SUNW,Ultra-250, Class 5 Call Manager</example>
+    <example os.version="10" os.arch="sun4u" hw.product="UltraAX-i2">SunOS 5.10 sun4u sparc SUNW,UltraAX-i2, Class 5 Call Manager</example>
     <example os.version="8" os.arch="sun4u" hw.product="Sun-Fire-V210">SunOS 5.8 sun4u sparc SUNW,Sun-Fire-V210, Class 5 Call Manager</example>
-    <example>SunOS 5.8 sun4u sparc SUNW,Ultra-60, Class 5 Call Manager</example>
-    <example>SunOS 5.8 sun4u sparc SUNW,UltraAX-i2, Class 4 Call Manager</example>
-    <example>SunOS 5.8 sun4u sparc SUNW,UltraAX-i2, Class 5 Call Manager</example>
+    <example os.version="8" os.arch="sun4u" hw.product="Ultra-60">SunOS 5.8 sun4u sparc SUNW,Ultra-60, Class 5 Call Manager</example>
+    <example os.version="8" os.arch="sun4u" hw.product="UltraAX-i2">SunOS 5.8 sun4u sparc SUNW,UltraAX-i2, Class 4 Call Manager</example>
+    <example os.version="8" os.arch="sun4u" hw.product="UltraAX-i2">SunOS 5.8 sun4u sparc SUNW,UltraAX-i2, Class 5 Call Manager</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -6902,11 +6902,11 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^SunOS (\S+) 5\.([789]|10) \S+ (\S+) \S+ SUNW,([^,]+)">
     <description>SunOS/Solaris 5.7-5.10 - SUNW variant</description>
     <example host.name="integra01" os.version="10" os.arch="sun4v" hw.product="T5240">SunOS integra01 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
-    <example>SunOS integra02 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
-    <example>SunOS magppg01 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
-    <example>SunOS magppg02 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
-    <example>SunOS rs1-s3 5.10 Generic_142900-09 sun4v sparc SUNW,Netra-CP3260</example>
-    <example hw.product="Sun-Fire-T200">SunOS sn 5.10 Generic_118833-36 sun4v sparc SUNW,Sun-Fire-T200</example>
+    <example host.name="integra02" os.version="10" os.arch="sun4v" hw.product="T5240">SunOS integra02 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+    <example host.name="magppg01" os.version="10" os.arch="sun4v" hw.product="T5240">SunOS magppg01 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+    <example host.name="magppg02" os.version="10" os.arch="sun4v" hw.product="T5240">SunOS magppg02 5.10 Generic_127127-11 sun4v sparc SUNW,T5240</example>
+    <example host.name="rs1-s3" os.version="10" os.arch="sun4v" hw.product="Netra-CP3260">SunOS rs1-s3 5.10 Generic_142900-09 sun4v sparc SUNW,Netra-CP3260</example>
+    <example hw.product="Sun-Fire-T200" host.name="sn" os.version="10" os.arch="sun4v">SunOS sn 5.10 Generic_118833-36 sun4v sparc SUNW,Sun-Fire-T200</example>
     <example hw.product="Sun-Fire-T200" host.name="sn" os.arch="sun4v" os.version="8">SunOS sn 5.8 Generic_118833-36 sun4v sparc SUNW,Sun-Fire-T200</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.certainty" value="0.9"/>
@@ -6937,15 +6937,15 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^SunOS 5\.([789]|10) \S+ (\S+)$">
     <description>SunOS/Solaris 5.7-5.10 - generic version</description>
     <example os.version="10" os.arch="sun4u">SunOS 5.10 Generic sun4u</example>
-    <example>SunOS 5.10 Generic_137111-07 sun4v</example>
-    <example>SunOS 5.10 Generic_142900-11 sun4v</example>
+    <example os.version="10" os.arch="sun4v">SunOS 5.10 Generic_137111-07 sun4v</example>
+    <example os.version="10" os.arch="sun4v">SunOS 5.10 Generic_142900-11 sun4v</example>
     <example os.version="8" os.arch="sun4u">SunOS 5.8 Generic_108528-16 sun4u</example>
-    <example>SunOS 5.8 Generic_108528-27 sun4u</example>
-    <example>SunOS 5.8 Generic_108528-29 sun4u</example>
-    <example>SunOS 5.8 Generic_117350-25 sun4u</example>
-    <example>SunOS 5.8 Generic_117350-62 sun4u</example>
+    <example os.version="8" os.arch="sun4u">SunOS 5.8 Generic_108528-27 sun4u</example>
+    <example os.version="8" os.arch="sun4u">SunOS 5.8 Generic_108528-29 sun4u</example>
+    <example os.version="8" os.arch="sun4u">SunOS 5.8 Generic_117350-25 sun4u</example>
+    <example os.version="8" os.arch="sun4u">SunOS 5.8 Generic_117350-62 sun4u</example>
     <example os.version="9" os.arch="sun4u">SunOS 5.9 Generic_118558-24 sun4u</example>
-    <example>SunOS 5.9 Generic_118558-36 sun4u</example>
+    <example os.version="9" os.arch="sun4u">SunOS 5.9 Generic_118558-36 sun4u</example>
     <param pos="0" name="os.vendor" value="Sun"/>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Solaris"/>
@@ -7002,12 +7002,12 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Symantec (Gateway Security .*)$">
     <description>Symantec Gateway Security firewall</description>
-    <example>Symantec Gateway Security 360</example>
-    <example>Symantec Gateway Security 300 Series</example>
-    <example>Symantec Gateway Security 320</example>
-    <example>Symantec Gateway Security 420</example>
-    <example>Symantec Gateway Security 440</example>
-    <example>Symantec Gateway Security 460</example>
+    <example os.product="Gateway Security 360">Symantec Gateway Security 360</example>
+    <example os.product="Gateway Security 300 Series">Symantec Gateway Security 300 Series</example>
+    <example os.product="Gateway Security 320">Symantec Gateway Security 320</example>
+    <example os.product="Gateway Security 420">Symantec Gateway Security 420</example>
+    <example os.product="Gateway Security 440">Symantec Gateway Security 440</example>
+    <example os.product="Gateway Security 460">Symantec Gateway Security 460</example>
     <param pos="0" name="os.vendor" value="Symantec"/>
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="Firewall"/>
@@ -7039,10 +7039,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Symbol (AP\S+|WS\S+) .* SW=(\S+)">
     <description>Symbol Access Point - abreviated variant</description>
-    <example>Symbol AP-7131 HW=E SW=4.0.3.0-010R MIB=01h18</example>
-    <example>Symbol AP5131 HW=A SW=0.0-045R MIB=01b15</example>
-    <example>Symbol WS2000 HW=R04 SW=0.0-035R MIB=08c12</example>
-    <example>Symbol WS2000 HW=R04 SW=1.5.0.0-216r MIB=08a43</example>
+    <example os.product="AP-7131" os.version="4.0.3.0-010R">Symbol AP-7131 HW=E SW=4.0.3.0-010R MIB=01h18</example>
+    <example os.product="AP5131" os.version="0.0-045R">Symbol AP5131 HW=A SW=0.0-045R MIB=01b15</example>
+    <example os.product="WS2000" os.version="0.0-035R">Symbol WS2000 HW=R04 SW=0.0-035R MIB=08c12</example>
+    <example os.product="WS2000" os.version="1.5.0.0-216r">Symbol WS2000 HW=R04 SW=1.5.0.0-216r MIB=08a43</example>
     <param pos="0" name="os.vendor" value="Symbol"/>
     <param pos="1" name="os.product"/>
     <param pos="0" name="os.device" value="WAP"/>
@@ -7086,8 +7086,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^TOSHIBA (e-STUDIO\S+)$">
     <description>Toshiba e-STUDIO Multifunction Device</description>
-    <example>TOSHIBA e-STUDIO451c</example>
-    <example>TOSHIBA e-STUDIO233</example>
+    <example os.product="e-STUDIO451c">TOSHIBA e-STUDIO451c</example>
+    <example os.product="e-STUDIO233">TOSHIBA e-STUDIO233</example>
     <param pos="0" name="os.vendor" value="Toshiba"/>
     <param pos="0" name="os.family" value="e-STUDIO"/>
     <param pos="1" name="os.product"/>
@@ -7096,7 +7096,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^TOSHIBA TEC (B\S+)$">
     <description>Toshiba TEC Printer</description>
-    <example>TOSHIBA TEC B-FV4</example>
+    <example hw.product="B-FV4">TOSHIBA TEC B-FV4</example>
     <param pos="0" name="hw.vendor" value="Toshiba"/>
     <param pos="0" name="hw.device" value="Printer"/>
     <param pos="1" name="hw.product"/>
@@ -7108,8 +7108,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^(TrueNAS|FreeNAS)-(\S+) \((?:\S+)\)\. Hardware: (\S+) ">
     <description>TrueNAS/FreeNAS Device</description>
-    <example os.product="FreeNAS" os.version="11.3-U3.2">FreeNAS-11.3-U3.2 (1e9dd3b3e2). Hardware: amd64 Intel(R) Xeon(R) CPU E3-1230 v6 @ 3.50GHz running at 3504. Software: FreeBSD 11.3-RELEASE-p9 (revision 199506)</example>
-    <example os.product="TrueNAS" os.version="12.0-U4.1">TrueNAS-12.0-U4.1 (fb0389beb0). Hardware: amd64 Intel(R) Xeon(R) CPU E5-1620 v3 @ 3.50GHz running at 3491 MHz. Software: FreeBSD 12.2-RELEASE-p6 (revision 199506)</example>
+    <example os.product="FreeNAS" os.version="11.3-U3.2" os.arch="amd64">FreeNAS-11.3-U3.2 (1e9dd3b3e2). Hardware: amd64 Intel(R) Xeon(R) CPU E3-1230 v6 @ 3.50GHz running at 3504. Software: FreeBSD 11.3-RELEASE-p9 (revision 199506)</example>
+    <example os.product="TrueNAS" os.version="12.0-U4.1" os.arch="amd64">TrueNAS-12.0-U4.1 (fb0389beb0). Hardware: amd64 Intel(R) Xeon(R) CPU E5-1620 v3 @ 3.50GHz running at 3491 MHz. Software: FreeBSD 12.2-RELEASE-p6 (revision 199506)</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.vendor" value="iXsystems"/>
     <param pos="0" name="os.device" value="NAS"/>
@@ -7194,7 +7194,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Unisys (\S+) version (\S+) kernel">
     <description>Unisys printer</description>
-    <example>Unisys UDS544 version NS.NP.N219 kernel 2.6.6 All-N-1</example>
+    <example os.product="UDS544" os.version="NS.NP.N219">Unisys UDS544 version NS.NP.N219 kernel 2.6.6 All-N-1</example>
     <param pos="0" name="os.vendor" value="Unisys"/>
     <param pos="0" name="os.device" value="Printer"/>
     <param pos="1" name="os.product"/>
@@ -7308,14 +7308,14 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Xerox (Phaser [^;]+).*[, ]OS ([^;,]+)" certainty="1.0">
     <description>Xerox Phaser Laser Printer - OS variant</description>
-    <example>Xerox Phaser 5500DN;PS G02.10,Net 22.42.11.22.2004,Eng 11.42.00,OS 4.46;SN RET570148</example>
-    <example>Xerox Phaser 6350DP;PS 5.0.0,Net 24.98.07.15.2005,Eng 3.2.0,OS 5.98</example>
-    <example>Xerox Phaser 6250DP;PS 4.8.0,Net 18.02.08.01.2003,Eng 1.1.1,OS 4.82;SN PWG464781</example>
-    <example>Xerox Phaser 6250DP;PS 4.11.0,Net 19.30.02.14.2004,Eng 1.1.2,OS 5.4;SN PWG678254</example>
-    <example>Xerox Phaser 7750GX;PS 4.0.4,Net 18.68.11.18.2003,Eng 3.10.1,OS 5.62;SN RRW531440</example>
-    <example>Xerox Phaser 8500N;PS 3.11.0,Net 24.38.04.28.2005,Eng 18.P1.3.11.0,OS 4.278</example>
-    <example>Xerox Phaser 8550DT;PS 4.8.0,Net 25.28.08.19.2005,Eng 18.P1.4.8.0,OS 4.302</example>
-    <example>Xerox Phaser 8560DN; OS 7.86, PS 4.1.0, Eng 22.L0.4.1.0, Net 31.92.12.14.2006</example>
+    <example os.product="Phaser 5500DN" os.version="4.46">Xerox Phaser 5500DN;PS G02.10,Net 22.42.11.22.2004,Eng 11.42.00,OS 4.46;SN RET570148</example>
+    <example os.product="Phaser 6350DP" os.version="5.98">Xerox Phaser 6350DP;PS 5.0.0,Net 24.98.07.15.2005,Eng 3.2.0,OS 5.98</example>
+    <example os.product="Phaser 6250DP" os.version="4.82">Xerox Phaser 6250DP;PS 4.8.0,Net 18.02.08.01.2003,Eng 1.1.1,OS 4.82;SN PWG464781</example>
+    <example os.product="Phaser 6250DP" os.version="5.4">Xerox Phaser 6250DP;PS 4.11.0,Net 19.30.02.14.2004,Eng 1.1.2,OS 5.4;SN PWG678254</example>
+    <example os.product="Phaser 7750GX" os.version="5.62">Xerox Phaser 7750GX;PS 4.0.4,Net 18.68.11.18.2003,Eng 3.10.1,OS 5.62;SN RRW531440</example>
+    <example os.product="Phaser 8500N" os.version="4.278">Xerox Phaser 8500N;PS 3.11.0,Net 24.38.04.28.2005,Eng 18.P1.3.11.0,OS 4.278</example>
+    <example os.product="Phaser 8550DT" os.version="4.302">Xerox Phaser 8550DT;PS 4.8.0,Net 25.28.08.19.2005,Eng 18.P1.4.8.0,OS 4.302</example>
+    <example os.product="Phaser 8560DN" os.version="7.86">Xerox Phaser 8560DN; OS 7.86, PS 4.1.0, Eng 22.L0.4.1.0, Net 31.92.12.14.2006</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -7328,7 +7328,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Xerox (Phaser .+) v\(.*/([^/]+)\)" certainty="1.0">
     <description>Xerox Phaser Laser Printer - memory variant</description>
-    <example>Xerox Phaser 6200 DX v(2.12/14.66.02.22.2002/1.6.7/4.26) Printer 256MB LPH130287</example>
+    <example os.product="Phaser 6200 DX" os.version="4.26">Xerox Phaser 6200 DX v(2.12/14.66.02.22.2002/1.6.7/4.26) Printer 256MB LPH130287</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -7341,9 +7341,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Xerox (Phaser [^;]+);" certainty="1.0">
     <description>Xerox Phaser Laser Printer</description>
-    <example>Xerox Phaser 6140N; NIC 14.31,ESS 200905190951,IOT 02.01.00,Boot 200809191035</example>
-    <example>Xerox Phaser 6180MFP-D; Net 11.74,ESS 200802151717,IOT 05.09.00,Boot 200706151125</example>
-    <example>Xerox Phaser 6130N; Net 10.80,ESS 200802181501,IOT 02.00.09</example>
+    <example os.product="Phaser 6140N">Xerox Phaser 6140N; NIC 14.31,ESS 200905190951,IOT 02.01.00,Boot 200809191035</example>
+    <example os.product="Phaser 6180MFP-D">Xerox Phaser 6180MFP-D; Net 11.74,ESS 200802151717,IOT 05.09.00,Boot 200706151125</example>
+    <example os.product="Phaser 6130N">Xerox Phaser 6130N; Net 10.80,ESS 200802181501,IOT 02.00.09</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Phaser"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -7369,10 +7369,10 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Xerox DocuPrint (\S+) Network Laser Printer - (\S+)$" certainty="1.0">
     <description>Xerox DocuPrint Laser Printer</description>
-    <example>Xerox DocuPrint N4525 Network Laser Printer - 2.15</example>
-    <example>Xerox DocuPrint N4025 Network Laser Printer - 2.12-54</example>
-    <example>Xerox DocuPrint N4525 Network Laser Printer - 2.15-04</example>
-    <example>Xerox DocuPrint N4025 Network Laser Printer - 2.12-02</example>
+    <example os.product="N4525" os.version="2.15">Xerox DocuPrint N4525 Network Laser Printer - 2.15</example>
+    <example os.product="N4025" os.version="2.12-54">Xerox DocuPrint N4025 Network Laser Printer - 2.12-54</example>
+    <example os.product="N4525" os.version="2.15-04">Xerox DocuPrint N4525 Network Laser Printer - 2.15-04</example>
+    <example os.product="N4025" os.version="2.12-02">Xerox DocuPrint N4025 Network Laser Printer - 2.12-02</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="DocuPrint"/>
     <param pos="0" name="os.device" value="Printer"/>
@@ -7396,8 +7396,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Xerox (WorkCentre [^\s;]+)" certainty="1.0">
     <description>Xerox WorkCentre</description>
-    <example>Xerox WorkCentre 5665 v1 Multifunction System; System Software 000.000.000.00000, ESS</example>
-    <example>Xerox WorkCentre 7132;ESS PS1.202.1,IOT 10.5.0,FIN B12.12.0,IIT 7.5.0,ADF 11.6.3,FAX 1.30.50</example>
+    <example os.product="WorkCentre 5665">Xerox WorkCentre 5665 v1 Multifunction System; System Software 000.000.000.00000, ESS</example>
+    <example os.product="WorkCentre 7132">Xerox WorkCentre 7132;ESS PS1.202.1,IOT 10.5.0,FIN B12.12.0,IIT 7.5.0,ADF 11.6.3,FAX 1.30.50</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="WorkCentre"/>
     <param pos="1" name="os.product"/>
@@ -7409,9 +7409,9 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^Xerox (\S+ [^\s;]+)" certainty="1.0">
     <description>Xerox Default</description>
-    <example>Xerox ColorQube 9203; System Software 000.000.000.00000, ESS</example>
-    <example>Xerox DocuTech 6115; DocuSP CP.4205.90</example>
-    <example>Xerox DocuColor 250 with EFI Fiery Controller; SW1.1,Controller ROM1.231.15, IOT 8.26.0, FIN C16.25.0, IIT 11.56.1, IIT D12.3.2, ADF 11.8.0</example>
+    <example os.product="ColorQube 9203">Xerox ColorQube 9203; System Software 000.000.000.00000, ESS</example>
+    <example os.product="DocuTech 6115">Xerox DocuTech 6115; DocuSP CP.4205.90</example>
+    <example os.product="DocuColor 250">Xerox DocuColor 250 with EFI Fiery Controller; SW1.1,Controller ROM1.231.15, IOT 8.26.0, FIN C16.25.0, IIT 11.56.1, IIT D12.3.2, ADF 11.8.0</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="1" name="os.product"/>
@@ -7421,7 +7421,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^XEROX (\d{4} WIDE FORMAT) PRINTER; ACCXES (\d+.\d+) \d+, IOT" certainty="1.0">
     <description>Xerox Wide Format Printer</description>
-    <example>XEROX 6204 WIDE FORMAT PRINTER; ACCXES 15.0 136, IOT 01.01.07</example>
+    <example os.product="6204 WIDE FORMAT" os.version="15.0">XEROX 6204 WIDE FORMAT PRINTER; ACCXES 15.0 136, IOT 01.01.07</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="0" name="os.family" value="Wide Format Printer"/>
@@ -7433,8 +7433,8 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="^XEROX (WIDE FORMAT \d{4}) PRINTER; ACCXES (\d+.\d+) \d+, IOT" certainty="1.0">
     <description>Xerox Wide Format Printer - variant 1</description>
-    <example>XEROX WIDE FORMAT 6605 PRINTER; ACCXES 14.0 142, IOT 01.01.04XXXXXX</example>
-    <example>XEROX WIDE FORMAT 6604 PRINTER; ACCXES 14.0 142, IOT 01.01.04XXXXXX</example>
+    <example os.product="WIDE FORMAT 6605" os.version="14.0">XEROX WIDE FORMAT 6605 PRINTER; ACCXES 14.0 142, IOT 01.01.04XXXXXX</example>
+    <example os.product="WIDE FORMAT 6604" os.version="14.0">XEROX WIDE FORMAT 6604 PRINTER; ACCXES 14.0 142, IOT 01.01.04XXXXXX</example>
     <param pos="0" name="os.vendor" value="Xerox"/>
     <param pos="0" name="hw.vendor" value="Xerox"/>
     <param pos="1" name="os.product"/>
@@ -7451,11 +7451,11 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="Xyplex hardware (\S+) .*Xyplex software Terminal Server V(\S+)\s*$">
     <description>Xyplex Terminal Server</description>
-    <example>- Netlink-Xyplex Xyplex hardware MX-1600 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0S91 </example>
-    <example>- WTF? Xyplex hardware CSERV-20 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0.3 </example>
-    <example>- Xyplex Terminal Server Xyplex hardware CSERV-20 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0 </example>
-    <example>WVN720D.WVNET.EDU - WVN720D Xyplex hardware CSERV-20 00.02.00 Rom 4C0000 Xyplex software Terminal Server V6.1 </example>
-    <example>Xyplex hardware CSERV-20 08.00.00 Rom 4A0000nXyplex software Terminal Server V6.0.1</example>
+    <example os.product="MX-1600" hw.product="MX-1600" os.version="6.0S91">- Netlink-Xyplex Xyplex hardware MX-1600 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0S91 </example>
+    <example os.product="CSERV-20" hw.product="CSERV-20" os.version="6.0.3">- WTF? Xyplex hardware CSERV-20 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0.3 </example>
+    <example os.product="CSERV-20" hw.product="CSERV-20" os.version="6.0">- Xyplex Terminal Server Xyplex hardware CSERV-20 00.00.00 Rom 470000 Xyplex software Terminal Server V6.0 </example>
+    <example os.product="CSERV-20" hw.product="CSERV-20" os.version="6.1">WVN720D.WVNET.EDU - WVN720D Xyplex hardware CSERV-20 00.02.00 Rom 4C0000 Xyplex software Terminal Server V6.1 </example>
+    <example os.product="CSERV-20" hw.product="CSERV-20" os.version="6.0.1">Xyplex hardware CSERV-20 08.00.00 Rom 4A0000nXyplex software Terminal Server V6.0.1</example>
     <param pos="0" name="os.vendor" value="Xyplex"/>
     <param pos="0" name="os.family" value="Device Server"/>
     <param pos="0" name="os.device" value="Device Server"/>

--- a/xml/snmp_sysobjid.xml
+++ b/xml/snmp_sysobjid.xml
@@ -89,8 +89,8 @@
 
   <fingerprint pattern="^Microsoft Windows CE Version ([\d.]+)">
     <description>Windows CE</description>
-    <example>Microsoft Windows CE Version 4.20 (Build 0)</example>
-    <example>Microsoft Windows CE Version 4.20 (Build 1088)</example>
+    <example os.version="4.20">Microsoft Windows CE Version 4.20 (Build 0)</example>
+    <example os.version="4.20">Microsoft Windows CE Version 4.20 (Build 1088)</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows CE"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -653,7 +653,7 @@
   <fingerprint pattern="^OpenSSH_(4\.2p1) (Debian-7ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 6.04</description>
     <example service.version="4.2p1" openssh.comment="Debian-7ubuntu3.1">OpenSSH_4.2p1 Debian-7ubuntu3.1</example>
-    <example>OpenSSH_4.2p1 Debian-7ubuntu3.2</example>
+    <example service.version="4.2p1" openssh.comment="Debian-7ubuntu3.2">OpenSSH_4.2p1 Debian-7ubuntu3.2</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -686,9 +686,9 @@
   <fingerprint pattern="^OpenSSH_(4\.6p1) (Debian-5ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 7.10</description>
     <example service.version="4.6p1" openssh.comment="Debian-5ubuntu0.2">OpenSSH_4.6p1 Debian-5ubuntu0.2</example>
-    <example>OpenSSH_4.6p1 Debian-5ubuntu0.5</example>
-    <example>OpenSSH_4.6p1 Debian-5ubuntu0.6</example>
-    <example>OpenSSH_4.6p1 Debian-5ubuntu0</example>
+    <example service.version="4.6p1" openssh.comment="Debian-5ubuntu0.5">OpenSSH_4.6p1 Debian-5ubuntu0.5</example>
+    <example service.version="4.6p1" openssh.comment="Debian-5ubuntu0.6">OpenSSH_4.6p1 Debian-5ubuntu0.6</example>
+    <example service.version="4.6p1" openssh.comment="Debian-5ubuntu0">OpenSSH_4.6p1 Debian-5ubuntu0</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>
@@ -858,7 +858,7 @@
   <fingerprint pattern="^OpenSSH_(6\.0p1) (Debian-3ubuntu\d(?:\.\d)?)$">
     <description>OpenSSH running on Ubuntu 12.10</description>
     <example service.version="6.0p1" openssh.comment="Debian-3ubuntu1">OpenSSH_6.0p1 Debian-3ubuntu1</example>
-    <example>OpenSSH_6.0p1 Debian-3ubuntu1.2</example>
+    <example service.version="6.0p1" openssh.comment="Debian-3ubuntu1.2">OpenSSH_6.0p1 Debian-3ubuntu1.2</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -248,7 +248,7 @@
   <fingerprint pattern="^CN=OA\-([a-fA-F0-9]+),OU=Onboard Administrator,">
     <description>HP iLO (Onboard Administrator)</description>
     <example host.mac="001F296E21A3">CN=OA-001F296E21A3,OU=Onboard Administrator,O=Corp.,L=Location,ST=N/A,C=US</example>
-    <example>CN=OA-80C16E999999,OU=Onboard Administrator,O=Hewlett-Packard</example>
+    <example host.mac="80C16E999999">CN=OA-80C16E999999,OU=Onboard Administrator,O=Hewlett-Packard</example>
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="iLO"/>
@@ -353,8 +353,8 @@
 
   <fingerprint pattern="^CN=HP Jetdirect [a-zA-Z0-9]+,OU=([a-fA-F0-9]{12})\+OU=([a-zA-Z0-9]+),O=Hewlett-Packard Co\.$">
     <description>HP Jet Direct - with host MAC and product</description>
-    <example host.mac="2C413883186A" hw.product="J8028E">CN=HP Jetdirect 38831831,OU=2C413883186A+OU=J8028E,O=Hewlett-Packard Co.</example>
-    <example os.product="J8016E">CN=HP Jetdirect FBFA31E7,OU=8851FBE33ABB+OU=J8016E,O=Hewlett-Packard Co.</example>
+    <example host.mac="2C413883186A" hw.product="J8028E" os.product="J8028E">CN=HP Jetdirect 38831831,OU=2C413883186A+OU=J8028E,O=Hewlett-Packard Co.</example>
+    <example os.product="J8016E" host.mac="8851FBE33ABB" hw.product="J8016E">CN=HP Jetdirect FBFA31E7,OU=8851FBE33ABB+OU=J8016E,O=Hewlett-Packard Co.</example>
     <param pos="0" name="hw.device" value="Printer"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.family" value="JetDirect"/>


### PR DESCRIPTION
## Description
Adds missing example attributes to `<example>` elements in recog fingerprint XML files, greatly reducing recog_verify warnings.

This is only round 1. Subsequent rounds will target some hand modifications to target fingerprints missing examples altogether. Additionally, there is one warning that is not fixed with this patch due to it being an edge case: The fingerprint regex conditionally matches a version, but the only example does not supply one. That will be fixed by hand as well in a subsequent PR.

The script that was used to make these changes is here:
https://gist.github.com/dabdine/6c641407e805ab33530ec67459a94c3a

## Motivation and Context
Clean up warnings so that more strict enforcement of quality can eventually be turned on.

## How Has This Been Tested?
Ran recog_verify

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
