### PR TITLE
Add Bitwarden Server fingerprints 

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -480,6 +480,7 @@ Sentinel Keys Server
 Sentinel Protection Server
 Serv-U
 Serv-U FTP Server
+Server
 ShellInABox
 SimpleDB
 SimpleHTTP

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -112,6 +112,7 @@ Bftpd Project
 Bigfoot
 Bird Home Automation
 Bitvise
+Bitwarden
 BlackBox
 Blue Coat
 BlueCat

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -61,9 +61,9 @@ describe Recog::DB do
               end
             end
 
-            it "has parameter values other than General, Server or Unknown, which are not helpful" do
-              if pos == 0 && value =~ /^(?i:general|server|unknown)$/
-                fail "'#{param_name}' has general/server/unknown value '#{value}'"
+            it "has *.device parameter values other than General, Server or Unknown, which are not helpful" do
+              if pos == 0 && param_name =~ /^(?:[^\.]+\.device*)$/ && value =~ /^(?i:general|server|unknown)$/
+                fail "'#{param_name}' has unhelpful value '#{value}'"
               end
             end
 

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2227,4 +2227,14 @@
     <param pos="0" name="service.product" value="Castopod"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:b071172979419bb7d7b0591409b952dd|17a40681aad7097ac6e06002abf2e7ec|2f0df01346ace9afb440288feeb5d974)$">
+    <description>Bitwarden Server</description>
+    <example>b071172979419bb7d7b0591409b952dd</example>
+    <example>17a40681aad7097ac6e06002abf2e7ec</example>
+    <example>2f0df01346ace9afb440288feeb5d974</example>
+    <param pos="0" name="service.vendor" value="Bitwarden"/>
+    <param pos="0" name="service.product" value="Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:bitwarden:server:-"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4036,6 +4036,14 @@
     <param pos="0" name="service.product" value="darkstat"/>
   </fingerprint>
 
+  <fingerprint pattern="^Bitwarden Web Vault$">
+    <description>Bitwarden Server</description>
+    <example>Bitwarden Web Vault</example>
+    <param pos="0" name="service.vendor" value="Bitwarden"/>
+    <param pos="0" name="service.product" value="Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:bitwarden:server:-"/>
+  </fingerprint>
+
   <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">


### PR DESCRIPTION
## Description
Adds two [Bitwarden Server](https://github.com/bitwarden/server) fingerprints. In addition, this modifies the scope of a spec test since it was causing a failure due to the `service.product` parameter value `Server` being considered unhelpful.

### Notes
Fingerprinted Bitwarden Server Version 2022.12.0.

* `<link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png"/>`
```
$ file favicon-32x32.png
favicon-32x32.png: PNG image data, 32 x 32, 8-bit colormap, non-interlaced
$ md5 favicon-32x32.png
MD5 (favicon-32x32.png) = b071172979419bb7d7b0591409b952dd
```
* `<link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png"/>`
```
$ file favicon-16x16.png
favicon-16x16.png: PNG image data, 16 x 16, 8-bit colormap, non-interlaced
$ md5 favicon-16x16.png
MD5 (favicon-16x16.png) = 17a40681aad7097ac6e06002abf2e7ec
```
* `favicon.ico`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 5 icons, 16x16, 32 bits/pixel, 24x24, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 2f0df01346ace9afb440288feeb5d974
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.