### PR TITLE
Add favicon hash for drupal 9.2 plus

### DIFF
--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -75,10 +75,21 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:tomcat:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:b6341dfc213100c61db4fb8775878cec|cf2445dcb53a031c02f9b57e2199bc03)$">
+  <fingerprint pattern="^(?:b6341dfc213100c61db4fb8775878cec|cf2445dcb53a031c02f9b57e2199bc03|fe22dd2bb09daccf58256611ac491469)$">
     <description>Drupal CMS</description>
+    <!-- Original Drupal favicon https://github.com/drupal/drupal/blob/f0a16bf2a4d1524aa33b656533e37d977cca4802/core/misc/favicon.ico -->
+
     <example>b6341dfc213100c61db4fb8775878cec</example>
+    <!--
+      High definition Drupal favicon
+      Drupal 8.0.0 https://github.com/drupal/drupal/blob/2ace26881d7a67a396caea6a79437c7e4e629f98/core/misc/favicon.ico
+      Drupal Bartik 9.2+ https://github.com/drupal/drupal/blob/cfa3a480fca997eaecdca2c81c8035ec61308abe/core/themes/bartik/favicon.ico
+    -->
+
     <example>cf2445dcb53a031c02f9b57e2199bc03</example>
+    <!-- Drupal 9.2+ https://github.com/drupal/drupal/blob/cfa3a480fca997eaecdca2c81c8035ec61308abe/core/misc/favicon.ico -->
+
+    <example>fe22dd2bb09daccf58256611ac491469</example>
     <param pos="0" name="service.vendor" value="Drupal"/>
     <param pos="0" name="service.product" value="CMS"/>
     <param pos="0" name="service.certainty" value="0.5"/>


### PR DESCRIPTION
## Description

Add latest favicon fingerprint hashes for drupal 9.2 plus

## Motivation and Context

Add latest favicon fingerprint hashes for drupal 9.2 plus

## How Has This Been Tested?

```
$ curl --silent https://raw.githubusercontent.com/drupal/drupal/10.1.x/core/misc/favicon.ico | md5sum | awk '{ print $1 }' | bin/recog_match xml/favicons.xml -
MATCH: {"matched"=>"Drupal CMS", "service.vendor"=>"Drupal", "service.product"=>"CMS", "service.certainty"=>"0.5", "service.cpe23"=>"cpe:/a:drupal:drupal:-", "service.protocol"=>"", "fingerprint_db"=>"favicon.md5", "data"=>"fe22dd2bb09daccf58256611ac491469"}
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
