### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'jruby-9.2', 'jruby']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout recog content
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -46,11 +46,11 @@ jobs:
 
     steps:
       - name: Checkout Java implementation
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: rapid7/recog-java
       - name: Checkout recog content
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: recog-content
       - uses: actions/setup-java@v2
@@ -58,7 +58,7 @@ jobs:
           distribution: zulu
           java-version: '17'
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -75,14 +75,14 @@ jobs:
 
     steps:
       - name: Checkout Go implementation
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: runZeroInc/recog-go
       - name: Checkout recog content
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: recog-content
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '^1.17.1'
       - name: Run recog verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,7 +3,7 @@ name: Verify
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'xml/**.xml'
   pull_request:


### PR DESCRIPTION
## Description
Updates the GitHub CI (`.github/workflows/ci.yml`) and Verify (`.github/workflows/verify.yml`) workflow action versions after I observed the following warning when inspecting our action's output.

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

Updates:
* `actions/checkout@v2` to `actions/checkout@v3`
* `actions/cache@v2` to `actions/cache@v3`
* `actions/setup-go@v2` to `actions/setup-go@v3`

## Motivation and Context
Keeping GitHub workflows up-to-date.


## How Has This Been Tested?
Changes confirmed by inspecting the GitHub actions run on this branch and PR.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
