### PR TITLE
Add Cacti fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -69,6 +69,7 @@ CODA
 CRM
 CUPS
 CacheServe
+Cacti
 Caddy
 CakePHP
 Calibre-Web

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -135,6 +135,7 @@ CBT
 CDVI
 CSM
 Cabletron
+Cacti
 CaddyServer
 Calibre-Web Project
 Calient

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2220,6 +2220,15 @@
     <param pos="0" name="service.product" value="CloudPanel"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:4f12cccd3c42a4a478f067337fe92794|5af2c34a740cf3d0f509d93bcbb41ef6)$">
+    <description>Cacti - network graphing solution</description>
+    <example>4f12cccd3c42a4a478f067337fe92794</example>
+    <example>5af2c34a740cf3d0f509d93bcbb41ef6</example>
+    <param pos="0" name="service.vendor" value="Cacti"/>
+    <param pos="0" name="service.product" value="Cacti"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cacti:cacti:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^53cbf6dd6891950b338d4764f38655c5$">
     <description>Castopod - Fediverse-aware podcast server</description>
     <example>53cbf6dd6891950b338d4764f38655c5</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4036,6 +4036,14 @@
     <param pos="0" name="service.product" value="darkstat"/>
   </fingerprint>
 
+  <fingerprint pattern="^Login to Cacti$">
+    <description>Cacti - network graphing solution</description>
+    <example>Login to Cacti</example>
+    <param pos="0" name="service.vendor" value="Cacti"/>
+    <param pos="0" name="service.product" value="Cacti"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:cacti:cacti:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^Bitwarden Web Vault$">
     <description>Bitwarden Server</description>
     <example>Bitwarden Web Vault</example>


### PR DESCRIPTION
## Description
Adds two [Cacti](https://www.cacti.net/) fingerprints.

### Notes
Fingerprinted Vaultwarden server Version 2022.12.0.

* `<link href='/cacti/include/themes/modern/images/favicon.ico' rel='shortcut icon'>`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 1 icon, 16x16, 8 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 4f12cccd3c42a4a478f067337fe92794
```
* `<link href='/cacti/include/themes/modern/images/cacti_logo.gif' rel='icon' sizes='96x96'>`
```
$ file cacti_logo.gif
cacti_logo.gif: GIF image data, version 89a, 76 x 121
$ md5 cacti_logo.gif
MD5 (cacti_logo.gif) = 5af2c34a740cf3d0f509d93bcbb41ef6
```
* Note, the file hashes are the same across all of the default themes.

## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
