### PR TITLE
DHCP fingerprint for Avaya device

### DIFF
--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -400,4 +400,13 @@
     <param pos="0" name="os.certainty" value="0.1"/>
   </fingerprint>
 
+  <fingerprint pattern="^ccp\.avaya\.com$">
+    <description>Avaya device</description>
+    <example>ccp.avaya.com</example>
+    <param pos="0" name="hw.vendor" value="Avaya"/>
+    <param pos="0" name="hw.certainty" value="0.8"/>
+    <param pos="0" name="os.vendor" value="Avaya"/>
+    <param pos="0" name="os.certainty" value="0.8"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Added DHCP fingerprint for Avaya device


## Motivation and Context
vi_vendor_class string seen in DHCP network traffic: `ccp.avaya.com`

## How Has This Been Tested?
Ran `recog_verify`, `recog_standardize` and `update_cpes.py`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
