### PR TITLE
Add Duo Device Health and Mac Certifier x509 fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -128,6 +128,8 @@ Dovecot
 Drive
 Dropbear SSH
 Druid
+Duo Certifier
+Duo Device Health
 Dynamo
 E-mail Firewall
 E-mail Services

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -1755,4 +1755,24 @@
     <param pos="0" name="os.product" value="Proxmox"/>
   </fingerprint>
 
+  <fingerprint pattern="^CN=(\S{1,512}),OU=Endpoint Health,O=Duo Security\\, Inc.,L=Ann Arbor,ST=Michigan,C=US(?:,\S+)?$">
+    <description>Duo Device Health</description>
+    <example host.name="127.0.0.1">CN=127.0.0.1,OU=Endpoint Health,O=Duo Security\, Inc.,L=Ann Arbor,ST=Michigan,C=US,1.2.840.113549.1.9.1=#0c1e656e64706f696e746865616c74684064756f73656375726974792e636f6d</example>
+    <param pos="0" name="service.vendor" value="Duo"/>
+    <param pos="0" name="service.product" value="Duo Device Health"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+
+  <fingerprint pattern="^CN=(\S{1,512}),OU=Mac Certifier,O=Duo Security\\, Inc.,L=Ann Arbor,ST=Michigan,C=US(?:,\S+)?$">
+    <description>Duo Certifier</description>
+    <example host.name="localhost">CN=localhost,OU=Mac Certifier,O=Duo Security\, Inc.,L=Ann Arbor,ST=Michigan,C=US,1.2.840.113549.1.9.1=#0c18656e64706f696e744064756f73656375726974792e636f6d</example>
+    <param pos="0" name="service.vendor" value="Duo"/>
+    <param pos="0" name="service.product" value="Duo Certifier"/>
+    <param pos="0" name="os.vendor" value="Apple"/>
+    <param pos="0" name="os.family" value="Mac OS"/>
+    <param pos="0" name="os.product" value="Mac OS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:apple:macos:-"/>
+    <param pos="1" name="host.name"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Adds [Duo Device Health](https://duo.com/docs/device-health) and [Duo Mac Certifier](https://duo.com/docs/trusted-endpoints-macos-certifier) x509 fingerprints. This is being added in the go string format so that it isn't lost in my backlog. #360 needs to be addressed in the near future.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/x509_subjects.xml`
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
