### PR TITLE
Add Apache Superset fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -521,6 +521,7 @@ Sun Directory Server
 Sun Java System Directory Server
 Sun ONE Directory Server
 Sunny WebBox
+Superset
 Supervisor
 SupportCenter Plus
 SurgeFTP

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2128,6 +2128,16 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:apache:spark:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^0629ce6bd8a86ff6b5dbb2a24c040849$">
+    <description>Apache Superset</description>
+    <!-- favicon.png from version 2.1.0 -->
+
+    <example>0629ce6bd8a86ff6b5dbb2a24c040849</example>
+    <param pos="0" name="service.vendor" value="Apache"/>
+    <param pos="0" name="service.product" value="Superset"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:superset:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^a3dcb28303f26786e262e0760781057a$">
     <description>Eltex device web interface</description>
     <example>a3dcb28303f26786e262e0760781057a</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3904,6 +3904,14 @@
     <param pos="1" name="host.name"/>
   </fingerprint>
 
+  <fingerprint pattern="^Superset$">
+    <description>Apache Superset</description>
+    <example>Superset</example>
+    <param pos="0" name="service.vendor" value="Apache"/>
+    <param pos="0" name="service.product" value="Superset"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:apache:superset:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^pfSense - Login$">
     <description>pfSense Firewall</description>
     <example>pfSense - Login</example>


### PR DESCRIPTION
## Description
Adds 2 [Apache Superset](https://superset.apache.org/) fingerprints.

### Notes
Fingerprinted Apache Superset version 2.1.0.

* `favicon.png`
```
$ file favicon.png
favicon.png: PNG image data, 260 x 260, 8-bit/color RGBA, non-interlaced
$ md5 favicon.png
MD5 (favicon.png) = 0629ce6bd8a86ff6b5dbb2a24c040849
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
