### PR TITLE
Fix port number portion of an assert nothing HTTP server regex

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -3038,9 +3038,10 @@
     <param pos="0" name="service.product" value="2wire"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:(?:\d{1,3}\.){3}\d{1,3}):\d{1,4}$">
+  <fingerprint pattern="^(?:(?:\d{1,3}\.){3}\d{1,3}):\d{1,5}$">
     <description>A banner consisting of an IPv4 address and port -- assert nothing.</description>
     <example>192.168.0.4:9999</example>
+    <example>192.168.0.5:65535</example>
     <param pos="0" name="hw.certainty" value="0.0"/>
     <param pos="0" name="os.certainty" value="0.0"/>
     <param pos="0" name="service.certainty" value="0.0"/>


### PR DESCRIPTION
## Description
Corrects the port number portion of an "assert nothing" HTTP server regex.


## Motivation and Context
Correct regex.


## How Has This Been Tested?
* Added example with 5 digit port number
* `./bin/recog_verify xml/http_servers.xml`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
