### PR TITLE
More fingerprints for the Polycom VVX family

### DIFF
--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -133,9 +133,10 @@
     <param pos="0" name="os.device" value="Printer"/>
   </fingerprint>
 
-  <fingerprint pattern="^Polycom-(VVX\d{3})$">
+  <fingerprint pattern="^(?:Polycom|Poly)-(VVX(?:-[A-Z])?\d{3})$">
     <description>Polycom IP Phone</description>
     <example hw.product="VVX410" hw.model="VVX410">Polycom-VVX410</example>
+    <example hw.product="VVX-D230" hw.model="VVX-D230">Poly-VVX-D230</example>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.family" value="VVX"/>


### PR DESCRIPTION
Poly (formerly Polycom) VVX D230

## Description
Fingerprint `Poly-VVX-D230` observed in DHCP traffic




## How Has This Been Tested?
Added example to exercise the fingerprint.
Ran `recog_verify`, `recog_standardize` and `update_cpes.py`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
