### PR TITLE
Add ManageEngine Active Directory 360 (AD360) HTTP cookie fingerprint

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -107,6 +107,7 @@ mappings:
       vendor: zohocorp
       products:
         access_manager_plus: manageengine_access_manager_plus
+        ad360: manageengine_ad360
         adaudit_plus: manageengine_adaudit_plus
         adselfservice_plus: manageengine_adselfservice_plus
         desktop_central: manageengine_desktop_central

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -5,6 +5,7 @@
 389 Directory Server
 3CX Web Server
 4690 FTP Server
+AD360
 ADAudit Plus
 ADSelfService Plus
 AIOHTTP

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -715,6 +715,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_adselfservice_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^ad360csrf=">
+    <description>ManageEngine Active Directory 360 (AD360)</description>
+    <example>ad360csrf=03c99789-515c-4aa9-8823-7e2e8e8b3026;path=/;SameSite=None;Secure;priority=high</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="AD360"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_ad360:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(dmid|opvc|sitevisitscookie)=">
     <description>dotCMS Content Management Platform</description>
     <example cookie="dmid">dmid=dcd46b93-54ab-4a43-a023-99154f879c3e; Max-Age=153792000; Expires=Thu, 18-Mar-2027 21:28:37 GMT; Path=/; HttpOnly; SameSite=Strict</example>


### PR DESCRIPTION
## Description
Adds one [ManageEngine Active Directory 360 (AD360)](https://www.manageengine.com/active-directory-360/index.html) HTTP cookie fingerprint.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/http_cookies.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
