### PR TITLE
added cpe for honewell devices

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3540,6 +3540,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="Honeywell"/>
     <param pos="0" name="os.product" value="Thermal Label Printer {hw.model}"/>
     <param pos="0" name="os.device" value="Printer"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:honeywell:intermec_{hw.model}_firmware:{hw.version}"/>
   </fingerprint>
 
   <!--======================================================================


### PR DESCRIPTION
## Description

Adding CPE for honeywell label printers.


## Motivation and Context


## How Has This Been Tested?
Yes:

```
mark@bleep:~/recog$ echo "Honeywell PM43;P10.17.019667" | bin/recog_match xml/snmp_sysdescr.xml
MATCH: {"matched"=>"Honeywell Thermal Label Printer (Previously Intermec)", "hw.vendor"=>"Honeywell", "hw.model"=>"PM43", "hw.version"=>"10.17.019667", "hw.product"=>"Thermal Label Printer PM43", "hw.device"=>"Printer", "os.vendor"=>"Honeywell", "os.product"=>"Thermal Label Printer PM43", "os.device"=>"Printer", "os.cpe23"=>"cpe:/o:honeywell:intermec_PM43_firmware:10.17.019667", "service.protocol"=>"snmp", "fingerprint_db"=>"snmp.sys_description", "data"=>"Honeywell PM43;P10.17.019667"}
```


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [* ] I have updated the documentation accordingly (or changes are not required).
- [* ] I have added tests to cover my changes (or new tests are not required).
- [* ] All new and existing tests passed.
