### PR TITLE
Fortigate snmp fingerprint

### DIFF
--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -88,6 +88,7 @@ Fiery Print Server
 Firepower
 Firewall-1
 Fireware
+FortiGate
 FortiOS
 FreeBSD
 FreeNAS Firmware

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2323,6 +2323,21 @@ Copyright (c) 1995-2005 by Cisco Systems
   </fingerprint>
 
   <!--======================================================================
+                            Fortinet FortiGate
+   =======================================================================-->
+
+  <fingerprint pattern="^[\w\-]+\s+v([\d\.]+),build\d+,\d+(?:\s+\(\w+\))?$">
+    <description>FortiGate</description>
+    <example os.version="6.2.2">FortiaGate-61F v6.2.2,build6083,19102</example>
+    <example os.version="6.2.2">FortiaGate-61F v6.2.2,build6083,19102 (GA)</example>
+    <param pos="0" name="os.vendor" value="Fortinet"/>
+    <param pos="0" name="os.family" value="FortiOS"/>
+    <param pos="0" name="os.device" value="Network management device"/>
+    <param pos="0" name="os.product" value="FortiGate"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+
+  <!--======================================================================
                               Foundry Networks
    =======================================================================-->
 

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -2332,7 +2332,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example os.version="6.2.2">FortiaGate-61F v6.2.2,build6083,19102 (GA)</example>
     <param pos="0" name="os.vendor" value="Fortinet"/>
     <param pos="0" name="os.family" value="FortiOS"/>
-    <param pos="0" name="os.device" value="Network management device"/>
+    <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.product" value="FortiGate"/>
     <param pos="1" name="os.version"/>
   </fingerprint>


### PR DESCRIPTION
## Description
Add support for Fortigate routers via SNMP. Appears to be version 6.x and newer can provide this information in sysdescr. Older versions do not populate sysdescr by default and this information can also be found in fmSysVersion (1.3.6.1.4.1.12356.103.2.1.7) for older Fortigate systems, version 5.x and older, and fgSysVersion (1.3.6.1.4.1.12356.101.4.1.1) for newer versions as part of the FORTINET-FORTIGATE-MIB. 


## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?

Nexpose scans of Fortigate 6.x test asset


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
