### PR TITLE
Cross language compatibility: case insensitivity flag

### DIFF
--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -8,7 +8,7 @@
     and inform (8) messages.
   -->
 
-  <fingerprint pattern="^[Mm]fg=(?:Fuji)?(?i:Xerox);[Tt]yp=(?:MFP|AIO|[Pp]rinter);[Mm]od=(?:Xerox )?(\S+) ([a-zA-Z0-9]+).*;[Ss]er=([A-Z0-9]{9,10})(?:;[Ll]oc=.*)?$">
+  <fingerprint pattern="(?i)^[Mm]fg=(?:Fuji)?Xerox;[Tt]yp=(?:MFP|AIO|[Pp]rinter);[Mm]od=(?:Xerox )?(\S+) ([a-zA-Z0-9]+).*;[Ss]er=([A-Z0-9]{9,10})(?:;[Ll]oc=.*)?$">
     <description>Xerox Multifunction Printer</description>
     <example hw.family="VersaLink" hw.model="C405" hw.serial_number="ABC123456">Mfg=Xerox;Typ=MFP;Mod=VersaLink C405;Ser=ABC123456;Loc=Print Room</example>
     <example hw.family="AltaLink" hw.model="C8055" hw.serial_number="1AB234567">Mfg=Xerox;Typ=MFP;Mod=Xerox AltaLink C8055 Multifunction Printer;Ser=1AB234567;Loc=Print Room2</example>

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -8,7 +8,7 @@
     and inform (8) messages.
   -->
 
-  <fingerprint pattern="(?i)^[Mm]fg=(?:Fuji)?Xerox;[Tt]yp=(?:MFP|AIO|[Pp]rinter);[Mm]od=(?:Xerox )?(\S+) ([a-zA-Z0-9]+).*;[Ss]er=([A-Z0-9]{9,10})(?:;[Ll]oc=.*)?$">
+  <fingerprint pattern="(?i)^Mfg=(?:Fuji)?Xerox;Typ=(?:MFP|AIO|Printer);Mod=(?:Xerox )?(\S+) ([a-zA-Z0-9]+).*;Ser=([A-Z0-9]{9,10})(?:;Loc=.*)?$">
     <description>Xerox Multifunction Printer</description>
     <example hw.family="VersaLink" hw.model="C405" hw.serial_number="ABC123456">Mfg=Xerox;Typ=MFP;Mod=VersaLink C405;Ser=ABC123456;Loc=Print Room</example>
     <example hw.family="AltaLink" hw.model="C8055" hw.serial_number="1AB234567">Mfg=Xerox;Typ=MFP;Mod=Xerox AltaLink C8055 Multifunction Printer;Ser=1AB234567;Loc=Print Room2</example>

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -539,7 +539,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:nlnetlabs:unbound:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i:unbound)$">
+  <fingerprint pattern="(?i)^unbound$">
     <description>NLnet Labs Unbound no version string</description>
     <example>unbound</example>
     <param pos="0" name="service.vendor" value="NLnet Labs"/>
@@ -813,7 +813,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i:djbdns)[\s-](\d.\d+)$">
+  <fingerprint pattern="(?i)^djbdns[\s-](\d.\d+)$">
     <description>djbdns</description>
     <example service.version="1.05">djbdns 1.05</example>
     <example service.version="1.05">djbdns-1.05</example>
@@ -824,7 +824,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i:djbdns)$">
+  <fingerprint pattern="(?i)^djbdns$">
     <description>djbdns: no version</description>
     <example>DJBDNS</example>
     <example>djbdns</example>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -143,7 +143,7 @@
 
   <!-- Hikvision is OEMd by a number of DVR manufacturers -->
 
-  <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(?i:hikvision)&quot;">
+  <fingerprint pattern="(?i)^(?:Basic|Digest) realm=&quot;hikvision&quot;">
     <description>Web server found on DVR and webcam servers sourced from Hikvision</description>
     <example>Basic realm="hikvision"</example>
     <param pos="0" name="service.vendor" value="Hikvision"/>

--- a/xml/imap_banners.xml
+++ b/xml/imap_banners.xml
@@ -142,7 +142,6 @@
     <example>Dovecot (Debian) ready.</example>
     <example>[CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+ AUTH=PLAIN AUTH=LOGIN] Dovecot (Debian) ready.</example>
     <param pos="0" name="service.vendor" value="Dovecot"/>
-    <param pos="0" name="service.vendor" value="Dovecot"/>
     <param pos="0" name="service.family" value="Dovecot"/>
     <param pos="0" name="service.product" value="Dovecot"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:dovecot:dovecot:-"/>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -855,7 +855,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?i:unix)$">
+  <fingerprint pattern="(?i)^unix$">
     <description>Generally some Samba variant, which reports Unix</description>
     <example>Unix</example>
     <param pos="0" name="os.family" value="Unix"/>

--- a/xml/smtp_banners.xml
+++ b/xml/smtp_banners.xml
@@ -345,7 +345,7 @@
     <param pos="1" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^ ?([^, ]{1,512}),? +ESMTP \(?(?i:Exim) +(\d+\.[\d_.bdRC-]+)\)?(?: +#\d+)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d{3,4})?) *(?:We do not authorize the use of this system to transport unsolicited, and\/or bulk e-mail.)?$">
+  <fingerprint pattern="(?i)^ ?([^, ]{1,512}),? +ESMTP \(?Exim +(\d+\.[\d_.bdRC-]+)\)?(?: +#\d+)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d{3,4})?) *(?:We do not authorize the use of this system to transport unsolicited, and\/or bulk e-mail.)?$">
     <description>Exim - with version string and optional timestamp</description>
     <example service.version="4.91" host.name="foo.bar" system.time="Thu, 29 Apr 2021 05:41:36 +400">foo.bar  ESMTP Exim 4.91 Thu, 29 Apr 2021 05:41:36 +400</example>
     <example service.version="4.89" host.name="foo.bar">foo.bar ESMTP Exim 4.89 "</example>
@@ -368,7 +368,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim) +(\d+) ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
+  <fingerprint pattern="(?i)^([^, ]{1,512}),? ESMTP Exim +(\d+) ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - with digit only version string and optional timestamp</description>
     <example service.version="125302" host.name="foo.bar" system.time="Thu, 16 Nov 2017 04:55:11 -0500">foo.bar ESMTP Exim 125302 Thu, 16 Nov 2017 04:55:11 -0500 </example>
     <param pos="0" name="service.vendor" value="exim"/>
@@ -381,7 +381,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim) +(\d+\.[\d_.]+)(?: +#\d)? Ubuntu ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
+  <fingerprint pattern="(?i)^([^, ]{1,512}),? ESMTP Exim +(\d+\.[\d_.]+)(?: +#\d)? Ubuntu ((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - with version string and optional timestamp (Ubuntu)</description>
     <example service.version="4.82" system.time="Thu, 16 Nov 2017 11:30:44 +0300" host.name="foo.bar">foo.bar ESMTP Exim 4.82 Ubuntu Thu, 16 Nov 2017 11:30:44 +0300 </example>
     <param pos="0" name="os.vendor" value="Ubuntu"/>
@@ -398,7 +398,7 @@
     <param pos="3" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^, ]{1,512}),? ESMTP (?i:Exim)(?: +#\d)? *((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
+  <fingerprint pattern="(?i)^([^, ]{1,512}),? ESMTP Exim(?: +#\d)? *((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - without version string and with optional timestamp</description>
     <example host.name="foo.bar">foo.bar ESMTP Exim</example>
     <example host.name="foo.bar" system.time="Thu, 16 Nov 2017 01:11:30 -0800">foo.bar ESMTP Exim Thu, 16 Nov 2017 01:11:30 -0800 </example>
@@ -412,7 +412,7 @@
     <param pos="2" name="system.time"/>
   </fingerprint>
 
-  <fingerprint pattern="^ ?ESMTP (?i:Exim) (\d+\.[\d_.]+)(?: +#\d)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
+  <fingerprint pattern="(?i)^ ?ESMTP Exim (\d+\.[\d_.]+)(?: +#\d)? ?.?((?:\w\w\w, \d+ \w\w\w \d\d\d\d [\d:]+ [-+]\d\d\d\d)?) *$">
     <description>Exim - without hostname</description>
     <example service.version="4.82" system.time="Thu, 16 Nov 2017 12:19:22 +0300">ESMTP Exim 4.82 Thu, 16 Nov 2017 12:19:22 +0300 </example>
     <example service.version="4.82" system.time="Thu, 16 Nov 2017 11:41:41 +0300"> ESMTP Exim 4.82 Thu, 16 Nov 2017 11:41:41 +0300 </example>
@@ -741,7 +741,7 @@
 
   <!-- example: 220 mail.db-list.com ESMTP MERAK 3.00.140; Tue, 24 Jul 2001 21:30:47 -0700 -->
 
-  <fingerprint pattern="^([^ ]{1,512}) +E?SMTP (?i:MERAK) ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
+  <fingerprint pattern="(?i)^([^ ]{1,512}) +E?SMTP MERAK ([^ ]+\.[^ ]+\.[^ ]+); *(.+) *$">
     <description>Merak mail server - http://www.icewarp.com/merakmail/ (runs on 2000/NT/9x)</description>
     <example host.name="foo.bar" service.version="8.0.3" system.time="Thu, 30 Nov 2017 20:01:41 +1000">foo.bar SMTP Merak 8.0.3; Thu, 30 Nov 2017 20:01:41 +1000</example>
     <example host.name="foo.bar" service.version="8.0.3" system.time="Thu, 30 Nov 2017 12:08:09 +0200">foo.bar ESMTP Merak 8.0.3; Thu, 30 Nov 2017 12:08:09 +0200</example>
@@ -1080,7 +1080,7 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
-  <fingerprint pattern="^([^ ]{1,512}) ESMTP server \((?i:P)ost\.(?i:O)ffice v([^ ]+\.[^ ]+)(?: release)? (.+) ID# ([^ ]+)\) ready (.+) *$">
+  <fingerprint pattern="^([^ ]{1,512}) ESMTP server \([Pp]ost\.[Oo]ffice v([^ ]+\.[^ ]+)(?: release)? (.+) ID# ([^ ]+)\) ready (.+) *$">
     <description>Post.Office</description>
     <example host.name="foo.bar" service.version="3.8.4" postoffice.build="116" postoffice.id="1001-65749U100L10S0V38" system.time="Thu, 30 Nov 2017 18:46:24 +0900">foo.bar ESMTP server (post.office v3.8.4 release 116 ID# 1001-65749U100L10S0V38) ready Thu, 30 Nov 2017 18:46:24 +0900</example>
     <example host.name="foo.bar" service.version="3.1" postoffice.build="PO205e" postoffice.id="0-42000U100L2S100" system.time="Tue, 6 Feb 2001 19:38:32 +0100">foo.bar ESMTP server (Post.Office v3.1 release PO205e ID# 0-42000U100L2S100) ready Tue, 6 Feb 2001 19:38:32 +0100</example>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3772,7 +3772,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <!-- These devices are all some form of device/terminal/serial/console server -->
 
-  <fingerprint pattern="^(?i:Lantronix) ((MSS|SCS|LRS|ETS|EDS)\S+) (?:Version |[VB])?([^/\(\s]+)[/\(\s]?">
+  <fingerprint pattern="(?i)^Lantronix ((MSS|SCS|LRS|ETS|EDS)\S+) (?:Version |[VB])?([^/\(\s]+)[/\(\s]?">
     <description>Lantronix terminal server</description>
     <example os.product="MSS100" os.family="MSS" os.version="V3.6">Lantronix MSS100 Version V3.6/9(030114)</example>
     <example os.product="EDS8PS" os.family="EDS" os.version="4.1.0.2R17">Lantronix EDS8PS V4.1.0.2R17 (03111515KK9H)</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1787,7 +1787,7 @@
     <param pos="1" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^([\d.]{1,8})[ _]sshlib:? (?i:GlobalScape)$">
+  <fingerprint pattern="(?i)^([\d.]{1,8})[ _]sshlib:? GlobalScape$">
     <description>GlobalScape SSH (which uses Bitvise sshlib)</description>
     <example service.component.version="1.36">1.36_sshlib GlobalSCAPE</example>
     <example service.component.version="1.82">1.82_sshlib Globalscape</example>
@@ -1953,7 +1953,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:vandyke:vshell:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^WRQReflection(?i:F)orSecureIT_(.*)$">
+  <fingerprint pattern="^WRQReflection[Ff]orSecureIT_(.*)$">
     <description>Attachmate Reflection (formerly WRQ Reflection for Secure IT)</description>
     <example service.version="6.1 Build 21">WRQReflectionForSecureIT_6.1 Build 21</example>
     <example service.version="8.2 Build 117">WRQReflectionforSecureIT_8.2 Build 117</example>


### PR DESCRIPTION
## Description
This PR moves the inline flag `(?i)` (case insensitivity)  to the beginning of the regex. In Python this flags has global meaning and use of it anywhere other than the start of the pattern is deprecated. This does not change the function of this flag in current patterns for other languages.

See previous work in https://github.com/rapid7/recog/pull/367

This was caught by internal testing in `recog-go` and the fixes are required in order for us to implement and test the changes from the following PRs into `recog-go`:
- https://github.com/rapid7/recog-ruby/pull/12
- https://github.com/rapid7/recog/pull/547

## How Has This Been Tested?
`bundle exec rake tests`
`ruby bin/recog_verify xml/*.xml | grep -v WARN | grep -v SUMMARY`


## Types of changes>
- Content


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
