### PR TITLE
Add pfSense and Netgate pfSense Plus firewall fingerprints

### DIFF
--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -480,6 +480,7 @@ NetData
 NetIQ
 NetSarang Computer, Inc.
 NetWin
+Netgate
 Netgear
 Netia
 Netopia

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1327,10 +1327,12 @@
     <description>pfSense Firewall</description>
     <example>5567e9ce23e5549e0fcd7195f3882816</example>
     <example>57f187c7a868faeac558007a8eb6cb2e</example>
-    <param pos="0" name="hw.vendor" value="pfSense"/>
-    <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.product" value="Firewall"/>
-    <param pos="0" name="hw.certainty" value="0.5"/>
+    <param pos="0" name="service.vendor" value="pfSense"/>
+    <param pos="0" name="service.product" value="pfSense"/>
+    <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="service.component.vendor" value="nginx"/>
+    <param pos="0" name="service.component.product" value="nginx"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:nginx:nginx:-"/>
     <param pos="0" name="os.vendor" value="pfSense"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.certainty" value="0.5"/>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3781,4 +3781,30 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
+  <fingerprint pattern="^pfSense - Login$">
+    <description>pfSense Firewall</description>
+    <example>pfSense - Login</example>
+    <param pos="0" name="service.vendor" value="pfSense"/>
+    <param pos="0" name="service.product" value="pfSense"/>
+    <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="service.component.vendor" value="nginx"/>
+    <param pos="0" name="service.component.product" value="nginx"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="os.vendor" value="pfSense"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Netgate pfSense Plus - Login$">
+    <description>pfSense Plus Firewall</description>
+    <example>Netgate pfSense Plus - Login</example>
+    <param pos="0" name="service.vendor" value="Netgate"/>
+    <param pos="0" name="service.product" value="pfSense"/>
+    <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="service.component.vendor" value="nginx"/>
+    <param pos="0" name="service.component.product" value="nginx"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="os.vendor" value="pfSense"/>
+    <param pos="0" name="os.product" value="FreeBSD"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
* Adds pfSense and Netgate pfSense Plus firewall fingerprints. Corrects `xml/favicons.xml` pfSense fingerprint since we are unable to assert hardware parameters based on the available data.


## Motivation and Context
More fingerprints!


## How Has This Been Tested?
* `./bin/recog_verify`
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
