### PR TITLE
Add Baxter SIGMA Spectrum Infusion System fingerprint

### DIFF
--- a/identifiers/device.txt
+++ b/identifiers/device.txt
@@ -48,6 +48,7 @@ Media Gateway
 Media Player
 Media Receiver
 Media Server
+Medical
 Mobile
 Mobile Phone
 Monitoring

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -281,6 +281,7 @@ S7 DALI Gateway
 SD-WAN
 SHDSL Router
 SHIELD
+SIGMA Spectrum Infusion System
 SIP Gateway
 SIParator Firewall
 SL2100

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -223,6 +223,7 @@ RouterOS
 SCM Manager module
 SCO UNIX
 SEHI
+SIGMA Spectrum Infusion System Firmware
 SINIX
 SL2100 Firmware
 SMG Firmware

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -102,6 +102,7 @@ Bangteng
 Barco
 Barix
 Barracuda
+Baxter
 Berkeley Software Design Inc.
 Bftpd Project
 Bigfoot

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -2294,4 +2294,37 @@
     <param pos="0" name="os.product" value="Fermentrack"/>
   </fingerprint>
 
+  <fingerprint pattern="(?m)^Welcome to the SIGMA Spectrum Diagnostic Terminal(?:\r|\n)*Wireless Battery Module \(802\.11[abgn\/]+\)(?:\r|\n)*MAC Address: ((?:[0-9a-f]{2}-?){6}) SW: \d+[\sD]*\d+\s*(?:\r|\n)*Sigma Spectrum SN: (\d+) SW: v([\d.]+)(?:\r|\n)*Radio up since: [\w\s:]+(?:\r|\n)*login:\s*$">
+    <description>Baxter SIGMA Spectrum Infusion System with Wireless Battery Module</description>
+    <!--
+      Welcome to the SIGMA Spectrum Diagnostic Terminal
+
+      Wireless Battery Module (802.11a/b/g/n)
+      MAC Address: 00-40-9d-12-34-56 SW: 20 D29
+      Sigma Spectrum SN: 1234567 SW: v8.00.01
+      Radio up since: Fri Mar  1 03:14:24 2019
+
+      login:
+    -->
+
+    <example host.mac="00-40-9d-12-34-56" hw.serial_number="1234567" os.version="8.00.01" _encoding="base64">
+      V2VsY29tZSB0byB0aGUgU0lHTUEgU3BlY3RydW0gRGlhZ25vc3RpYyBUZXJtaW5hbA0KDQpXa
+      XJlbGVzcyBCYXR0ZXJ5IE1vZHVsZSAoODAyLjExYS9iL2cvbikNCk1BQyBBZGRyZXNzOiAwMC
+      00MC05ZC0xMi0zNC01NiBTVzogMjAgRDI5DQpTaWdtYSBTcGVjdHJ1bSBTTjogMTIzNDU2NyB
+      TVzogdjguMDAuMDENClJhZGlvIHVwIHNpbmNlOiBGcmkgTWFyICAxIDAzOjE0OjI0IDIwMTkN
+      Cg0KbG9naW46IA==
+    </example>
+    <param pos="0" name="os.vendor" value="Baxter"/>
+    <param pos="0" name="os.product" value="SIGMA Spectrum Infusion System Firmware"/>
+    <param pos="0" name="os.device" value="Medical"/>
+    <param pos="3" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:baxter:sigma_spectrum_infusion_system_firmware:{os.version}"/>
+    <param pos="0" name="hw.vendor" value="Baxter"/>
+    <param pos="0" name="hw.product" value="SIGMA Spectrum Infusion System"/>
+    <param pos="0" name="hw.device" value="Medical"/>
+    <param pos="2" name="hw.serial_number"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:baxter:sigma_spectrum_infusion_system:-"/>
+    <param pos="1" name="host.mac"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Adds a telnet banner fingerprint for the Baxter SIGMA Spectrum Infusion System. The Wireless Battery Module is a separate device from the infusion system and has its own firmware (`SW: 20 D29` in the example). The fingerprint should be revisited to extract the value when there is a more clear path for handling sub-devices.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `./bin/recog_verify`
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
