### PR TITLE
Enhance CPE update script and update CPE values

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -52,6 +52,8 @@ mappings:
         crushftp_web_interface: crushftp
     cz.nic:
       vendor: knot-dns
+    d-link:
+      vendor: dlink
     drupal:
       products:
         cms: drupal
@@ -264,6 +266,8 @@ mappings:
         netscaler_gateway: netscaler_gateway_firmware
     cumulus:
       vendor: cumulusnetworks
+    d-link:
+      vendor: dlink
     data_domain:
       vendor: dell
       products:
@@ -290,6 +294,9 @@ mappings:
       products:
         os%2f400: os_400
         i5%2fos: i5os
+    intel:
+      products:
+        intel%28r%29_active_management_technology_firmware: active_management_technology_firmware
     juniper:
       products:
         junos_os: junos
@@ -383,6 +390,8 @@ mappings:
     citrix:
       products:
         netscaler_sdx_gateway: netscaler_sdx
+    d-link:
+      vendor: dlink
     eltex:
       vendor: eltex-co
     emc:

--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -81,8 +81,8 @@ mappings:
       vendor: igniterealtime
     intel:
       products:
-        intel(r)_active_management_technology: active_management_technology
-        intel(r)_standard_manageability: standard_manageability
+        intel%28r%29_active_management_technology: active_management_technology
+        intel%28r%29_standard_manageability: standard_manageability
     jamf:
       products:
         jamf_pro: jamf
@@ -227,7 +227,7 @@ mappings:
     zaphoyd_studios:
       vendor: zaphoyd
       products:
-        websocket++: websocketpp
+        websocket%2b%2b: websocketpp
 
   # The following section contains CPE operating system or 'o' remappings. These will
   # ONLY be used for mapping Recog 'os' attributes.
@@ -288,8 +288,8 @@ mappings:
         tru64_unix: tru64
     ibm:
       products:
-        os/400: os_400
-        i5/os: i5os
+        os%2f400: os_400
+        i5%2fos: i5os
     juniper:
       products:
         junos_os: junos
@@ -346,37 +346,37 @@ mappings:
   h:
     apple:
       products:
-        imac_(retina_4k_21.5-inch_late_2015): imac
-        imac_(retina_4k_21.5-inch_2017): imac
-        imac_(retina_4k_21.5-inch_2019): imac
-        imac_(retina_5k_27-inch_2017): imac
-        imac_(retina_5k_27-inch_2019): imac
-        imac_(retina_5k_27-inch_2020): imac
+        imac_%28retina_4k_21.5-inch_late_2015%29: imac
+        imac_%28retina_4k_21.5-inch_2017%29: imac
+        imac_%28retina_4k_21.5-inch_2019%29: imac
+        imac_%28retina_5k_27-inch_2017%29: imac
+        imac_%28retina_5k_27-inch_2019%29: imac
+        imac_%28retina_5k_27-inch_2020%29: imac
         imac_pro: imac
-        macbook_air_(13-inch_2017): macbook_air
-        macbook_air_(13-inch_2018): macbook_air
-        macbook_air_(m1_2020): macbook_air
-        macbook_air_(m1_2022): macbook_air
-        macbook_air_(m2_2022): macbook_air
-        macbook_air_(retina_13-inch_2018): macbook_air
-        macbook_air_(retina_13-inch_2019): macbook_air
-        macbook_air_(retina_13-inch_2020): macbook_air
-        macbook_pro_(13-inch_2017_four_thunderbolt_3_ports): macbook_pro
-        macbook_pro_(13-inch_2018_four_thunderbolt_3_ports): macbook_pro
-        macbook_pro_(13-inch_2020_four_thunderbolt_3_ports): macbook_pro
-        macbook_pro_(13-inch_2016_two_thunderbolt_3_ports): macbook_pro
-        macbook_pro_(13-inch_2017_two_thunderbolt_3_ports): macbook_pro
-        macbook_pro_(13-inch_2019_two_thunderbolt_3_ports): macbook_pro
-        macbook_pro_(13-inch_2020_two_thunderbolt_3_ports): macbook_pro
-        macbook_pro_(13-inch_2020): macbook_pro
-        macbook_pro_(13-inch_m1_2020): macbook_pro
-        macbook_pro_(14-inch_2021): macbook_pro
-        macbook_pro_(15-inch_2018): macbook_pro
-        macbook_pro_(15-inch_2019): macbook_pro
-        macbook_pro_(16-inch_2019): macbook_pro
-        macbook_pro_(16-inch_2021): macbook_pro
-        macbook_pro_(retina_13-inch_early_2015): macbook_pro
-        macbook_pro_(retina_15-inch_mid_2015): macbook_pro
+        macbook_air_%2813-inch_2017%29: macbook_air
+        macbook_air_%2813-inch_2018%29: macbook_air
+        macbook_air_%28m1_2020%29: macbook_air
+        macbook_air_%28m1_2022%29: macbook_air
+        macbook_air_%28m2_2022%29: macbook_air
+        macbook_air_%28retina_13-inch_2018%29: macbook_air
+        macbook_air_%28retina_13-inch_2019%29: macbook_air
+        macbook_air_%28retina_13-inch_2020%29: macbook_air
+        macbook_pro_%2813-inch_2017_four_thunderbolt_3_ports%29: macbook_pro
+        macbook_pro_%2813-inch_2018_four_thunderbolt_3_ports%29: macbook_pro
+        macbook_pro_%2813-inch_2020_four_thunderbolt_3_ports%29: macbook_pro
+        macbook_pro_%2813-inch_2016_two_thunderbolt_3_ports%29: macbook_pro
+        macbook_pro_%2813-inch_2017_two_thunderbolt_3_ports%29: macbook_pro
+        macbook_pro_%2813-inch_2019_two_thunderbolt_3_ports%29: macbook_pro
+        macbook_pro_%2813-inch_2020_two_thunderbolt_3_ports%29: macbook_pro
+        macbook_pro_%2813-inch_2020%29: macbook_pro
+        macbook_pro_%2813-inch_m1_2020%29: macbook_pro
+        macbook_pro_%2814-inch_2021%29: macbook_pro
+        macbook_pro_%2815-inch_2018%29: macbook_pro
+        macbook_pro_%2815-inch_2019%29: macbook_pro
+        macbook_pro_%2816-inch_2019%29: macbook_pro
+        macbook_pro_%2816-inch_2021%29: macbook_pro
+        macbook_pro_%28retina_13-inch_early_2015%29: macbook_pro
+        macbook_pro_%28retina_15-inch_mid_2015%29: macbook_pro
     cisco:
       products:
         nam: network_analysis_module

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -437,14 +437,14 @@ iPad mini (6th generation)
 iPad mini 2
 iPad mini 3
 iPad mini 4
-iPhone
+iPhone (1st generation)
 iPhone 11
 iPhone 11 Pro
 iPhone 11 Pro Max
-iPhone 12 5G
-iPhone 12 Mini 5G
-iPhone 12 Pro 5G
-iPhone 12 Pro Max 5G
+iPhone 12
+iPhone 12 Mini
+iPhone 12 Pro
+iPhone 12 Pro Max
 iPhone 13
 iPhone 13 Pro
 iPhone 13 Pro Max
@@ -464,8 +464,8 @@ iPhone 7
 iPhone 7 Plus
 iPhone 8
 iPhone 8 Plus
-iPhone SE
-iPhone SE (2020)
+iPhone SE (1st generation)
+iPhone SE (2nd generation)
 iPhone X
 iPhone XR
 iPhone XS

--- a/identifiers/os_family.txt
+++ b/identifiers/os_family.txt
@@ -89,6 +89,7 @@ Imagio
 Imagistics
 Infoprint
 Integrity
+Intel(R) Active Management Technology
 IntelliJack
 Irix
 IronWare

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -68,7 +68,7 @@ Discover
 Document Centre
 Dynix
 EDR G902 Firmware
-EDR G903 Firmware
+EDR-G903 Firmware
 EdgeBlaster
 EdgeOS
 Email Appliance
@@ -123,6 +123,7 @@ IPVPN Firmware
 IRIX
 IVE OS
 Integrated Lights Out Manager
+Intel(R) Active Management Technology Firmware
 Irix
 Isilon OneFS OS
 JetDirect
@@ -243,7 +244,7 @@ ScanFront
 ScreenOS
 Secure Linux
 SecureOS
-Serenity
+SerenityOS
 SmartEdge OS
 SmartServer
 SmoothWall

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -362,8 +362,8 @@ NetVanta
 NetWare Enterprise Web Server
 NetWare HTTP Server
 NetWare HTTP Stack
-NetWeaver AS ABAP
 NetWeaver Application Server
+NetWeaver Application Server ABAP
 NetWeaver Application Server Java
 NetWeaver Internet Communication Manager
 NetWeaver Web AS
@@ -572,7 +572,7 @@ VOPMail
 VPOP3
 VRP
 VShell
-Varnish
+Varnish Cache
 Vault
 Vaultwarden
 VcXsrv

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -803,7 +803,7 @@ Vaddio
 Valcom
 VanDyke Software
 Vanguard Managed Solutions
-Varnish-cache
+Varnish Cache Project
 Vaultwarden
 VcXsrv
 Vegastream

--- a/xml/apache_modules.xml
+++ b/xml/apache_modules.xml
@@ -1196,6 +1196,7 @@
     <param pos="0" name="service.component.vendor" value="Apache"/>
     <param pos="0" name="service.component.product" value="mod_jk"/>
     <param pos="1" name="service.component.version"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:mod_jk:{service.component.version}"/>
   </fingerprint>
 
   <fingerprint pattern="mod_jk/?$">
@@ -1203,6 +1204,7 @@
     <example>mod_jk/</example>
     <param pos="0" name="service.component.vendor" value="Apache"/>
     <param pos="0" name="service.component.product" value="mod_jk"/>
+    <param pos="0" name="service.component.cpe23" value="cpe:/a:apache:mod_jk:-"/>
   </fingerprint>
 
   <fingerprint pattern="mod_jk2/(\S+)$">

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -32,18 +32,30 @@
 
   <fingerprint pattern="^(?:1a60f7f928a659f763204d525b3cf90d|6d4c72194ecff7ead96f65db45851be9|55ece828b1329741c1d553a6575d71f1)$">
     <description>Radarr</description>
-    <example>1a60f7f928a659f763204d525b3cf90d</example><!-- favicon-16x16.png-->
-    <example>6d4c72194ecff7ead96f65db45851be9</example><!-- favicon-32x32.png-->
-    <example>55ece828b1329741c1d553a6575d71f1</example><!-- favicon.ico-->
+    <!-- favicon-16x16.png -->
+
+    <example>1a60f7f928a659f763204d525b3cf90d</example>
+    <!-- favicon-32x32.png -->
+
+    <example>6d4c72194ecff7ead96f65db45851be9</example>
+    <!-- favicon.ico -->
+
+    <example>55ece828b1329741c1d553a6575d71f1</example>
     <param pos="0" name="service.vendor" value="Radarr"/>
     <param pos="0" name="service.product" value="Radarr"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:b3ae051d2c6b875b2064288104856291|c24b156cfaa12860760793f43b487c21|657ebbffad0e5c71a1010fbc9b279b1e)$">
     <description>Sonarr</description>
-    <example>b3ae051d2c6b875b2064288104856291</example><!-- favicon-32x32.png-->
-    <example>c24b156cfaa12860760793f43b487c21</example><!-- favicon-16x16.png-->
-    <example>657ebbffad0e5c71a1010fbc9b279b1e</example><!-- favicon.ico-->
+    <!-- favicon-32x32.png -->
+
+    <example>b3ae051d2c6b875b2064288104856291</example>
+    <!-- favicon-16x16.png -->
+
+    <example>c24b156cfaa12860760793f43b487c21</example>
+    <!-- favicon.ico -->
+
+    <example>657ebbffad0e5c71a1010fbc9b279b1e</example>
     <param pos="0" name="service.vendor" value="Sonarr"/>
     <param pos="0" name="service.product" value="Sonarr"/>
   </fingerprint>
@@ -2376,9 +2388,15 @@
 
   <fingerprint pattern="^(?:cc21dae362a981ea9ce93138cb855e66|372be2fa33d5836cdcf8c1867e6900c2|54bb0b4a353b89c42e63b8e8bd6ea504)$">
     <description>Jellyseerr</description>
-    <example>cc21dae362a981ea9ce93138cb855e66</example><!-- favicon.ico-->
-    <example>372be2fa33d5836cdcf8c1867e6900c2</example><!-- favicon-16x16.png-->
-    <example>54bb0b4a353b89c42e63b8e8bd6ea504</example><!-- favicon-32x32.png-->
+    <!-- favicon.ico-->
+
+    <example>cc21dae362a981ea9ce93138cb855e66</example>
+    <!-- favicon-16x16.png-->
+
+    <example>372be2fa33d5836cdcf8c1867e6900c2</example>
+    <!-- favicon-32x32.png-->
+
+    <example>54bb0b4a353b89c42e63b8e8bd6ea504</example>
     <param pos="0" name="service.vendor" value="Jellyseerr"/>
     <param pos="0" name="service.product" value="Jellyseerr"/>
   </fingerprint>

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1321,7 +1321,6 @@
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.certainty" value="0.5"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -1716,6 +1715,7 @@
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.product" value="iLO 3"/>
     <param pos="0" name="hw.certainty" value="0.5"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out_3:-"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.family" value="iLO"/>

--- a/xml/ftp_banners.xml
+++ b/xml/ftp_banners.xml
@@ -615,7 +615,7 @@ more text</example>
     <param pos="0" name="os.family" value="z/OS"/>
     <param pos="0" name="os.device" value="Mainframe"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:z\/os:{os.version}"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:z%2fos:{os.version}"/>
     <param pos="2" name="host.name"/>
   </fingerprint>
 

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -1112,6 +1112,7 @@
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.product" value="iLO 3"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out_3:-"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.family" value="iLO"/>
@@ -1125,6 +1126,7 @@
     <param pos="0" name="hw.device" value="Lights Out Management"/>
     <param pos="0" name="hw.vendor" value="HP"/>
     <param pos="0" name="hw.product" value="iLO 4"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:hp:integrated_lights-out_4:-"/>
     <param pos="0" name="os.vendor" value="HP"/>
     <param pos="0" name="os.device" value="Lights Out Management"/>
     <param pos="0" name="os.family" value="iLO"/>

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -205,7 +205,6 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -1059,10 +1059,10 @@
     <description>Varnish Cache</description>
     <example>Varnish</example>
     <example>Varnish-Cache</example>
-    <param pos="0" name="service.vendor" value="Varnish-cache"/>
+    <param pos="0" name="service.vendor" value="Varnish Cache Project"/>
     <param pos="0" name="service.family" value="Varnish"/>
-    <param pos="0" name="service.product" value="Varnish"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:varnish-cache:varnish:-"/>
+    <param pos="0" name="service.product" value="Varnish Cache"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:varnish_cache_project:varnish_cache:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Tengine\/?([\d.]+)?$">
@@ -1913,10 +1913,10 @@
     <description>SAP NetWeaver Application Server - Advanced Business Application Programming</description>
     <example service.version="731">SAP NetWeaver Application Server / ABAP 731</example>
     <param pos="0" name="service.vendor" value="SAP"/>
-    <param pos="0" name="service.product" value="NetWeaver AS ABAP"/>
+    <param pos="0" name="service.product" value="NetWeaver Application Server ABAP"/>
     <param pos="0" name="service.family" value="NetWeaver"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:sap:netweaver_as_abap:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:sap:netweaver_application_server_abap:{service.version}"/>
     <param pos="0" name="service.component.vendor" value="SAP"/>
     <param pos="0" name="service.component.product" value="NetWeaver Application Server"/>
     <param pos="0" name="service.component.cpe23" value="cpe:/a:sap:netweaver_application_server:-"/>
@@ -2167,7 +2167,6 @@
     <param pos="0" name="service.vendor" value="Cisco"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.product" value="IOS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
@@ -2182,7 +2181,6 @@
     <param pos="0" name="service.vendor" value="Cisco"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.product" value="IOS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
@@ -2200,7 +2198,6 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -3004,7 +3001,7 @@
     <param pos="0" name="service.vendor" value="Treck"/>
     <param pos="0" name="service.product" value="TCP/IP"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:treck:tcp\/ip:{service.version}"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:treck:tcp%2fip:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^WEBrick/([\d\.]+)">
@@ -3292,12 +3289,16 @@
 
   <fingerprint pattern="^Intel\(R\) Active Management Technology\s(\d+\.\d+\.\d+\.\d+|\d+\.\d+\.\d+|\d+\.\d+)">
     <description>Intel(R) Active Management Technology (AMT) with a version</description>
-    <example service.version="7.1.86">Intel(R) Active Management Technology 7.1.86</example>
+    <example service.version="7.1.86" os.version="7.1.86">Intel(R) Active Management Technology 7.1.86</example>
     <param pos="0" name="service.vendor" value="Intel"/>
-    <param pos="0" name="service.product" value="Intel(R) Active Management Technology"/>
     <param pos="0" name="service.family" value="Intel(R) Active Management Technology"/>
+    <param pos="0" name="service.product" value="Intel(R) Active Management Technology"/>
     <param pos="1" name="service.version"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:intel:active_management_technology:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Intel"/>
+    <param pos="0" name="os.family" value="Intel(R) Active Management Technology"/>
+    <param pos="0" name="os.product" value="Intel(R) Active Management Technology Firmware"/>
+    <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:intel:active_management_technology_firmware:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:AMT|Intel\(R\) Active Management Technology)$">
@@ -3305,9 +3306,12 @@
     <example>AMT</example>
     <example>Intel(R) Active Management Technology</example>
     <param pos="0" name="service.vendor" value="Intel"/>
-    <param pos="0" name="service.product" value="Intel(R) Active Management Technology"/>
     <param pos="0" name="service.family" value="Intel(R) Active Management Technology"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:intel:active_management_technology:-"/>
+    <param pos="0" name="service.product" value="Intel(R) Active Management Technology"/>
+    <param pos="0" name="os.vendor" value="Intel"/>
+    <param pos="0" name="os.family" value="Intel(R) Active Management Technology"/>
+    <param pos="0" name="os.product" value="Intel(R) Active Management Technology Firmware"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:intel:active_management_technology_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Intel\(R\) Standard Manageability\s(\d+\.\d+\.\d+\.\d+|\d+\.\d+\.\d+|\d+\.\d+)">
@@ -3315,8 +3319,8 @@
     <example service.version="5.0.50">Intel(R) Standard Manageability 5.0.50</example>
     <example service.version="9.0.3">Intel(R) Standard Manageability 9.0.3</example>
     <param pos="0" name="service.vendor" value="Intel"/>
-    <param pos="0" name="service.product" value="Intel(R) Standard Manageability"/>
     <param pos="0" name="service.family" value="Intel(R) Active Management Technology"/>
+    <param pos="0" name="service.product" value="Intel(R) Standard Manageability"/>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:intel:standard_manageability:{service.version}"/>
   </fingerprint>
@@ -3411,6 +3415,7 @@
     <param pos="0" name="service.family" value="Niagara"/>
     <param pos="0" name="service.product" value="Niagara AX"/>
     <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:tridium:niagara_ax:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^Microsoft WinCE Fidelix v([\d.]+)$">
@@ -4721,8 +4726,8 @@
     <param pos="0" name="service.vendor" value="SerenityOS"/>
     <param pos="0" name="service.product" value="WebServer"/>
     <param pos="0" name="os.vendor" value="SerenityOS"/>
-    <param pos="0" name="os.product" value="Serenity"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:serenityos:serenity:-"/>
+    <param pos="0" name="os.product" value="SerenityOS"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:serenityos:serenityos:-"/>
   </fingerprint>
 
   <!-- This is a version of ACME mini_httpd where the value 'mini_httpd' has been

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -25,7 +25,6 @@
     <param pos="0" name="service.product" value="IOS"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.version" value="11"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:11"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="IOS"/>
@@ -44,7 +43,6 @@
     <param pos="0" name="service.product" value="IOS"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.version" value="12"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:12"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="IOS"/>
@@ -63,7 +61,6 @@
     <param pos="0" name="service.product" value="IOS"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.version" value="12"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:12"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="IOS"/>
@@ -693,6 +690,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="FreshTomato"/>
     <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freshtomato:freshtomato:-"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^Basic realm=&quot;NetPing \d+/PWR-220\s*v\d+/(?:ETH|SMS|GSM(?:3G)?)&quot;">

--- a/xml/mdns_device-info_txt.xml
+++ b/xml/mdns_device-info_txt.xml
@@ -381,6 +381,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2017, Four Thunderbolt 3 ports)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro14,1$">
@@ -394,6 +395,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro13,3$">
@@ -433,6 +435,7 @@
     <param pos="0" name="hw.family" value="MacBook Pro"/>
     <param pos="0" name="hw.product" value="MacBook Pro (13-inch, 2016, Two Thunderbolt 3 ports)"/>
     <param pos="0" name="hw.device" value="Laptop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:macbook_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=MacBookPro12,1$">
@@ -1357,6 +1360,7 @@
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="iMac (Retina 4K, 21.5-inch, 2017)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:imac:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=iMac18,1$">
@@ -1396,6 +1400,7 @@
     <param pos="0" name="hw.family" value="iMac"/>
     <param pos="0" name="hw.product" value="iMac (Retina 4K, 21.5-inch, Late 2015)"/>
     <param pos="0" name="hw.device" value="Desktop"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:imac:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=iMac16,1$">
@@ -2096,6 +2101,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 13 Pro Max"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_13_pro_max:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D63AP|iPhone14,2)$">
@@ -2110,6 +2116,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 13 Pro"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_13_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D16AP|iPhone14,4)$">
@@ -2124,6 +2131,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 13 mini"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_13_mini:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D17AP|iPhone14,5)$">
@@ -2138,10 +2146,11 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 13"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_13:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D79AP|iPhone12,8)$">
-    <description>iPhone SE (2020)</description>
+    <description>iPhone SE (2nd generation)</description>
     <example>model=D79AP</example>
     <example>model=iPhone12,8</example>
     <param pos="0" name="os.vendor" value="Apple"/>
@@ -2150,12 +2159,13 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPhone"/>
-    <param pos="0" name="hw.product" value="iPhone SE (2020)"/>
+    <param pos="0" name="hw.product" value="iPhone SE (2nd generation)"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_se_%282nd_generation%29:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D54pAP|iPhone13,4)$">
-    <description>iPhone 12 Pro Max 5G</description>
+    <description>iPhone 12 Pro Max</description>
     <example>model=D54pAP</example>
     <example>model=iPhone13,4</example>
     <param pos="0" name="os.vendor" value="Apple"/>
@@ -2164,12 +2174,13 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPhone"/>
-    <param pos="0" name="hw.product" value="iPhone 12 Pro Max 5G"/>
+    <param pos="0" name="hw.product" value="iPhone 12 Pro Max"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_12_pro_max:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D53pAP|iPhone13,3)$">
-    <description>iPhone 12 Pro 5G</description>
+    <description>iPhone 12 Pro</description>
     <example>model=D53pAP</example>
     <example>model=iPhone13,3</example>
     <param pos="0" name="os.vendor" value="Apple"/>
@@ -2178,12 +2189,13 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPhone"/>
-    <param pos="0" name="hw.product" value="iPhone 12 Pro 5G"/>
+    <param pos="0" name="hw.product" value="iPhone 12 Pro"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_12_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D53gAP|iPhone13,2)$">
-    <description>iPhone 12 5G</description>
+    <description>iPhone 12</description>
     <example>model=D53gAP</example>
     <example>model=iPhone13,2</example>
     <param pos="0" name="os.vendor" value="Apple"/>
@@ -2192,12 +2204,13 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPhone"/>
-    <param pos="0" name="hw.product" value="iPhone 12 5G"/>
+    <param pos="0" name="hw.product" value="iPhone 12"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_12:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D52g?AP|Phone13,1)$">
-    <description>iPhone 12 Mini 5G</description>
+    <description>iPhone 12 Mini</description>
     <example>model=D52gAP</example>
     <example>model=D52AP</example>
     <example>model=Phone13,1</example>
@@ -2207,8 +2220,9 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPhone"/>
-    <param pos="0" name="hw.product" value="iPhone 12 Mini 5G"/>
+    <param pos="0" name="hw.product" value="iPhone 12 Mini"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_12_mini:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D431p?AP|iPhone12,5)$">
@@ -2224,6 +2238,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 11 Pro Max"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_11_pro_max:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D421p?AP|iPhone12,3)$">
@@ -2239,6 +2254,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 11 Pro"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_11_pro:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:N104AP|iPhone12,1)$">
@@ -2253,6 +2269,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 11"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_11:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D331p?AP|iPhone11,[46])$">
@@ -2269,6 +2286,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone XS Max"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_xs_max:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D321AP|iPhone11,2)$">
@@ -2283,6 +2301,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone XS"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_xs:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:N841AP|iPhone11,8)$">
@@ -2297,6 +2316,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone XR"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_xr:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D221?AP|iPhone10,[36])$">
@@ -2313,6 +2333,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone X"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_x:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D211?A?AP|iPhone10,[25])$">
@@ -2331,6 +2352,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 8 Plus"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_8_plus:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D201?A?AP|iPhone10,[14])$">
@@ -2349,6 +2371,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 8"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_8:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D111?AP|iPhone9,[24])$">
@@ -2365,6 +2388,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 7 Plus"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_7_plus:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=(?:D101?AP$|iPhone9,3)">
@@ -2380,10 +2404,11 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 7"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_7:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N69u?AP$">
-    <description>iPhone SE</description>
+    <description>iPhone SE (1st generation)</description>
     <example>model=N69AP</example>
     <example>model=N69uAP</example>
     <param pos="0" name="os.vendor" value="Apple"/>
@@ -2392,8 +2417,9 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPhone"/>
-    <param pos="0" name="hw.product" value="iPhone SE"/>
+    <param pos="0" name="hw.product" value="iPhone SE (1st generation)"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_se_%281st_generation%29:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N66m?AP$">
@@ -2408,6 +2434,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 6s Plus"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_6s_plus:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N71m?AP$">
@@ -2422,6 +2449,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 6s"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_6s:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N56AP$">
@@ -2435,6 +2463,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 6 Plus"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_6_plus:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N61AP$">
@@ -2448,6 +2477,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 6"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_6:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N5[13]AP$">
@@ -2462,6 +2492,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 5s"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_5s:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N4[89]AP$">
@@ -2476,6 +2507,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 5c"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_5c:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N4[12]AP$">
@@ -2520,6 +2552,7 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 4"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_4:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=N88AP$">
@@ -2547,10 +2580,11 @@
     <param pos="0" name="hw.family" value="iPhone"/>
     <param pos="0" name="hw.product" value="iPhone 3G"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_3g:-"/>
   </fingerprint>
 
   <fingerprint pattern="^model=M68AP$">
-    <description>iPhone</description>
+    <description>iPhone (1st generation)</description>
     <example>model=M68AP</example>
     <param pos="0" name="os.vendor" value="Apple"/>
     <param pos="0" name="os.family" value="iOS"/>
@@ -2558,9 +2592,9 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:apple:iphone_os:-"/>
     <param pos="0" name="hw.vendor" value="Apple"/>
     <param pos="0" name="hw.family" value="iPhone"/>
-    <param pos="0" name="hw.product" value="iPhone"/>
+    <param pos="0" name="hw.product" value="iPhone (1st generation)"/>
     <param pos="0" name="hw.device" value="Mobile Phone"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:apple:iphone_%281st_generation%29:-"/>
   </fingerprint>
 
   <!-- iPod -->

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -12,7 +12,6 @@
     <param pos="0" name="service.vendor" value="Cisco"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.product" value="IOS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>
@@ -34,7 +33,6 @@
     <param pos="0" name="service.vendor" value="Cisco"/>
     <param pos="0" name="service.family" value="IOS"/>
     <param pos="0" name="service.product" value="IOS"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:cisco:ios:-"/>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="IOS"/>
     <param pos="0" name="os.product" value="IOS"/>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -165,7 +165,7 @@
     <example>FRITZ!OS</example>
     <param pos="0" name="os.vendor" value="AVM"/>
     <param pos="0" name="os.product" value="FRITZ!OS"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:avm:fritz\!os:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:avm:fritz%21os:-"/>
     <param pos="0" name="hw.vendor" value="AVM"/>
   </fingerprint>
 

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1610,7 +1610,6 @@
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="1" name="os.version"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:{os.version}"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -3466,7 +3465,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.vendor" value="IBM"/>
     <param pos="0" name="os.family" value="z/OS"/>
     <param pos="0" name="os.product" value="z/OS"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:z\/os:-"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:ibm:z%2fos:-"/>
   </fingerprint>
 
   <fingerprint pattern="^BladeCenter Management Module$">

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1068,8 +1068,8 @@
     <param pos="0" name="os.vendor" value="Moxa"/>
     <param pos="0" name="os.family" value="EDR"/>
     <param pos="0" name="os.device" value="Router"/>
-    <param pos="0" name="os.product" value="EDR G903 Firmware"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:moxa:edr_g903_firmware:-"/>
+    <param pos="0" name="os.product" value="EDR-G903 Firmware"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:moxa:edr-g903_firmware:-"/>
   </fingerprint>
 
   <fingerprint pattern="^EDR-G902 login:">
@@ -1097,6 +1097,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:redhat:linux:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="(?m)^Red Hat Enterprise Linux ES release (.*) \(.*\).*Kernel (.*) on a[^ ]* ([^ ]*\d)" flags="REG_MULTILINE">

--- a/xml/tls_jarm.xml
+++ b/xml/tls_jarm.xml
@@ -92,7 +92,7 @@
     <example>06d06d07d06d06d06c06d06d06d06d7991b0b1ad2cbf06082e3b1a9dcaaa8d</example>
     <param pos="0" name="hw.vendor" value="D-Link"/>
     <param pos="0" name="hw.product" value="DCS-825L"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:d-link:dcs-825l:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:dlink:dcs-825l:-"/>
   </fingerprint>
 
   <fingerprint pattern="^0ed3dd16d25d00000042d43d000000e9435856b7ee99e87c06831602602f2d$">

--- a/xml/x11_banners.xml
+++ b/xml/x11_banners.xml
@@ -183,6 +183,7 @@
     <param pos="0" name="service.product" value="SCO X server"/>
     <param pos="0" name="os.product" value="SCO UNIX"/>
     <param pos="0" name="os.family" value="SCO UNIX"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:sco:sco_unix:-"/>
   </fingerprint>
 
   <fingerprint pattern="^StarNet Communications Corp\.$">

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -216,7 +216,6 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
@@ -383,6 +382,7 @@
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="FreshTomato"/>
     <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:freshtomato:freshtomato:-"/>
   </fingerprint>
 
   <fingerprint pattern="(?i)^SERIALNUMBER=(\d+),CN=(\S+),OU=ST-VS,O=Bosch Sicherheitssysteme GmbH,L=Grasbrunn,C=DE">

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -398,7 +398,6 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>


### PR DESCRIPTION
## Description
Updates `update_cpes.py` to make CPE string handling more consistent throughout the script and remap process, and implement CPE URI binding format percent-encoding. Corrects `service`, `os` and `hw` parameters and updates CPE values.

### Notes
* `o:cisco:adaptive_security_appliance_software` deprecated by `a:cisco:adaptive_security_appliance_software` on 2022-05-26
  * This seems incorrect since Cisco's states "Cisco Adaptive Security Appliance (ASA) Software is the core operating system for the Cisco ASA Family."[^1]
* `h:cisco:ios` deprecated by `o:cisco:ios` on 2022-09-02
* `a:cisco:ios` deprecated by `o:cisco:ios` on 2021-10-06
* `a:varnish-cache:varnish_cache` deprecated by `a:varnish_cache_project:varnish_cache` on 2022-08-02
  * `a:varnish-cache:varnish` deprecated by `a:varnish-cache:varnish_cache` on 2022-06-21
* `o:serenityos:serenity` deprecated by `o:serenityos:serenityos` on 2022-12-08
* `a:sap:netweaver_as_abap` deprecated by `a:sap:netweaver_application_server_abap` on 2022-10-05
* `o:moxa:edr_g903_firmware` deprecated by `o:moxa:edr-g903_firmware` on 2022-04-12
* `h:apple:iphone` deprecated by `o:apple:iphone_os` on 2022-08-09
  * This is odd since there are hardware entries for most of the iPhones. After getting in contact with the NVD CPE team, `h:apple:iphone_%281st_generation%29` was added as a replacement.
* `a:d-link:`, `h:d-link:` and `o:d-link:` deprecated by `a:dlink:`, `h:dlink:` and `o:dlink:` on 2023-04-26
* `a:intel:active_management_technology` deprecated by `o:intel:active_management_technology_firmware` on 2023-05-16

[^1]: https://www.cisco.com/c/en/us/products/security/adaptive-security-appliance-asa-software/index.html


## Motivation and Context
Valid CPE values are great!


## How Has This Been Tested?
* `rake tests`
* `bundle exec ./bin/recog_verify --no-warnings xml/*.xml`


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
