### PR TITLE
Fix greedy service.version capture group for EmWeb variants

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2378,7 +2378,7 @@
     <param pos="2" name="securetransport.build"/>
   </fingerprint>
 
-  <fingerprint pattern="(Agranat|Conexant|(?:Globespan)?Virata)-EmWeb/(.*)$">
+  <fingerprint pattern="(Agranat|Conexant|(?:Globespan)?Virata)-EmWeb/(R[\d_]+)$">
     <description>EmWeb variants</description>
     <example service.vendor="Agranat" service.version="R4_01">Agranat-EmWeb/R4_01</example>
     <example service.vendor="Agranat" service.version="R5_1_2">Agranat-EmWeb/R5_1_2</example>


### PR DESCRIPTION
## Description
Fixes a greedy `service.version` capture group for EmWeb variants.


## Motivation and Context
Fixes incorrect matches where the EmWeb variant server header appears in a large string of HTTP server headers.


## How Has This Been Tested?
* `rake tests`
* `echo "Server Server Server Virata-EmWeb/R6_2_1 Server Server Server" | ./bin/recog_match xml/http_servers.xml`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
