### PR TITLE
Add ManageEngine Analytics Plus fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -113,6 +113,7 @@ mappings:
         adaudit_plus: manageengine_adaudit_plus
         admanager_plus: manageengine_admanager_plus
         adselfservice_plus: manageengine_adselfservice_plus
+        analytics_plus: manageengine_analytics_plus
         desktop_central: manageengine_desktop_central
         opmanager: manageengine_opmanager
         pam360: manageengine_pam360

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -30,6 +30,7 @@ Advanced Web Server
 AirTunes
 Airflow
 Alteon Web Switch
+Analytics Plus
 Android Debug Database
 AnswerX
 Antivirus for Gateways

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -258,6 +258,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_admanager_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^1b476eae7d17844198fa494251ba910a$">
+    <description>ManageEngine Analytics Plus</description>
+    <example>1b476eae7d17844198fa494251ba910a</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="Analytics Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_analytics_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^895eea03838bb521717d632eec739e57$">
     <description>ManageEngine PAM360</description>
     <example>895eea03838bb521717d632eec739e57</example>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -743,6 +743,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_ad360:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^ZROPJSESSIONID=">
+    <description>ManageEngine Analytics Plus</description>
+    <example>ZROPJSESSIONID=FECE4724AC1990DBCC45DD3DA6CB3002; Path=/; Secure; HttpOnly</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="Analytics Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_analytics_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(dmid|opvc|sitevisitscookie)=">
     <description>dotCMS Content Management Platform</description>
     <example cookie="dmid">dmid=dcd46b93-54ab-4a43-a023-99154f879c3e; Max-Age=153792000; Expires=Thu, 18-Mar-2027 21:28:37 GMT; Path=/; HttpOnly; SameSite=Strict</example>


### PR DESCRIPTION
## Description
Adds 2 [ManageEngine Analytics Plus](https://www.manageengine.com/analytics-plus/) fingerprints.

### Notes
Fingerprinted Analytics Plus version 5.1.2, build number 5121.

* `favicon.ico`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 3 icons, 48x48, 32 bits/pixel, 32x32, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 1b476eae7d17844198fa494251ba910a
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/http_cookies.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
