### PR TITLE
Temporary fix to restore rspec progress formatter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,12 +38,13 @@ RSpec.configure do |config|
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
+  # TODO: uncomment when the project has more than a single spec
+  # if config.files_to_run.one?
+  #   # Use the documentation formatter for detailed output,
+  #   # unless a formatter has already been configured
+  #   # (e.g. via a command-line flag).
+  #   config.default_formatter = 'doc'
+  # end
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
## Description
A temporary fix to restore the rspec progress formatter. `spec/spec_helper.rb` contains a configuration to modify the formatter to documentation when an individual file is specified, however, after the repository split the repo only contains the single spec `spec/lib/fingerprint_self_test_spec.rb`. This change should be undone when another spec is introduced.


## Motivation and Context
Restore expected rspec behavior for previous committers.


## How Has This Been Tested?
* `rake tests`
* `bundle exec rspec`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
