### PR TITLE
Restore non-capturing groups to fix anchored regex issue

### DIFF
--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -6,7 +6,7 @@
 
   <!-- Services -->
 
-  <fingerprint pattern="^4297c114f263c206ed12aaff4b0c7a50|e5af3b68e837498a85b25ef2c36a0825$">
+  <fingerprint pattern="^(?:4297c114f263c206ed12aaff4b0c7a50|e5af3b68e837498a85b25ef2c36a0825)$">
     <description>Metabase</description>
     <example>4297c114f263c206ed12aaff4b0c7a50</example>
     <example>e5af3b68e837498a85b25ef2c36a0825</example>
@@ -75,7 +75,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^b6341dfc213100c61db4fb8775878cec|cf2445dcb53a031c02f9b57e2199bc03$">
+  <fingerprint pattern="^(?:b6341dfc213100c61db4fb8775878cec|cf2445dcb53a031c02f9b57e2199bc03)$">
     <description>Drupal CMS</description>
     <example>b6341dfc213100c61db4fb8775878cec</example>
     <example>cf2445dcb53a031c02f9b57e2199bc03</example>
@@ -102,7 +102,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^268ee26a1219a611828d5fd4bc4d69c0|5a84c349c00d95c8ebd174ded3b50a86|2b37c7f35285c341ec1f2cf7e40a3c22$">
+  <fingerprint pattern="^(?:268ee26a1219a611828d5fd4bc4d69c0|5a84c349c00d95c8ebd174ded3b50a86|2b37c7f35285c341ec1f2cf7e40a3c22)$">
     <description>Jenkins</description>
     <example>268ee26a1219a611828d5fd4bc4d69c0</example>
     <example>5a84c349c00d95c8ebd174ded3b50a86</example>
@@ -113,7 +113,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:jenkins:jenkins:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^6eb4a43cb64c97f76562af703893c8fd|3bd2ec61324ad4d27cb7b0f484cd4289$">
+  <fingerprint pattern="^(?:6eb4a43cb64c97f76562af703893c8fd|3bd2ec61324ad4d27cb7b0f484cd4289)$">
     <description>XAMPP Server</description>
     <example>6eb4a43cb64c97f76562af703893c8fd</example>
     <example>3bd2ec61324ad4d27cb7b0f484cd4289</example>
@@ -122,7 +122,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^1391664373e72311a656c4a5504682af|88717398db158e3330ce94fc1784e4a7|04d89d5b7a290334f5ce37c7e8b6a349|08aa365c2d0863df2735d386f77c22c2$">
+  <fingerprint pattern="^(?:1391664373e72311a656c4a5504682af|88717398db158e3330ce94fc1784e4a7|04d89d5b7a290334f5ce37c7e8b6a349|08aa365c2d0863df2735d386f77c22c2)$">
     <description>Atlassian Jira</description>
     <example>1391664373e72311a656c4a5504682af</example>
     <example>88717398db158e3330ce94fc1784e4a7</example>
@@ -168,7 +168,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^e467554976ad3162eec9dfbf83e2c324|b338542efc5676d771c21fe94faf12b3$">
+  <fingerprint pattern="^(?:e467554976ad3162eec9dfbf83e2c324|b338542efc5676d771c21fe94faf12b3)$">
     <description>ownCloud</description>
     <example>e467554976ad3162eec9dfbf83e2c324</example>
     <example>b338542efc5676d771c21fe94faf12b3</example>
@@ -354,7 +354,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^c02e22ca67f83a0fb6f2fd265074910a|68e1a9c89026b0efeddf718a48c282a5$">
+  <fingerprint pattern="^(?:c02e22ca67f83a0fb6f2fd265074910a|68e1a9c89026b0efeddf718a48c282a5)$">
     <description>HashiCorp Vault</description>
     <example>c02e22ca67f83a0fb6f2fd265074910a</example>
     <example>68e1a9c89026b0efeddf718a48c282a5</example>
@@ -386,7 +386,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apple:cups:1.x"/>
   </fingerprint>
 
-  <fingerprint pattern="^448fa67ece2a35d57e8d19808d350e9b|0c9183bd23ed47288c733499fce4498c|c4302a71aae96e158c3057c66184abbd$">
+  <fingerprint pattern="^(?:448fa67ece2a35d57e8d19808d350e9b|0c9183bd23ed47288c733499fce4498c|c4302a71aae96e158c3057c66184abbd)$">
     <description>Apple CUPS 2.x</description>
     <example>448fa67ece2a35d57e8d19808d350e9b</example>
     <example>0c9183bd23ed47288c733499fce4498c</example>
@@ -416,7 +416,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^4f21edb50ae95a99bbd4aa0a956a179e|1531801cb9e3047e72034ed34da9d104$">
+  <fingerprint pattern="^(?:4f21edb50ae95a99bbd4aa0a956a179e|1531801cb9e3047e72034ed34da9d104)$">
     <description>Apache Airflow</description>
     <example>4f21edb50ae95a99bbd4aa0a956a179e</example>
     <example>1531801cb9e3047e72034ed34da9d104</example>
@@ -434,7 +434,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^9b67ee27ad29bd721c0c1f5e5a1a5211|801164802554cf799c6fc3851f93e0e1$">
+  <fingerprint pattern="^(?:9b67ee27ad29bd721c0c1f5e5a1a5211|801164802554cf799c6fc3851f93e0e1)$">
     <description>Gerrit Code Review</description>
     <example>9b67ee27ad29bd721c0c1f5e5a1a5211</example>
     <example>801164802554cf799c6fc3851f93e0e1</example>
@@ -443,7 +443,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^9e312675a79186e08436bcc2cf314608|ed9dc05a5dde54b22d2edb16d9b68ab0$">
+  <fingerprint pattern="^(?:9e312675a79186e08436bcc2cf314608|ed9dc05a5dde54b22d2edb16d9b68ab0)$">
     <description>Apache Druid</description>
     <example>9e312675a79186e08436bcc2cf314608</example>
     <example>ed9dc05a5dde54b22d2edb16d9b68ab0</example>
@@ -453,7 +453,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:druid:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^ec60d8d2f3b0ded27c5767189882685c|5856edf7bcbea0817312d9e535e5eb2a|f4f3cb900258441d5dbc9105b7ab9b44|c6acedaff906029fc5455d9ec52c7f42$">
+  <fingerprint pattern="^(?:ec60d8d2f3b0ded27c5767189882685c|5856edf7bcbea0817312d9e535e5eb2a|f4f3cb900258441d5dbc9105b7ab9b44|c6acedaff906029fc5455d9ec52c7f42)$">
     <description>VMware Horizon</description>
     <example>ec60d8d2f3b0ded27c5767189882685c</example>
     <example>5856edf7bcbea0817312d9e535e5eb2a</example>
@@ -495,7 +495,7 @@
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>
 
-  <fingerprint pattern="^bad2c1f96cd66e70b4aa119e7270cc62|966e60f8eb85b7ea43a7b0095f3e2336$">
+  <fingerprint pattern="^(?:bad2c1f96cd66e70b4aa119e7270cc62|966e60f8eb85b7ea43a7b0095f3e2336)$">
     <description>Atlassian Confluence</description>
     <example>bad2c1f96cd66e70b4aa119e7270cc62</example>
     <example>966e60f8eb85b7ea43a7b0095f3e2336</example>
@@ -540,7 +540,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:cpanel:cpanel:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^765835f9b71c7f8405f5776d2a6ce49b|e6942b8d321aee26b514ef5513583d52$">
+  <fingerprint pattern="^(?:765835f9b71c7f8405f5776d2a6ce49b|e6942b8d321aee26b514ef5513583d52)$">
     <description>Spiceworks</description>
     <example>765835f9b71c7f8405f5776d2a6ce49b</example>
     <example>e6942b8d321aee26b514ef5513583d52</example>
@@ -549,7 +549,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^07ba76de1eb6c4550bfbf627a21cd6f8|9cc719577e8de0abd0d76f43a40c2956|5f09cded07bb864fd9b3d2dd72b5418e$">
+  <fingerprint pattern="^(?:07ba76de1eb6c4550bfbf627a21cd6f8|9cc719577e8de0abd0d76f43a40c2956|5f09cded07bb864fd9b3d2dd72b5418e)$">
     <description>Twonky Server</description>
     <example>07ba76de1eb6c4550bfbf627a21cd6f8</example>
     <example>9cc719577e8de0abd0d76f43a40c2956</example>
@@ -628,7 +628,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^f7e3d97f404e71d302b3239eef48d5f2|bfac77149bf662238eb92d9b65c88a2a|85c754581e1d4b628be5b7712c042224$">
+  <fingerprint pattern="^(?:f7e3d97f404e71d302b3239eef48d5f2|bfac77149bf662238eb92d9b65c88a2a|85c754581e1d4b628be5b7712c042224)$">
     <description>GitLab</description>
     <example>f7e3d97f404e71d302b3239eef48d5f2</example>
     <example>bfac77149bf662238eb92d9b65c88a2a</example>
@@ -663,7 +663,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^e43ad9b75957c46a5975ded0f85a95b4|2145225dd4406c274c317f8d80ccf584$">
+  <fingerprint pattern="^(?:e43ad9b75957c46a5975ded0f85a95b4|2145225dd4406c274c317f8d80ccf584)$">
     <description>Elastic Kibana</description>
     <example>e43ad9b75957c46a5975ded0f85a95b4</example>
     <example>2145225dd4406c274c317f8d80ccf584</example>
@@ -673,7 +673,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:elastic:kibana:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^ef07026465d7b449a9759132486d1e3b|bcc4933f81eff43e5d9bcc5b2828aa70|b204c198a410e5ee28346c4a2110535e|c00da11c81f9b887eed4123daee89909$">
+  <fingerprint pattern="^(?:ef07026465d7b449a9759132486d1e3b|bcc4933f81eff43e5d9bcc5b2828aa70|b204c198a410e5ee28346c4a2110535e|c00da11c81f9b887eed4123daee89909)$">
     <description>Grafana</description>
     <example>ef07026465d7b449a9759132486d1e3b</example>
     <example>bcc4933f81eff43e5d9bcc5b2828aa70</example>
@@ -742,7 +742,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:wildfly:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^05664fb0c7afcd6436179437e31f3aa6|f45f040baaf5200eb82a54296e6040cd$">
+  <fingerprint pattern="^(?:05664fb0c7afcd6436179437e31f3aa6|f45f040baaf5200eb82a54296e6040cd)$">
     <description>Apache ActiveMQ</description>
     <example>05664fb0c7afcd6436179437e31f3aa6</example>
     <example>f45f040baaf5200eb82a54296e6040cd</example>
@@ -753,7 +753,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:activemq:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^8bbf74c036031fd834342ca75e9603d8|09353a60731f33fea28b3379407e20a2$">
+  <fingerprint pattern="^(?:8bbf74c036031fd834342ca75e9603d8|09353a60731f33fea28b3379407e20a2)$">
     <description>OpenStack Director</description>
     <example>8bbf74c036031fd834342ca75e9603d8</example>
     <example>09353a60731f33fea28b3379407e20a2</example>
@@ -778,7 +778,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^97c6417ed01bdc0ae3ef32ae4894fd03|e2f298e9811cd34a08bf5bb69e2d1d6a$">
+  <fingerprint pattern="^(?:97c6417ed01bdc0ae3ef32ae4894fd03|e2f298e9811cd34a08bf5bb69e2d1d6a)$">
     <description>Jupyter Products</description>
     <example>97c6417ed01bdc0ae3ef32ae4894fd03</example>
     <example>e2f298e9811cd34a08bf5bb69e2d1d6a</example>
@@ -802,7 +802,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^0000eeec59841e6e63dd9f90424cac75|34f1c18ed89e1b514473434351edc181|b4d64bf2e42da188164d2a43cc71b5fb$">
+  <fingerprint pattern="^(?:0000eeec59841e6e63dd9f90424cac75|34f1c18ed89e1b514473434351edc181|b4d64bf2e42da188164d2a43cc71b5fb)$">
     <description>Tenable Nessus</description>
     <example>0000eeec59841e6e63dd9f90424cac75</example>
     <example>34f1c18ed89e1b514473434351edc181</example>
@@ -821,7 +821,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^78ee71862e89db1b1870197b40d026e5|799f70b71314a7508326d1d2f68f7519$">
+  <fingerprint pattern="^(?:78ee71862e89db1b1870197b40d026e5|799f70b71314a7508326d1d2f68f7519)$">
     <description>Red Hat JBoss AS</description>
     <example>78ee71862e89db1b1870197b40d026e5</example>
     <example>799f70b71314a7508326d1d2f68f7519</example>
@@ -848,7 +848,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:redhat:jboss_enterprise_application_platform:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^b4e4785d5852c563b9ae47cbb7af06fe|fa0d535bff80ca916d7d7a782a6b8dc0$">
+  <fingerprint pattern="^(?:b4e4785d5852c563b9ae47cbb7af06fe|fa0d535bff80ca916d7d7a782a6b8dc0)$">
     <description>SonarQube</description>
     <example>b4e4785d5852c563b9ae47cbb7af06fe</example>
     <example>fa0d535bff80ca916d7d7a782a6b8dc0</example>
@@ -992,7 +992,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^afbc222b5f04fce3ec3e381d87ebfc55|7a7cf293daa5b528bd49941630684c00$">
+  <fingerprint pattern="^(?:afbc222b5f04fce3ec3e381d87ebfc55|7a7cf293daa5b528bd49941630684c00)$">
     <description>Seagate Storage</description>
     <example>afbc222b5f04fce3ec3e381d87ebfc55</example>
     <example>7a7cf293daa5b528bd49941630684c00</example>
@@ -1048,7 +1048,7 @@
     <param pos="0" name="hw.cpe23" value="cpe:/h:ui:edgeswitch:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^7da8813873190b6e3d7d8957d798bd1e|31ccf4e22ba33dbec54cc357a43a36d3$">
+  <fingerprint pattern="^(?:7da8813873190b6e3d7d8957d798bd1e|31ccf4e22ba33dbec54cc357a43a36d3)$">
     <description>OpenMediaVault</description>
     <example>7da8813873190b6e3d7d8957d798bd1e</example>
     <example>31ccf4e22ba33dbec54cc357a43a36d3</example>
@@ -1216,7 +1216,7 @@
     <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^af13b379bdb4ae7a5e68d9aa4419b2e4|cd844ad9671131f5464458a2ef58b7bc|c32e2dc4d7caedd5cefc9d44cc4f62ec$">
+  <fingerprint pattern="^(?:af13b379bdb4ae7a5e68d9aa4419b2e4|cd844ad9671131f5464458a2ef58b7bc|c32e2dc4d7caedd5cefc9d44cc4f62ec)$">
     <description>Cisco APIC</description>
     <example>af13b379bdb4ae7a5e68d9aa4419b2e4</example>
     <example>cd844ad9671131f5464458a2ef58b7bc</example>
@@ -1293,7 +1293,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^c60ea375c39d1ab273c4d1bee717287a|9052ab290483b0bd75c05b857c182bba|3acbef1d83ac34f19a2631d6c1a4ac57$">
+  <fingerprint pattern="^(?:c60ea375c39d1ab273c4d1bee717287a|9052ab290483b0bd75c05b857c182bba|3acbef1d83ac34f19a2631d6c1a4ac57)$">
     <description>Synology DSM</description>
     <example>c60ea375c39d1ab273c4d1bee717287a</example>
     <example>9052ab290483b0bd75c05b857c182bba</example>
@@ -1329,7 +1329,7 @@
     <param pos="0" name="hw.vendor" value="APC"/>
   </fingerprint>
 
-  <fingerprint pattern="^ddc75b0899dbf4f7b15290a77fbeb8ff|7f027d6d3eb672117ba63f246bc10f62|4aef220ab05308e3a3e8e4bec5984b2b$">
+  <fingerprint pattern="^(?:ddc75b0899dbf4f7b15290a77fbeb8ff|7f027d6d3eb672117ba63f246bc10f62|4aef220ab05308e3a3e8e4bec5984b2b)$">
     <description>RabbitMQ</description>
     <example>ddc75b0899dbf4f7b15290a77fbeb8ff</example>
     <example>7f027d6d3eb672117ba63f246bc10f62</example>
@@ -1339,7 +1339,7 @@
     <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^5567e9ce23e5549e0fcd7195f3882816|57f187c7a868faeac558007a8eb6cb2e$">
+  <fingerprint pattern="^(?:5567e9ce23e5549e0fcd7195f3882816|57f187c7a868faeac558007a8eb6cb2e)$">
     <description>pfSense Firewall</description>
     <example>5567e9ce23e5549e0fcd7195f3882816</example>
     <example>57f187c7a868faeac558007a8eb6cb2e</example>
@@ -1364,7 +1364,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^3d79fa32f03540637418f85d19c3ed60|76c6e492cb8cc73a2a50d62176f205c9$">
+  <fingerprint pattern="^(?:3d79fa32f03540637418f85d19c3ed60|76c6e492cb8cc73a2a50d62176f205c9)$">
     <description>HP Printer</description>
     <example>3d79fa32f03540637418f85d19c3ed60</example>
     <example>76c6e492cb8cc73a2a50d62176f205c9</example>
@@ -1421,7 +1421,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:citrix:netscaler:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^953e0d0190e50d247f4ece5620569ef1|52794c5e8a69a8b03ba891e24c39da65$">
+  <fingerprint pattern="^(?:953e0d0190e50d247f4ece5620569ef1|52794c5e8a69a8b03ba891e24c39da65)$">
     <description>Citrix NetScaler SDX Gateway</description>
     <example>953e0d0190e50d247f4ece5620569ef1</example>
     <example>52794c5e8a69a8b03ba891e24c39da65</example>
@@ -1438,7 +1438,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:citrix:netscaler:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^35c390dade9419b4d6e9b83a8fc361c7|3a7de0a4ee1ee78de3f06bfce823dc44$">
+  <fingerprint pattern="^(?:35c390dade9419b4d6e9b83a8fc361c7|3a7de0a4ee1ee78de3f06bfce823dc44)$">
     <description>Crestron Video Conferencing</description>
     <example>35c390dade9419b4d6e9b83a8fc361c7</example>
     <example>3a7de0a4ee1ee78de3f06bfce823dc44</example>
@@ -1451,7 +1451,7 @@
     <param pos="0" name="os.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^89b932fcc47cf4ca3faadb0cfdef89cf|efca7d9aeaad122133c65cdf628ac574$">
+  <fingerprint pattern="^(?:89b932fcc47cf4ca3faadb0cfdef89cf|efca7d9aeaad122133c65cdf628ac574)$">
     <description>Hikvision DVR</description>
     <example>89b932fcc47cf4ca3faadb0cfdef89cf</example>
     <example>efca7d9aeaad122133c65cdf628ac574</example>
@@ -1559,7 +1559,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^9c845f917bb1720d80df603f26878d42|9baf402c0fccb225c134eb9bdf9678c7|5e760a3842c5c2a0278545c2ad5d88b0|bf5c71bad91e3bb1fb0029ff1bf6ea06$">
+  <fingerprint pattern="^(?:9c845f917bb1720d80df603f26878d42|9baf402c0fccb225c134eb9bdf9678c7|5e760a3842c5c2a0278545c2ad5d88b0|bf5c71bad91e3bb1fb0029ff1bf6ea06)$">
     <description>Mersive SolsticePod</description>
     <example>9c845f917bb1720d80df603f26878d42</example>
     <example>9baf402c0fccb225c134eb9bdf9678c7</example>
@@ -1571,7 +1571,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^6dcab71e60f0242907940f0fcda69ea5|255b6fcbcb463e11ed763b2b892a2965$">
+  <fingerprint pattern="^(?:6dcab71e60f0242907940f0fcda69ea5|255b6fcbcb463e11ed763b2b892a2965)$">
     <description>Ubiquiti WAP (Vague)</description>
     <example>6dcab71e60f0242907940f0fcda69ea5</example>
     <example>255b6fcbcb463e11ed763b2b892a2965</example>
@@ -1608,7 +1608,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:hp:integrated_lights-out_3_firmware:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^ad93b3973782b03ea62a43bd6602ba8b|d521487f45fa7657450edfd6c16e4a63$">
+  <fingerprint pattern="^(?:ad93b3973782b03ea62a43bd6602ba8b|d521487f45fa7657450edfd6c16e4a63)$">
     <description>HP Integrated Lights-Out</description>
     <example>ad93b3973782b03ea62a43bd6602ba8b</example>
     <example>d521487f45fa7657450edfd6c16e4a63</example>
@@ -1633,7 +1633,7 @@
     <param pos="0" name="hw.product" value="GigaVUE"/>
   </fingerprint>
 
-  <fingerprint pattern="^04d9541338e525258daf47cc844d59f3|486373b021971d0a95af04c811799e21$">
+  <fingerprint pattern="^(?:04d9541338e525258daf47cc844d59f3|486373b021971d0a95af04c811799e21)$">
     <description>F5 BIG-IP Load Balancer</description>
     <example>04d9541338e525258daf47cc844d59f3</example>
     <example>486373b021971d0a95af04c811799e21</example>
@@ -1657,7 +1657,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^df56ab6e924269e77945a0299716e679|faeab99d83cdd05b875382a690bc60f3$">
+  <fingerprint pattern="^(?:df56ab6e924269e77945a0299716e679|faeab99d83cdd05b875382a690bc60f3)$">
     <description>S2 Access Control Appliances</description>
     <example>df56ab6e924269e77945a0299716e679</example>
     <example>faeab99d83cdd05b875382a690bc60f3</example>
@@ -1729,7 +1729,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^1437920c973b2b7c03d075028440a656|9422fe1eb162eb5329788a6cb6d408cb$">
+  <fingerprint pattern="^(?:1437920c973b2b7c03d075028440a656|9422fe1eb162eb5329788a6cb6d408cb)$">
     <description>BrightSign Digital Signage Player</description>
     <example>1437920c973b2b7c03d075028440a656</example>
     <example>9422fe1eb162eb5329788a6cb6d408cb</example>
@@ -1787,7 +1787,7 @@
     <param pos="0" name="os.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^ed61e4c9e9a176e82734aa42c6a00ce4|0dc6bff9bdabf1184c157d75ac73c22a$">
+  <fingerprint pattern="^(?:ed61e4c9e9a176e82734aa42c6a00ce4|0dc6bff9bdabf1184c157d75ac73c22a)$">
     <description>Lifesize TelePresence</description>
     <example>ed61e4c9e9a176e82734aa42c6a00ce4</example>
     <example>0dc6bff9bdabf1184c157d75ac73c22a</example>
@@ -1808,7 +1808,7 @@
     <param pos="0" name="hw.product" value="Key Management Server"/>
   </fingerprint>
 
-  <fingerprint pattern="^302fe34dc0e9515e2d0509ff5f3217e5|8565497731f799fdd25ae59286807055$">
+  <fingerprint pattern="^(?:302fe34dc0e9515e2d0509ff5f3217e5|8565497731f799fdd25ae59286807055)$">
     <description>Riverbed Steelhead Appliance</description>
     <example>302fe34dc0e9515e2d0509ff5f3217e5</example>
     <example>8565497731f799fdd25ae59286807055</example>
@@ -1882,7 +1882,7 @@
     <param pos="0" name="hw.cpe23" value="cpe:/h:swhouse:istar_ultra:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^fc83221e4a9e57f2e0b10416de541ca3|e518c347f94a594de49e3f3948b8e6e5$">
+  <fingerprint pattern="^(?:fc83221e4a9e57f2e0b10416de541ca3|e518c347f94a594de49e3f3948b8e6e5)$">
     <description>SpotterRF</description>
     <example>fc83221e4a9e57f2e0b10416de541ca3</example>
     <example>e518c347f94a594de49e3f3948b8e6e5</example>
@@ -1944,7 +1944,7 @@
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 
-  <fingerprint pattern="^908db8e56aeee8bb7a911b5df4eaf90e|02f4db63a9cfb650c05ffd82956cbfd6$">
+  <fingerprint pattern="^(?:908db8e56aeee8bb7a911b5df4eaf90e|02f4db63a9cfb650c05ffd82956cbfd6)$">
     <description>Proxmox</description>
     <example>908db8e56aeee8bb7a911b5df4eaf90e</example>
     <example>02f4db63a9cfb650c05ffd82956cbfd6</example>
@@ -2088,7 +2088,7 @@
     <param pos="0" name="hw.device" value="Power Device"/>
   </fingerprint>
 
-  <fingerprint pattern="^e174f317b4491295c63e5bc9d9b6115b|cd2461f62d76fbbc905fa15160c0788f|37fdaeebc861719280205e7107b78d52$">
+  <fingerprint pattern="^(?:e174f317b4491295c63e5bc9d9b6115b|cd2461f62d76fbbc905fa15160c0788f|37fdaeebc861719280205e7107b78d52)$">
     <description>dotCMS Content Management Platform</description>
     <example>e174f317b4491295c63e5bc9d9b6115b</example>
     <example>cd2461f62d76fbbc905fa15160c0788f</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -333,7 +333,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^NETIASPOT Management Console|Konsola zarzdzania NETIASPOT$">
+  <fingerprint pattern="^(?:NETIASPOT Management Console|Konsola zarzdzania NETIASPOT)$">
     <description>Netia Spot wireless router</description>
     <example>Konsola zarzdzania NETIASPOT</example>
     <example>NETIASPOT Management Console</example>
@@ -576,7 +576,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:ui:unifi_video:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^UniFi NVR: Software Portal|airVision: \[NVR\] - Software Portal$">
+  <fingerprint pattern="^(?:UniFi NVR: Software Portal|airVision: \[NVR\] - Software Portal)$">
     <description>UniFi NVR for recording from UniFi video cameras</description>
     <example>UniFi NVR: Software Portal</example>
     <example>airVision: [NVR] - Software Portal</example>
@@ -682,7 +682,7 @@
     <param pos="0" name="hw.device" value="Switch"/>
   </fingerprint>
 
-  <fingerprint pattern="^Welcome to nginx!|Test Page for the Nginx HTTP Server$">
+  <fingerprint pattern="^(?:Welcome to nginx!|Test Page for the Nginx HTTP Server)$">
     <description>Default OS-agnostic nginx</description>
     <example>Welcome to nginx!</example>
     <example>Test Page for the Nginx HTTP Server</example>
@@ -2387,7 +2387,7 @@
     <param pos="0" name="hw.product" value="Network Node"/>
   </fingerprint>
 
-  <fingerprint pattern="^S2 Netbox Login|Home - NetBox$">
+  <fingerprint pattern="^(?:S2 Netbox Login|Home - NetBox)$">
     <description>S2 Netbox Appliance</description>
     <example>S2 Netbox Login</example>
     <example>Home - NetBox</example>
@@ -2439,7 +2439,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:ibm:tivoli_storage_flashcopy_manager:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Jupyter Notebook|JupyterLab|Home Page - Select or create a notebook$">
+  <fingerprint pattern="^(?:Jupyter Notebook|JupyterLab|Home Page - Select or create a notebook)$">
     <description>Jupyter Notebook Server</description>
     <example>Jupyter Notebook</example>
     <example>JupyterLab</example>
@@ -2500,7 +2500,7 @@
     <param pos="0" name="service.product" value="Network Monitor"/>
   </fingerprint>
 
-  <fingerprint pattern="^BrightSign&amp;reg;|BrightSign Applications|Diagnostics Web Server$">
+  <fingerprint pattern="^(?:BrightSign&amp;reg;|BrightSign Applications|Diagnostics Web Server)$">
     <description>BrightSign Controller</description>
     <example>BrightSign&amp;reg;</example>
     <example>BrightSign Applications</example>
@@ -2521,7 +2521,7 @@
     <param pos="0" name="hw.device" value="WAP"/>
   </fingerprint>
 
-  <fingerprint pattern="^DD System Manager|System Manager$">
+  <fingerprint pattern="^(?:DD System Manager|System Manager)$">
     <description>Data Domain System Manager</description>
     <example>DD System Manager</example>
     <example>System Manager</example>
@@ -2574,7 +2574,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:influxdata:influxdb:2.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^Sign in . GitLab|GitLab|GitLab is not responding$">
+  <fingerprint pattern="^(?:Sign in . GitLab|GitLab|GitLab is not responding)$">
     <description>GitLab</description>
     <example>Sign in · GitLab</example>
     <example>GitLab is not responding</example>
@@ -2585,7 +2585,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:gitlab:gitlab:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^GitHub Enterprise|Setup GitHub Enterprise|GitHub Enterprise preflight check$">
+  <fingerprint pattern="^(?:GitHub Enterprise|Setup GitHub Enterprise|GitHub Enterprise preflight check)$">
     <description>GitHub Enterprise</description>
     <example>GitHub Enterprise</example>
     <example>Setup GitHub Enterprise</example>
@@ -2594,7 +2594,7 @@
     <param pos="0" name="service.product" value="Enterprise"/>
   </fingerprint>
 
-  <fingerprint pattern="^SAP NetWeaver Application Server Java|SAP&amp;#x20;NetWeaver&amp;#x20;Portal|Loading Portal\.\.\.$">
+  <fingerprint pattern="^(?:SAP NetWeaver Application Server Java|SAP&amp;#x20;NetWeaver&amp;#x20;Portal|Loading Portal\.\.\.)$">
     <description>SAP NetWeaver Portal</description>
     <example>SAP NetWeaver Application Server Java</example>
     <example>SAP&amp;#x20;NetWeaver&amp;#x20;Portal</example>
@@ -2613,7 +2613,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:lansweeper:lansweeper:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Celery Flower|Flower$">
+  <fingerprint pattern="^(?:Celery Flower|Flower)$">
     <description>Celery Flower Dashboard</description>
     <example>Celery Flower</example>
     <example>Flower</example>
@@ -2753,7 +2753,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:flink:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Twonky|Twonky Server|TwonkyMedia|TwonkyMedia server media browser$">
+  <fingerprint pattern="^(?:Twonky|Twonky Server|TwonkyMedia|TwonkyMedia server media browser)$">
     <description>Twonky Server</description>
     <example>Twonky</example>
     <example>Twonky Server</example>
@@ -2798,7 +2798,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:sabnzbd:sabnzbd:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Zabbix|.*: Zabbix$">
+  <fingerprint pattern="^(?:Zabbix|.*: Zabbix)$">
     <description>Zabbix</description>
     <example>Zabbix</example>
     <example>appliance: Zabbix</example>
@@ -2820,7 +2820,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:dd-wrt:dd-wrt:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^Apache Druid|Druid Console|Legacy Coordinator Console$">
+  <fingerprint pattern="^(?:Apache Druid|Druid Console|Legacy Coordinator Console)$">
     <description>Apache Druid</description>
     <example>Apache Druid</example>
     <example>Legacy Coordinator Console</example>
@@ -3030,7 +3030,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:solarwinds:virtualization_manager:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Gitea: .*|LocalRepo|TurnKey Gitea$">
+  <fingerprint pattern="^(?:Gitea: .*|LocalRepo|TurnKey Gitea)$">
     <description>Gitea</description>
     <example>Gitea: Git with a cup of tea</example>
     <example>TurnKey Gitea</example>
@@ -3118,7 +3118,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:rstudio:connect:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^TurnKey Moodle|New Site$">
+  <fingerprint pattern="^(?:TurnKey Moodle|New Site)$">
     <description>Moodle</description>
     <example>TurnKey Moodle</example>
     <example>New Site</example>
@@ -3157,7 +3157,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:atlassian:jira:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Welcome to XAMPP|XAMPP for Linux">
+  <fingerprint pattern="^(?:Welcome to XAMPP|XAMPP for Linux)">
     <description>XAMPP Server</description>
     <example>Welcome to XAMPP</example>
     <example>XAMPP for Linux</example>
@@ -3182,7 +3182,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:kodi:kodi:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Drupal|TurnKey Drupal\d+|Select an installation profile$">
+  <fingerprint pattern="^(?:Drupal|TurnKey Drupal\d+|Select an installation profile)$">
     <description>Drupal CMS</description>
     <example>Drupal</example>
     <example>TurnKey Drupal8</example>
@@ -3859,7 +3859,7 @@
     <param pos="0" name="hw.family" value="Vigor"/>
   </fingerprint>
 
-  <fingerprint pattern="^WSO2 API Manager|\[Publisher Portal\]WSO2 APIM$">
+  <fingerprint pattern="^(?:WSO2 API Manager|\[Publisher Portal\]WSO2 APIM)$">
     <description>WSO2 API Manager</description>
     <example>WSO2 API Manager</example>
     <example>[Publisher Portal]WSO2 APIM</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1256,7 +1256,7 @@
     <param pos="1" name="apache.variant.version"/>
   </fingerprint>
 
-  <fingerprint pattern="(?i)^IBM_HTTP_SERVER|IBM-HTTP-SERVER$">
+  <fingerprint pattern="(?i)^(?:IBM_HTTP_SERVER|IBM-HTTP-SERVER)$">
     <description>IBM HTTP Server with no version info</description>
     <example>IBM_HTTP_SERVER</example>
     <example>IBM_HTTP_Server</example>
@@ -2018,7 +2018,7 @@
     <param pos="0" name="os.product" value="Appliance"/>
   </fingerprint>
 
-  <fingerprint pattern="^BigIP|BIG-IP$">
+  <fingerprint pattern="^(?:BigIP|BIG-IP)$">
     <description>F5 BIG-IP</description>
     <param pos="0" name="service.vendor" value="F5"/>
     <param pos="0" name="service.product" value="BIG-IP LTM"/>
@@ -3264,7 +3264,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:intel:active_management_technology:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^AMT|Intel\(R\) Active Management Technology$">
+  <fingerprint pattern="^(?:AMT|Intel\(R\) Active Management Technology)$">
     <description>Intel(R) Active Management Technology (AMT) without a version</description>
     <example>AMT</example>
     <example>Intel(R) Active Management Technology</example>

--- a/xml/tls_jarm.xml
+++ b/xml/tls_jarm.xml
@@ -4,7 +4,7 @@
     Fingerprint based on https://github.com/salesforce/jarm
   -->
 
-  <fingerprint pattern="^2ad2ad16d2ad2ad00042d42d000000332dc9cd7d90589195193c8bb05d84fa|2ad2ad16d2ad2ad22c2ad2ad2ad2adce2e4c8c53174ecbf5529ce7584d5518$|2ad2ad16d2ad2ad22c42d42d000000d342d5966a57139eeaff9f8bc4841b25$">
+  <fingerprint pattern="^(?:2ad2ad16d2ad2ad00042d42d000000332dc9cd7d90589195193c8bb05d84fa|2ad2ad16d2ad2ad22c2ad2ad2ad2adce2e4c8c53174ecbf5529ce7584d5518|2ad2ad16d2ad2ad22c42d42d000000d342d5966a57139eeaff9f8bc4841b25)$">
     <description>Tor relay</description>
     <example>2ad2ad16d2ad2ad00042d42d000000332dc9cd7d90589195193c8bb05d84fa</example>
     <example>2ad2ad16d2ad2ad22c2ad2ad2ad2adce2e4c8c53174ecbf5529ce7584d5518</example>
@@ -14,7 +14,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:torproject:tor:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^2ad2ad0002ad2ad0002ad2ad2ad2ada9e96d3ba9f7903758a731e0fa01453d|29d29d15d29d29d21c29d29d29d29d10d7a07cb776562eccb97246005feba5|2ad2ad0002ad2ad0002ad2ad2ad2ad5bf44aec534289dfa8e33148b66cd6c3|29d29d15d29d29d21c29d29d29d29de857600fcd9f89735d87c3704c4e141b$">
+  <fingerprint pattern="^(?:2ad2ad0002ad2ad0002ad2ad2ad2ada9e96d3ba9f7903758a731e0fa01453d|29d29d15d29d29d21c29d29d29d29d10d7a07cb776562eccb97246005feba5|2ad2ad0002ad2ad0002ad2ad2ad2ad5bf44aec534289dfa8e33148b66cd6c3|29d29d15d29d29d21c29d29d29d29de857600fcd9f89735d87c3704c4e141b)$">
     <description>Synology NAS DSM 6</description>
     <example>29d29d15d29d29d21c29d29d29d29d10d7a07cb776562eccb97246005feba5</example>
     <example>29d29d15d29d29d21c29d29d29d29de857600fcd9f89735d87c3704c4e141b</example>
@@ -29,7 +29,7 @@
     <param pos="0" name="hw.device" value="NAS"/>
   </fingerprint>
 
-  <fingerprint pattern="^00000000000000000042d42d0000009535d5979f591ae8e547c5e5743e5b64|29d29d15d29d29d00042d42d00000068f5dc63852f94da932cd6b61b1cd9e3|29d29d15d29d29d21c42d42d000000bf85d79ff39d9f5079675604a74fc04b|29d29d15d29d29d00042d42d000000038eaaf490bec8dc33757f165ce01762|29d29d15d29d29d21c42d42d000000790cb01ea78cc2a73fe8428d61afc0c8$">
+  <fingerprint pattern="^(?:00000000000000000042d42d0000009535d5979f591ae8e547c5e5743e5b64|29d29d15d29d29d00042d42d00000068f5dc63852f94da932cd6b61b1cd9e3|29d29d15d29d29d21c42d42d000000bf85d79ff39d9f5079675604a74fc04b|29d29d15d29d29d00042d42d000000038eaaf490bec8dc33757f165ce01762|29d29d15d29d29d21c42d42d000000790cb01ea78cc2a73fe8428d61afc0c8)$">
     <description>Synology NAS DSM 7</description>
     <example>00000000000000000042d42d0000009535d5979f591ae8e547c5e5743e5b64</example>
     <example>29d29d15d29d29d00042d42d000000038eaaf490bec8dc33757f165ce01762</example>
@@ -56,7 +56,7 @@
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>
 
-  <fingerprint pattern="^07d14d16d21d21d00042d43d000000aa99ce74e2c6d013c745aa52b5cc042d|07d14d16d21d21d07c42d43d000000f50d155305214cf247147c43c0f1a823|07b08b09b21b21b07b07b08b07b21b23aeefb38b723c523befb314af6e95ac|07c08c09c21c21c07c07c08c07c21c23aeefb38b723c523befb314af6e95ac|07d14d16d21d21d00007d14d07d21d0ae59125bcd90b8876b50928af8f6cd4$">
+  <fingerprint pattern="^(?:07d14d16d21d21d00042d43d000000aa99ce74e2c6d013c745aa52b5cc042d|07d14d16d21d21d07c42d43d000000f50d155305214cf247147c43c0f1a823|07b08b09b21b21b07b07b08b07b21b23aeefb38b723c523befb314af6e95ac|07c08c09c21c21c07c07c08c07c21c23aeefb38b723c523befb314af6e95ac|07d14d16d21d21d00007d14d07d21d0ae59125bcd90b8876b50928af8f6cd4)$">
     <description>Metasploit listener</description>
     <example>07b08b09b21b21b07b07b08b07b21b23aeefb38b723c523befb314af6e95ac</example>
     <example>07c08c09c21c21c07c07c08c07c21c23aeefb38b723c523befb314af6e95ac</example>
@@ -71,7 +71,7 @@
   <!-- This fingerprint matches Java's TLS stack,
     see https://blog.cobaltstrike.com/2020/12/08/a-red-teamer-plays-with-jarm/ for details -->
 
-  <fingerprint pattern="^07d14d16d21d21d07c42d41d00041d24a458a375eef0c576d23a7bab9a9fb1|07d14d16d21d21d00042d41d00041de5fb3038104f457d92ba02e9311512c2$">
+  <fingerprint pattern="^(?:07d14d16d21d21d07c42d41d00041d24a458a375eef0c576d23a7bab9a9fb1|07d14d16d21d21d00042d41d00041de5fb3038104f457d92ba02e9311512c2)$">
     <description>Cobalt Strike listener</description>
     <example>07d14d16d21d21d07c42d41d00041d24a458a375eef0c576d23a7bab9a9fb1</example>
     <example>07d14d16d21d21d00042d41d00041de5fb3038104f457d92ba02e9311512c2</example>
@@ -146,7 +146,7 @@
     <param pos="0" name="hw.cpe23" value="cpe:/h:google:chromecast:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^21d14d00021d21d21c21d14d21d21d3e9a0dda94718e521eb7d1409c9e3601|2ad2ad0002ad2ad0002ad2ad2ad2ad755a2cec4b52fb1bce1ac7f1e48c8a7d$">
+  <fingerprint pattern="^(?:21d14d00021d21d21c21d14d21d21d3e9a0dda94718e521eb7d1409c9e3601|2ad2ad0002ad2ad0002ad2ad2ad2ad755a2cec4b52fb1bce1ac7f1e48c8a7d)$">
     <description>VMware ESXi</description>
     <example>21d14d00021d21d21c21d14d21d21d3e9a0dda94718e521eb7d1409c9e3601</example>
     <example>2ad2ad0002ad2ad0002ad2ad2ad2ad755a2cec4b52fb1bce1ac7f1e48c8a7d</example>


### PR DESCRIPTION
## Description
Restores non-capturing groups removed in #381 to fix issues where the anchors will only apply to the immediate value they are next to rather than the sequence of values in an OR match. The tests on the previous PR passed since the examples do not contain any leading or trailing text. Thanks to @dmoinescu-r7 for drawing attention to the issue.

### Example
* The current regex `^NETIASPOT Management Console|Konsola zarzdzania NETIASPOT$"` matches the following strings:
  ```
  NETIASPOT Management Console
  NETIASPOT Management Consoletest
  NETIASPOT Management Console test
  Konsola zarzdzania NETIASPOT
  testKonsola zarzdzania NETIASPOT
  test Konsola zarzdzania NETIASPOT
  ```
* The corrected regex `^(?:NETIASPOT Management Console|Konsola zarzdzania NETIASPOT)$` only matches the following strings:
  ```
  NETIASPOT Management Console
  Konsola zarzdzania NETIASPOT
  ```


## Motivation and Context
Fix regex issue.


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify FILENAME`
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
