### PR TITLE
Add a WebSocket++ fingerprint

### DIFF
--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -216,6 +216,7 @@ WebGUI
 WebLogic
 WebServer
 WebShield
+WebSocket++
 WebSphere
 WebTrends
 Webserver

--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -216,7 +216,6 @@ WebGUI
 WebLogic
 WebServer
 WebShield
-WebSocket++
 WebSphere
 WebTrends
 Webserver

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -534,6 +534,7 @@ WebGUI
 WebLogic
 WebServer
 WebShield
+WebSocket++
 WebSphere
 WebSphere Load Balancer
 WebTrends

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -814,6 +814,7 @@ Youngzsoft
 ZMailer
 ZTE
 Zabbix
+Zaphoyd Studios
 ZebraNet
 Zed Shaw
 Zyxel

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1525,7 +1525,6 @@
     <example service.version="2011-09-25">WebSocket++/2011-09-25</example>
     <param pos="0" name="service.vendor" value="Zaphoyd Studios"/>
     <param pos="0" name="service.product" value="WebSocket++"/>
-    <param pos="0" name="service.family" value="WebSocket++"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:zaphoyd:websocketpp:{service.version}"/>
   </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1516,6 +1516,20 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:teamspeak:teamspeak:{service.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="^WebSocket\+\+/([\d.-]+(?:-dev)?)$">
+    <description>WebSocket++ web server - https://github.com/zaphoyd/websocketpp</description>
+    <example service.version="0.8.1">WebSocket++/0.8.1</example>
+    <example service.version="0.8.2">WebSocket++/0.8.2</example>
+    <example service.version="0.4.0">WebSocket++/0.4.0</example>
+    <example service.version="0.8.0-dev">WebSocket++/0.8.0-dev</example>
+    <example service.version="2011-09-25">WebSocket++/2011-09-25</example>
+    <param pos="0" name="service.vendor" value="Zaphoyd Studios"/>
+    <param pos="0" name="service.product" value="WebSocket++"/>
+    <param pos="0" name="service.family" value="WebSocket++"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zaphoyd:websocketpp:{service.version}"/>
+  </fingerprint>
+
   <fingerprint pattern="^Lotus(?:-Domino)?(?:/|/0|/Release)?$">
     <description>IBM Lotus Notes/Domino with no useful version info</description>
     <example>Lotus</example>


### PR DESCRIPTION
## Description
Adds a fingerprint for WebSocket++. There are over 72K of these on the internet, [according to Censys](https://search.censys.io/search?resource=hosts&sort=RELEVANCE&per_page=25&virtual_hosts=EXCLUDE&q=same_service%28not+services.software.product%3A*+and+services.service_name%3A+HTTP+and+services.http.response.headers.server%3AWebSocket%2B%2B*%29).

The server git repository is on GH:
https://github.com/zaphoyd/websocketpp

## Motivation and Context
Adds a fingerprint

## How Has This Been Tested?
`bundle exec rake tests`

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
