### PR TITLE
Add Zaphoyd Studios WebSocket++ remap entry

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -204,6 +204,10 @@ mappings:
     x.org:
       products:
         x.org_x11: x11
+    zaphoyd_studios:
+      vendor: zaphoyd
+      products:
+        websocket++: websocketpp
 
   # The following section contains CPE operating system or 'o' remappings. These will
   # ONLY be used for mapping Recog 'os' attributes.


### PR DESCRIPTION
## Description
A follow-up to #414 to prevent `update_cpes.py` from removing the `service.cpe23` param by adding a Zaphoyd Studios WebSocket++ remap entry to `cpe-remap.yaml`


## Motivation and Context
The motivation is to maintain the correct `service.cpe23` value for Zaphoyd Studios WebSocket++. I considered updating fingerprint's `service.vendor` and `service.product`, however, those values seem more correct and complete.


## How Has This Been Tested?
* `python update_cpes.py xml/http_servers.xml official-cpe-dictionary_v2.3.xml cpe-remap.yaml`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
