### PR TITLE
Add Control Web Panel (formerly CentOS Web Panel) fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -30,8 +30,6 @@ mappings:
       vendor: cmu
       products:
         cyrus_imap: cyrus_imap_server
-    centos_webpanel:
-      vendor: centos-webpanel
     check_point:
       vendor: checkpoint
     cherokee_project:
@@ -42,6 +40,10 @@ mappings:
     cloudflare:
       products:
         cloudflare_load_balancer: load_balancing
+    control_web_panel:
+      vendor: control-webpanel
+      products:
+        control_web_panel: webpanel
     cpanel:
       products:
         cpanel_service_daemon: cpanel

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -78,7 +78,6 @@ Carbon
 Castopod
 Celerra
 CentOS Directory Server
-CentOS Web Panel
 Cherokee
 CherryPy
 Chronograf
@@ -102,6 +101,7 @@ ConnectUPS
 Consul
 Content Server
 Control
+Control Web Panel
 CouchDB
 Couchbase Server
 Courier IMAP

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -148,7 +148,6 @@ Caucho
 Celery
 Cellopoint
 CentOS
-CentOS WebPanel
 Ceph
 Cesanta
 Chainpoint
@@ -184,6 +183,7 @@ Conexant
 Congruency, Inc.
 ConnectWise
 Control Solutions
+Control Web Panel
 Couchbase
 Cradlepoint
 Crestron

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2220,6 +2220,16 @@
     <param pos="0" name="service.product" value="CloudPanel"/>
   </fingerprint>
 
+  <fingerprint pattern="^6b774f15b254a3d1548db63b6f411150$">
+    <description>Control Web Panel (CWP) (formerly CentOS Web Panel) - web hosting control panel</description>
+    <example>6b774f15b254a3d1548db63b6f411150</example>
+    <param pos="0" name="service.vendor" value="Control Web Panel"/>
+    <param pos="0" name="service.product" value="Control Web Panel"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:control-webpanel:webpanel:-"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:4f12cccd3c42a4a478f067337fe92794|5af2c34a740cf3d0f509d93bcbb41ef6)$">
     <description>Cacti - network graphing solution</description>
     <example>4f12cccd3c42a4a478f067337fe92794</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4028,6 +4028,17 @@
     <param pos="0" name="service.product" value="CloudPanel"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:Login \| Control WebPanel|CWP \| User)$">
+    <description>Control Web Panel (CWP) (formerly CentOS Web Panel) - web hosting control panel</description>
+    <example>Login | Control WebPanel</example>
+    <example>CWP | User</example>
+    <param pos="0" name="service.vendor" value="Control Web Panel"/>
+    <param pos="0" name="service.product" value="Control Web Panel"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:control-webpanel:webpanel:-"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+  </fingerprint>
+
   <fingerprint pattern="^Graphs \(darkstat [^)]+\)$">
     <description>darkstat - network statistics gatherer</description>
     <example>Graphs (darkstat eth0)</example>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -741,6 +741,16 @@
     <param pos="0" name="service.product" value="CloudPanel"/>
   </fingerprint>
 
+  <fingerprint pattern="^cwpsrv-[0-9a-f]{32}=">
+    <description>Control Web Panel (CWP) (formerly CentOS Web Panel) - web hosting control panel</description>
+    <example>cwpsrv-5df9a64aa14f59216453d6f07164a7f1=aq0jsl5muvuli7cif5p9ut7dtm; path=/</example>
+    <param pos="0" name="service.vendor" value="Control Web Panel"/>
+    <param pos="0" name="service.product" value="Control Web Panel"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:control-webpanel:webpanel:-"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+  </fingerprint>
+
   <fingerprint pattern="^FileRunSID=">
     <description>FileRun - self-hosted Google Drive alternative</description>
     <example>FileRunSID=966e9a0441b5fea1a72af53b1a6adc8f; path=/; HttpOnly</example>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -113,11 +113,11 @@
   -->
 
   <fingerprint pattern="(?i)^cwpsrv$">
-    <description>CentOS Web Panel</description>
+    <description>Control Web Panel (CWP) (formerly CentOS Web Panel) - web hosting control panel web server</description>
     <example>cwpsrv</example>
-    <param pos="0" name="service.vendor" value="CentOS WebPanel"/>
-    <param pos="0" name="service.product" value="CentOS Web Panel"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:centos-webpanel:centos_web_panel:-"/>
+    <param pos="0" name="service.vendor" value="Control Web Panel"/>
+    <param pos="0" name="service.product" value="Control Web Panel"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:control-webpanel:webpanel:-"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
   </fingerprint>


### PR DESCRIPTION
## Description
Adds three new [Control Web Panel](https://control-webpanel.com/) (formerly CentOS Web Panel) fingerprints.

### Notes
Fingerprinted CWP7 version 0.9.8.1148.

* `<link rel="icon" href="design/img/ico/favicon.ico" type="image/png">`
* `<link rel="icon" href="/login/cwp_theme/original/img/ico/favicon.ico" type="image/png">`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 2 icons, 16x16, 32 bits/pixel, 32x32, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 6b774f15b254a3d1548db63b6f411150
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml xml/http_cookies.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
