### PR TITLE
Add Eltex fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -255,6 +255,8 @@ mappings:
     debian:
       products:
         linux: debian_linux
+    eltex:
+      vendor: eltex-co
     fedora_project:
       vendor: fedoraproject
     hp:
@@ -350,6 +352,8 @@ mappings:
     citrix:
       products:
         netscaler_sdx_gateway: netscaler_sdx
+    eltex:
+      vendor: eltex-co
     emc:
       products:
         celerra: celerra_network_attached_storage

--- a/identifiers/hw_device.txt
+++ b/identifiers/hw_device.txt
@@ -25,6 +25,7 @@ Handheld Scanner
 Hypervisor
 IP Camera
 IPS
+IPTV
 Industrial Control
 JTAG Adapter
 KVM
@@ -73,6 +74,7 @@ Video Conferencing
 Video Decoder
 Video Encoder
 VoIP
+VoIP Gateway
 VoIP Server
 VoIP Switch
 Voice Appliance

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -227,6 +227,8 @@ NAS4Free
 NFVIS
 NPort
 NR900
+NTP-2
+NTP-RG-1402G
 NetScaler Gateway
 NetScaler SDX Gateway
 NetScreen

--- a/identifiers/os_device.txt
+++ b/identifiers/os_device.txt
@@ -23,6 +23,7 @@ Hypervisor
 IDS
 IP Camera
 IPS
+IPTV
 KVM
 Lights Out Management
 Linux
@@ -67,6 +68,7 @@ VPN
 Video Conferencing
 ViewStation
 VoIP
+VoIP Gateway
 VoIP Switch
 WAN Accelerator
 WAP

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -153,6 +153,8 @@ NET+OS
 NFVIS
 NRG Printer
 NT
+NTP-2 Firmware
+NTP-RG-1402G Firmware
 NX-OS
 NetBSD
 NetCache

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -760,6 +760,7 @@ qpopper-mysql
 raptor
 rbldnsd
 sfcb
+sofia-sip
 sshlib
 thttpd
 tnftpd

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -228,6 +228,7 @@ Eclipse
 Ektron
 Elastic
 Eltek
+Eltex
 EmbedThis
 Embedthis
 Emby

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3830,7 +3830,7 @@
     <param pos="0" name="hw.family" value="Vigor"/>
   </fingerprint>
 
-  <!-- Specific fingerprints to enable CPE generation -->
+  <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">
     <description>Eltex - NTP-RG-1402G broadband router</description>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3835,27 +3835,27 @@
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">
     <description>Eltex - NTP-RG-1402G broadband router</description>
     <example>Eltex - NTP-RG-1402G</example>
-    <param pos="0" name="hw.vendor" value="Eltex"/>
-    <param pos="0" name="hw.product" value="NTP-RG-1402G"/>
-    <param pos="0" name="hw.device" value="Broadband Router"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:eltex-co:ntp-rg-1402g:-"/>
     <param pos="0" name="os.vendor" value="Eltex"/>
     <param pos="0" name="os.product" value="NTP-RG-1402G Firmware"/>
     <param pos="0" name="os.device" value="Broadband Router"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:eltex-co:ntp-rg-1402g_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="0" name="hw.product" value="NTP-RG-1402G"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:eltex-co:ntp-rg-1402g:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Eltex - NTP-2$">
     <description>Eltex - NTP-2 broadband router</description>
     <example>Eltex - NTP-2</example>
-    <param pos="0" name="hw.vendor" value="Eltex"/>
-    <param pos="0" name="hw.product" value="NTP-2"/>
-    <param pos="0" name="hw.device" value="Broadband Router"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:eltex-co:ntp-2:-"/>
     <param pos="0" name="os.vendor" value="Eltex"/>
     <param pos="0" name="os.product" value="NTP-2 Firmware"/>
     <param pos="0" name="os.device" value="Broadband Router"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:eltex-co:ntp-2_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="0" name="hw.product" value="NTP-2"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:eltex-co:ntp-2:-"/>
   </fingerprint>
 
   <!-- General Eltex fingerprints -->
@@ -3865,12 +3865,12 @@
     <example hw.product="NTU-RG-1402G-W">Eltex - NTU-RG-1402G-W</example>
     <example hw.product="NTU-RG-1421G-Wac" hw.version="rev.A1">Eltex - NTU-RG-1421G-Wac:rev.A1</example>
     <example hw.product="NTP-RG-1402G-W" hw.version="rev.C">Eltex - NTP-RG-1402G-W:rev.C</example>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="Broadband Router"/>
     <param pos="0" name="hw.vendor" value="Eltex"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="hw.version"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
-    <param pos="0" name="os.vendor" value="Eltex"/>
-    <param pos="0" name="os.device" value="Broadband Router"/>
   </fingerprint>
 
   <fingerprint pattern="^Eltex - (NT[PU]-2\w\w?)$">
@@ -3878,11 +3878,11 @@
     <example hw.product="NTU-2V">Eltex - NTU-2V</example>
     <example hw.product="NTU-2VC">Eltex - NTU-2VC</example>
     <example hw.product="NTP-2C">Eltex - NTP-2C</example>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="Broadband Router"/>
     <param pos="0" name="hw.vendor" value="Eltex"/>
     <param pos="1" name="hw.product"/>
     <param pos="0" name="hw.device" value="Broadband Router"/>
-    <param pos="0" name="os.vendor" value="Eltex"/>
-    <param pos="0" name="os.device" value="Broadband Router"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3830,4 +3830,59 @@
     <param pos="0" name="hw.family" value="Vigor"/>
   </fingerprint>
 
+  <!-- Specific fingerprints to enable CPE generation -->
+
+  <fingerprint pattern="^Eltex - NTP-RG-1402G$">
+    <description>Eltex - NTP-RG-1402G broadband router</description>
+    <example>Eltex - NTP-RG-1402G</example>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="0" name="hw.product" value="NTP-RG-1402G"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:eltex-co:ntp-rg-1402g:-"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="NTP-RG-1402G Firmware"/>
+    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:eltex-co:ntp-rg-1402g_firmware:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Eltex - NTP-2$">
+    <description>Eltex - NTP-2 broadband router</description>
+    <example>Eltex - NTP-2</example>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="0" name="hw.product" value="NTP-2"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:eltex-co:ntp-2:-"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="NTP-2 Firmware"/>
+    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:eltex-co:ntp-2_firmware:-"/>
+  </fingerprint>
+
+  <!-- General Eltex fingerprints -->
+
+  <fingerprint pattern="^Eltex - (NT[PU]-RG-\d[\w-]+):?(:?rev\.\w\w?)?$">
+    <description>Eltex RG model ONT class broadband router</description>
+    <example hw.product="NTU-RG-1402G-W">Eltex - NTU-RG-1402G-W</example>
+    <example hw.product="NTU-RG-1421G-Wac" hw.version="rev.A1">Eltex - NTU-RG-1421G-Wac:rev.A1</example>
+    <example hw.product="NTP-RG-1402G-W" hw.version="rev.C">Eltex - NTP-RG-1402G-W:rev.C</example>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="2" name="hw.version"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="Broadband Router"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Eltex - (NT[PU]-2\w\w?)$">
+    <description>Eltex - NTP / NTU model broadband router</description>
+    <example hw.product="NTU-2V">Eltex - NTU-2V</example>
+    <example hw.product="NTU-2VC">Eltex - NTU-2VC</example>
+    <example hw.product="NTP-2C">Eltex - NTP-2C</example>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="Broadband Router"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4732,11 +4732,11 @@
     <description>Eltex TAU model VoIP gateway</description>
     <example hw.product="TAU-72">Eltex TAU-72</example>
     <example hw.product="TAU-1.IP">Eltex TAU-1.IP</example>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="VoIP Gateway"/>
     <param pos="0" name="hw.vendor" value="Eltex"/>
     <param pos="1" name="hw.product"/>
     <param pos="0" name="hw.device" value="VoIP Gateway"/>
-    <param pos="0" name="os.vendor" value="Eltex"/>
-    <param pos="0" name="os.device" value="VoIP Gateway"/>
   </fingerprint>
 
 </fingerprints>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4728,4 +4728,15 @@
     <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
 
+  <fingerprint pattern="^Eltex (TAU-\d[\d.IP]+)$">
+    <description>Eltex TAU model VoIP gateway</description>
+    <example hw.product="TAU-72">Eltex TAU-72</example>
+    <example hw.product="TAU-1.IP">Eltex TAU-1.IP</example>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="VoIP Gateway"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="VoIP Gateway"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -716,4 +716,15 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^Eltex (ESR-\d\w{1,4})$">
+    <description>Eltex ESR model service gateway</description>
+    <example hw.product="ESR-12V">Eltex ESR-12V</example>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="Router"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -618,4 +618,81 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^(TAU-\d[\w.IP]+)/([\d.]+) SN/(VI\d+)$">
+    <description>Eltex TAU model VoIP gateway - with serial number</description>
+    <example hw.product="TAU-8.IP" os.version="2.6.3">TAU-8.IP/2.6.3 SN/VI12345678</example>
+    <example os.version="2.0.0.229" hw.serial_number="VI12345678">TAU-4M.IP/2.0.0.229 SN/VI12345678</example>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="VoIP Gateway"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="3" name="hw.serial_number"/>
+    <param pos="0" name="hw.device" value="VoIP Gateway"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(TAU-\d[\d.IP]+)/([\d.]+) SN/(VI\w+) (?:SHA/[0-9a-f]+ )?sofia-sip/([\d.]+)$">
+    <description>Eltex TAU model VoIP gateway - with serial number and sofia version</description>
+    <example hw.product="TAU-8.IP" hw.serial_number="VI12345678">TAU-8.IP/2.3.0 SN/VI12345678 sofia-sip/1.12.10</example>
+    <example os.version="1.9.1" service.component.version="1.12.10">TAU-8.IP/1.9.1 SN/VI12345678 SHA/7404bd4 sofia-sip/1.12.10</example>
+    <param pos="0" name="service.vendor" value="FreeSWITCH"/>
+    <param pos="0" name="service.product" value="FreeSWITCH"/>
+    <param pos="0" name="service.device" value="SIP Gateway"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:freeswitch:freeswitch:-"/>
+    <param pos="0" name="service.component.vendor" value="FreeSWITCH"/>
+    <param pos="0" name="service.component.product" value="sofia-sip"/>
+    <param pos="4" name="service.component.version"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="VoIP Gateway"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="3" name="hw.serial_number"/>
+    <param pos="0" name="hw.device" value="VoIP Gateway"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(TAU-\d{1,2}) (?:build |v)(\d[\d.]+) (?:with )?sofia-sip/([\d.]+)$">
+    <description>Eltex TAU model VoIP gateway - build variant with sofia version</description>
+    <example hw.product="TAU-72" os.version="2.18.0.35">TAU-72 build 2.18.0.35 sofia-sip/1.12.10</example>
+    <example service.component.version="1.12.10">TAU-1 v1.2 with sofia-sip/1.12.10</example>
+    <param pos="0" name="service.vendor" value="FreeSWITCH"/>
+    <param pos="0" name="service.product" value="FreeSWITCH"/>
+    <param pos="0" name="service.device" value="SIP Gateway"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:freeswitch:freeswitch:-"/>
+    <param pos="0" name="service.component.vendor" value="FreeSWITCH"/>
+    <param pos="0" name="service.component.product" value="sofia-sip"/>
+    <param pos="3" name="service.component.version"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="VoIP Gateway"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="VoIP Gateway"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(RG-\d[\w-]+)/([\d.]+) SN/(VI\w+) (?:SHA/[0-9a-f]+ )?sofia-sip/([\d.]+)$">
+    <description>Eltex - NTP / NTU model broadband router - with serial number and sofia version</description>
+    <example hw.product="RG-5421G-Wac" hw.serial_number="VI12E45678">RG-5421G-Wac/2.4.2.87 SN/VI12E45678 sofia-sip/1.12.10</example>
+    <example os.version="1.11.0">RG-1404GF/1.11.0 SN/VI12E45678 sofia-sip/1.12.10</example>
+    <example service.component.version="1.12.1">RG-1404GF/1.8.0 SN/VI12E45678 SHA/0270864 sofia-sip/1.12.1</example>
+    <param pos="0" name="service.vendor" value="FreeSWITCH"/>
+    <param pos="0" name="service.product" value="FreeSWITCH"/>
+    <param pos="0" name="service.device" value="SIP Gateway"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:freeswitch:freeswitch:-"/>
+    <param pos="0" name="service.component.vendor" value="FreeSWITCH"/>
+    <param pos="0" name="service.component.product" value="sofia-sip"/>
+    <param pos="4" name="service.component.version"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.device" value="Broadband Router"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="3" name="hw.serial_number"/>
+    <param pos="0" name="hw.device" value="Broadband Router"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -2242,12 +2242,12 @@
     <description>Eltex - NV model IPTV set top box</description>
     <example hw.model="101">eltex-nv101 login:</example>
     <example hw.product="NV102">eltex-nv102 login:</example>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="IPTV"/>
     <param pos="1" name="hw.model"/>
     <param pos="0" name="hw.vendor" value="Eltex"/>
     <param pos="0" name="hw.product" value="NV{hw.model}"/>
     <param pos="0" name="hw.device" value="IPTV"/>
-    <param pos="0" name="os.vendor" value="Eltex"/>
-    <param pos="0" name="os.device" value="IPTV"/>
   </fingerprint>
 
   <fingerprint pattern="&quot;BeerTemp&quot;:.*&quot;FridgeTemp&quot;:">

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -2238,6 +2238,18 @@
     <param pos="3" name="hw.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^eltex-nv(\d+) login:$">
+    <description>Eltex - NV model IPTV set top box</description>
+    <example hw.model="101">eltex-nv101 login:</example>
+    <example hw.product="NV102">eltex-nv102 login:</example>
+    <param pos="1" name="hw.model"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="0" name="hw.product" value="NV{hw.model}"/>
+    <param pos="0" name="hw.device" value="IPTV"/>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.device" value="IPTV"/>
+  </fingerprint>
+
   <fingerprint pattern="&quot;BeerTemp&quot;:.*&quot;FridgeTemp&quot;:">
     <description>Fermentrack Beer Brewing Monitor</description>
     <example>T:{"BeerTemp":null,"BeerSet":null,"BeerAnn":null,"FridgeTemp":null,"FridgeSet":null,"FridgeAnn":null,"State":0}</example>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -2238,11 +2238,24 @@
     <param pos="3" name="hw.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^(TAU-[\w.]{1,6}) login:$$">
+    <description>Eltex TAU model VoIP gateway</description>
+    <example hw.product="TAU-8">TAU-8 login:</example>
+    <example hw.product="TAU-2M.IP">TAU-2M.IP login:</example>
+    <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="0" name="os.device" value="VoIP Gateway"/>
+    <param pos="0" name="hw.vendor" value="Eltex"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="VoIP Gateway"/>
+  </fingerprint>
+
   <fingerprint pattern="^eltex-nv(\d+) login:$">
     <description>Eltex - NV model IPTV set top box</description>
     <example hw.model="101">eltex-nv101 login:</example>
     <example hw.product="NV102">eltex-nv102 login:</example>
     <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
     <param pos="0" name="os.device" value="IPTV"/>
     <param pos="1" name="hw.model"/>
     <param pos="0" name="hw.vendor" value="Eltex"/>


### PR DESCRIPTION
## Description
Add fingerprints for various Eltex branded network equipment.

Vendor website: https://eltex-co.com/catalog/

All existing CPE currently issued by NIST.
```
h:eltex-co:ntp-2
h:eltex-co:ntp-rg-1402g
h:eltex:esp-200
o:eltex-co:ntp-2_firmware
o:eltex-co:ntp-rg-1402g_firmware
o:eltex:esp-200_firmware
```

`sofia-sip` reference: https://github.com/freeswitch/sofia-sip

Verification of TAU firmware numbering scheme: https://eltex-co.com/catalog/tau-16-ip-en.php
Verification of sofia-sip version numbering scheme: https://github.com/freeswitch/sofia-sip/releases


## Motivation and Context
Improved coverage


## How Has This Been Tested?
`rspec`


## Types of changes
Fingerprint additions

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
