### PR TITLE
Add WSO2 product fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -9,6 +9,7 @@ ADAudit Plus
 ADSelfService Plus
 AIOHTTP
 AOS
+API Manager
 APIC
 ARRIS
 ASDM
@@ -66,6 +67,7 @@ Caddy
 CakePHP
 Calibre-Web
 CallPilot
+Carbon
 Celerra
 CentOS Directory Server
 CentOS Web Panel
@@ -139,6 +141,7 @@ Email Security Gateway
 Embedded SSH Server
 Endpoint Protection Manager
 Enterprise
+Enterprise Integrator
 Envoy
 Exchange 2000 Server
 Exchange 2003 Server
@@ -207,6 +210,7 @@ IPVA
 ISEE
 Icecast
 Idea Web Server
+Identity Server
 Ignition Gateway
 InfluxDB
 InsightVM

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -786,6 +786,7 @@ VocalTec Communications, Inc.
 Västgöta-Data AB
 WFTPServer
 WRQ, Inc.
+WSO2
 Washington University
 WatchGuard
 WeOnlyDo

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2046,4 +2046,12 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:watchguard:fireware:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^20197040d99f50747a953d163fef982e$">
+    <description>WSO2 Carbon - service-oriented platform for WSO2 products</description>
+    <example>20197040d99f50747a953d163fef982e</example>
+    <param pos="0" name="service.vendor" value="WSO2"/>
+    <param pos="0" name="service.product" value="Carbon"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:wso2:carbon:-"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3843,6 +3843,40 @@
     <param pos="0" name="hw.family" value="Vigor"/>
   </fingerprint>
 
+  <fingerprint pattern="^WSO2 API Manager|\[Publisher Portal\]WSO2 APIM$">
+    <description>WSO2 API Manager</description>
+    <example>WSO2 API Manager</example>
+    <example>[Publisher Portal]WSO2 APIM</example>
+    <param pos="0" name="service.vendor" value="WSO2"/>
+    <param pos="0" name="service.product" value="API Manager"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:wso2:api_manager:-"/>
+    <param pos="0" name="service.component.vendor" value="WSO2"/>
+    <param pos="0" name="service.component.product" value="Carbon"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:wso2:carbon:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^WSO2 Management Console$">
+    <description>WSO2 Identity Server</description>
+    <example>WSO2 Management Console</example>
+    <param pos="0" name="service.vendor" value="WSO2"/>
+    <param pos="0" name="service.product" value="Identity Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:wso2:identity_server:-"/>
+    <param pos="0" name="service.component.vendor" value="WSO2"/>
+    <param pos="0" name="service.component.product" value="Carbon"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:wso2:carbon:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^WSO2 Enterprise Integrator \(WSO2 EI\)$">
+    <description>WSO2 Enterprise Integrator</description>
+    <example>WSO2 Enterprise Integrator (WSO2 EI)</example>
+    <param pos="0" name="service.vendor" value="WSO2"/>
+    <param pos="0" name="service.product" value="Enterprise Integrator"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:wso2:enterprise_integrator:-"/>
+    <param pos="0" name="service.component.vendor" value="WSO2"/>
+    <param pos="0" name="service.component.product" value="Carbon"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:wso2:carbon:-"/>
+  </fingerprint>
+
   <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4762,4 +4762,16 @@
     <param pos="0" name="hw.device" value="VoIP Gateway"/>
   </fingerprint>
 
+  <fingerprint pattern="^WSO2 Carbon Server$">
+    <description>WSO2 Carbon - service-oriented platform for WSO2 products</description>
+    <example>WSO2 Carbon Server</example>
+    <param pos="0" name="service.vendor" value="WSO2"/>
+    <param pos="0" name="service.product" value="Carbon"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:wso2:carbon:-"/>
+    <param pos="0" name="service.component.vendor" value="Apache"/>
+    <param pos="0" name="service.component.product" value="Tomcat"/>
+    <param pos="0" name="service.component.family" value="Tomcat"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:tomcat:-"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Adds fingerprints for WSO2 Carbon, API Manager, Identity Server and Enterprise Integrator.

### Notes
The `service.component.product` param for the various products is set to "Carbon" as they all appear to be built on top of it. From [WSO2 Carbon Documentation (4.4.11)](https://docs.wso2.com/display/Carbon4411/WSO2+Carbon+Documentation):
> WSO2 Carbon is the award-winning, light-weight, service-oriented platform that includes all WSO2 products.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `rake tests`
* `./bin/recog_verify`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
