### PR TITLE
mirror doc changes from recog-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec name: 'recog-content'
 
-gem 'recog', '~>3.0'
+gem 'recog', '~>3.0.5'
 
 group :test do
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec name: 'recog-content'
 
-gem 'recog', '~>3.0.5'
+gem 'recog', '~>3.1'
 
 group :test do
   gem 'rake'

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Here is an example from`http_servers.xml` where `hw.product` is captured and reu
 There is special handling for temporary attributes that have a name starting with
 `_tmp.`. These attributes can be used for interpolation but are not emitted in the
 output. This is useful when a particular product name is inconsistent in various
-banners, vendor marketing, or with NIST values when trying to generated CPEs. In
+banners, vendor marketing, or with NIST values when trying to generate CPEs. In
 these cases the useful parts of the banner can be extracted and a new value
 crafted without cluttering the data emitted by a match.
 

--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ Here is an example from`http_servers.xml` where `hw.product` is captured and reu
   </fingerprint>
 ```
 
-There is special handling for temporary `name` attributes starting with `_tmp.` such
-that they can be used for interpolation but are not emitted in the output. This is
-useful when a particular product name is inconsistent in various banners, vendor
-marketing, or with NIST values when trying to generated CPEs. In these cases the useful
-parts of the banner can be extracted and a new value crafted without cluttering the
-data emitted by a match.
+There is special handling for temporary attributes that have a name starting with
+`_tmp.`. These attributes can be used for interpolation but are not emitted in the
+output. This is useful when a particular product name is inconsistent in various
+banners, vendor marketing, or with NIST values when trying to generated CPEs. In
+these cases the useful parts of the banner can be extracted and a new value
+crafted without cluttering the data emitted by a match.
 
 ```xml
 <fingerprint pattern="^foo baz switchThing-(\d{4})$">
@@ -196,10 +196,7 @@ data emitted by a match.
 </fingerprint>
 ```
 
-In order to reduce churn in the `identifiers/fields.txt` file any `names` values starting
-with `_tmp.` should be followed by three digits such as `_tmp.001`, `_tmp.002`, etc. These
-only need to be unique within a specific fingerprint and so there shouldn't generally be
-a need for many of them.
+These temporary attributes are not tracked in the `identifiers/fields.txt`.
 
 [^back to top](#recog-a-recognition-framework)
 

--- a/bin/recog_standardize
+++ b/bin/recog_standardize
@@ -59,7 +59,7 @@ end
 
 # @param current [Hash] Indentifiers extracted from fingerprints
 # @param original [Hash] Indentifiers loaded from the existing identifiers file
-# param msg [String] Context to include in messaging to user
+# @param msg [String] Context to include in messaging to user
 # @param ident_type [String] Key used to get the identifier file path
 # @param write [Boolean] Indicate if changes should be written to disk
 def handle_changes(current, original, msg, ident_type, write)
@@ -151,6 +151,8 @@ ARGV.each do |arg|
     ndb.fingerprints.each do |f|
       f.params.each do |k, v|
 
+        # Don't track temporary attributes.
+        next if k.start_with?("_tmp.")
         curr_fields[k] = true
 
         param_index, val = v

--- a/features/data/successful_tests.xml
+++ b/features/data/successful_tests.xml
@@ -15,4 +15,11 @@
      <param pos="1" name="os.version" />
      <param pos="0" name="os.name" value="Bar" />
    </fingerprint>
+   <fingerprint pattern="^foo sb\-([\d.]+)$">
+     <description>test of temp params</description>
+     <example os.version="Super Beta 1.0">foo sb-1.0</example>
+     <param pos="1" name="_tmp.001" />
+     <param pos="0" name="os.version" value="Super Beta {_tmp.001}" />
+     <param pos="0" name="os.name" value="Bar" />
+   </fingerprint>
 </fingerprints>

--- a/features/verify.feature
+++ b/features/verify.feature
@@ -12,7 +12,7 @@ Feature: Verify
     When I run `recog_verify successful_tests.xml`
     Then it should pass with exactly:
       """
-      successful_tests.xml: SUMMARY: Test completed with 4 successful, 0 warnings, and 0 failures
+      successful_tests.xml: SUMMARY: Test completed with 5 successful, 0 warnings, and 0 failures
       """
 
   @no-clobber


### PR DESCRIPTION
## Description
This PR mirrors README changes from https://github.com/rapid7/recog-ruby/pull/12
Please see that PR for discussion.

it also prevents the `_tmp.` attributes from being added to the `identifiers/fields.txt` file.

NOTE: Tests involving `features/data/successful_tests.xml` and the `recog-ruby` implementation SHOULD fail until that PR is landed.
