### PR TITLE
Add Cambium Wireless Access Point to dhcp_vendor_class

### DIFF
--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -879,4 +879,12 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:mac_os_x:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^Cambium-WiFi-AP$">
+    <description>Cambium Wireless Access Point</description>
+    <example>Cambium-WiFi-AP</example>
+    <param pos="0" name="hw.vendor" value="Cambium Networks"/>
+    <param pos="0" name="hw.device" value="WAP"/>
+    <param pos="0" name="os.vendor" value="Cambium Networks"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Add Cambium Wireless Access Point to dhcp_vendor_class

### Notes


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `./bin/recog_verify xml/dhcp_vendor_class.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.