### PR TITLE
Add darkhttpd HTTP server fingerprint

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -613,6 +613,7 @@ bashttpd
 bsnmpd
 cPanel
 cPanel Service Daemon
+darkhttpd
 darkstat
 djbdns
 dnsd

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -851,6 +851,7 @@ aCola
 axTLS Project
 cPanel
 cz.nic
+darkhttpd Project
 darkstat Project
 dotCMS
 enGenius

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4910,4 +4910,14 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
+  <fingerprint pattern="^darkhttpd/(\d+(?:\.\d+)*)(?:\.from\.git)?$">
+    <description>darkhttpd - web server</description>
+    <example service.version="1.12">darkhttpd/1.12</example>
+    <example service.version="1.13">darkhttpd/1.13.from.git</example>
+    <param pos="0" name="service.vendor" value="darkhttpd Project"/>
+    <param pos="0" name="service.product" value="darkhttpd"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:darkhttpd_project:darkhttpd:{service.version}"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Adds a [darkhttpd](https://unix4lyfe.org/darkhttpd/) HTTP server fingerprint.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/http_servers.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
