### PR TITLE
Add Avaya E129 to dhcp_vendor_class

### DIFF
--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -64,6 +64,7 @@ DocCam
 Document Centre
 Drone Detector
 DuraFon
+E129
 E5810 Gateway Device
 ECOM100
 EDR-G902

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -578,6 +578,15 @@
     <param pos="0" name="os.certainty" value="0.8"/>
   </fingerprint>
 
+  <fingerprint pattern="^Avaya E129 dslforum.org$">
+    <description>Avaya E129 IP Phone</description>
+    <example>Avaya E129 dslforum.org</example>
+    <param pos="0" name="hw.vendor" value="Avaya"/>
+    <param pos="0" name="hw.product" value="E129"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="0" name="os.vendor" value="Avaya"/>
+  </fingerprint>
+
   <fingerprint pattern="^AAPLBSDPC/i386/iMac16,2$">
     <description>iMac (Retina 4K, 21.5-inch, Late 2015)</description>
     <example>AAPLBSDPC/i386/iMac16,2</example>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -585,6 +585,7 @@
     <param pos="0" name="hw.product" value="E129"/>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="os.vendor" value="Avaya"/>
+    <param pos="0" name="os.product" value="{hw.product} Firmware"/>
   </fingerprint>
 
   <fingerprint pattern="^AAPLBSDPC/i386/iMac16,2$">


### PR DESCRIPTION
## Description
Added Avaya E129 IP Phone to dhcp_vendor_class
Added E129 to hw_product.tx


## Motivation and Context
Extend coverage

## How Has This Been Tested?
 ./bin/recog_verify xml/dhcp_vendor_class.xml 
rake tests

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
