### PR TITLE
Add ManageEngine Access Manager Plus fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -106,6 +106,7 @@ mappings:
     manageengine:
       vendor: zohocorp
       products:
+        access_manager_plus: manageengine_access_manager_plus
         adaudit_plus: manageengine_adaudit_plus
         adselfservice_plus: manageengine_adselfservice_plus
         desktop_central: manageengine_desktop_central

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -18,6 +18,7 @@ ASP.NET
 Abyss Web Server X1
 Abyss Web Server X2
 Access Manager
+Access Manager Plus
 Active Directory Controller
 Active Intelligence Engine
 ActiveMQ

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -264,6 +264,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_password_manager_pro:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^9db18be9073f41227b4fb0c1715ce82d$">
+    <description>ManageEngine Access Manager Plus</description>
+    <example>9db18be9073f41227b4fb0c1715ce82d</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="Access Manager Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_access_manager_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^e9d6d23a961ea23a3e961266876e0ffd$">
     <description>HPE OfficeConnect Switch</description>
     <example>e9d6d23a961ea23a3e961266876e0ffd</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -2050,6 +2050,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_password_manager_pro:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^ManageEngine Access Manager Plus$">
+    <description>ManageEngine Access Manager Plus</description>
+    <example>ManageEngine Access Manager Plus</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="Access Manager Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_access_manager_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(ScanFront \d.+)Web Menu$">
     <!-- no space between the product model and "Web Menu" in the title -->
 


### PR DESCRIPTION
## Description
Adds [ManageEngine Access Manager Plus](https://www.manageengine.com/privileged-session-management/) fingerprints

### Notes
* `/favicon.ico`:
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 6 icons, 256x256 with PNG image data, 256 x 256, 8-bit/color RGBA, non-interlacedPNG image data, 256 x 256, 8-bit/color RGBA, non-interlaced, 32 bits/pixel, -128x-128, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 9db18be9073f41227b4fb0c1715ce82d
```
* The shortcut icon from ManageEngine Password Manager Pro (`<link rel="SHORTCUT ICON" href="/themes/passtrix/V12121/images/ps_ico.ico">`) is identical to the `favicon.ico` from ManageEngine Access Manager Plus.

## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
