### PR TITLE
Add Exchange 2007 POP3 Quit Message banner pattern

### DIFF
--- a/xml/pop_banners.xml
+++ b/xml/pop_banners.xml
@@ -152,6 +152,19 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_server_2003:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^Microsoft Exchange Server 2007 POP3 server signing off\.?$">
+    <description>Microsoft Exchange Server 2007 quit message</description>
+    <example>Microsoft Exchange Server 2007 POP3 server signing off</example>
+    <param pos="0" name="service.vendor" value="Microsoft"/>
+    <param pos="0" name="service.family" value="Exchange Server"/>
+    <param pos="0" name="service.product" value="Exchange 2007 Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:microsoft:exchange_server:-"/>
+    <param pos="0" name="os.vendor" value="Microsoft"/>
+    <param pos="0" name="os.family" value="Windows"/>
+    <param pos="0" name="os.product" value="Windows"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^Microsoft Exchange Server 2007 POP3 service ready\.?$">
     <description>Microsoft Exchange Server 2007</description>
     <example>Microsoft Exchange Server 2007 POP3 service ready</example>


### PR DESCRIPTION
## Description
Add a banner pattern for a quit message for Microsoft Exchange Server 2007


## Motivation and Context
We observed a POP3 quit message exposing the underlying service, in this case Microsoft Exchange Server 2007. A pattern has been added to match against that banner

## How Has This Been Tested?
- rake tests
- bundle exec ./bin/recog_verify xml/pop_banners.xml


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
