### PR TITLE
Update recently deprecated o:redhat:fedora_core CPE

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -250,6 +250,8 @@ mappings:
     debian:
       products:
         linux: debian_linux
+    fedora_project:
+      vendor: fedoraproject
     hp:
       products:
         ilo: integrated_lights-out_firmware
@@ -293,8 +295,6 @@ mappings:
       vendor: phoenixcontact
     red_hat:
       vendor: redhat
-      products:
-        fedora_core_linux: fedora_core
     software_house:
       vendor: swhouse
     sun:

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -81,7 +81,7 @@ Fabric OS
 Fastmark M5
 FaxPress
 Fedora
-Fedora Core Linux
+Fedora Core
 Fermentrack
 Fiery Print Server
 Firepower

--- a/xml/apache_os.xml
+++ b/xml/apache_os.xml
@@ -110,60 +110,60 @@
   <fingerprint pattern="^Apache\/2\.2\.11.*\(Fedora\)">
     <description>Red Hat Fedora 11</description>
     <example>Apache/2.2.11 (Fedora)</example>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="11"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:11"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:11"/>
   </fingerprint>
 
   <fingerprint pattern="^Apache\/2\.2\.15.*\(Fedora\)">
     <description>Red Hat Fedora 13</description>
     <example>Apache/2.2.15 (Fedora)</example>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="13"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:13"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:13"/>
   </fingerprint>
 
   <fingerprint pattern="^Apache\/2\.2\.16.*\(Fedora\)">
     <description>Red Hat Fedora 14</description>
     <example>Apache/2.2.16 (Fedora)</example>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="14"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:14"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:14"/>
   </fingerprint>
 
   <fingerprint pattern="^Apache\/2\.2\.23.*\(Fedora\)">
     <description>Red Hat Fedora 17</description>
     <example>Apache/2.2.23 (Fedora)</example>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="17"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:17"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:17"/>
   </fingerprint>
 
   <fingerprint pattern="^Apache\/2\.4\.3.*\(Fedora\)">
     <description>Red Hat Fedora 18</description>
     <example>Apache/2.4.3 (Fedora) PHP/5.4.12</example>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="18"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:18"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:18"/>
   </fingerprint>
 
   <fingerprint pattern="\(Fedora\)">
     <description>Red Hat Fedora</description>
     <example>Apache (Fedora)</example>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:-"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:-"/>
   </fingerprint>
 
   <fingerprint pattern="\(RHEL\)">

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -95,11 +95,11 @@
     <param pos="0" name="service.product" value="BIND"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:isc:bind:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:{os.version}"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^(9.[^-]+(?:-[SP]\d)?)-RedHat-[\w.-]+amzn1$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -684,9 +684,9 @@
     <param pos="0" name="service.vendor" value="nginx"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:-"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Welcome to nginx on Debian!$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3461,10 +3461,10 @@
     <param pos="2" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:{os.version}"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^Ubuntu\/([\d\.]+) UPnP/\S+ MiniUPnPd/(\S+)$">

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -4297,13 +4297,13 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example host.name="hostname" linux.kernel.version="2.6.11-1.1369_FC4" os.arch="i686">Linux hostname 2.6.11-1.1369_FC4 #1 Thu Jun 2 22:55:56 EDT 2005 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="6"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:6"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:6"/>
   </fingerprint>
 
   <fingerprint pattern="^Linux (\S+) (2\S+.fc6) .* (\S+)$">
@@ -4311,13 +4311,13 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example host.name="hostname" linux.kernel.version="2.6.20-1.2948.fc6" os.arch="i686">Linux hostname 2.6.20-1.2948.fc6 #1 SMP Fri Apr 27 19:48:40 EDT 2007 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="6"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:6"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:6"/>
   </fingerprint>
 
   <fingerprint pattern="^Linux (\S+) (2\S+.fc7) .* (\S+)$">
@@ -4325,13 +4325,13 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example host.name="hostname" linux.kernel.version="2.6.22.9-91.fc7" os.arch="i686">Linux hostname 2.6.22.9-91.fc7 #1 SMP Thu Sep 27 23:10:59 EDT 2007 i686</example>
     <param pos="0" name="os.certainty" value="0.9"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.version" value="7"/>
     <param pos="1" name="host.name"/>
     <param pos="2" name="linux.kernel.version"/>
     <param pos="3" name="os.arch"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:7"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:7"/>
   </fingerprint>
 
   <fingerprint pattern="^Linux (\S+) (2\.6\.4-52(?:-smp)) .* (\S+)$">

--- a/xml/x11_banners.xml
+++ b/xml/x11_banners.xml
@@ -62,13 +62,13 @@
   <fingerprint pattern="^Fedora Project$">
     <description>Fedora Project</description>
     <example>Fedora Project</example>
-    <param pos="0" name="os.vendor" value="Red Hat"/>
+    <param pos="0" name="os.vendor" value="Fedora Project"/>
     <param pos="0" name="service.vendor" value="X.Org"/>
     <param pos="0" name="service.product" value="X.Org X11"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:x.org:x11:-"/>
-    <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.product" value="Fedora Core"/>
     <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fedoraproject:fedora_core:-"/>
   </fingerprint>
 
   <fingerprint pattern="^freedesktop\.org$">


### PR DESCRIPTION
## Description
Updates `os.vendor` and `os.product` parameter values on fingerprints for the recently deprecated `o:redhat:fedora_core` CPE. The OS vendor remap was added to improve fingerprint readability ("Fedora Project" rather than "FedoraProject").

From official-cpe-dictionary_v2.3.xml:
```
  <cpe-item name="cpe:/o:redhat:fedora_core:-" deprecated="true" deprecation_date="2022-02-03T17:19:40.583Z">
```


## Motivation and Context
Updated CPE values is good for consumers.


## How Has This Been Tested?
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
