### PR TITLE
Add another ManageEngine ADSelfService Plus cookie fingerprint

### DIFF
--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -727,9 +727,11 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_adaudit_plus:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^adscsrf=">
+  <fingerprint pattern="^(JSESSIONIDADSSP|adscsrf)=">
     <description>ManageEngine ADSelfService Plus</description>
-    <example>adscsrf=cffff6b5-bd68-4c35-92ef-e45127e68289;path=/;priority=high</example>
+    <example cookie="JSESSIONIDADSSP">JSESSIONIDADSSP=A7FECBD71C67184E929AF80715C29C20; Path=/; Secure; HttpOnly</example>
+    <example cookie="adscsrf">adscsrf=cffff6b5-bd68-4c35-92ef-e45127e68289;path=/;priority=high</example>
+    <param pos="1" name="cookie"/>
     <param pos="0" name="service.vendor" value="ManageEngine"/>
     <param pos="0" name="service.product" value="ADSelfService Plus"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_adselfservice_plus:-"/>


### PR DESCRIPTION
## Description
Adds another [ManageEngine ADSelfService Plus](https://www.manageengine.com/products/self-service-password/) cookie fingerprint.

### Notes
Fingerprinted ADSelfService Plus version 6.2 build 6215.


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/http_cookies.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
