### PR TITLE
Add recog_match support for JSON output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ require 'cucumber'
 require 'cucumber/rake/task'
 
 Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = "features --format pretty"
+    t.cucumber_opts = %w(features --format pretty)
 end
 
 task :default => [ :tests, :yard ]

--- a/bin/recog_match
+++ b/bin/recog_match
@@ -5,7 +5,7 @@ require 'ostruct'
 require 'recog'
 require 'recog/matcher_factory'
 
-options = OpenStruct.new(color: false, detail: false, fail_fast: false, multi_match: false)
+options = OpenStruct.new(color: false, detail: false, json_format: false, fail_fast: false, multi_match: false)
 
 option_parser = OptionParser.new do |opts|
   opts.banner = "Usage: #{$0} [options] XML_FINGERPRINT_FILE [BANNERS_FILE]"
@@ -16,9 +16,12 @@ option_parser = OptionParser.new do |opts|
   opts.on("-f", "--format FORMATTER",
           "Choose a formatter.",
           "  [s]ummary (default - failure/match msgs)",
-          "  [d]etail  (msgs with total counts)") do |format|
+          "  [d]etail  (msgs with total counts)",
+          "  [j]son  (JSON failure/match msgs)") do |format|
     if format.start_with? 'd'
       options.detail = true
+    elsif format.start_with? 'j'
+      options.json_format = true
     end
   end
 

--- a/bin/recog_match
+++ b/bin/recog_match
@@ -13,14 +13,17 @@ option_parser = OptionParser.new do |opts|
   opts.separator ""
   opts.separator "Options"
 
-  opts.on("-f", "--format FORMATTER",
+  opts.on("-f", "--format FORMATTER", [:summary, :detail, :json],
           "Choose a formatter.",
           "  [s]ummary (default - failure/match msgs)",
           "  [d]etail  (msgs with total counts)",
-          "  [j]son  (JSON failure/match msgs)") do |format|
-    if format.start_with? 'd'
+          "  [j]son    (JSON failure/match msgs)") do |format|
+    if format == :summary
+      options.detail = false
+      options.json_format = false
+    elsif format == :detail
       options.detail = true
-    elsif format.start_with? 'j'
+    elsif format == :json
       options.json_format = true
     end
   end
@@ -44,9 +47,17 @@ option_parser = OptionParser.new do |opts|
     exit
   end
 end
-option_parser.parse!(ARGV)
 
-if ARGV.count != 1 && ARGV.count != 2
+
+begin
+  option_parser.parse!(ARGV)
+rescue OptionParser::ParseError => e
+  puts e.message
+  puts option_parser
+  exit(1)
+end
+
+if ARGV.count < 1 || ARGV.count > 2
   puts option_parser
   exit(1)
 end

--- a/features/match.feature
+++ b/features/match.feature
@@ -34,3 +34,21 @@ Feature: Match
     MATCH: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "service.protocol"=>"", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"}
     MATCH: {"matched"=>"Generic FTP, Checks for the existence of the word FTP in the line", "service.protocol"=>"", "fingerprint_db"=>"multiple_banners_fingerprints", "data"=>"polaris FTP server (SunOS 5.8) ready."}
     """
+
+  @no-clobber
+  Scenario: Finds matches JSON output format
+    When I run `recog_match --format json matching_banners_fingerprints.xml sample_banner.txt`
+    Then it should pass with:
+    """
+    {"data":"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------","match":{"matched":"Pure-FTPd Config data can be zero or more of: [privsep] [TLS]","pureftpd.config":"[privsep] [TLS] ","service.family":"Pure-FTPd","service.product":"Pure-FTPd","service.protocol":"ftp","fingerprint_db":"matching_banners_fingerprints"}}
+    {"data":"polaris FTP server (SunOS 5.8) ready.","match":{"matched":"SunOS/Solaris","os.vendor":"Sun","os.family":"Solaris","os.product":"Solaris","os.device":"General","host.name":"polaris","os.version":"5.8","service.protocol":"ftp","fingerprint_db":"matching_banners_fingerprints"}}
+    """
+
+  @no-clobber
+  Scenario: Finds matches using multi-match flag and JSON output format
+    When I run `recog_match --format json --multi-match multiple_banners_fingerprints.xml sample_banner.txt`
+    Then it should pass with:
+    """
+    {"data":"---------- Welcome to Pure-FTPd [privsep] [TLS] ----------","matches":[{"matched":"Generic FTP, Checks for the existence of the word FTP in the line","service.protocol":"","fingerprint_db":"multiple_banners_fingerprints"},{"matched":"Pure-FTPd Config data can be zero or more of: [privsep] [TLS]","pureftpd.config":"[privsep] [TLS] ","service.family":"Pure-FTPd","service.product":"Pure-FTPd","service.protocol":"ftp","fingerprint_db":"multiple_banners_fingerprints"}]}
+    {"data":"polaris FTP server (SunOS 5.8) ready.","matches":[{"matched":"Generic FTP, Checks for the existence of the word FTP in the line","service.protocol":"","fingerprint_db":"multiple_banners_fingerprints"},{"matched":"SunOS/Solaris","service.protocol":"ftp","os.vendor":"Sun","os.family":"Solaris","os.product":"Solaris","os.device":"General","host.name":"polaris","os.version":"5.8","fingerprint_db":"multiple_banners_fingerprints"}]}
+    """


### PR DESCRIPTION
## Description
Adds `recog_match` support for JSON output. These changes require recog gem enhancements from rapid7/recog-ruby#7. Note, the tests on this branch will fail until the recog gem is updated.

### Example output
#### Multiple matches disabled (default)
```
$ echo "Linksys\nApache\nDNE" | bundle exec ./recog_match --format json xml/http_servers.xml
{"data":"Linksys","match":{"matched":"Linksys Wireless Access Point","os.vendor":"Linksys","os.device":"WAP","hw.vendor":"Linksys","hw.device":"WAP","service.protocol":"http","fingerprint_db":"http_header.server"}}
{"data":"Apache","match":{"matched":"Apache returning no version information","service.vendor":"Apache","service.product":"HTTPD","service.family":"Apache","service.cpe23":"cpe:/a:apache:http_server:-","service.protocol":"http","fingerprint_db":"http_header.server"}}
{"data":"DNE","match_failure":true,"match":null}
```
#### Multiple matches enabled
```
$ echo "Linksys\nApache\nDNE" | bundle exec ./recog_match --format json --multi-match xml/http_servers.xml
{"data":"Linksys","matches":[{"matched":"Linksys Wireless Access Point","os.vendor":"Linksys","os.device":"WAP","hw.vendor":"Linksys","hw.device":"WAP","service.protocol":"http","fingerprint_db":"http_header.server"}]}
{"data":"Apache","matches":[{"matched":"Apache returning no version information","service.vendor":"Apache","service.product":"HTTPD","service.family":"Apache","service.cpe23":"cpe:/a:apache:http_server:-","service.protocol":"http","fingerprint_db":"http_header.server"},{"matched":"Apache","service.vendor":"Apache","service.product":"HTTPD","service.family":"Apache","service.version":null,"service.cpe23":"cpe:/a:apache:http_server:-","apache.info":null,"service.protocol":"http","fingerprint_db":"http_header.server"}]}
{"data":"DNE","match_failure":true,"matches":null}
```

## Motivation and Context
Increase the usability of `recog_match` in command pipelines since JSON is easier to parse with other tools such as `jq`.


## How Has This Been Tested?
* Added new feature tests for `recog_match`
* Temporary modified `Gemfile` to load the recog gem from my development branch
```
diff --git a/Gemfile b/Gemfile
index 2890fd8..b97e60c 100644
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'

 gemspec name: 'recog-content'

-gem 'recog', '~>3.0'
+gem 'recog', '~>3.0', git: 'https://github.com/mkienow-r7/recog-ruby', branch: 'feature/recog-match-json-output'

 group :test do
   gem 'rake'
```
* `bundle install`
* `rake test`

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
