### PR TITLE
Eliminate warnings when no examples are present in fingerprints

### DIFF
--- a/features/verify.feature
+++ b/features/verify.feature
@@ -24,10 +24,9 @@ Feature: Verify
     Then it should fail with:
       """
       tests_with_warnings.xml:10: WARN: 'Pure-FTPd' has no test cases
-      tests_with_warnings.xml:10: WARN: 'Pure-FTPd' is missing an example that checks for parameter 'pureftpd.config' which is derived from a capture group
-      tests_with_warnings.xml: SUMMARY: Test completed with 1 successful, 2 warnings, and 0 failures
+      tests_with_warnings.xml: SUMMARY: Test completed with 1 successful, 1 warnings, and 0 failures
       """
-    And the exit status should be 2
+    And the exit status should be 1
 
   @no-clobber
   Scenario: Tests with warnings, warnings disabled

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -168,6 +168,7 @@ class Fingerprint
     # look for the presence of test cases
     if tests.size == 0
       yield :warn, "'#{@name}' has no test cases"
+      return
     end
 
     # make sure each test case passes


### PR DESCRIPTION
## Description
A simple change to eliminate spurious warnings produced by Ruby `recog_verify` when no examples are present. In other words, instead of emitting these warnings:
```
xml/smtp_help.xml:49: WARN: 'IBM VM' has no test cases
xml/smtp_help.xml:49: WARN: 'IBM VM' is missing an example that checks for parameter 'host.name' which is derived from a capture group
```
The code will now emit:
```
xml/smtp_help.xml:49: WARN: 'IBM VM' has no test cases
```

For this fingerprint:
```
  <fingerprint pattern="^214[ -]([^ ]+) is running the IBM VM operating system$">
    <description>IBM VM</description>
    <param pos="0" name="service.vendor" value="IBM"/>
    <param pos="0" name="service.family" value="VM"/>
    <param pos="0" name="service.product" value="VM"/>
    <param pos="1" name="host.name"/>
  </fingerprint>
```

It will still emit the "checks for parameter" warnings when it should, however. For example, in the case where there's a legitimate missing attribute:

```
  <fingerprint pattern="^502[ -]5\.3\.0 Sendmail ([^ ]+) -- HELP not implemented$">
    <description>Sendmail - help not implemented variant</description>
    <example>502 5.3.0 Sendmail 8.11.2 -- HELP not implemented</example>
    <param pos="0" name="service.family" value="Sendmail"/>
    <param pos="0" name="service.product" value="Sendmail"/>
    <param pos="1" name="service.version"/>
  </fingerprint>
```

You'll get:

```
xml/smtp_help.xml:149: WARN: 'Sendmail - help not implemented variant' is missing an example that checks for parameter 'service.version' which is derived from a capture group
```

## Motivation and Context
This clutters `recog_verify` output unnecessarily. As there are no examples to begin with, there's no point in mentioning whether any attributes aren't tested.

## How Has This Been Tested?
1. A run of `recog_verify`
2. A run of `bundle exec rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
