### PR TITLE
Add WatchGuard Fireware XTM favicon fingerprint

### DIFF
--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2030,4 +2030,20 @@
     <param pos="0" name="hw.vendor" value="Eltex"/>
   </fingerprint>
 
+  <fingerprint pattern="^1ecd8df7909afd77188cee9c33042c55$">
+    <description>WatchGuard Fireware XTM web interface</description>
+    <example>1ecd8df7909afd77188cee9c33042c55</example>
+    <param pos="0" name="service.vendor" value="WatchGuard"/>
+    <param pos="0" name="service.product" value="Fireware XTM"/>
+    <param pos="0" name="service.device" value="Firewall"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:watchguard:fireware_xtm:-"/>
+    <param pos="0" name="service.component.vendor" value="nginx"/>
+    <param pos="0" name="service.component.product" value="nginx"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:f5:nginx:-"/>
+    <param pos="0" name="os.vendor" value="WatchGuard"/>
+    <param pos="0" name="os.product" value="Fireware"/>
+    <param pos="0" name="os.device" value="Firewall"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:watchguard:fireware:-"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -438,9 +438,14 @@
     <example>Fireware XTM User Authentication</example>
     <param pos="0" name="service.vendor" value="WatchGuard"/>
     <param pos="0" name="service.product" value="Fireware XTM"/>
+    <param pos="0" name="service.device" value="Firewall"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:watchguard:fireware_xtm:-"/>
+    <param pos="0" name="service.component.vendor" value="nginx"/>
+    <param pos="0" name="service.component.product" value="nginx"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:f5:nginx:-"/>
     <param pos="0" name="os.vendor" value="WatchGuard"/>
     <param pos="0" name="os.product" value="Fireware"/>
+    <param pos="0" name="os.device" value="Firewall"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:watchguard:fireware:-"/>
   </fingerprint>
 


### PR DESCRIPTION
## Description
Adds a WatchGuard Fireware XTM web interface favicon fingerprint and enhances the existing HTML title fingerprint with `service.device`, `os.device`, and `service.component.*`.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `./bin/recog_verify xml/favicons.xml`
* `./bin/recog_verify xml/html_title.xml`
* `rake tests`

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
