### PR TITLE
Add Progress MOVEit Transfer fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -299,6 +299,7 @@ MAILsweeper
 MDaemon
 MERCUR
 MOVEit DMZ
+MOVEit Transfer
 Mail Security for SMTP
 Mail Server
 Mail-Max

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -805,6 +805,17 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:filerun:filerun:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^(DMZCookieTest|MIDMZLang|siLockLongTermInstID)=">
+    <description>Progress MOVEit Transfer (formerly MOVEit DMZ, MOVEit File Transfer)</description>
+    <example cookie="DMZCookieTest">DMZCookieTest=ifyoucanreadthisyourbrowsersupportscookies; path=/</example>
+    <example cookie="MIDMZLang">MIDMZLang=en; expires=Fri, 30-May-2025 05:08:54 GMT; path=/</example>
+    <example cookie="siLockLongTermInstID">siLockLongTermInstID=1337; expires=Fri, 30-May-2025 05:08:54 GMT; path=/</example>
+    <param pos="1" name="cookie"/>
+    <param pos="0" name="service.vendor" value="Progress"/>
+    <param pos="0" name="service.product" value="MOVEit Transfer"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:progress:moveit_transfer:-"/>
+  </fingerprint>
+
   <!--
         Ignore various cookies that are very generic cookies for session IDs
         that are not necessarily indicative of any particular

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1876,6 +1876,14 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^MOVEit Transfer SFTP$">
+    <description>Progress MOVEit Transfer (formerly MOVEit DMZ, MOVEit File Transfer)</description>
+    <example>MOVEit Transfer SFTP</example>
+    <param pos="0" name="service.vendor" value="Progress"/>
+    <param pos="0" name="service.product" value="MOVEit Transfer"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:progress:moveit_transfer:-"/>
+  </fingerprint>
+
   <fingerprint pattern="^paramiko_([\d\.]+)">
     <description>Paramiko</description>
     <example service.version="2.1.3">paramiko_2.1.3 501 command not implemented ERROR</example>


### PR DESCRIPTION
## Description
Adds 2 [Progress MOVEit Transfer](https://www.progress.com/moveit) fingerprints.


### Notes
Fingerprinted unknown versions of MOVEit Transfer.
The favicon fingerprint was not added at this time since it appears to only be the Progress logo.

* `favicon.ico`
```
$ file favicon.ico
progress-moveit-transfer-favicon.ico: MS Windows icon resource - 8 icons, 256x256, 32 bits/pixel, 16x16, 32 bits/pixel
$ md5 favicon.ico
MD5 (favicon.ico) = 9dffe2772e6553e2bb480dde2fe0c4a6
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/http_cookies.xml xml/ssh_banners.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
