### PR TITLE
Add ConnectWise R1Soft Server Backup Manager fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -434,6 +434,7 @@ Pure-FTPd
 QTSS
 QVT/Net
 Qpopper
+R1Soft Server Backup Manager
 RT
 Rapid Logic
 RealServer

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2328,4 +2328,11 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:helpsystems:goanywhere_managed_file_transfer:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^f46baa8367ecf994a9c50ce7fb89f483$">
+    <description>ConnectWise R1Soft Server Backup Manager (SBM)</description>
+    <example>f46baa8367ecf994a9c50ce7fb89f483</example>
+    <param pos="0" name="service.vendor" value="ConnectWise"/>
+    <param pos="0" name="service.product" value="R1Soft Server Backup Manager"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4131,6 +4131,16 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:helpsystems:goanywhere_managed_file_transfer:{service.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="^Server Backup Manager SE\s*(?:- .{1,512})?$">
+    <description>ConnectWise R1Soft Server Backup Manager (SBM)</description>
+    <example>Server Backup Manager SE</example>
+    <example>Server Backup Manager SE </example>
+    <example>Server Backup Manager SE - foo.bar</example>
+    <example>Server Backup Manager SE - [1234] FooBar</example>
+    <param pos="0" name="service.vendor" value="ConnectWise"/>
+    <param pos="0" name="service.product" value="R1Soft Server Backup Manager"/>
+  </fingerprint>
+
   <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">


### PR DESCRIPTION
## Description
Adds 2 [ConnectWise R1Soft Server Backup Manager (SBM)](https://www.connectwise.com/platform/integrations/business-efficiency/r1soft) fingerprints.

### Notes
* `favicon.ico`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 4 icons, 48x48, 32 bits/pixel, 32x32, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = f46baa8367ecf994a9c50ce7fb89f483
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
