### PR TITLE
Add more Jupyter product fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -52,6 +52,7 @@ BRCM400
 Ballerina
 Bftpd
 Bigfoot Email Tools
+BinderHub
 BlackJumboDog
 BladeSystems
 Boa
@@ -246,6 +247,8 @@ JetDirect
 Jetty
 Jira
 Joom!Fish
+Jupyter Server
+JupyterHub
 KM FTPD
 KM-MFP-HTTP
 Kamailio

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -779,13 +779,11 @@
   </fingerprint>
 
   <fingerprint pattern="^97c6417ed01bdc0ae3ef32ae4894fd03|e2f298e9811cd34a08bf5bb69e2d1d6a$">
-    <description>Jupyter Notebook</description>
+    <description>Jupyter Products</description>
     <example>97c6417ed01bdc0ae3ef32ae4894fd03</example>
     <example>e2f298e9811cd34a08bf5bb69e2d1d6a</example>
     <param pos="0" name="service.vendor" value="Jupyter"/>
-    <param pos="0" name="service.product" value="Notebook"/>
     <param pos="0" name="service.certainty" value="0.5"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:jupyter:notebook:-"/>
   </fingerprint>
 
   <fingerprint pattern="^7102bb857703a0fece6d039a6777fc3f$">

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -788,6 +788,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:jupyter:notebook:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^7102bb857703a0fece6d039a6777fc3f$">
+    <description>Jupyter BinderHub</description>
+    <example>7102bb857703a0fece6d039a6777fc3f</example>
+    <param pos="0" name="service.vendor" value="Jupyter"/>
+    <param pos="0" name="service.product" value="BinderHub"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:jupyter:binderhub:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^36b3ef286fa4befbb797a0966b456479$">
     <description>PRTG Network Monitor</description>
     <example>36b3ef286fa4befbb797a0966b456479</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -2449,6 +2449,22 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:jupyter:notebook:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^Jupyter Server$">
+    <description>Jupyter Server - backend to Jupyter web applications</description>
+    <example>Jupyter Server</example>
+    <param pos="0" name="service.vendor" value="Jupyter"/>
+    <param pos="0" name="service.product" value="Jupyter Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:jupyter:jupyter_server:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^JupyterHub$">
+    <description>JupyterHub - Multi-user server for Jupyter notebooks</description>
+    <example>JupyterHub</example>
+    <param pos="0" name="service.vendor" value="Jupyter"/>
+    <param pos="0" name="service.product" value="JupyterHub"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:jupyter:jupyterhub:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^Redirect to userimage: /control/userimage\.html$">
     <description>Mobotix Network Camera</description>
     <example>Redirect to userimage: /control/userimage.html</example>


### PR DESCRIPTION
## Description
Adds fingerprints for more Jupyter products (Jupyter Server, JupyterHub, BinderHub) and removes the product from the existing favicon since it is used on multiple products.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `rake tests`
* `./bin/recog_verify xml/favicons.xml`
* `./bin/recog_verify xml/html_title.xml`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
