### PR TITLE
Fix pre-commit hook for updated recog_standardize

### DIFF
--- a/tools/dev/hooks/pre-commit
+++ b/tools/dev/hooks/pre-commit
@@ -4,18 +4,24 @@
 # The hook should exit with non-zero status after issuing an appropriate
 # message if it wants to stop the commit.
 
-# Verify that each fingerprint asserts known identifiers.
-git diff --cached --name-only --diff-filter=ACM -z xml/*.xml | xargs -0 ./bin/recog_standardize --write
+git diff --cached --diff-filter=ACM --quiet xml/*.xml
 
 # get status
 status=$?
 
 if [ $status -ne 0 ]; then
-    echo "Please review any new additions to the text files under 'identifiers/'."
-    echo "If any of these names are close to an existing name, update the offending"
-    echo "fingerprint to use the existing name instead. Once the fingerprints are fixed"
-    echo "run the 'bin/recog_standardize' tool again."
-    exit 1
+    # Verify that each fingerprint asserts known identifiers.
+    ./bin/recog_standardize --write xml/*.xml
+    # get status
+    status=$?
+
+    if [ $status -ne 0 ]; then
+        echo "Please review any new additions to the text files under 'identifiers/'."
+        echo "If any of these names are close to an existing name, update the offending"
+        echo "fingerprint to use the existing name instead. Once the fingerprints are fixed"
+        echo "run the 'bin/recog_standardize' tool again."
+        exit 1
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
## Description
Fixes the pre-commit hook use of `recog_standardize`, that was recently updated in #438.

## Motivation and Context
To ensure that fingerprint quality is maintained.


## How Has This Been Tested?
* `rake tests`
* Temporary fingerprint change to demonstrate the issue
```
$ git diff
diff --git a/xml/html_title.xml b/xml/html_title.xml
index 58c02c7..435b14c 100644
--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1455,7 +1455,7 @@
   <fingerprint pattern="^Duo Access Gateway$">
     <description>Duo Access Gateway</description>
     <example>Duo Access Gateway</example>
-    <param pos="0" name="hw.vendor" value="Duo"/>
+    <param pos="0" name="hw.vendor" value="DNE"/>
     <param pos="0" name="hw.device" value="Security Appliance"/>
     <param pos="0" name="hw.product" value="Access Gateway"/>
     <param pos="0" name="os.vendor" value="Duo"/>
```

### Pre-commit hook issue

```
$ git add xml/html_title.xml
$ git commit
VENDORS REMOVED VALUE: 2N Telekomunikace
...(removed 619 lines)...
VENDORS REMOVED VALUE: vsFTPd Project
VENDORS NEW VALUE: DNE
DEVICE REMOVED VALUE: ADSL Modem
...(removed 56 lines)...
DEVICE REMOVED VALUE: Whiteboard
FIELDS REMOVED VALUE: apache.info
...(removed 66 lines)...
FIELDS REMOVED VALUE: zmailer.ident
OS ARCH REMOVED VALUE: ARM
...(removed 8 lines)...
OS ARCH REMOVED VALUE: x86_64
OS PRODUCT REMOVED VALUE: 10Gb Blade Switch
...(removed 294 lines)...
OS PRODUCT REMOVED VALUE: z/OS
OS FAMILY REMOVED VALUE: 3155 Series
...(removed 220 lines)...
OS FAMILY REMOVED VALUE: z/OS
HW PRODUCT REMOVED VALUE: 3PAR
...(removed 336 lines)...
HW PRODUCT REMOVED VALUE: iSTAR Ultra
HW FAMILY REMOVED VALUE: AR Series
...(removed 104 lines)...
HW FAMILY REMOVED VALUE: imageRunner
SERVICE PRODUCT REMOVED VALUE: .NET CLR
...(removed 627 lines)...
SERVICE PRODUCT REMOVED VALUE: zFTPServer
SERVICE FAMILY REMOVED VALUE: .NET
...(removed 233 lines)...
SERVICE FAMILY REMOVED VALUE: vsFTPd
Please review any new additions to the text files under 'identifiers/'.
If any of these names are close to an existing name, update the offending
fingerprint to use the existing name instead. Once the fingerprints are fixed
run the 'bin/recog_standardize' tool again.
```

### Pre-commit hook after patch
```
$ git add xml/html_title.xml
$ git commit
VENDORS NEW VALUE: DNE
Please review any new additions to the text files under 'identifiers/'.
If any of these names are close to an existing name, update the offending
fingerprint to use the existing name instead. Once the fingerprints are fixed
run the 'bin/recog_standardize' tool again.
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
