### PR TITLE
update_cpes.py: add deprecation info to output

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -130,6 +130,8 @@ mappings:
       vendor: mortbay
     munin:
       vendor: munin-monitoring
+    nginx:
+      vendor: f5
     nlnet_labs:
       vendor: nlnetlabs
       products:
@@ -232,6 +234,7 @@ mappings:
     cisco:
       products:
         adaptive_security_appliance: adaptive_security_appliance_software
+        mds_9000: mds_9000_san-os
         nam: network_analysis_module_software
         pix: pix_firewall_software
         telepresence: telepresence_video_communication_server_software

--- a/update_cpes.py
+++ b/update_cpes.py
@@ -19,6 +19,8 @@ def parse_r7_remapping(file):
         return yaml.safe_load(remap_file)["mappings"]
 
 def update_vp_map(target_map, cpe_type, vendor, product):
+    """Add an entry to the dict tracking valid combinations
+    """
 
     if cpe_type not in target_map:
         target_map[cpe_type] = {}

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1333,6 +1333,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:pfsense:pfsense:-"/>
     <param pos="0" name="service.component.vendor" value="nginx"/>
     <param pos="0" name="service.component.product" value="nginx"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:f5:nginx:-"/>
     <param pos="0" name="os.vendor" value="pfSense"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.certainty" value="0.5"/>

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1330,9 +1330,9 @@
     <param pos="0" name="service.vendor" value="pfSense"/>
     <param pos="0" name="service.product" value="pfSense"/>
     <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:pfsense:pfsense:-"/>
     <param pos="0" name="service.component.vendor" value="nginx"/>
     <param pos="0" name="service.component.product" value="nginx"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:nginx:nginx:-"/>
     <param pos="0" name="os.vendor" value="pfSense"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
     <param pos="0" name="os.certainty" value="0.5"/>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -686,6 +686,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
     <param pos="0" name="os.product" value="Fedora Core Linux"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Welcome to nginx on Debian!$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -673,7 +673,7 @@
     <param pos="0" name="service.product" value="nginx"/>
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:f5:nginx:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Test Page for the Nginx HTTP Server on (?:Fedora|EPEL)$">
@@ -682,11 +682,10 @@
     <param pos="0" name="service.product" value="nginx"/>
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:f5:nginx:-"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.vendor" value="Red Hat"/>
     <param pos="0" name="os.product" value="Fedora Core Linux"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Welcome to nginx on Debian!$">
@@ -695,7 +694,7 @@
     <param pos="0" name="service.product" value="nginx"/>
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:f5:nginx:-"/>
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:-"/>
@@ -1367,6 +1366,7 @@
     <param pos="0" name="os.device" value="Switch"/>
     <param pos="0" name="os.product" value="MDS 9000"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:mds_9000_san-os:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Stealthwatch Management Console$">
@@ -3787,9 +3787,10 @@
     <param pos="0" name="service.vendor" value="pfSense"/>
     <param pos="0" name="service.product" value="pfSense"/>
     <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:pfsense:pfsense:-"/>
     <param pos="0" name="service.component.vendor" value="nginx"/>
     <param pos="0" name="service.component.product" value="nginx"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:f5:nginx:-"/>
     <param pos="0" name="os.vendor" value="pfSense"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
   </fingerprint>
@@ -3800,9 +3801,10 @@
     <param pos="0" name="service.vendor" value="Netgate"/>
     <param pos="0" name="service.product" value="pfSense"/>
     <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:netgate:pfsense:-"/>
     <param pos="0" name="service.component.vendor" value="nginx"/>
     <param pos="0" name="service.component.product" value="nginx"/>
-    <param pos="0" name="service.component.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:f5:nginx:-"/>
     <param pos="0" name="os.vendor" value="pfSense"/>
     <param pos="0" name="os.product" value="FreeBSD"/>
   </fingerprint>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1490,7 +1490,7 @@
     <param pos="0" name="service.product" value="nginx"/>
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:f5:nginx:-"/>
   </fingerprint>
 
   <fingerprint pattern="^nginx\/?([\d.]+)?">
@@ -1503,7 +1503,7 @@
     <param pos="0" name="service.family" value="nginx"/>
     <param pos="0" name="service.vendor" value="nginx"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:nginx:nginx:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:f5:nginx:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^TeamSpeak Server ([\d.]+)$">
@@ -3464,7 +3464,6 @@
     <param pos="0" name="os.vendor" value="Red Hat"/>
     <param pos="0" name="os.product" value="Fedora Core Linux"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^Ubuntu\/([\d\.]+) UPnP/\S+ MiniUPnPd/(\S+)$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3464,6 +3464,7 @@
     <param pos="0" name="os.vendor" value="Red Hat"/>
     <param pos="0" name="os.product" value="Fedora Core Linux"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:fedora_core:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^Ubuntu\/([\d\.]+) UPnP/\S+ MiniUPnPd/(\S+)$">


### PR DESCRIPTION
## Description
This PR updates the output of the `update_cpes.py` script so as to indicate when it failed to generate a CPE due to that CPE being deprecated in the NIST official database.

```
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product mds_9000 from vendor cisco invalid for CPE o and no mapping.  This combination is DEPRECATED by o:cisco:mds_9000_san-os at 2010-12-28T17:36:45.943Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
```

It also fixes SOME but NOT all of the deprecated CPEs.

I recommend looking to see if we can modify the log output to emit the file name in a manner similar to what is done in our other tests. That would make identifying issues across all files MUCH easier.


## Motivation and Context
While troubleshooting some CPE changes it became obvious that the effort was much more time consuming that it should have been and probably too much to ask of an outside contributor.  


## How Has This Been Tested?
Tested by running against the existing codebase using an up to date NIST database. This was done using the instructions in CONTRIBUTING.MD

```
curl -o official-cpe-dictionary_v2.3.xml.gz https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz && \
gunzip official-cpe-dictionary_v2.3.xml.gz
```

```
ls xml/*.xml | parallel --gnu "python update_cpes.py {} official-cpe-dictionary_v2.3.xml cpe-remap.yaml"  2>>errors.txt 
bin/recog_cleanup
```

```shell
$ cat errors.txt | grep DEPRE
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product mds_9000 from vendor cisco invalid for CPE o and no mapping.  This combination is DEPRECATED by o:cisco:mds_9000_san-os at 2010-12-28T17:36:45.943Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product mds_9000 from vendor cisco invalid for CPE o and no mapping.  This combination is DEPRECATED by o:cisco:mds_9000_san-os at 2010-12-28T17:36:45.943Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product nginx from vendor nginx invalid for CPE a and no mapping.  This combination is DEPRECATED by a:f5:nginx at 2021-11-01T16:02:37.240Z
ERROR:root:Product vios from vendor ibm invalid for CPE o and no mapping.  This combination is DEPRECATED by a:ibm:vios at 2021-08-31T15:42:22.903Z
ERROR:root:Product vios from vendor ibm invalid for CPE o and no mapping.  This combination is DEPRECATED by a:ibm:vios at 2021-08-31T15:42:22.903Z
```

## Types of changes
New feature


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
