### PR TITLE
Castopod favicon fingerprint

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -74,6 +74,7 @@ CakePHP
 Calibre-Web
 CallPilot
 Carbon
+Castopod
 Celerra
 CentOS Directory Server
 CentOS Web Panel

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -33,6 +33,7 @@ AVTECH
 AXIS
 Aastra
 Accelerated Technology
+Ad Aures
 AdGuard
 Adaptec
 AdminDroid

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2211,4 +2211,11 @@
     <param pos="0" name="service.product" value="CloudPanel"/>
   </fingerprint>
 
+  <fingerprint pattern="^53cbf6dd6891950b338d4764f38655c5$">
+    <description>Castopod - Fediverse-aware podcast server</description>
+    <example>53cbf6dd6891950b338d4764f38655c5</example>
+    <param pos="0" name="service.vendor" value="Ad Aures"/>
+    <param pos="0" name="service.product" value="Castopod"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Add a fingerprint for [Castopod](https://castopod.org/) based entirely on the favicon

## Notes

`<link rel="icon" type="image/x-icon" href="/favicon.ico" />`

This was pulled from the current-latest of Castopod, version 1.0.2.

Alas, there were no interesting cookies or `<title>` tags to sample -- Castopod is built using [CodeIgniter](https://codeigniter.com/) and just uses a `ci_session` session cookie without renaming, and `<title>` tags are entirely custom to the content being hosted.

## Motivation and Context
After Twitter changed ownership October of 2022, [Fediverse](https://fediverse.info/) services kind of exploded all over the internet. It would be nice to track them. I suspect there are a lot of new server operators who are diving into the deep end of self-hosted services.

## How Has This Been Tested?

Collected the MD5 of the favicon, hoping for the best! I need to figure out how to test locally. 

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
