### PR TITLE
CI Workflow: pin upper JRuby version to 9.4.2 as workaround for test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'jruby-9.2', 'jruby']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'jruby-9.2', 'jruby-9.4.2']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Updates the GitHub CI workflow `.github/workflows/ci.yml` to pin the upper JRuby version to `9.4.2` as a temporary workaround for Nokogiri method redefined warnings causing test failures.
```
/home/runner/work/recog/recog/vendor/bundle/jruby/3.1.0/gems/nokogiri-1.15.2-java/lib/nokogiri/xml/node.rb:1007: warning: method redefined; discarding old attr
       (RSpec::Expectations::ExpectationNotMetError)
```
The source of the issue appears to be related to jruby/jruby#7183.


## Motivation and Context
Unblock CI testing issue.


## How Has This Been Tested?
* Inspect test results in this PR


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
