### PR TITLE
Add PaperCut MF and NG vendor only fingerprints

### DIFF
--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -559,6 +559,7 @@ Palm
 Palo Alto Networks
 Panasonic
 Panduit
+PaperCut
 Paperless-ng
 Paperless-ngx
 Papermerge

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2355,6 +2355,7 @@
         * FatPipe WARP versions: 9.1.2r161p19, 9.1.2r161p26, 9.1.2r185
         * FatPipe SDWAN versions: unknown
     -->
+
     <example>eddb2b697c8c3dab5a9572de564976d1</example>
     <!--
       favicon.ico from multiple products and builds:
@@ -2362,6 +2363,7 @@
         * FatPipe IPVPN versions: 9.1.2r129
         * FatPipe WARP versions: 9.1.2r161p19, 9.1.2r161p26, 9.1.2r185
     -->
+
     <example>b0f000f8041a6f1d2c366972b1dbad69</example>
     <param pos="0" name="os.vendor" value="FatPipe Networks"/>
     <param pos="0" name="hw.vendor" value="FatPipe Networks"/>

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2375,4 +2375,19 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:3cx:3cx_web_server:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:4764ad78b4c0d93bc48d4d0df3b36c7e|8d8030454ec1d7f96c8fdf670d4eb3c6)$">
+    <description>PaperCut MF and PaperCut NG - print management system</description>
+    <!--
+      favicon.ico across two products and multiple builds
+        * PaperCut MF builds: 54736 to 65997
+        * PaperCut NG builds: 59505
+    -->
+
+    <example>4764ad78b4c0d93bc48d4d0df3b36c7e</example>
+    <!-- favicon.ico from PaperCut MF builds: 47777 -->
+
+    <example>8d8030454ec1d7f96c8fdf670d4eb3c6</example>
+    <param pos="0" name="service.vendor" value="PaperCut"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4155,6 +4155,12 @@
     <param pos="0" name="service.product" value="R1Soft Server Backup Manager"/>
   </fingerprint>
 
+  <fingerprint pattern="^PaperCut Login for (?:.{1,512})$">
+    <description>PaperCut MF and PaperCut NG - print management system</description>
+    <example>PaperCut Login for Foo Bar</example>
+    <param pos="0" name="service.vendor" value="PaperCut"/>
+  </fingerprint>
+
   <fingerprint pattern="^Transmission Web Interface$">
     <description>Transmission</description>
     <example>Transmission Web Interface</example>


### PR DESCRIPTION
## Description
Adds 2 [PaperCut](https://www.papercut.com/) MF and NG fingerprints that only emit the service vendor.

### Notes
Fingerprinted PaperCut MF builds 54736, 57908, 63915, 65190 and 65997, and PaperCut NG build 59505.
* `/images/icons3/favicon.ico`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 6 icons, 256x256 with PNG image data, 256 x 256, 8-bit/color RGBA, non-interlaced, 32 bits/pixel, -128x-128, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 4764ad78b4c0d93bc48d4d0df3b36c7e
```

Fingerprinted PaperCut MF build 47777.
* `/images/icons3/favicon.ico`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 5 icons, 64x64, 32 bits/pixel, 48x48, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 8d8030454ec1d7f96c8fdf670d4eb3c6
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
