### PR TITLE
Add ManageEngine AssetExplorer fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -114,6 +114,7 @@ mappings:
         admanager_plus: manageengine_admanager_plus
         adselfservice_plus: manageengine_adselfservice_plus
         analytics_plus: manageengine_analytics_plus
+        assetexplorer: manageengine_assetexplorer
         desktop_central: manageengine_desktop_central
         opmanager: manageengine_opmanager
         pam360: manageengine_pam360

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -45,6 +45,7 @@ Appweb
 Arachni
 Artifactory
 Aspen
+AssetExplorer
 Aura Communication Manager
 AuthServ
 Authoritative Server

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -266,6 +266,15 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_analytics_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:a79bce1c22f081b0d1e38b142827a0e8|ae9449edb0067aa8c2c292acbe93da6a)$">
+    <description>ManageEngine AssetExplorer</description>
+    <example>a79bce1c22f081b0d1e38b142827a0e8</example>
+    <example>ae9449edb0067aa8c2c292acbe93da6a</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="AssetExplorer"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_assetexplorer:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^895eea03838bb521717d632eec739e57$">
     <description>ManageEngine PAM360</description>
     <example>895eea03838bb521717d632eec739e57</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -2044,6 +2044,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_admanager_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^ManageEngine AssetExplorer$">
+    <description>ManageEngine AssetExplorer</description>
+    <example>ManageEngine AssetExplorer</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="AssetExplorer"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_assetexplorer:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^ManageEngine PAM360$">
     <description>ManageEngine PAM360</description>
     <example>ManageEngine PAM360</example>


### PR DESCRIPTION
## Description
Adds 2 [ManageEngine AssetExplorer](https://www.manageengine.com/products/asset-explorer/) fingerprints.

### Notes
Fingerprinted AssetExplorer version 6.9, build 6987.

* `<link rel="SHORTCUT ICON" href="images/favicon.ico"/>`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 1 icon, 48x48, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = ae9449edb0067aa8c2c292acbe93da6a
```
* `favicon.ico` (alternative from unknown version)
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 4 icons, 48x48, 32 bits/pixel, 32x32, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = a79bce1c22f081b0d1e38b142827a0e8
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
