### PR TITLE
DHCP fingeprints for devices of unknown type/model

### DIFF
--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -249,6 +249,7 @@ Equivalence (OpenH323)
 Ericsson
 Eudora
 Evolis
+Ewon
 ExtraHop
 Extreme Networks
 Extron
@@ -289,6 +290,7 @@ GFI
 GNU
 GPT Video Systems
 GStreamer
+Gallagher
 GarrettCom
 Gene6
 General Dynamics
@@ -837,6 +839,7 @@ ZMailer
 ZTE
 Zabbix
 Zaphoyd Studios
+Zebra
 ZebraNet
 Zed Shaw
 Zimbra

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -234,6 +234,62 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^AXIS,Network$">
+    <description>Axis Communications device</description>
+    <example>AXIS,Network</example>
+    <param pos="0" name="hw.vendor" value="AXIS"/>
+    <param pos="0" name="os.vendor" value="AXIS"/>
+  </fingerprint>
+
+  <fingerprint pattern="^APC$">
+    <description>APC device</description>
+    <example>APC</example>
+    <param pos="0" name="hw.vendor" value="APC"/>
+    <param pos="0" name="os.vendor" value="APC"/>
+  </fingerprint>
+
+  <fingerprint pattern="^AEROHIVE$">
+    <description>Aerohive (Extreme Networks) device</description>
+    <example>AEROHIVE</example>
+    <param pos="0" name="hw.vendor" value="Aerohive"/>
+    <param pos="0" name="os.vendor" value="Aerohive"/>
+  </fingerprint>
+
+  <fingerprint pattern="^yealink$">
+    <description>Yealink device</description>
+    <example>yealink</example>
+    <param pos="0" name="hw.vendor" value="Yealink"/>
+    <param pos="0" name="os.vendor" value="Yealink"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Gallagher Group Limited$">
+    <description>Gallagher device</description>
+    <example>Gallagher Group Limited</example>
+    <param pos="0" name="hw.vendor" value="Gallagher"/>
+    <param pos="0" name="os.vendor" value="Gallagher"/>
+  </fingerprint>
+
+  <fingerprint pattern="^eWON$">
+    <description>Ewon device</description>
+    <example>eWON</example>
+    <param pos="0" name="hw.vendor" value="Ewon"/>
+    <param pos="0" name="os.vendor" value="Ewon"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ZEBRA$">
+    <description>Zebra device</description>
+    <example>ZEBRA</example>
+    <param pos="0" name="hw.vendor" value="Zebra"/>
+    <param pos="0" name="os.vendor" value="Zebra"/>
+  </fingerprint>
+
+  <fingerprint pattern="^vaddio$">
+    <description>Vaddio (Legrand AV) device</description>
+    <example>vaddio</example>
+    <param pos="0" name="hw.vendor" value="Vaddio"/>
+    <param pos="0" name="os.vendor" value="Vaddio"/>
+  </fingerprint>
+
   <fingerprint pattern="^PCoIP Endpoint$">
     <description>PCoIP Endpoint Device</description>
     <example>PCoIP Endpoint</example>
@@ -293,6 +349,13 @@
     <example>MSFT 5.0</example>
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
+  </fingerprint>
+
+  <fingerprint pattern="^Cisco Systems, Inc\.$">
+    <description>Cisco device</description>
+    <example>Cisco Systems, Inc.</example>
+    <param pos="0" name="hw.vendor" value="Cisco"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
   </fingerprint>
 
   <fingerprint pattern="^(?i)Cisco Systems Inc\. Wireless Phone (\d{4}g?)$" certainty="0.8">


### PR DESCRIPTION
## Description

Devices whose DHCP identifiers mention only the manufacturer (not the type, model etc):
* Axis
* APC
* Aerohive (part of Extreme Networks)
* Yealink
* Gallagher Group
* Ewon
* Zebra
* Vaddio (part of Legrand AV)
* Cisco

## Motivation and Context
Fingerprints from observed DHCP traffic

## How Has This Been Tested?
Ran `recog_verify`, `recog_standardize` and `update_cpes`


## Types of changes
New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
