### PR TITLE
Add Atlassian Jira Service Management favicon fingerprint

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -263,6 +263,7 @@ Jenkins
 JetDirect
 Jetty
 Jira
+Jira Service Management
 Joom!Fish
 Jupyter Server
 JupyterHub

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -134,6 +134,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:atlassian:jira:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^2fa69f2bc9174ffc21fc3c7925da6862$">
+    <description>Atlassian Jira Service Management</description>
+    <example>2fa69f2bc9174ffc21fc3c7925da6862</example>
+    <param pos="0" name="service.vendor" value="Atlassian"/>
+    <param pos="0" name="service.product" value="Jira Service Management"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:atlassian:jira_service_management:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^d9edf2a6f791120dea5f27ae4faf1212$">
     <description>Atlassian Bitbucket</description>
     <example>d9edf2a6f791120dea5f27ae4faf1212</example>


### PR DESCRIPTION
## Description
Adds [Atlassian Jira Service Management](https://www.atlassian.com/software/jira/service-management) favicon fingerprint.

### Notes
Fingerprinted JIRA Service Management Application version 5.6.0.

* `<link rel="shortcut icon" href="/s/-8ncmrq/960000/1dlckms/_/images/fav-jsd.png">`
```
$ file fav-jsd.png
fav-jsd.png: PNG image data, 128 x 128, 8-bit/color RGBA, non-interlaced
$ md5 fav-jsd.png
MD5 (fav-jsd.png) = 2fa69f2bc9174ffc21fc3c7925da6862
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
