### PR TITLE
Correct Zebra vendor and minor fingerprint param changes

### DIFF
--- a/identifiers/hw_family.txt
+++ b/identifiers/hw_family.txt
@@ -109,6 +109,7 @@ Xserve
 ZXDSL
 ZXHN
 ZXV
+ZebraNet
 airMAX
 iLO
 iMac

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -369,6 +369,7 @@ Xserve (Late 2006)
 Xserve G4
 Xserve G4 (Slot Load)
 Xserve G5
+ZebraNet PrintServer
 Zone Director
 airCube
 e-STUDIO

--- a/identifiers/os_family.txt
+++ b/identifiers/os_family.txt
@@ -222,6 +222,7 @@ WorkCentre Pro
 XC
 XPort
 XPress
+ZebraNet
 audioOS
 bizhub
 e-STUDIO

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -202,7 +202,6 @@ Prestige 660HW-D1
 Prestige 660ME-61
 Prime Collaboration Manager
 Print Server
-PrintServer
 Printer
 Printer Board
 ProLiant
@@ -337,6 +336,7 @@ X3e 31C-M
 XCC Linux
 XOS
 XenServer
+ZebraNet PrintServer Firmware
 Zentyal
 Zone Director
 ZyNOS firmware

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -840,7 +840,6 @@ ZTE
 Zabbix
 Zaphoyd Studios
 Zebra
-ZebraNet
 Zed Shaw
 Zimbra
 Zyxel

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1277,17 +1277,19 @@ more text</example>
   </fingerprint>
 
   <fingerprint pattern="^(ZBR-\d+) Version (\S+) ready\.?$">
-    <description>ZebraNet Print Server FTP</description>
-    <example os.product="ZBR-46686" os.version="7.02" hw.product="ZBR-46686">ZBR-46686 Version 7.02 ready.</example>
-    <example os.version="V56.17.5Z" os.product="ZBR-79071" hw.product="ZBR-79071">ZBR-79071 Version V56.17.5Z ready.</example>
-    <example os.version="7.02" os.product="ZBR-46687" hw.product="ZBR-46687">ZBR-46687 Version 7.02 ready.</example>
-    <param pos="0" name="os.vendor" value="ZebraNet"/>
-    <param pos="0" name="os.device" value="Print Server"/>
-    <param pos="1" name="os.product"/>
+    <description>Zebra ZebraNet Print Server FTP</description>
+    <example hw.product="ZBR-46686" os.version="7.02">ZBR-46686 Version 7.02 ready.</example>
+    <example hw.product="ZBR-79071" os.version="V56.17.5Z">ZBR-79071 Version V56.17.5Z ready.</example>
+    <example hw.product="ZBR-46687" os.version="7.02">ZBR-46687 Version 7.02 ready.</example>
+    <param pos="0" name="os.vendor" value="Zebra"/>
+    <param pos="0" name="os.family" value="ZebraNet"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
     <param pos="2" name="os.version"/>
-    <param pos="0" name="hw.vendor" value="ZebraNet"/>
-    <param pos="0" name="hw.device" value="Print Server"/>
+    <param pos="0" name="os.device" value="Print Server"/>
+    <param pos="0" name="hw.vendor" value="Zebra"/>
+    <param pos="0" name="hw.family" value="ZebraNet"/>
     <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="Print Server"/>
   </fingerprint>
 
   <fingerprint pattern="^(ET(\S{1,32})) Dell (\S+ Laser Printer) FTP Server">

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -7489,15 +7489,20 @@ Copyright (c) 1995-2005 by Cisco Systems
   </fingerprint>
 
   <!--======================================================================
-                              ZEBRANET
+                              Zebra
    =======================================================================-->
 
   <fingerprint pattern="^ZebraNet PrintServer$">
-    <description>ZebraNet PrintServer</description>
+    <description>Zebra ZebraNet PrintServer</description>
     <example>ZebraNet PrintServer</example>
-    <param pos="0" name="os.vendor" value="ZebraNet"/>
-    <param pos="0" name="os.product" value="PrintServer"/>
+    <param pos="0" name="os.vendor" value="Zebra"/>
+    <param pos="0" name="os.family" value="ZebraNet"/>
+    <param pos="0" name="os.product" value="ZebraNet PrintServer Firmware"/>
     <param pos="0" name="os.device" value="Print Server"/>
+    <param pos="0" name="hw.vendor" value="Zebra"/>
+    <param pos="0" name="hw.family" value="ZebraNet"/>
+    <param pos="0" name="hw.product" value="ZebraNet PrintServer"/>
+    <param pos="0" name="hw.device" value="Print Server"/>
   </fingerprint>
 
   <!--======================================================================


### PR DESCRIPTION
## Description
Fixes #503 by correcting the `ZebraNet` vendor to `Zebra`, and making some minor updates to the param of the two fingerprints. The "Zebra ZebraNet Print Server FTP" fingerprint was modified to build `os.product` using the `hw.product` value rather than simply duplicating the value to reflect existing CPE patterns. However, the the `ZBR-#####` values extracted from the banner appear to be more of a product number rather than the product model / name so it is unlikely this will correctly match CPE strings.

### Notes
* From [ZebraNet II Print Server Firmware – V7.06 (0264A)](https://www.zebra.com/content/dam/zebra_new_ia/en-us/software-printer/firmware/en/release-notes/zebranet-7-06-notes.pdf):
  > Note the Product Number that is listed for that print server. In the example below, the Product Number is 46688. Your print server may report the number 46686 or 46687.

* Investigated a particular device with an FTP banner that included "ZBR-79071 Version V61.17.17Z" and I found the web interface referred to "GK420d", a printer with an internal wired print server.

## Motivation and Context
More accurate fingerprint data.


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/ftp_banners.xml xml/snmp_sysdescr.xml`
* `rake tests`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
