### PR TITLE
More DHCP-based fingerprints

### DIFF
--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -218,7 +218,7 @@
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
-    <param pos="0" name="hw.certainty" value="0.9"/>
+    <param pos="0" name="hw.certainty" value="0.8"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
@@ -228,7 +228,7 @@
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
-    <param pos="0" name="hw.certainty" value="0.9"/>
+    <param pos="0" name="hw.certainty" value="0.8"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
@@ -242,7 +242,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco AP (c(?:1540|1550|1560|1700|1815|1830|1850|2700|2800|3700|3800|701|702))$" certainty="0.9">
+  <fingerprint pattern="^Cisco AP (c(?:1540|1550|1560|1700|1815|1830|1850|2700|2800|3700|3800|701|702))$" certainty="0.8">
     <description>Cisco Aironet Wireless Access Point</description>
     <example hw.model="c1830">Cisco AP c1830</example>
     <param pos="0" name="hw.device" value="WAP"/>
@@ -251,7 +251,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco AP (C9115AX|C9120AX)" certainty="0.9">
+  <fingerprint pattern="^Cisco AP (C9115AX|C9120AX)" certainty="0.8">
     <description>Cisco Catalyst 9100 Series Wireless Access Point</description>
     <example hw.model="C9115AX">Cisco AP C9115AX</example>
     <param pos="0" name="hw.device" value="WAP"/>
@@ -260,7 +260,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco (AP80[123])$" certainty="0.9">
+  <fingerprint pattern="^Cisco (AP80[123])$" certainty="0.8">
     <description>Cisco 800 Series Integrated Access Point</description>
     <example hw.model="AP801">Cisco AP801</example>
     <example hw.model="AP802">Cisco AP802</example>
@@ -271,7 +271,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco (AIR-CTVM-K9)$" certainty="0.9">
+  <fingerprint pattern="^Cisco (AIR-CTVM-K9)$" certainty="0.8">
     <description>Cisco Virtual Wireless Controller</description>
     <example hw.model="AIR-CTVM-K9">Cisco AIR-CTVM-K9</example>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
@@ -280,7 +280,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco (AIR-CT55\d\d-K9)$" certainty="0.9">
+  <fingerprint pattern="^Cisco (AIR-CT55\d\d-K9)$" certainty="0.8">
     <description>Cisco 5500 Series Wireless Controller</description>
     <example hw.model="AIR-CT5508-K9">Cisco AIR-CT5508-K9</example>
     <param pos="0" name="hw.device" value="Wireless Controller"/>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -212,20 +212,24 @@
     <param pos="0" name="os.family" value="Windows"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Cisco Systems Inc. Wireless Phone (.*)" certainty="0.9">
+  <fingerprint pattern="^(?i)Cisco Systems Inc. Wireless Phone (\d{4})$">
     <description>Cisco Wireless Phone</description>
     <example hw.model="7925">Cisco Systems Inc. Wireless Phone 7925</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="hw.certainty" value="0.9"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Cisco Systems, Inc. IP Phone (.*)" certainty="0.9">
+  <fingerprint pattern="^(?i)Cisco Systems, Inc. IP Phone (.*)">
     <description>Cisco IP Phone</description>
     <example hw.model="CP-7911G">Cisco Systems, Inc. IP Phone CP-7911G</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="hw.certainty" value="0.9"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
   <fingerprint pattern="^Cisco AP (c(?:1130|1140|1240|1250|1260|1600|2600|3500|3600))$" certainty="0.9">
@@ -235,6 +239,7 @@
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
   <fingerprint pattern="^Cisco AP (c(?:1540|1550|1560|1700|1815|1830|1850|2700|2800|3700|3800|701|702))$" certainty="0.9">
@@ -243,6 +248,7 @@
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
   <fingerprint pattern="^Cisco AP (C9115AX|C9120AX)" certainty="0.9">
@@ -251,6 +257,7 @@
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
   <fingerprint pattern="^Cisco (AP80[123])$" certainty="0.9">
@@ -261,6 +268,7 @@
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
   <fingerprint pattern="^Cisco (AIR-CTVM-K9)$" certainty="0.9">
@@ -269,13 +277,15 @@
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco (AIR-CT55..-K9)$" certainty="0.9">
+  <fingerprint pattern="^Cisco (AIR-CT55\d\d-K9)$" certainty="0.9">
     <description>Cisco 5500 Series Wireless Controller</description>
     <example hw.model="AIR-CT5508-K9">Cisco AIR-CT5508-K9</example>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 </fingerprints>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -178,6 +178,7 @@
     <param pos="0" name="os.vendor" value="Google"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Android"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:google:android:-"/>
   </fingerprint>
 
   <fingerprint pattern="^dhcpcd-(?:[\d\.]+):Linux-([\d\.]+).*:(\S*):">

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -171,6 +171,15 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:google:android:{os.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="HUAWEI:android:" certainty="0.9">
+    <description>Huawei Android Device</description>
+    <example>HUAWEI:android:ABC</example>
+    <param pos="0" name="hw.vendor" value="Huawei"/>
+    <param pos="0" name="os.vendor" value="Google"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Android"/>
+  </fingerprint>
+
   <fingerprint pattern="^dhcpcd-(?:[\d\.]+):Linux-([\d\.]+).*:(\S*):">
     <description>Linux</description>
     <example os.version="4.14.78" os.arch="armv7l">dhcpcd-6.11.5:Linux-4.14.78:armv7l:Freescale</example>
@@ -203,4 +212,70 @@
     <param pos="0" name="os.family" value="Windows"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?i)Cisco Systems Inc. Wireless Phone (.*)" certainty="0.9">
+    <description>Cisco Wireless Phone</description>
+    <example hw.model="7925">Cisco Systems Inc. Wireless Phone 7925</example>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?i)Cisco Systems, Inc. IP Phone (.*)" certainty="0.9">
+    <description>Cisco IP Phone</description>
+    <example hw.model="CP-7911G">Cisco Systems, Inc. IP Phone CP-7911G</example>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco AP (c(?:1130|1140|1240|1250|1260|1600|2600|3500|3600))$" certainty="0.9">
+    <description>Cisco Aironet Wireless Access Point (obsolete)</description>
+    <example hw.model="c1140">Cisco AP c1140</example>
+    <example hw.model="c1260">Cisco AP c1260</example>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco AP (c(?:1540|1550|1560|1700|1815|1830|1850|2700|2800|3700|3800|701|702))$" certainty="0.9">
+    <description>Cisco Aironet Wireless Access Point</description>
+    <example hw.model="c1830">Cisco AP c1830</example>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco AP (C9115AX|C9120AX)" certainty="0.9">
+    <description>Cisco Catalyst 9100 Series Wireless Access Point</description>
+    <example hw.model="C9115AX">Cisco AP C9115AX</example>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco (AP80[123])$" certainty="0.9">
+    <description>Cisco 800 Series Integrated Access Point</description>
+    <example hw.model="AP801">Cisco AP801</example>
+    <example hw.model="AP802">Cisco AP802</example>
+    <example hw.model="AP803">Cisco AP803</example>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco (AIR-CTVM-K9)$" certainty="0.9">
+    <description>Cisco Virtual Wireless Controller</description>
+    <example hw.model="AIR-CTVM-K9">Cisco AIR-CTVM-K9</example>
+    <param pos="0" name="hw.device" value="Wireless Controller"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco (AIR-CT55..-K9)$" certainty="0.9">
+    <description>Cisco 5500 Series Wireless Controller</description>
+    <example hw.model="AIR-CT5508-K9">Cisco AIR-CT5508-K9</example>
+    <param pos="0" name="hw.device" value="Wireless Controller"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+  </fingerprint>
 </fingerprints>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -212,54 +212,64 @@
     <param pos="0" name="os.family" value="Windows"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Cisco Systems Inc\. Wireless Phone (\d{4})$">
+  <fingerprint pattern="^(?i)Cisco Systems Inc\. Wireless Phone (\d{4}g?)$" certainty="0.8">
     <description>Cisco Wireless Phone</description>
-    <example hw.model="7925">Cisco Systems Inc. Wireless Phone 7925</example>
+    <example hw.model="7920">Cisco Systems Inc. Wireless Phone 7920</example>
+    <example hw.model="7925G">Cisco Systems Inc. Wireless Phone 7925G</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
-    <param pos="0" name="hw.certainty" value="0.8"/>
+    <param pos="0" name="hw.product" value="Unified Wireless IP Phone {hw.model}"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.product" value="Unified Wireless IP Phone {hw.model} Firmware"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Cisco Systems, Inc\. IP Phone (CP.{4,10})$">
+  <fingerprint pattern="^Cisco systems, Inc\. IP Phone CP(39\d{2})$" certainty="0.8">
+    <description>Cisco SIP Phone</description>
+    <example hw.model="3911">Cisco systems, Inc. IP Phone CP3911</example>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="1" name="hw.model"/>
+    <param pos="0" name="hw.product" value="Unified SIP Phone {hw.model}"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.product" value="Unified SIP Phone {hw.model} Firmware"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco Systems, Inc\. IP Phone CP-(\d{4}G?)(?:-GE)?$" certainty="0.8">
     <description>Cisco IP Phone</description>
-    <example hw.model="CP3911">Cisco systems, Inc. IP Phone CP3911</example>
-    <example hw.model="CP-6921">Cisco Systems, Inc. IP Phone CP-6921</example>
-    <example hw.model="CP-7911G">Cisco Systems, Inc. IP Phone CP-7911G</example>
-    <example hw.model="CP-7941G-GE">Cisco Systems, Inc. IP Phone CP-7941G-GE</example>
+    <example hw.model="6921">Cisco Systems, Inc. IP Phone CP-6921</example>
+    <example hw.model="7911G">Cisco Systems, Inc. IP Phone CP-7911G</example>
+    <example hw.model="7941G">Cisco Systems, Inc. IP Phone CP-7941G-GE</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
-    <param pos="0" name="hw.certainty" value="0.8"/>
+    <param pos="0" name="hw.product" value="Unified IP Phone {hw.model}"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.product" value="Unified IP Phone {hw.model} Firmware"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco AP (c(?:1130|1140|1240|1250|1260|1600|2600|3500|3600))$" certainty="0.8">
-    <description>Cisco Aironet Wireless Access Point (obsolete)</description>
-    <example hw.model="c1140">Cisco AP c1140</example>
-    <example hw.model="c1260">Cisco AP c1260</example>
-    <param pos="0" name="hw.device" value="WAP"/>
-    <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="1" name="hw.model"/>
-    <param pos="0" name="os.vendor" value="Cisco"/>
-  </fingerprint>
-
-  <fingerprint pattern="^Cisco AP (c(?:1540|1550|1560|1700|1815|1830|1850|2700|2800|3700|3800|701|702))$" certainty="0.8">
+  <fingerprint pattern="^Cisco AP c(\d{3,4})$" certainty="0.8">
     <description>Cisco Aironet Wireless Access Point</description>
-    <example hw.model="c1830">Cisco AP c1830</example>
+    <example hw.model="701">Cisco AP c701</example>
+    <example hw.model="1830">Cisco AP c1830</example>
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="hw.product" value="Aironet {hw.model}"/>
+    <param pos="0" name="os.product" value="Aironet {hw.model} Firmware"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco AP (C9115AX|C9120AX)$" certainty="0.8">
+  <fingerprint pattern="^Cisco AP C(9115|9120)AX$" certainty="0.8">
     <description>Cisco Catalyst 9100 Series Wireless Access Point</description>
-    <example hw.model="C9115AX">Cisco AP C9115AX</example>
+    <example hw.model="9115">Cisco AP C9115AX</example>
+    <example hw.model="9120">Cisco AP C9120AX</example>
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
+    <param pos="0" name="hw.product" value="Catalyst {hw.model} AP"/>
+    <param pos="0" name="os.product" value="Catalyst {hw.model} AP Firmware"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
@@ -274,12 +284,12 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco (AIR-CTVM-K9)$" certainty="0.8">
+  <fingerprint pattern="^Cisco AIR-CTVM-K9$" certainty="0.8">
     <description>Cisco Virtual Wireless Controller</description>
-    <example hw.model="AIR-CTVM-K9">Cisco AIR-CTVM-K9</example>
+    <example>Cisco AIR-CTVM-K9</example>
     <param pos="0" name="hw.device" value="Wireless Controller"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
-    <param pos="1" name="hw.model"/>
+    <param pos="0" name="hw.model" value="AIR-CTVM-K9"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -236,11 +236,12 @@
     <param pos="0" name="os.product" value="Unified SIP Phone {hw.model} Firmware"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco Systems, Inc\. IP Phone CP-(\d{4}(?:G|G-GE)?)$" certainty="0.8">
+  <fingerprint pattern="^Cisco Systems, Inc\. IP Phone CP-(\d{4}(?:G|G-GE|NR)?)$" certainty="0.8">
     <description>Cisco IP Phone</description>
     <example hw.model="6921">Cisco Systems, Inc. IP Phone CP-6921</example>
     <example hw.model="7911G">Cisco Systems, Inc. IP Phone CP-7911G</example>
     <example hw.model="7941G-GE">Cisco Systems, Inc. IP Phone CP-7941G-GE</example>
+    <example hw.model="8865NR">Cisco Systems, Inc. IP Phone CP-8865NR</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -212,7 +212,7 @@
     <param pos="0" name="os.family" value="Windows"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Cisco Systems Inc. Wireless Phone (\d{4})$">
+  <fingerprint pattern="^(?i)Cisco Systems Inc\. Wireless Phone (\d{4})$">
     <description>Cisco Wireless Phone</description>
     <example hw.model="7925">Cisco Systems Inc. Wireless Phone 7925</example>
     <param pos="0" name="hw.device" value="VoIP"/>
@@ -222,9 +222,12 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i)Cisco Systems, Inc. IP Phone (.*)">
+  <fingerprint pattern="^(?i)Cisco Systems, Inc\. IP Phone (CP.{4,10})$">
     <description>Cisco IP Phone</description>
+    <example hw.model="CP3911">Cisco systems, Inc. IP Phone CP3911</example>
+    <example hw.model="CP-6921">Cisco Systems, Inc. IP Phone CP-6921</example>
     <example hw.model="CP-7911G">Cisco Systems, Inc. IP Phone CP-7911G</example>
+    <example hw.model="CP-7941G-GE">Cisco Systems, Inc. IP Phone CP-7941G-GE</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
@@ -232,7 +235,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco AP (c(?:1130|1140|1240|1250|1260|1600|2600|3500|3600))$" certainty="0.9">
+  <fingerprint pattern="^Cisco AP (c(?:1130|1140|1240|1250|1260|1600|2600|3500|3600))$" certainty="0.8">
     <description>Cisco Aironet Wireless Access Point (obsolete)</description>
     <example hw.model="c1140">Cisco AP c1140</example>
     <example hw.model="c1260">Cisco AP c1260</example>
@@ -280,7 +283,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco (AIR-CT55\d\d-K9)$" certainty="0.8">
+  <fingerprint pattern="^Cisco (AIR-CT55\d{2}-K9)$" certainty="0.8">
     <description>Cisco 5500 Series Wireless Controller</description>
     <example hw.model="AIR-CT5508-K9">Cisco AIR-CT5508-K9</example>
     <param pos="0" name="hw.device" value="Wireless Controller"/>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -236,11 +236,11 @@
     <param pos="0" name="os.product" value="Unified SIP Phone {hw.model} Firmware"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco Systems, Inc\. IP Phone CP-(\d{4}G?)(?:-GE)?$" certainty="0.8">
+  <fingerprint pattern="^Cisco Systems, Inc\. IP Phone CP-(\d{4}(?:G|G-GE)?)$" certainty="0.8">
     <description>Cisco IP Phone</description>
     <example hw.model="6921">Cisco Systems, Inc. IP Phone CP-6921</example>
     <example hw.model="7911G">Cisco Systems, Inc. IP Phone CP-7911G</example>
-    <example hw.model="7941G">Cisco Systems, Inc. IP Phone CP-7941G-GE</example>
+    <example hw.model="7941G-GE">Cisco Systems, Inc. IP Phone CP-7941G-GE</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>
@@ -249,10 +249,11 @@
     <param pos="0" name="os.product" value="Unified IP Phone {hw.model} Firmware"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco AP c(\d{3,4})$" certainty="0.8">
+  <fingerprint pattern="^Cisco AP c(\d{3,4}[a-z]?)$" certainty="0.8">
     <description>Cisco Aironet Wireless Access Point</description>
     <example hw.model="701">Cisco AP c701</example>
     <example hw.model="1830">Cisco AP c1830</example>
+    <example hw.model="1840i">Cisco AP c1840i</example>
     <param pos="0" name="hw.device" value="WAP"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="1" name="hw.model"/>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -171,7 +171,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:google:android:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="HUAWEI:android:" certainty="0.9">
+  <fingerprint pattern="^HUAWEI:android:" certainty="0.8">
     <description>Huawei Android Device</description>
     <example>HUAWEI:android:ABC</example>
     <param pos="0" name="hw.vendor" value="Huawei"/>
@@ -251,7 +251,7 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
-  <fingerprint pattern="^Cisco AP (C9115AX|C9120AX)" certainty="0.8">
+  <fingerprint pattern="^Cisco AP (C9115AX|C9120AX)$" certainty="0.8">
     <description>Cisco Catalyst 9100 Series Wireless Access Point</description>
     <example hw.model="C9115AX">Cisco AP C9115AX</example>
     <param pos="0" name="hw.device" value="WAP"/>


### PR DESCRIPTION
## Description
Added more fingerprints from observed DHCP vendor_class strings:
* Huawei Android
* Cisco IP Phones
* Cisco Wireless Phones
* Cisco Aironet Wireless Access Points
* Cisco Catalyst Wireless Access Points
* Cisco Integrated Access Points
* Cisco Wireless Controllers


## Motivation and Context
These fingerprints can be used for identifying network devices based on the DHCP fields they advertise


## How Has This Been Tested?
Ran `./bin/recog_verify xml/dhcp_vendor_class.xml`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New fingerprints


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
