### PR TITLE
Add ManageEngine SupportCenter Plus fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -123,6 +123,7 @@ mappings:
         opmanager: manageengine_opmanager
         pam360: manageengine_pam360
         servicedesk_plus_msp: manageengine_servicedesk_plus_msp
+        supportcenter_plus: manageengine_supportcenter_plus
     microsoft:
       products:
         active_directory_controller: active_directory

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -516,6 +516,7 @@ Sun Java System Directory Server
 Sun ONE Directory Server
 Sunny WebBox
 Supervisor
+SupportCenter Plus
 SurgeFTP
 Swagger UI
 Sync Gateway

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -307,6 +307,15 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_servicedesk_plus:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:4098755981824f02879b05ea2cc4da14|f8affc42a31d3c2fa044b882b4656bc9)$">
+    <description>ManageEngine SupportCenter Plus</description>
+    <example>4098755981824f02879b05ea2cc4da14</example>
+    <example>f8affc42a31d3c2fa044b882b4656bc9</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="SupportCenter Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_supportcenter_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^e9d6d23a961ea23a3e961266876e0ffd$">
     <description>HPE OfficeConnect Switch</description>
     <example>e9d6d23a961ea23a3e961266876e0ffd</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -2092,6 +2092,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_servicedesk_plus_msp:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^ManageEngine SupportCenter Plus$">
+    <description>ManageEngine SupportCenter Plus</description>
+    <example>ManageEngine SupportCenter Plus</example>
+    <param pos="0" name="service.vendor" value="ManageEngine"/>
+    <param pos="0" name="service.product" value="SupportCenter Plus"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:zohocorp:manageengine_supportcenter_plus:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^(ScanFront \d.+)Web Menu$">
     <!-- no space between the product model and "Web Menu" in the title -->
 


### PR DESCRIPTION
## Description
Adds 2 [ManageEngine SupportCenter Plus](https://www.manageengine.com/products/support-center/) fingerprints.

### Notes
Fingerprinted SupportCenter Plus version 14.0, build 14000.

* `<link rel="shortcut icon" href="/images/favicon.ico?14000">`
```
$ file favicon.ico
favicon.ico: PNG image data, 48 x 48, 8-bit/color RGBA, non-interlaced
$ md5 favicon.ico
MD5 (favicon.ico) = 4098755981824f02879b05ea2cc4da14
```
* `favicon.ico` (alternative from unknown version)
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 1 icon, 16x16, 4 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = f8affc42a31d3c2fa044b882b4656bc9
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
