### PR TITLE
Enhance Eltex TAU model VoIP gateway fingerprints

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4733,6 +4733,7 @@
     <example hw.product="TAU-72">Eltex TAU-72</example>
     <example hw.product="TAU-1.IP">Eltex TAU-1.IP</example>
     <param pos="0" name="os.vendor" value="Eltex"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
     <param pos="0" name="os.device" value="VoIP Gateway"/>
     <param pos="0" name="hw.vendor" value="Eltex"/>
     <param pos="1" name="hw.product"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4728,7 +4728,7 @@
     <param pos="0" name="hw.device" value="Printer"/>
   </fingerprint>
 
-  <fingerprint pattern="^Eltex (TAU-\d[\d.IP]+)$">
+  <fingerprint pattern="^Eltex (TAU-\d+[A-Z]*(?:\.IP)?)$">
     <description>Eltex TAU model VoIP gateway</description>
     <example hw.product="TAU-72">Eltex TAU-72</example>
     <example hw.product="TAU-1.IP">Eltex TAU-1.IP</example>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -618,10 +618,12 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(TAU-\d[\w.IP]+)/([\d.]+) SN/(VI\d+)$">
+  <fingerprint pattern="^(TAU-\d+[A-Z]*(?:\.IP)?)/([\d.]+) SN/(VI[0-9A-Z]+)$">
     <description>Eltex TAU model VoIP gateway - with serial number</description>
     <example hw.product="TAU-8.IP" os.version="2.6.3">TAU-8.IP/2.6.3 SN/VI12345678</example>
-    <example os.version="2.0.0.229" hw.serial_number="VI12345678">TAU-4M.IP/2.0.0.229 SN/VI12345678</example>
+    <example os.version="2.0.0.229" hw.serial_number="VI4D012345">TAU-4M.IP/2.0.0.229 SN/VI4D012345</example>
+    <example hw.product="TAU-2M.IP" os.version="2.3.1.11" hw.serial_number="VI12345678">TAU-2M.IP/2.3.1.11 SN/VI12345678</example>
+    <example hw.product="TAU-1M.IP" os.version="2.0.0.229" hw.serial_number="VI3A012345">TAU-1M.IP/2.0.0.229 SN/VI3A012345</example>
     <param pos="0" name="os.vendor" value="Eltex"/>
     <param pos="0" name="os.product" value="{hw.product} Firmware"/>
     <param pos="2" name="os.version"/>
@@ -632,10 +634,12 @@
     <param pos="0" name="hw.device" value="VoIP Gateway"/>
   </fingerprint>
 
-  <fingerprint pattern="^(TAU-\d[\d.IP]+)/([\d.]+) SN/(VI\w+) (?:SHA/[0-9a-f]+ )?sofia-sip/([\d.]+)$">
+  <fingerprint pattern="^(TAU-\d+[A-Z]*(?:\.IP)?)/([\d.]+) SN/(VI[0-9A-Z]+) (?:SHA/[0-9a-f]+ )?sofia-sip/([\d.]+)$">
     <description>Eltex TAU model VoIP gateway - with serial number and sofia version</description>
     <example hw.product="TAU-8.IP" hw.serial_number="VI12345678">TAU-8.IP/2.3.0 SN/VI12345678 sofia-sip/1.12.10</example>
     <example os.version="1.9.1" service.component.version="1.12.10">TAU-8.IP/1.9.1 SN/VI12345678 SHA/7404bd4 sofia-sip/1.12.10</example>
+    <example hw.product="TAU-2M.IP" os.version="1.13.3.5" hw.serial_number="VI12345678" service.component.version="1.12.10">TAU-2M.IP/1.13.3.5 SN/VI12345678 sofia-sip/1.12.10</example>
+    <example hw.product="TAU-1M.IP" os.version="1.9.3" hw.serial_number="VI3A012345" service.component.version="1.12.10">TAU-1M.IP/1.9.3 SN/VI3A012345 sofia-sip/1.12.10</example>
     <param pos="0" name="service.vendor" value="FreeSWITCH"/>
     <param pos="0" name="service.product" value="FreeSWITCH"/>
     <param pos="0" name="service.device" value="SIP Gateway"/>
@@ -653,7 +657,7 @@
     <param pos="0" name="hw.device" value="VoIP Gateway"/>
   </fingerprint>
 
-  <fingerprint pattern="^(TAU-\d{1,2}) (?:build |v)(\d[\d.]+) (?:with )?sofia-sip/([\d.]+)$">
+  <fingerprint pattern="^(TAU-\d{1,2}) (?:build |v)([\d.]+) (?:with )?sofia-sip/([\d.]+)$">
     <description>Eltex TAU model VoIP gateway - build variant with sofia version</description>
     <example hw.product="TAU-72" os.version="2.18.0.35">TAU-72 build 2.18.0.35 sofia-sip/1.12.10</example>
     <example service.component.version="1.12.10">TAU-1 v1.2 with sofia-sip/1.12.10</example>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -2238,7 +2238,7 @@
     <param pos="3" name="hw.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(TAU-[\w.]{1,6}) login:$$">
+  <fingerprint pattern="^(TAU-\d+[A-Z]*(?:\.IP)?) login:$$">
     <description>Eltex TAU model VoIP gateway</description>
     <example hw.product="TAU-8">TAU-8 login:</example>
     <example hw.product="TAU-2M.IP">TAU-2M.IP login:</example>


### PR DESCRIPTION
## Description
Follow-up to enhance Eltex TAU-* fingerprints introduced in #434.
* Add `os.product` for Eltex TAU HTTP server fingerprint
* Constrain model match to avoid matching non-existing models such as `TAU-8.I`, `TAU-8.P`, `TAU-8.100`
* Expand regex with serial number and sofia version allow matching models that include a letter in the model number such as `TAU-32M.IP`
* Expand serial number regex to include alpha characters since I located devices that included a single letter following the format `VI3A######` and `VI4D######`.


## Motivation and Context
Improved Eltex coverage.

## How Has This Been Tested?
* `rake tests`
* ` ./bin/recog_verify`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
