### PR TITLE
Enhance recog verify to report an untested parameter as a failure

### DIFF
--- a/features/data/tests_with_failures.xml
+++ b/features/data/tests_with_failures.xml
@@ -17,4 +17,10 @@
      <param pos="2" name="os.version" />
      <param pos="1" name="os.name" value="Bar" />
    </fingerprint>
+  <fingerprint pattern="^(\S+) ([\d.]+)$">
+    <description>example with untested parameter</description>
+    <!-- Fail: missing example test os.version parameter -->
+    <example>bar 1.0</example>
+    <param pos="1" name="os.version" />
+  </fingerprint>
 </fingerprints>

--- a/features/verify.feature
+++ b/features/verify.feature
@@ -48,6 +48,7 @@ Feature: Verify
       tests_with_failures.xml:8: FAIL: '' failed to match "This almost matches" with (?-mix:^This matches$)'
       tests_with_failures.xml:13: FAIL: 'bar test's os.name is a non-zero pos but specifies a value of 'Bar'
       tests_with_failures.xml:13: FAIL: 'bar test' failed to find expected capture group os.version '5.0'. Result was 1.0
-      tests_with_failures.xml: SUMMARY: Test completed with 0 successful, 0 warnings, and 4 failures
+      tests_with_failures.xml:20: FAIL: 'example with untested parameter' is missing an example that checks for parameter 'os.version' which is derived from a capture group
+      tests_with_failures.xml: SUMMARY: Test completed with 1 successful, 0 warnings, and 5 failures
       """
-    And the exit status should be 4
+    And the exit status should be 5

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -234,7 +234,7 @@ class Fingerprint
       if !param_used
         message = "'#{@name}' is missing an example that checks for parameter '#{param_name}' " +
                   "which is derived from a capture group"
-        yield :warn, message
+        yield :fail, message
       end
     end
   end

--- a/spec/lib/recog/fingerprint_spec.rb
+++ b/spec/lib/recog/fingerprint_spec.rb
@@ -75,7 +75,7 @@ describe Recog::Fingerprint do
       let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[6]) }
 
       it "identifies when a parameter defined by a capture group is not included in one example" do
-        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String])
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:fail, String])
       end
     end
 
@@ -83,7 +83,7 @@ describe Recog::Fingerprint do
       let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[7]) }
 
       it "identifies when two parameters defined by a capture groups are not included in one example" do
-        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String], [:warn, String])
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:fail, String], [:fail, String])
       end
     end
 
@@ -92,7 +92,7 @@ describe Recog::Fingerprint do
       let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[8]) }
 
       it "identifies when a parameter defined by a capture group is not included in one example" do
-        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String])
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:fail, String])
       end
     end
 
@@ -100,7 +100,7 @@ describe Recog::Fingerprint do
       let(:entry) { described_class.new(doc.xpath("//fingerprints/fingerprint")[9]) }
 
       it "identifies when two parameters defined by a capture groups are not included in one example" do
-        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:warn, String], [:warn, String])
+        expect { |unused| entry.verify_tests_have_capture_groups(&unused) }.to yield_successive_args([:fail, String], [:fail, String])
       end
     end
 


### PR DESCRIPTION
## Description
Enhances `recog_verify` to report an untested parameter as a failure instead of a warning.


## Motivation and Context
Ensure all fingerprints have examples that fully verify all capture group parameters.


## How Has This Been Tested?
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.