### PR TITLE
Adds various Tomato router firmware fingerprints

### DIFF
--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -91,6 +91,7 @@ FortiOS
 FreeBSD
 FreeNAS Firmware
 Freebox OS
+FreshTomato
 G2 Console Switch
 GAiA OS
 GXP1610 Firmware
@@ -259,6 +260,8 @@ Tenable Core
 TetrationOS
 TimOS
 Time Capsule Firmware
+Tomato
+TomatoUSB
 Traverse
 Tru64 Unix
 UCM6202 Firmware

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -737,6 +737,8 @@ Tinyproxy Project
 Tivo
 Tobit Software
 Tokutek
+Tomato
+TomatoUSB
 Tor Project
 TornadoWeb
 Toshiba

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -486,6 +486,15 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:dd-wrt:dd-wrt:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^cff908861188a1246a35c3f8325c7d2c$">
+    <description>Tomato Router Firmware</description>
+    <example>cff908861188a1246a35c3f8325c7d2c</example>
+    <param pos="0" name="os.vendor" value="Tomato"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Tomato"/>
+    <param pos="0" name="os.device" value="Router"/>
+  </fingerprint>
+
   <fingerprint pattern="^bad2c1f96cd66e70b4aa119e7270cc62|966e60f8eb85b7ea43a7b0095f3e2336$">
     <description>Atlassian Confluence</description>
     <example>bad2c1f96cd66e70b4aa119e7270cc62</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3399,6 +3399,27 @@
     <param pos="0" name="service.product" value="MiniUPnPd"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Tomato"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Tomato"/>
+    <param pos="0" name="os.device" value="Router"/>
+  </fingerprint>
+
+  <fingerprint pattern="^UPnP/Tomato ([\d\.]+)?[\w\s\.-]{1,30} UPnP/[\d\.]+ MiniUPnPd/([\d\.]+)$">
+    <description>TomatoUSB UPnP Server</description>
+    <example os.version="1.28.9014" service.version="1.8">UPnP/Tomato 1.28.9014 MIPSR2-RAF-v1.3g K26 UPnP/1.1 MiniUPnPd/1.8</example>
+    <example os.version="1.28.0000" service.version="1.9">UPnP/Tomato 1.28.0000 MIPSR2-132 K26 USB VPN UPnP/1.1 MiniUPnPd/1.9</example>
+    <example service.version="2.0">UPnP/Tomato MIPSR2-140 K26 UPnP/1.1 MiniUPnPd/2.0</example>
+    <example service.version="2.0">UPnP/Tomato MIPSR2Toastman-RT K26 UPnP/1.1 MiniUPnPd/2.0</example>
+    <param pos="0" name="service.vendor" value="MiniUPnP Project"/>
+    <param pos="0" name="service.product" value="MiniUPnPd"/>
+    <param pos="2" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:miniupnp_project:miniupnpd:{service.version}"/>
+    <param pos="0" name="os.vendor" value="TomatoUSB"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="TomatoUSB"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="1" name="os.version"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^(RT-\w+) UPnP/\S+ MiniUPnPd/([\d.]+)$">

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -662,6 +662,24 @@
     <param pos="0" name="hw.family" value="Eurotherm"/>
   </fingerprint>
 
+  <fingerprint pattern="(?i)^Basic realm=&quot;TomatoUSB&quot;">
+    <description>TomatoUSB Router Firmware</description>
+    <example>Basic realm="TomatoUSB"</example>
+    <param pos="0" name="os.vendor" value="TomatoUSB"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="TomatoUSB"/>
+    <param pos="0" name="os.device" value="Router"/>
+  </fingerprint>
+
+  <fingerprint pattern="(?i)^Basic realm=&quot;FreshTomato&quot;">
+    <description>FreshTomato Router Firmware</description>
+    <example>Basic realm="FreshTomato"</example>
+    <param pos="0" name="os.vendor" value="FreshTomato"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="FreshTomato"/>
+    <param pos="0" name="os.device" value="Router"/>
+  </fingerprint>
+
   <!-- a variety of headers we currently just ignore -->
 
   <fingerprint pattern="(?i)^NTLM$">

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -377,10 +377,11 @@
   </fingerprint>
 
   <fingerprint pattern="(?i)^CN=\S+,OU=FreshTomato Team,O=FreshTomato,L=Columbus,ST=Ohio,C=US(?:.*)$">
-    <description>FreshTomato Router Fireware</description>
+    <description>FreshTomato Router Firmware</description>
     <example>CN=192.168.1.1,OU=FreshTomato Team,O=FreshTomato,L=Columbus,ST=Ohio,C=US</example>
     <param pos="0" name="os.vendor" value="FreshTomato"/>
-    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="FreshTomato"/>
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>
 


### PR DESCRIPTION
## Description
Adds fingerprints for [Tomato](http://www.polarcloud.com/tomato), [TomatoUSB](http://tomatousb.org/) (including [mods](http://tomatousb.org/mods) or "community developed branches of TomatoUSB"), and [FreshTomato](https://freshtomato.org/) router firmware. Note, the favicon file is the same across all of the firmware versions.


## Motivation and Context
More fingerprints!


## How Has This Been Tested?
* `rake tests`
* `./bin/recog_verify`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
