### PR TITLE
Add FatPipe Networks MPVPN, IPVPN, WARP, SDWAN fingerprints

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -273,6 +273,8 @@ mappings:
         linux: debian_linux
     eltex:
       vendor: eltex-co
+    fatpipe_networks:
+      vendor: fatpipeinc
     fedora_project:
       vendor: fedoraproject
     hp:
@@ -386,6 +388,8 @@ mappings:
     emc:
       products:
         celerra: celerra_network_attached_storage
+    fatpipe_networks:
+      vendor: fatpipeinc
     hp:
       products:
         ilo: integrated_lights-out

--- a/identifiers/hw_product.txt
+++ b/identifiers/hw_product.txt
@@ -122,6 +122,7 @@ IP Camera
 IP Link Control Processor
 IP2IR
 IPMI
+IPVPN
 IVR
 Infinity Controler
 Instreamer
@@ -142,6 +143,7 @@ LORIX ONE
 Lantick Ethernet Relay Controller
 Lencore Sound Manager 2
 MDS 9000
+MPVPN
 MXA Signal Analyzer
 Mac Pro (Early 2008)
 Mac Pro (Early 2009)
@@ -287,6 +289,7 @@ Room Alert
 Roomba
 S7 DALI Gateway
 SD-WAN
+SDWAN
 SHDSL Router
 SHIELD
 SIGMA Spectrum Infusion System
@@ -357,6 +360,7 @@ Vigor
 Virtual Connect Manager
 Virtual Traffic Manager
 Vood
+WARP
 WLAN AP
 WNR2000
 WebBox

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -119,6 +119,7 @@ IMC
 IOS
 IPReach
 IPSO
+IPVPN Firmware
 IRIX
 IVE OS
 Integrated Lights Out Manager
@@ -136,6 +137,7 @@ Linux Enterprise Desktop
 Linux Enterprise Server
 MDS 9000
 MPE XL
+MPVPN Firmware
 MPX100 iSCSI Bridge
 MSL Tape Library
 Mac OS
@@ -224,6 +226,7 @@ Router
 RouterOS
 SCM Manager module
 SCO UNIX
+SDWAN Firmware
 SEHI
 SIGMA Spectrum Infusion System Firmware
 SINIX
@@ -296,6 +299,7 @@ Virtual Library
 VoIP
 VxWorks
 WAP
+WARP Firmware
 WBR204G
 WaveCore
 WebCSU

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -262,6 +262,7 @@ FUJI XEROX
 Facebook
 FarSite Communications
 FastHTTP Project
+FatPipe Networks
 FatWire
 Fedora Project
 Ferner

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2346,4 +2346,25 @@
     <param pos="0" name="service.product" value="R1Soft Server Backup Manager"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:eddb2b697c8c3dab5a9572de564976d1|b0f000f8041a6f1d2c366972b1dbad69)$">
+    <description>FatPipe Networks device web interface</description>
+    <!--
+      favicon.ico from multiple products and builds:
+        * FatPipe MPVPN versions: 9.1.2r161p26, 9.1.2r164p5
+        * FatPipe IPVPN versions: 9.1.2r129, 10.1.2r60p89
+        * FatPipe WARP versions: 9.1.2r161p19, 9.1.2r161p26, 9.1.2r185
+        * FatPipe SDWAN versions: unknown
+    -->
+    <example>eddb2b697c8c3dab5a9572de564976d1</example>
+    <!--
+      favicon.ico from multiple products and builds:
+        * FatPipe MPVPN version 9.1.2r161p26 to 9.1.2r164p5
+        * FatPipe IPVPN versions: 9.1.2r129
+        * FatPipe WARP versions: 9.1.2r161p19, 9.1.2r161p26, 9.1.2r185
+    -->
+    <example>b0f000f8041a6f1d2c366972b1dbad69</example>
+    <param pos="0" name="os.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="hw.vendor" value="FatPipe Networks"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4196,4 +4196,59 @@
     <param pos="0" name="hw.device" value="Broadband Router"/>
   </fingerprint>
 
+  <!-- FatPipe Networks fingerprints -->
+
+  <fingerprint pattern="^FatPipe MPVPN(?:.nbsp;\| Log in| Remote Configuration)$">
+    <description>FatPipe Networks MPVPN</description>
+    <example>FatPipe MPVPN&amp;nbsp;| Log in</example>
+    <example>FatPipe MPVPN Remote Configuration</example>
+    <param pos="0" name="os.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="os.product" value="MPVPN Firmware"/>
+    <param pos="0" name="os.device" value="Multiplexer"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fatpipeinc:mpvpn_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="hw.product" value="MPVPN"/>
+    <param pos="0" name="hw.device" value="Multiplexer"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:fatpipeinc:mpvpn:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^FatPipe IPVPN(?:.nbsp;\| Log in| Remote Configuration)$">
+    <description>FatPipe Networks IPVPN</description>
+    <example>FatPipe IPVPN&amp;nbsp;| Log in</example>
+    <example>FatPipe IPVPN Remote Configuration</example>
+    <param pos="0" name="os.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="os.product" value="IPVPN Firmware"/>
+    <param pos="0" name="os.device" value="Multiplexer"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fatpipeinc:ipvpn_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="hw.product" value="IPVPN"/>
+    <param pos="0" name="hw.device" value="Multiplexer"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:fatpipeinc:ipvpn:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^FatPipe WARP(?:.nbsp;\| Log in| Remote Configuration)$">
+    <description>FatPipe Networks WARP</description>
+    <example>FatPipe WARP&amp;nbsp;| Log in</example>
+    <example>FatPipe WARP Remote Configuration</example>
+    <param pos="0" name="os.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="os.product" value="WARP Firmware"/>
+    <param pos="0" name="os.device" value="Multiplexer"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:fatpipeinc:warp_firmware:-"/>
+    <param pos="0" name="hw.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="hw.product" value="WARP"/>
+    <param pos="0" name="hw.device" value="Multiplexer"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:fatpipeinc:warp:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^FatPipe SDWAN.nbsp;\| Log in$">
+    <description>FatPipe Networks SDWAN</description>
+    <example>FatPipe SDWAN&amp;nbsp;| Log in</example>
+    <param pos="0" name="os.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="os.product" value="SDWAN Firmware"/>
+    <param pos="0" name="os.device" value="SD-WAN Appliance"/>
+    <param pos="0" name="hw.vendor" value="FatPipe Networks"/>
+    <param pos="0" name="hw.product" value="SDWAN"/>
+    <param pos="0" name="hw.device" value="SD-WAN Appliance"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Adds 5 fingerprints for FatPipe Networks MPVPN, IPVPN, WARP and SDWAN products.

### Notes
Fingerprinted various product versions (7.1.2r186p12, 9.1.2r156, 9.1.2r161p26, etc.)

* `/fpui/img/favicon.ico` (login)
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 1 icon, 16x16, 16 colors, 4 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = eddb2b697c8c3dab5a9572de564976d1
```
* `favicon.ico` (remote configuration)
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 1 icon, 16x16
$ md5 favicon.ico
MD5 (favicon.ico) = b0f000f8041a6f1d2c366972b1dbad69
```



## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
