### PR TITLE
Add Vaultwarden fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -551,6 +551,7 @@ VRP
 VShell
 Varnish
 Vault
+Vaultwarden
 VcXsrv
 View
 Vignette

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -791,6 +791,7 @@ Valcom
 VanDyke Software
 Vanguard Managed Solutions
 Varnish-cache
+Vaultwarden
 VcXsrv
 Vegastream
 Vermillion

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2237,4 +2237,12 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:bitwarden:server:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:9e8ba456e7e39ea364cc538959813719|86157069c9574d4c75b907e614d6a521)$">
+    <description>Vaultwarden - unofficial Bitwarden compatible server</description>
+    <example>9e8ba456e7e39ea364cc538959813719</example>
+    <example>86157069c9574d4c75b907e614d6a521</example>
+    <param pos="0" name="service.vendor" value="Vaultwarden"/>
+    <param pos="0" name="service.product" value="Vaultwarden"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4044,6 +4044,13 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:bitwarden:server:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^Vaultwarden Web Vault$">
+    <description>Vaultwarden - unofficial Bitwarden compatible server</description>
+    <example>Vaultwarden Web Vault</example>
+    <param pos="0" name="service.vendor" value="Vaultwarden"/>
+    <param pos="0" name="service.product" value="Vaultwarden"/>
+  </fingerprint>
+
   <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">


### PR DESCRIPTION
## Description
Adds two [Vaultwarden](https://github.com/dani-garcia/vaultwarden), unofficial Bitwarden server, fingerprints.

### Notes
Fingerprinted Vaultwarden server Version 2022.12.0.
* `<link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png"/>`
```
$ favicon-32x32.png
favicon-32x32.png: PNG image data, 32 x 32, 8-bit gray+alpha, non-interlaced
$ md5 favicon-32x32.png
MD5 (favicon-32x32.png) = 9e8ba456e7e39ea364cc538959813719
```
* `<link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png"/>`
```
$ file favicon-16x16.png
favicon-16x16.png: PNG image data, 16 x 16, 8-bit gray+alpha, non-interlaced
$ md5 favicon-16x16.png
MD5 (favicon-16x16.png) = 86157069c9574d4c75b907e614d6a521
```
* favicon.ico matches Bitwarden's hash `2f0df01346ace9afb440288feeb5d974` so it was excluded from the fingerprint


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
