### PR TITLE
Add Server Technology Sentry Switched device fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -24,6 +24,7 @@ Active Intelligence Engine
 ActiveMQ
 AdGuard Home
 Adminer
+Advanced Web Server
 AirTunes
 Airflow
 Alteon Web Switch

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -675,7 +675,6 @@ SerenityOS
 Serome Technology, Inc.
 Serv-U
 Server Technology
-ServerTech
 Sharp
 ShellInABox
 Shelly

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -674,6 +674,7 @@ Sercomm
 SerenityOS
 Serome Technology, Inc.
 Serv-U
+Server Technology
 ServerTech
 Sharp
 ShellInABox

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1317,11 +1317,13 @@
   </fingerprint>
 
   <fingerprint pattern="^b56508cc967af50baddfd69596901dab$">
-    <description>ServerTech Sentry Switched CDU</description>
+    <description>Server Technology Sentry Switched CDU</description>
     <example>b56508cc967af50baddfd69596901dab</example>
-    <param pos="0" name="hw.vendor" value="ServerTech"/>
-    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="os.vendor" value="Server Technology"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="0" name="hw.vendor" value="Server Technology"/>
     <param pos="0" name="hw.product" value="Sentry Switched CDU"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>
 

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -1794,6 +1794,18 @@ more text</example>
     <param pos="0" name="hw.device" value="Power Device"/>
   </fingerprint>
 
+  <fingerprint pattern="^(Sentry Switched (?:PDU|CDU)) v(\d+(?:\.\d+)*[a-z](?:-[a-z][0-9])*) FTP server ready\.">
+    <description>Server Technology Sentry Switched Device</description>
+    <example hw.product="Sentry Switched PDU" os.product="Sentry Switched PDU Firmware" os.version="8.0w">Sentry Switched PDU v8.0w FTP server ready.</example>
+    <example hw.product="Sentry Switched CDU" os.product="Sentry Switched CDU Firmware" os.version="7.1e-d1">Sentry Switched CDU v7.1e-d1 FTP server ready.</example>
+    <param pos="0" name="os.vendor" value="Server Technology"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="hw.vendor" value="Server Technology"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+  </fingerprint>
+
   <fingerprint pattern="^Printer's ftp server (?:\d+) Please login with USER and PASS\.$">
     <description>Weidmüller Printer</description>
     <example>Printer's ftp server 530 Please login with USER and PASS.</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -921,11 +921,13 @@
   </fingerprint>
 
   <fingerprint pattern="^Sentry Switched CDU$">
-    <description>Sentry Switched CDU</description>
+    <description>Server Technology Sentry Switched CDU</description>
     <example>Sentry Switched CDU</example>
-    <param pos="0" name="hw.vendor" value="ServerTech"/>
-    <param pos="0" name="hw.device" value="Power Device"/>
+    <param pos="0" name="os.vendor" value="Server Technology"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="0" name="hw.vendor" value="Server Technology"/>
     <param pos="0" name="hw.product" value="Sentry Switched CDU"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
   </fingerprint>
 
   <fingerprint pattern="^Emerson Network Power Rack PDU Card$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4920,6 +4920,17 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:darkhttpd_project:darkhttpd:{service.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="^ServerTech-AWS/v(\d+(?:\.\d+)*[a-z](?:-[a-z][0-9])*)$">
+    <description>Server Technology Advanced Web Server (AWS)</description>
+    <example service.version="7.1g-b1">ServerTech-AWS/v7.1g-b1</example>
+    <example service.version="8.0x">ServerTech-AWS/v8.0x</example>
+    <param pos="0" name="service.vendor" value="Server Technology"/>
+    <param pos="0" name="service.product" value="Advanced Web Server"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="os.vendor" value="Server Technology"/>
+    <param pos="0" name="hw.vendor" value="Server Technology"/>
+  </fingerprint>
+
   <!-- ntopng -->
 
   <fingerprint pattern="^ntopng (\d+(?:\.\d+)*) \[(?:FreeBSD |[\w-]+-freebsd)(\d+(?:\.\d+)*)(?:[a-z0-9-])* \[(\w+)\]\[[^\]]*\]\]$">

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -701,6 +701,18 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:amazon:opensearch:-"/>
   </fingerprint>
 
+  <fingerprint pattern="(?i)^Basic realm=&quot;(Sentry Switched (?:CDU|(?:DC )*PDU))&quot;">
+    <description>Server Technology Sentry Switched Device</description>
+    <example hw.product="Sentry Switched CDU" os.product="Sentry Switched CDU Firmware">Basic realm="Sentry Switched CDU"</example>
+    <example hw.product="Sentry Switched PDU" os.product="Sentry Switched PDU Firmware">Basic realm="Sentry Switched PDU"</example>
+    <example hw.product="Sentry Switched DC PDU" os.product="Sentry Switched DC PDU Firmware">Basic realm="Sentry Switched DC PDU"</example>
+    <param pos="0" name="os.vendor" value="Server Technology"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="0" name="hw.vendor" value="Server Technology"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+  </fingerprint>
+
   <!-- a variety of headers we currently just ignore -->
 
   <fingerprint pattern="(?i)^NTLM$">

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6265,6 +6265,22 @@ Copyright (c) 1995-2005 by Cisco Systems
   </fingerprint>
 
   <!--======================================================================
+                               Server Technology
+   =======================================================================-->
+
+  <fingerprint pattern="^(Sentry Switched (?:CDU|(?:DC )*PDU))$">
+    <description>Server Technology Sentry Switched Device</description>
+    <example hw.product="Sentry Switched CDU" os.product="Sentry Switched CDU Firmware">Sentry Switched CDU</example>
+    <example hw.product="Sentry Switched PDU" os.product="Sentry Switched PDU Firmware">Sentry Switched PDU</example>
+    <example hw.product="Sentry Switched DC PDU" os.product="Sentry Switched DC PDU Firmware">Sentry Switched DC PDU</example>
+    <param pos="0" name="os.vendor" value="Server Technology"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
+    <param pos="0" name="hw.vendor" value="Server Technology"/>
+    <param pos="1" name="hw.product"/>
+    <param pos="0" name="hw.device" value="Power Device"/>
+  </fingerprint>
+
+  <!--======================================================================
                               SonicWall
    =======================================================================-->
 


### PR DESCRIPTION
## Description
Adds four new [Server Technology](https://www.servertech.com/) Sentry Switched device fingerprints, and updates two existing fingerprints. This PR closes #521.

### Notes
From [Sentry Smart CDU Firmware Revision History](https://cdn10.servertech.com/assets/documents/documents/776/original/smcdu-history.txt):
```
12-03-30	7.0a	smcdu-v70a.bin	First production release
...
	Changed the FTP server 220 response code (service ready) login banner
		to "220 Sentry Smart CDU <version> FTP server ready.", where
		<version> is currently "v7.0a".

	Changed the web server identification in HTTP response headers to
		"ServerTech-AWS/<version>", where <version> is currently
		"v7.0a".  "AWS" is short for Advanced Web Server.
```

## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/ftp_banners.xml xml/html_title.xml xml/http_servers.xml xml/http_wwwauth.xml xml/snmp_sysdescr.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
