### PR TITLE
Update README.md testing matches to set grep color to never

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Fingerprint FTP servers based on the server's banner response after connecting:
 echo -n '220 Microsoft FTP Service' | bin/recog_match xml/ftp_banners.xml -
 
 # Example command using nmap
-nmap -sV -script=banner -p 21 192.168.123.13 | grep '_banner' | cut -d: -f2- | bin/recog_match xml/ftp_banners.xml -
+nmap -sV -script=banner -p 21 192.168.123.13 | grep --color=never '_banner' | cut -d: -f2- | bin/recog_match xml/ftp_banners.xml -
 
 # Example output
 MATCH: {"matched"=>"Microsoft FTP Server on Windows XP, 2003 or later without version", "service.vendor"=>"Microsoft", "service.product"=>"IIS", "service.family"=>"IIS", "service.cpe23"=>"cpe:/a:microsoft:iis:-", "os.vendor"=>"Microsoft", "os.family"=>"Windows", "os.product"=>"Windows", "os.cpe23"=>"cpe:/o:microsoft:windows:-", "host.name"=>"220", "service.protocol"=>"ftp", "fingerprint_db"=>"ftp.banner", "data"=>"220 Microsoft FTP Service"}
@@ -228,7 +228,7 @@ Using the HTTP `Set-Cookie` header value to fingerprint an HTTP server:
 echo 'laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax' | bin/recog_match xml/http_cookies.xml -
 
 # Example cURL command
-curl --silent -I http://localhost:9001 | grep -i '^Set-Cookie:' | cut -d: -f2- | bin/recog_match xml/http_cookies.xml -
+curl --silent -I http://localhost:9001 | grep --color=never -i '^Set-Cookie:' | cut -d: -f2- | bin/recog_match xml/http_cookies.xml -
 
 # Example output
 MATCH: {"matched"=>"Laravel PHP web application framework", "service.vendor"=>"Laravel", "service.product"=>"Laravel", "service.cpe23"=>"cpe:/a:laravel:laravel:-", "service.protocol"=>"http", "fingerprint_db"=>"http_header.cookie", "data"=>"laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax"}
@@ -243,7 +243,7 @@ Using the HTTP `Server` header value to fingerprint an HTTP server:
 echo -n 'Apache/2.4.38 (Debian)' | bin/recog_match xml/http_servers.xml -
 
 # Example cURL command
-curl --silent -I http://localhost:9001 | grep -i '^Server:' | cut -d: -f2- | bin/recog_match xml/http_servers.xml -
+curl --silent -I http://localhost:9001 | grep --color=never -i '^Server:' | cut -d: -f2- | bin/recog_match xml/http_servers.xml -
 
 # Example output
 MATCH: {"matched"=>"Apache", "service.vendor"=>"Apache", "service.product"=>"HTTPD", "service.family"=>"Apache", "service.version"=>"2.4.38", "service.cpe23"=>"cpe:/a:apache:http_server:2.4.38", "apache.info"=>"(Debian)", "service.protocol"=>"http", "fingerprint_db"=>"http_header.server", "data"=>"Apache/2.4.38 (Debian)"}
@@ -273,7 +273,7 @@ Using the HTTP `WWW-Authenticate` header value to fingerprint an HTTP server:
 echo -n 'Basic realm="monit"' | bin/recog_match xml/http_wwwauth.xml -
 
 # Example cURL command
-curl --silent -I http://localhost:9001 | grep -i '^WWW-Authenticate:' | cut -d: -f2- | bin/recog_match xml/http_wwwauth.xml -
+curl --silent -I http://localhost:9001 | grep --color=never -i '^WWW-Authenticate:' | cut -d: -f2- | bin/recog_match xml/http_wwwauth.xml -
 
 # Example output
 MATCH: {"matched"=>"Minot", "service.vendor"=>"Tildeslash", "service.product"=>"Monit", "service.cpe23"=>"cpe:/a:tildeslash:monit:-", "service.protocol"=>"http", "fingerprint_db"=>"http_header.wwwauth", "data"=>"Basic realm=\"monit\""}
@@ -288,7 +288,7 @@ Fingerprint TLS servers based on the server's response to 10 TLS Client Hello pa
 echo -n 07d14d16d21d21d07c42d43d000000f50d155305214cf247147c43c0f1a823 | bin/recog_match xml/jarm.xml -
 
 # Example command using Salesforce's JARM against a running Metasploit listener
-python3 $code/jarm/jarm.py -p 8443 192.168.123.1 | grep 'JARM: ' | awk -F: '{ print $2 }' | bin/recog_match xml/tls_jarm.xml -
+python3 $code/jarm/jarm.py -p 8443 192.168.123.1 | grep --color=never 'JARM: ' | awk -F: '{ print $2 }' | bin/recog_match xml/tls_jarm.xml -
 
 # Example output
 MATCH: {"matched"=>"Metasploit listener", "service.vendor"=>"Rapid7", "service.product"=>"Metasploit", "service.cpe23"=>"cpe:/a:rapid7:metasploit:-", "service.protocol"=>"tls", "fingerprint_db"=>"tls.jarm", "data"=>"07d14d16d21d21d07c42d43d000000f50d155305214cf247147c43c0f1a823"}


### PR DESCRIPTION
## Description
Updates `README.md` testing matches examples to set the grep color to `never` to avoid possible issues.

I discovered having grep aliased to `grep --color=always` caused some confusion when experimenting with the new examples under the "Testing matches" section added in #557.

```
$ echo 'laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax' | bin/recog_match xml/http_cookies.xml -
MATCH: {"matched"=>"Laravel PHP web application framework", "service.vendor"=>"Laravel", "service.product"=>"Laravel", "service.cpe23"=>"cpe:/a:laravel:laravel:-", "service.protocol"=>"http", "fingerprint_db"=>"http_header.cookie", "data"=>"laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax"}

$ echo 'Set-Cookie: laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax' | grep -i '^Set-Cookie:' | cut -d: -f2- | bin/recog_match xml/http_cookies.xml -
FAIL:  laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax
```

```
$ echo 'Set-Cookie: laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax' | grep -i '^Set-Cookie:' | cut -d: -f2- | hexdump -C
C
00000000  1b 5b 6d 1b 5b 4b 20 6c  61 72 61 76 65 6c 5f 73  |.[m.[K laravel_s|
00000000  1b 5b 6d 1b 5b 4b 20 6c  61 72 61 76 65 6c 5f 73  |.[m.[K laravel_s|
...

$ echo 'Set-Cookie: laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax' | grep -i --color=never '^Set-Cookie:' | cut -d: -f2- | hexdump -CC
00000000  20 6c 61 72 61 76 65 6c  5f 73 65 73 73 69 6f 6e  | laravel_session|
00000000  20 6c 61 72 61 76 65 6c  5f 73 65 73 73 69 6f 6e  | laravel_session|
...

$ echo 'Set-Cookie: laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax' | grep -i --color=never '^Set-Cookie:' | cut -d: -f2- | bin/recog_match xml/http_cookies.xml -
MATCH: {"matched"=>"Laravel PHP web application framework", "service.vendor"=>"Laravel", "service.product"=>"Laravel", "service.cpe23"=>"cpe:/a:laravel:laravel:-", "service.protocol"=>"http", "fingerprint_db"=>"http_header.cookie", "data"=>"laravel_session=eyJ...etc..etc...%3D; expires=Mon, 13-Mar-2023 16:48:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax"}
```

## Motivation and Context
Help reduce the barrier to testing Recog fingerprint matches


## How Has This Been Tested?
See notes under description


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
