### PR TITLE
Correct param order in Sonarr, Radarr, Prowlarr fingerprints

### DIFF
--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -35,8 +35,8 @@
     <example>1a60f7f928a659f763204d525b3cf90d</example><!-- favicon-16x16.png-->
     <example>6d4c72194ecff7ead96f65db45851be9</example><!-- favicon-32x32.png-->
     <example>55ece828b1329741c1d553a6575d71f1</example><!-- favicon.ico-->
-    <param pos="0" name="service.product" value="Radarr"/>
     <param pos="0" name="service.vendor" value="Radarr"/>
+    <param pos="0" name="service.product" value="Radarr"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:b3ae051d2c6b875b2064288104856291|c24b156cfaa12860760793f43b487c21|657ebbffad0e5c71a1010fbc9b279b1e)$">
@@ -44,8 +44,8 @@
     <example>b3ae051d2c6b875b2064288104856291</example><!-- favicon-32x32.png-->
     <example>c24b156cfaa12860760793f43b487c21</example><!-- favicon-16x16.png-->
     <example>657ebbffad0e5c71a1010fbc9b279b1e</example><!-- favicon.ico-->
-    <param pos="0" name="service.product" value="Sonarr"/>
     <param pos="0" name="service.vendor" value="Sonarr"/>
+    <param pos="0" name="service.product" value="Sonarr"/>
   </fingerprint>
 
   <fingerprint pattern="^0f584138aacfb79aaba7e2539fc4e642$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4130,8 +4130,8 @@
   <fingerprint pattern="^Login - Radarr$">
     <description>Radarr</description>
     <example>Login - Radarr</example>
-    <param pos="0" name="service.product" value="Radarr"/>
     <param pos="0" name="service.vendor" value="Radarr"/>
+    <param pos="0" name="service.product" value="Radarr"/>
   </fingerprint>
 
   <fingerprint pattern="^Login - Sonarr$">

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -455,8 +455,8 @@
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;Prowlarr&quot;$">
     <description>Prowlarr</description>
     <example>Basic realm="Prowlarr"</example>
-    <param pos="0" name="service.product" value="Prowlarr"/>
     <param pos="0" name="service.vendor" value="Prowlarr"/>
+    <param pos="0" name="service.product" value="Prowlarr"/>
   </fingerprint>
 
   <!-- HP ProCurve -->


### PR DESCRIPTION
## Description
Corrects the `param` order in the Sonarr, Radarr and Prowlarr fingerprints added in #571.


## Motivation and Context
Maintain consistent `param` order


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml xml/http_wwwauth.xml`
* `rake tests`


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
