### PR TITLE
Add fast reverse proxy (frp) fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -645,6 +645,7 @@ emHTTPD
 etherpad
 exim
 flowssh
+frp
 gSOAP
 gdnsd
 httpd

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -869,6 +869,7 @@ enGenius
 estos
 etherpad
 exim
+frp
 gdnsd
 home.pl
 i.LON

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2410,4 +2410,13 @@
     <param pos="0" name="service.vendor" value="PaperCut"/>
   </fingerprint>
 
+  <fingerprint pattern="^57801ef5135f6a6e8ea69baef85f8607$">
+    <description>frp - fast reverse proxy</description>
+    <!-- favicon.ico from frp version 0.48.0 -->
+
+    <example>57801ef5135f6a6e8ea69baef85f8607</example>
+    <param pos="0" name="service.vendor" value="frp"/>
+    <param pos="0" name="service.product" value="frp"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4185,6 +4185,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:metersphere:metersphere:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:frps dashboard|frp client admin UI)$">
+    <description>frp - fast reverse proxy</description>
+    <example>frps dashboard</example>
+    <example>frp client admin UI</example>
+    <param pos="0" name="service.vendor" value="frp"/>
+    <param pos="0" name="service.product" value="frp"/>
+  </fingerprint>
+
   <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -4939,6 +4939,14 @@
     <param pos="0" name="hw.vendor" value="Server Technology"/>
   </fingerprint>
 
+  <fingerprint pattern="^frp/(\d+(?:\.\d+)*)$">
+    <description>frp - fast reverse proxy, not found response</description>
+    <example service.version="0.48.0">frp/0.48.0</example>
+    <param pos="0" name="service.vendor" value="frp"/>
+    <param pos="0" name="service.product" value="frp"/>
+    <param pos="1" name="service.version"/>
+  </fingerprint>
+
   <!-- ntopng -->
 
   <fingerprint pattern="^ntopng (\d+(?:\.\d+)*) \[(?:FreeBSD |[\w-]+-freebsd)(\d+(?:\.\d+)*)(?:[a-z0-9-])* \[(\w+)\]\[[^\]]*\]\]$">


### PR DESCRIPTION
## Description
Adds 3 [fast reverse proxy (frp)](https://github.com/fatedier/frp) fingerprints.

### Notes
Fingerprinted frp version 0.48.0.

* `favicon.ico`
```
$ file favicon.ico
favicon.ico: MS Windows icon resource - 1 icon, 48x48, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 57801ef5135f6a6e8ea69baef85f8607
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
