### PR TITLE
Add ManageEngine ADManager Plus fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -108,6 +108,7 @@ mappings:
       products:
         access_manager_plus: manageengine_access_manager_plus
         adaudit_plus: manageengine_adaudit_plus
+        admanager_plus: manageengine_admanager_plus
         adselfservice_plus: manageengine_adselfservice_plus
         desktop_central: manageengine_desktop_central
         opmanager: manageengine_opmanager

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -6,6 +6,7 @@
 3CX Web Server
 4690 FTP Server
 ADAudit Plus
+ADManager Plus
 ADSelfService Plus
 AIOHTTP
 AOS

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -248,6 +248,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_adaudit_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^6d14f0aa6a61fe4780b94b42eed19e83$">
+    <description>ManageEngine ADManager Plus</description>
+    <example>6d14f0aa6a61fe4780b94b42eed19e83</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="ADManager Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_admanager_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^895eea03838bb521717d632eec739e57$">
     <description>ManageEngine PAM360</description>
     <example>895eea03838bb521717d632eec739e57</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -2036,6 +2036,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_adaudit_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^ManageEngine - ADManager Plus$">
+    <description>ManageEngine ADManager Plus</description>
+    <example>ManageEngine - ADManager Plus</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="ADManager Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_admanager_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^ManageEngine PAM360$">
     <description>ManageEngine PAM360</description>
     <example>ManageEngine PAM360</example>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -707,6 +707,16 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:mongo-express_project:mongo-express:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^(JSESSIONIDADMP|admpcsrf)=">
+    <description>ManageEngine ADManager Plus</description>
+    <example cookie="JSESSIONIDADMP">JSESSIONIDADMP=3A92A25349FECF56B7D7D6FF915545B5; Path=/; HttpOnly</example>
+    <example cookie="admpcsrf">admpcsrf=f5fe4a87-0365-4d04-a8e2-87b3c640092e;path=/;priority=high</example>
+    <param pos="1" name="cookie"/>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="ADManager Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_admanager_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^adscsrf=">
     <description>ManageEngine ADSelfService Plus</description>
     <example>adscsrf=cffff6b5-bd68-4c35-92ef-e45127e68289;path=/;priority=high</example>


### PR DESCRIPTION
## Description
Adds three [ManageEngine ADManager Plus](https://www.manageengine.com/products/ad-manager/) fingerprints.

### Notes
Fingerprinted ADManager Plus version 7.1.0 build 7180.
* `<link rel="icon" type="image/x-icon" href="images/favicon.ico"/>`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 1 icon, 16x16, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 6d14f0aa6a61fe4780b94b42eed19e83
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml xml/http_cookies.xml`
* `rake tests`



## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
