### PR TITLE
Added LG TV to dhcp_vendor_class

### DIFF
--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -897,4 +897,18 @@
     <param pos="0" name="os.vendor" value="Cambium Networks"/>
   </fingerprint>
 
+  <fingerprint pattern="^LG_\d{2}[ULPS][A-Z]">
+    <description>LG TV</description>
+    <example>LG_65UH5F-HJ</example>
+    <example>LG_55UT672M0UC</example>
+    <example>LG_32LT662MBUC</example>
+    <example>LG_55SM5KE-BJ</example>
+    <example>LG_86UL3J-B</example>
+    <param pos="0" name="hw.vendor" value="LG"/>
+    <param pos="0" name="hw.device" value="Smart TV"/>
+    <param pos="0" name="os.vendor" value="LG"/>
+    <param pos="0" name="os.product" value="webOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:lg:webos:-"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -898,7 +898,7 @@
   </fingerprint>
 
   <fingerprint pattern="^LG_\d{2}[ULPS][A-Z]">
-    <description>LG TV</description>
+    <description>LG Smart TV</description>
     <example>LG_65UH5F-HJ</example>
     <example>LG_55UT672M0UC</example>
     <example>LG_32LT662MBUC</example>


### PR DESCRIPTION
## Description
Added LG TV DHCP vendor class fingerprint
This covers a variety of devices that are described by LG as 
TV, Commercial TV, Digital Signage
Details from
https://www.lg.com/ca_en/support/product-help/CT20098005-20150585049620
Selected webOS as all LG TV appear to be webOS

## Motivation and Context
Extends coverage 

## How Has This Been Tested?
./bin/recog_verify xml/dhcp_vendor_class.xml
rake tests


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
