### PR TITLE
Rename SSL-VPN *.device parameter values to be more generic

### DIFF
--- a/identifiers/device.txt
+++ b/identifiers/device.txt
@@ -78,7 +78,6 @@ Router
 SD-WAN Appliance
 SIP Device
 SIP Gateway
-SSL-VPN
 Scanner
 Security Appliance
 Sensor

--- a/xml/dhcp_vendor_class.xml
+++ b/xml/dhcp_vendor_class.xml
@@ -947,7 +947,7 @@
   <fingerprint pattern="^JNPR\.IVE$">
     <description>Juniper SSL VPN</description>
     <example>JNPR.IVE</example>
-    <param pos="0" name="hw.device" value="SSL-VPN"/>
+    <param pos="0" name="hw.device" value="VPN"/>
     <param pos="0" name="hw.vendor" value="Juniper"/>
     <param pos="0" name="os.vendor" value="Juniper"/>
     <param pos="0" name="os.product" value="IVE OS"/>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3333,7 +3333,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:pulsesecure:pulse_connect_secure:-"/>
     <param pos="0" name="os.vendor" value="Pulse Secure"/>
     <param pos="0" name="os.family" value="SSL-VPN"/>
-    <param pos="0" name="os.device" value="SSL-VPN"/>
+    <param pos="0" name="os.device" value="VPN"/>
     <param pos="0" name="os.product" value="Pulse Connect Secure"/>
   </fingerprint>
 

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -246,7 +246,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:pulsesecure:pulse_connect_secure:-"/>
     <param pos="0" name="os.vendor" value="Pulse Secure"/>
     <param pos="0" name="os.family" value="SSL-VPN"/>
-    <param pos="0" name="os.device" value="SSL-VPN"/>
+    <param pos="0" name="os.device" value="VPN"/>
     <param pos="0" name="os.product" value="Pulse Connect Secure"/>
   </fingerprint>
 


### PR DESCRIPTION
## Description
Renames "SSL-VPN" `*.device` parameter values to the more generic value "VPN".


## Motivation and Context
Provide concise device classification


## How Has This Been Tested?
* `rake tests`
* `bundle exec ./bin/recog_verify xml/dhcp_vendor_class.xml xml/html_title.xml xml/http_cookies.xml`


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
