### PR TITLE
Add ManageEngine ServiceDesk Plus MSP HTML title fingerprint

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -112,6 +112,7 @@ mappings:
         desktop_central: manageengine_desktop_central
         opmanager: manageengine_opmanager
         pam360: manageengine_pam360
+        servicedesk_plus_msp: manageengine_servicedesk_plus_msp
     microsoft:
       products:
         active_directory_controller: active_directory

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -484,6 +484,7 @@ Sentinel Protection Server
 Serv-U
 Serv-U FTP Server
 Server
+ServiceDesk Plus MSP
 ShellInABox
 SimpleDB
 SimpleHTTP

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -2068,6 +2068,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_servicedesk_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^ManageEngine ServiceDesk Plus - MSP$">
+    <description>ManageEngine ServiceDesk Plus MSP</description>
+    <example>ManageEngine ServiceDesk Plus - MSP</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="ServiceDesk Plus MSP"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_servicedesk_plus_msp:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(ScanFront \d.+)Web Menu$">
     <!-- no space between the product model and "Web Menu" in the title -->
 


### PR DESCRIPTION
## Description
Adds one [ManageEngine ServiceDesk Plus MSP](https://www.manageengine.com/products/service-desk-msp/) HTML title fingerprint.

### Notes
Fingerprinted ServiceDesk Plus MSP 13.0 Build 13002.
* `<link rel="SHORTCUT ICON" href="/images/favicon.ico?13002"/>`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 3 icons, 48x48, 32 bits/pixel, 32x32, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 3691a7e782c685b44023c9c4e3f3a31c
```
No fingerprint was created for the favicon.ico at this time since it appeared to match some other products.

## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
