### PR TITLE
Add CALDERA C2 fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -50,6 +50,7 @@ BlackJumboDog
 BladeSystems
 Boa
 Bugzilla
+CALDERA
 CCProxy
 CMS
 CMS400.NET

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -410,6 +410,7 @@ Lucent
 Lynx Technology
 Lyris
 MBP Kommunikationssysteme GmbH
+MITRE
 MPI Technologies
 MPS Software
 MRV Communications

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1954,4 +1954,11 @@
     <param pos="0" name="service.product" value="Covenant"/>
   </fingerprint>
 
+  <fingerprint pattern="^5508e5abca6493613e11c72f4296ebf4$">
+    <description>MITRE CALDERA C2 framework</description>
+    <example>5508e5abca6493613e11c72f4296ebf4</example>
+    <param pos="0" name="service.vendor" value="MITRE"/>
+    <param pos="0" name="service.product" value="CALDERA"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1959,6 +1959,7 @@
     <example>5508e5abca6493613e11c72f4296ebf4</example>
     <param pos="0" name="service.vendor" value="MITRE"/>
     <param pos="0" name="service.product" value="CALDERA"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mitre:caldera:-"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3730,4 +3730,11 @@
     <param pos="0" name="service.product" value="Covenant"/>
   </fingerprint>
 
+  <fingerprint pattern="^Login | CALDERA$">
+    <description>MITRE CALDERA C2 framework</description>
+    <example>Login | CALDERA</example>
+    <param pos="0" name="service.vendor" value="MITRE"/>
+    <param pos="0" name="service.product" value="CALDERA"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3735,6 +3735,7 @@
     <example>Login | CALDERA</example>
     <param pos="0" name="service.vendor" value="MITRE"/>
     <param pos="0" name="service.product" value="CALDERA"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mitre:caldera:-"/>
   </fingerprint>
 
 </fingerprints>


### PR DESCRIPTION
## Description
Adds two fingerprints for MITRE's [CALDERA](https://github.com/mitre/caldera) C2 framework. Note, while the comment at the top of `xml/favicons.xml` mentions `favicon.ico` explicitly the MD5 for CALDERA's favicon is from a PNG.
```
<link rel="shortcut icon" type="image/png" href="/gui/img/favicon.png"/>
``` 

## Motivation and Context
More C2 fingerprints for recog.


## How Has This Been Tested?
* CALDERA installed and run following the directions for [Docker Deployment](https://caldera.readthedocs.io/en/latest/Installing-CALDERA.html#docker-deployment)
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
