### PR TITLE
Add darkstat fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -613,6 +613,7 @@ bashttpd
 bsnmpd
 cPanel
 cPanel Service Daemon
+darkstat
 djbdns
 dnsd
 dotCMS

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -851,6 +851,7 @@ aCola
 axTLS Project
 cPanel
 cz.nic
+darkstat Project
 dotCMS
 enGenius
 estos

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4028,6 +4028,14 @@
     <param pos="0" name="service.product" value="CloudPanel"/>
   </fingerprint>
 
+  <fingerprint pattern="^Graphs \(darkstat [^)]+\)$">
+    <description>darkstat - network statistics gatherer</description>
+    <example>Graphs (darkstat eth0)</example>
+    <example>Graphs (darkstat lagg0.4091, lagg0.21, lagg0.101, lagg0.102, lagg0.4001, lagg0.4081)</example>
+    <param pos="0" name="service.vendor" value="darkstat Project"/>
+    <param pos="0" name="service.product" value="darkstat"/>
+  </fingerprint>
+
   <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4902,4 +4902,12 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:crowcpp:crow:{service.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="^darkstat/(\d+(?:\.\d+)*)$">
+    <description>darkstat - network statistics gatherer</description>
+    <example service.version="3.0.719">darkstat/3.0.719</example>
+    <param pos="0" name="service.vendor" value="darkstat Project"/>
+    <param pos="0" name="service.product" value="darkstat"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Adds 2 [darkstat](https://unix4lyfe.org/darkstat/) fingerprints. The vendor name was assembled following from a CPE for another project from the same author (`a:darkhttpd_project:darkhttpd`) since no CPE exists for this project.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/html_title.xml xml/http_servers.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
