### PR TITLE
Fix examples in architecture.xml, ftp_banners.xml, and ssh_banners.xml

### DIFF
--- a/xml/architecture.xml
+++ b/xml/architecture.xml
@@ -16,28 +16,42 @@
     <param pos="0" name="os.arch" value="x86"/>
   </fingerprint>
 
-  <fingerprint pattern="PowerPC|PPC|POWER|ppc">
+  <fingerprint pattern="PowerPC|PPC|POWER" flags="REG_ICASE">
     <description>PowerPC</description>
+    <example>PowerPC</example>
+    <example>PPC</example>
+    <example>POWER</example>
+    <example>ppc</example>
     <param pos="0" name="os.arch" value="PowerPC"/>
   </fingerprint>
 
   <fingerprint pattern="SPARC" flags="REG_ICASE">
     <description>SPARC</description>
+    <example>SPARC</example>
+    <example>sparc</example>
     <param pos="0" name="os.arch" value="Sparc"/>
   </fingerprint>
 
   <fingerprint pattern="mips" flags="REG_ICASE">
     <description>MIPS</description>
+    <example>MIPS</example>
+    <example>mips</example>
     <param pos="0" name="os.arch" value="MIPS"/>
   </fingerprint>
 
   <fingerprint pattern="arm64|aarch64" flags="REG_ICASE">
     <description>ARM64 (aarch64)</description>
+    <example>arm64</example>
+    <example>ARM64</example>
+    <example>aarch64</example>
+    <example>AARCH64</example>
     <param pos="0" name="os.arch" value="ARM64"/>
   </fingerprint>
 
   <fingerprint pattern="arm" flags="REG_ICASE">
     <description>ARM</description>
+    <example>arm</example>
+    <example>ARM</example>
     <param pos="0" name="os.arch" value="ARM"/>
   </fingerprint>
 

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -683,7 +683,7 @@ more text</example>
     <param pos="0" name="os.device" value="IP Camera"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^AXIS (\S+) (?:(?:Mk II )?Video) (?:Encoder Blade|Encoder|Module|Server|Decoder) (\S+)">
+  <fingerprint pattern="(?i)^AXIS (\S+) (?:(?:Mk II )?Video) (?:Encoder(?: Blade)?|Module|Server|Decoder) (\S+)">
     <description>Axis Video encoders/servers</description>
     <example hw.product="Q7406" hw.version="5.01">AXIS Q7406 Video Encoder Blade 5.01 (Aug 01 2008) ready.</example>
     <example hw.product="241Q" hw.version="4.47.2">AXIS 241Q Video Server 4.47.2 (Dec 11 2008) ready.</example>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -202,7 +202,7 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
 
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Linksys(W.+)\) \[(.+)\]$">
     <description>ProFTPD on a Linksys Wireless Access Point/Router</description>
-    <example service.version="1.3.0rc2" os.product="WRT350N" host.name="host">ProFTPD 1.3.0rc2 Server (LinksysWRT350N) [host]</example>
+    <example service.version="1.3.0rc2" os.product="WRT350N" hw.product="WRT350N" host.name="host">ProFTPD 1.3.0rc2 Server (LinksysWRT350N) [host]</example>
     <param pos="0" name="service.family" value="ProFTPD"/>
     <param pos="0" name="service.vendor" value="ProFTPD Project"/>
     <param pos="0" name="service.product" value="ProFTPD"/>
@@ -211,6 +211,8 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="os.vendor" value="Linksys"/>
     <param pos="0" name="os.device" value="WAP"/>
     <param pos="2" name="os.product"/>
+    <param pos="0" name="hw.vendor" value="Linksys"/>
+    <param pos="2" name="hw.product"/>
     <param pos="3" name="host.name"/>
   </fingerprint>
 
@@ -239,19 +241,6 @@ example.com FTP server (Version:  Mac OS X Server) ready.</example>
     <param pos="0" name="hw.device" value="NAS"/>
     <param pos="0" name="hw.product" value="ReadyNAS"/>
     <param pos="1" name="host.name"/>
-  </fingerprint>
-
-  <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \(Linksys(.*)\) \[(.+)\]$">
-    <description>ProFTPD on a wired Linksys device</description>
-    <param pos="0" name="service.family" value="ProFTPD"/>
-    <param pos="0" name="service.vendor" value="ProFTPD Project"/>
-    <param pos="0" name="service.product" value="ProFTPD"/>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:proftpd:proftpd:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Linksys"/>
-    <param pos="0" name="os.device" value="Router"/>
-    <param pos="2" name="os.product"/>
-    <param pos="3" name="host.name"/>
   </fingerprint>
 
   <fingerprint pattern="^ProFTPD (\d+\.[^\s]+) Server \((.*)\) \[(.+)\]$">
@@ -611,6 +600,7 @@ more text</example>
 
   <fingerprint pattern="^---freeFTPd 1.0---warFTPd 1.65---$">
     <description>Nepenthes honeypot</description>
+    <example>---freeFTPd 1.0---warFTPd 1.65---</example>
     <param pos="0" name="service.family" value="Nepenthes"/>
     <param pos="0" name="service.product" value="Nepenthes"/>
   </fingerprint>
@@ -693,9 +683,9 @@ more text</example>
     <param pos="0" name="os.device" value="IP Camera"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^AXIS (\S+) (?:(?:Mk II )?Video) (?:Encoder|Encoder Blade|Module|Server|Decoder) (\S+)">
+  <fingerprint pattern="(?i)^AXIS (\S+) (?:(?:Mk II )?Video) (?:Encoder Blade|Encoder|Module|Server|Decoder) (\S+)">
     <description>Axis Video encoders/servers</description>
-    <example hw.product="Q7406" hw.version="Blade">AXIS Q7406 Video Encoder Blade 5.01 (Aug 01 2008) ready.</example>
+    <example hw.product="Q7406" hw.version="5.01">AXIS Q7406 Video Encoder Blade 5.01 (Aug 01 2008) ready.</example>
     <example hw.product="241Q" hw.version="4.47.2">AXIS 241Q Video Server 4.47.2 (Dec 11 2008) ready.</example>
     <example hw.version="5.07.2" hw.product="P7701">AXIS P7701 Video Decoder 5.07.2 (Apr 20 2010) ready.</example>
     <example hw.product="Q7401" hw.version="5.01">AXIS Q7401 Video Encoder 5.01 (Aug 01 2008) ready.</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1732,6 +1732,7 @@
 
   <fingerprint pattern="^SSH Protocol Compatible Server SCS (.*)$">
     <description>Netscreen with version</description>
+    <example service.version="2.0">SSH Protocol Compatible Server SCS 2.0</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="Juniper"/>
     <param pos="0" name="service.family" value="NetScreen"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1860,6 +1860,7 @@
 
   <fingerprint pattern="^([\d.]{1,8}) sshlib: MOVEit DMZ SSH (.*)$">
     <description>MOVEit DMZ (which uses Bitvise sshlib)</description>
+    <example service.component.version="1.29" service.version="3.0.5.0">1.29 sshlib: MOVEit DMZ SSH 3.0.5.0</example>
     <param pos="1" name="service.component.version"/>
     <param pos="2" name="service.version"/>
     <param pos="0" name="service.component.vendor" value="Bitvise"/>
@@ -1887,6 +1888,7 @@
 
   <fingerprint pattern="^Pragma SecureShell\s*(.*)$">
     <description>Pragma SecureShell</description>
+    <example service.version="3.0">Pragma SecureShell 3.0</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="Pragma Systems"/>
     <param pos="0" name="service.family" value="FortressSSH Server"/>
@@ -2048,6 +2050,7 @@
 
   <fingerprint pattern="MultiNet">
     <description>Process Software MultiNet is a suite of network apps for OpenVMS</description>
+    <example>Process Software SSH 6.1.5.0 MultiNet</example>
     <param pos="0" name="service.vendor" value="Process Software"/>
     <param pos="0" name="service.family" value="MultiNet"/>
     <param pos="0" name="service.product" value="MultiNet"/>


### PR DESCRIPTION
## Description
Fixes fingerprint examples & regular expression issues in `ftp_banners.xml`, `architecture.xml`, and `ssh_banners.xml`. These files no longer yield any warnings whatsoever.

## Motivation and Context
Eliminate more warnings & fix bad regular expressions in some fingerprints.

## How Has This Been Tested?
`bundle exec rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
