### PR TITLE
Add teamspeak http server fingerprint

### DIFF
--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -184,7 +184,6 @@ Squid
 Sunny
 SystemEdge
 TBS FTP Server
-TeamSpeak
 Tengine
 Thin
 TippingPoint

--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -184,6 +184,7 @@ Squid
 Sunny
 SystemEdge
 TBS FTP Server
+TeamSpeak
 Tengine
 Thin
 TippingPoint

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -475,6 +475,7 @@ TCPIP POP server
 TUX Web Server
 Tableau Server
 TeamCity
+TeamSpeak
 Tengine
 TestCenter IQ
 Thin

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -711,6 +711,7 @@ Tableau
 Tandberg
 Taobao
 Tasman Networks
+TeamSpeak
 Technicolor
 Tektronix
 Teldat H. Kruszynski, M. Cichocki Sp. J.

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1512,7 +1512,6 @@
     <example service.version="3.13.3">TeamSpeak Server 3.13.3</example>
     <param pos="0" name="service.vendor" value="TeamSpeak"/>
     <param pos="0" name="service.product" value="TeamSpeak"/>
-    <param pos="0" name="service.family" value="TeamSpeak"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:teamspeak:teamspeak:{service.version}"/>
   </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1506,6 +1506,17 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:{service.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="^TeamSpeak Server ([\d.]+)$">
+    <description>TeamSpeak HTTP server</description>
+    <example service.version="3.13.6">TeamSpeak Server 3.13.6</example>
+    <example service.version="3.13.3">TeamSpeak Server 3.13.3</example>
+    <param pos="0" name="service.vendor" value="TeamSpeak"/>
+    <param pos="0" name="service.product" value="TeamSpeak"/>
+    <param pos="0" name="service.family" value="TeamSpeak"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:teamspeak:teamspeak:{service.version}"/>
+  </fingerprint>
+
   <fingerprint pattern="^Lotus(?:-Domino)?(?:/|/0|/Release)?$">
     <description>IBM Lotus Notes/Domino with no useful version info</description>
     <example>Lotus</example>


### PR DESCRIPTION
## Description
Adds a fingerprint for teamspeak. Over 20K of these on the internet, [according to Censys](https://search.censys.io/search?resource=hosts&sort=RELEVANCE&per_page=25&virtual_hosts=EXCLUDE&q=same_service%28not+services.software.product%3A*+and+services.service_name%3A+HTTP+and+services.http.response.headers.server%3ATeamSpeak*%29).

## How Has This Been Tested?
`bundle exec rake tests`

```
echo -n "TeamSpeak Server 3.13.6" | bin/recog_match xml/http_servers.xml | cut -c 8- | sed 's/=>/:/g' | jq .
{
  "matched": "TeamSpeak HTTP server",
  "service.vendor": "TeamSpeak",
  "service.product": "TeamSpeak",
  "service.family": "TeamSpeak",
  "service.version": "3.13.6",
  "service.cpe23": "cpe:/a:teamspeak:teamspeak:3.13.6",
  "service.protocol": "http",
  "fingerprint_db": "http_header.server",
  "data": "TeamSpeak Server 3.13.6"
}
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
