### PR TITLE
Fix path traversal issue with example filename

### DIFF
--- a/bin/recog_verify
+++ b/bin/recog_verify
@@ -84,6 +84,10 @@ ARGV.each do |arg|
       db = Recog::DB.new(file)
       verifier = Recog::Verifier.new(db, reporter)
       verifier.verify
+    rescue Recog::FingerprintParseError => e
+      reporter.failure(e.message, e.line_number)
+    rescue => e
+      reporter.failure(e.message)
     ensure
       failures += reporter.failure_count
       warnings += reporter.warning_count

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -5,6 +5,7 @@ module Recog
 class Fingerprint
   require 'set'
 
+  require 'recog/fingerprint_parse_error'
   require 'recog/fingerprint/regexp_factory'
   require 'recog/fingerprint/test'
 
@@ -269,7 +270,9 @@ class Fingerprint
         contents = ""
         filename = attrs["_filename"]
         fn = File.expand_path(File.join(example_path, filename))
-        raise "illegal file path '#{filename}'" unless fn.start_with?(File.expand_path(example_path) + File::Separator)
+        unless fn.start_with?(File.expand_path(example_path) + File::Separator)
+          raise FingerprintParseError.new("an example specifies an illegal file path '#{filename}'", line_number = @line)
+        end
 
         File.open(fn, "rb") do |file|
           contents = file.read

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -267,7 +267,9 @@ class Fingerprint
       attrs = elem.attributes.values.reduce({}) { |a,e| a.merge(e.name => e.value) }
       if attrs["_filename"]
         contents = ""
-        fn = File.join(example_path, attrs["_filename"])
+        filename = attrs["_filename"]
+        fn = File.expand_path(File.join(example_path, filename))
+        raise "illegal file path '#{filename}'" unless fn.start_with?(File.expand_path(example_path) + File::Separator)
 
         File.open(fn, "rb") do |file|
           contents = file.read

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -37,8 +37,8 @@ class Fingerprint
   # @param xml [Nokogiri::XML::Element]
   # @param match_key [String] See Recog::DB
   # @param protocol [String] Protocol such as ftp, mssql, http, etc.
-  # @param filepath [String] Directory path for fingerprint example files
-  def initialize(xml, match_key=nil, protocol=nil, filepath=nil)
+  # @param example_path [String] Directory path for fingerprint example files
+  def initialize(xml, match_key=nil, protocol=nil, example_path=nil)
     @match_key = match_key
     @protocol = protocol
     @name   = parse_description(xml)
@@ -48,7 +48,7 @@ class Fingerprint
     @tests = []
 
     @protocol.downcase! if @protocol
-    parse_examples(xml, filepath)
+    parse_examples(xml, example_path)
     parse_params(xml)
   end
 
@@ -257,9 +257,9 @@ class Fingerprint
   end
 
   # @param xml [Nokogiri::XML::Element]
-  # @param filepath [String] Directory path for fingerprint example files
+  # @param example_path [String] Directory path for fingerprint example files
   # @return [void]
-  def parse_examples(xml, filepath)
+  def parse_examples(xml, example_path)
     elements = xml.xpath('example')
 
     elements.each do |elem|
@@ -267,7 +267,8 @@ class Fingerprint
       attrs = elem.attributes.values.reduce({}) { |a,e| a.merge(e.name => e.value) }
       if attrs["_filename"]
         contents = ""
-        fn = File.join(filepath, attrs["_filename"])
+        fn = File.join(example_path, attrs["_filename"])
+
         File.open(fn, "rb") do |file|
           contents = file.read
           contents.force_encoding(Encoding::ASCII_8BIT)

--- a/lib/recog/fingerprint_parse_error.rb
+++ b/lib/recog/fingerprint_parse_error.rb
@@ -1,0 +1,10 @@
+module Recog
+  class FingerprintParseError < StandardError
+    attr_reader :line_number
+
+    def initialize(msg, line_number=nil)
+      @line_number = line_number
+      super(msg)
+    end
+  end
+end

--- a/spec/data/external_example_fingerprint.xml
+++ b/spec/data/external_example_fingerprint.xml
@@ -1,0 +1,8 @@
+<fingerprints>
+  <fingerprint pattern="laserjet (.*)(?: series)?" flags="REG_ICASE">
+    <description>HP JetDirect Printer</description>
+    <example _filename="hp_printer_ex_01.txt"/>
+    <example _filename="hp_printer_ex_02.txt"/>
+    <param pos="0" name="service.vendor" value="HP"/>
+  </fingerprint>
+</fingerprints>

--- a/spec/data/external_example_fingerprint/hp_printer_ex_01.txt
+++ b/spec/data/external_example_fingerprint/hp_printer_ex_01.txt
@@ -1,0 +1,1 @@
+HP LaserJet 4100 Series

--- a/spec/data/external_example_fingerprint/hp_printer_ex_02.txt
+++ b/spec/data/external_example_fingerprint/hp_printer_ex_02.txt
@@ -1,0 +1,1 @@
+HP LaserJet 2200

--- a/spec/data/external_example_illegal_path_fingerprint.xml
+++ b/spec/data/external_example_illegal_path_fingerprint.xml
@@ -1,0 +1,7 @@
+<fingerprints>
+  <fingerprint pattern="laserjet (.*)(?: series)?" flags="REG_ICASE">
+    <description>HP JetDirect Printer</description>
+    <example _filename="../bad_path.txt"/>
+    <param pos="0" name="service.vendor" value="HP"/>
+  </fingerprint>
+</fingerprints>

--- a/spec/lib/recog/db_spec.rb
+++ b/spec/lib/recog/db_spec.rb
@@ -1,97 +1,100 @@
 require 'recog/db'
 
 describe Recog::DB do
-  let(:xml_file) { File.expand_path File.join('spec', 'data', 'test_fingerprints.xml') }
-  subject { Recog::DB.new(xml_file) }
 
   describe "#fingerprints" do
-    subject(:fingerprints) { described_class.new(xml_file).fingerprints }
+    context "with inline example content" do
+      let(:xml_file) { File.expand_path File.join('spec', 'data', 'test_fingerprints.xml') }
+      subject { Recog::DB.new(xml_file) }
 
-    it { is_expected.to be_a(Enumerable) }
+      subject(:fingerprints) { described_class.new(xml_file).fingerprints }
 
-    context "with only a pattern" do
-      subject(:entry) { described_class.new(xml_file).fingerprints[0] }
+      it { is_expected.to be_a(Enumerable) }
 
-      it "has a blank name with no description" do
-        expect(entry.name).to be_empty
+      context "with only a pattern" do
+        subject(:entry) { described_class.new(xml_file).fingerprints[0] }
+
+        it "has a blank name with no description" do
+          expect(entry.name).to be_empty
+        end
+
+        it "has a pattern" do
+          expect(entry.regex.source).to eq(".*\\(iSeries\\).*")
+        end
+
+        it "has no params" do
+          expect(entry.params).to be_empty
+        end
+
+        it "has no tests" do
+          expect(entry.tests).to be_empty
+        end
       end
 
-      it "has a pattern" do
-        expect(entry.regex.source).to eq(".*\\(iSeries\\).*")
+      context "with params" do
+        subject(:entry) { described_class.new(xml_file).fingerprints[1] }
+
+        it "has a name" do
+          expect(entry.name).to eq('PalmOS')
+        end
+
+        it "has a pattern" do
+          expect(entry.regex.source).to eq(".*\\(PalmOS\\).*")
+        end
+
+        it "has params" do
+          expect(entry.params).to eq({"os.vendor"=>[1, "Palm"], "os.device"=>[2, "General"]})
+        end
+
+        it "has no tests" do
+          expect(entry.tests).to be_empty
+        end
       end
 
-      it "has no params" do
-        expect(entry.params).to be_empty
+      context "with pattern flags" do
+        subject(:entry) { described_class.new(xml_file).fingerprints[2] }
+
+        it "has a name and only uses the first value" do
+          expect(entry.name).to eq('HP Designjet printer')
+        end
+
+        it 'creates a Regexp with expected flags' do
+          expect(entry.regex).to be_a(Regexp)
+          expect(entry.regex.options).to eq(Recog::Fingerprint::RegexpFactory::DEFAULT_FLAGS | Regexp::IGNORECASE)
+        end
+
+        it "has a pattern" do
+          expect(entry.regex).to be_a(Regexp)
+          expect(entry.regex.source).to eq("(designjet \\S+)")
+        end
+
+        it "has params" do
+          expect(entry.params).to eq({"service.vendor"=>[0, "HP"]})
+        end
+
+        it "has no tests" do
+          expect(entry.tests).to be_empty
+        end
       end
 
-      it "has no tests" do
-        expect(entry.tests).to be_empty
-      end
-    end
+      context "with test" do
+        subject(:entry) { described_class.new(xml_file).fingerprints[3] }
 
-    context "with params" do
-      subject(:entry) { described_class.new(xml_file).fingerprints[1] }
+        it "has a name" do
+          expect(entry.name).to eq('HP JetDirect Printer')
+        end
 
-      it "has a name" do
-        expect(entry.name).to eq('PalmOS')
-      end
+        it "has a pattern" do
+          expect(entry.regex.source).to eq("laserjet (.*)(?: series)?")
+        end
 
-      it "has a pattern" do
-        expect(entry.regex.source).to eq(".*\\(PalmOS\\).*")
-      end
+        it "has params" do
+          expect(entry.params).to eq({"service.vendor"=>[0, "HP"]})
+        end
 
-      it "has params" do
-        expect(entry.params).to eq({"os.vendor"=>[1, "Palm"], "os.device"=>[2, "General"]})
-      end
-
-      it "has no tests" do
-        expect(entry.tests).to be_empty
-      end
-    end
-
-    context "with pattern flags" do
-      subject(:entry) { described_class.new(xml_file).fingerprints[2] }
-
-      it "has a name and only uses the first value" do
-        expect(entry.name).to eq('HP Designjet printer')
-      end
-
-      it 'creates a Regexp with expected flags' do
-        expect(entry.regex).to be_a(Regexp)
-        expect(entry.regex.options).to eq(Recog::Fingerprint::RegexpFactory::DEFAULT_FLAGS | Regexp::IGNORECASE)
-      end
-
-      it "has a pattern" do
-        expect(entry.regex).to be_a(Regexp)
-        expect(entry.regex.source).to eq("(designjet \\S+)")
-      end
-
-      it "has params" do
-        expect(entry.params).to eq({"service.vendor"=>[0, "HP"]})
-      end
-
-      it "has no tests" do
-        expect(entry.tests).to be_empty
-      end
-    end
-
-    context "with test" do
-      subject(:entry) { described_class.new(xml_file).fingerprints[3] }
-
-      it "has a name" do
-        expect(entry.name).to eq('HP JetDirect Printer')
-      end
-
-      it "has a pattern" do
-        expect(entry.regex.source).to eq("laserjet (.*)(?: series)?")
-      end
-
-      it "has params" do
-        expect(entry.params).to eq({"service.vendor"=>[0, "HP"]})
-      end
-
-      it "has no tests" do
-        expect(entry.tests.map(&:content)).to match_array(["HP LaserJet 4100 Series", "HP LaserJet 2200"])
+        it "has no tests" do
+          expect(entry.tests.map(&:content)).to match_array(["HP LaserJet 4100 Series", "HP LaserJet 2200"])
+        end
       end
     end
   end

--- a/spec/lib/recog/db_spec.rb
+++ b/spec/lib/recog/db_spec.rb
@@ -92,7 +92,7 @@ describe Recog::DB do
           expect(entry.params).to eq({"service.vendor"=>[0, "HP"]})
         end
 
-        it "has no tests" do
+        it "has tests" do
           expect(entry.tests.map(&:content)).to match_array(["HP LaserJet 4100 Series", "HP LaserJet 2200"])
         end
       end

--- a/spec/lib/recog/db_spec.rb
+++ b/spec/lib/recog/db_spec.rb
@@ -97,5 +97,25 @@ describe Recog::DB do
         end
       end
     end
+
+    context "with external example content" do
+      let(:xml_file) { File.expand_path File.join('spec', 'data', 'external_example_fingerprint.xml') }
+      subject { Recog::DB.new(xml_file) }
+
+      subject(:entry) { described_class.new(xml_file).fingerprints[0] }
+
+      it "has tests" do
+        expect(entry.tests.map(&:content)).to match_array(["HP LaserJet 4100 Series", "HP LaserJet 2200"])
+      end
+    end
+
+    context "with external example content illegal path" do
+      let(:xml_file) { File.expand_path File.join('spec', 'data', 'external_example_illegal_path_fingerprint.xml') }
+      subject { Recog::DB.new(xml_file) }
+
+      it "raises an illegal file path error" do
+        expect { subject }.to raise_error(/illegal file path '.+'/)
+      end
+    end
   end
 end

--- a/spec/lib/recog/db_spec.rb
+++ b/spec/lib/recog/db_spec.rb
@@ -114,7 +114,7 @@ describe Recog::DB do
       subject { Recog::DB.new(xml_file) }
 
       it "raises an illegal file path error" do
-        expect { subject }.to raise_error(/illegal file path '.+'/)
+        expect { subject }.to raise_error(/an example specifies an illegal file path '.+'/)
       end
     end
   end


### PR DESCRIPTION
## Description
Fixes path traversal issue with example `_filename` attribute. Thanks to @dabdine for bringing attention to the issue! In addition, this enhances `bin/recog_verify` to be more resilient if an exception occurs while processing more than one fingerprint file.

```
<example _filename="../../../illegal/path"/>
```

## Motivation and Context
Ensure recog doesn't access files and directories that are out of scope.


## How Has This Been Tested?
* `rake tests`
* `./bin/recog_verify` with test fingerprints copied into the XML directory

#### `path-traversal.xml`
```
<?xml version='1.0' encoding='UTF-8'?>
<fingerprints matches="test-path-traversal" protocol="test" database_type="test" preference="0.90">
  <fingerprint pattern="^dne$">
    <description>path traversal test</description>
     <example _filename="../path-traversal"></example>
  </fingerprint>
</fingerprints>
```

#### `bad-regex.xml`
```
<?xml version='1.0' encoding='UTF-8'?>
<fingerprints matches="test-bad-regex" protocol="test" database_type="test" preference="0.90">
  <fingerprint pattern="^($">
  </fingerprint>
</fingerprints>
```

#### Test Output
```
$ ./bin/recog_verify xml/path-traversal.xml
xml/path-traversal.xml:3: FAIL: an example specifies an illegal file path '../path-traversal'
```

```
$ ./bin/recog_verify xml/bad-regex.xml
xml/bad-regex.xml: FAIL: end pattern with unmatched parenthesis: /^($/
```

```
$ ./bin/recog_verify xml/*.xml
xml/apache_modules.xml: SUMMARY: Test completed with 298 successful, 0 warnings, and 0 failures
xml/apache_os.xml: SUMMARY: Test completed with 42 successful, 0 warnings, and 0 failures
xml/architecture.xml: SUMMARY: Test completed with 16 successful, 0 warnings, and 0 failures
xml/bad-regex.xml: FAIL: end pattern with unmatched parenthesis: /^($/
...
xml/path-traversal.xml:3: FAIL: an example specifies an illegal file path '../path-traversal'
...
xml/x509_subjects.xml: SUMMARY: Test completed with 195 successful, 0 warnings, and 0 failures
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
