### PR TITLE
Add Roundcube Webmail fingerprints

### DIFF
--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -605,6 +605,7 @@ WebSocket++
 WebSphere
 WebSphere Load Balancer
 WebTrends
+Webmail
 Webmin
 Webserver
 Werkzeug

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -638,6 +638,7 @@ Rockliffe
 Rockwell Automation
 Rohde & Schwarz
 Roku
+Roundcube
 Roxen
 Ruby-Lang
 Ruckus

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -2464,4 +2464,18 @@
     <param pos="0" name="service.product" value="frp"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:924a68d347c80d0e502157e83812bb23|f1ac749564d5ba793550ec6bdc472e7c|ef9c0362bf20a086bb7c2e8ea346b9f0)$">
+    <description>Roundcube Webmail</description>
+    <!-- favicon.ico from Roundcube Webmail version 1.5.0+ -->
+
+    <example>924a68d347c80d0e502157e83812bb23</example>
+    <!-- favicon.ico from Roundcube Webmail up to version 1.4.13 -->
+
+    <example>f1ac749564d5ba793550ec6bdc472e7c</example>
+    <example>ef9c0362bf20a086bb7c2e8ea346b9f0</example>
+    <param pos="0" name="service.vendor" value="Roundcube"/>
+    <param pos="0" name="service.product" value="Webmail"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:roundcube:webmail:-"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -4217,6 +4217,14 @@
     <param pos="0" name="service.product" value="frp"/>
   </fingerprint>
 
+  <fingerprint pattern="^Roundcube Webmail :: Welcome to Roundcube Webmail$">
+    <description>Roundcube Webmail</description>
+    <example>Roundcube Webmail :: Welcome to Roundcube Webmail</example>
+    <param pos="0" name="service.vendor" value="Roundcube"/>
+    <param pos="0" name="service.product" value="Webmail"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:roundcube:webmail:-"/>
+  </fingerprint>
+
   <!-- Specific Eltex fingerprints to enable CPE generation -->
 
   <fingerprint pattern="^Eltex - NTP-RG-1402G$">

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -815,6 +815,14 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:progress:moveit_transfer:-"/>
   </fingerprint>
 
+  <fingerprint pattern="^roundcube_sessid=">
+    <description>Roundcube Webmail</description>
+    <example>roundcube_sessid=bdd66fb23fa3ce907a1e792475273145; path=/; HttpOnly</example>
+    <param pos="0" name="service.vendor" value="Roundcube"/>
+    <param pos="0" name="service.product" value="Webmail"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:roundcube:webmail:-"/>
+  </fingerprint>
+
   <!--
         Ignore various cookies that are very generic cookies for session IDs
         that are not necessarily indicative of any particular


### PR DESCRIPTION
## Description
Adds 3 [Roundcube Webmail](https://roundcube.net/) fingerprints.

### Notes
Fingerprinted Roundcube Webmail versions 1.6.1, 1.5.0, 1.4.13 and 1.4.12.

* `skins/elastic/images/favicon.ico` ([1.6.1](https://github.com/roundcube/roundcubemail/releases/tag/1.6.1))
```
$ file roundcubemail-1.6.1/skins/elastic/images/favicon.ico
roundcubemail-1.6.1/skins/elastic/images/favicon.ico: MS Windows icon resource - 1 icon, 64x64, 32 bits/pixel
$ md5 roundcubemail-1.6.1/skins/elastic/images/favicon.ico
MD5 (roundcubemail-1.6.1/skins/elastic/images/favicon.ico) = 924a68d347c80d0e502157e83812bb23
```
* `skins/elastic/images/favicon.ico` ([1.5.0](https://github.com/roundcube/roundcubemail/releases/tag/1.5.0))
* `skins/classic/images/favicon.ico` ([1.5.0](https://github.com/roundcube/roundcubemail/releases/tag/1.5.0))
* `skins/larry/images/favicon.ico` ([1.5.0](https://github.com/roundcube/roundcubemail/releases/tag/1.5.0))
```
$ file roundcubemail-1.5.0/skins/elastic/images/favicon.ico
roundcubemail-1.5.0/skins/elastic/images/favicon.ico: MS Windows icon resource - 1 icon, 64x64, 32 bits/pixel
$ md5 roundcubemail-1.5.0/skins/elastic/images/favicon.ico
MD5 (roundcubemail-1.5.0/skins/elastic/images/favicon.ico) = 924a68d347c80d0e502157e83812bb23
$ md5 roundcubemail-1.5.0/skins/classic/images/favicon.ico
MD5 (roundcubemail-1.5.0/skins/classic/images/favicon.ico) = 924a68d347c80d0e502157e83812bb23
$ md5 roundcubemail-1.5.0/skins/larry/images/favicon.ico
MD5 (roundcubemail-1.5.0/skins/larry/images/favicon.ico) = 924a68d347c80d0e502157e83812bb23
```
* `skins/elastic/images/favicon.ico` ([1.4.13](https://github.com/roundcube/roundcubemail/releases/tag/1.4.13))
```
$ file roundcubemail-1.4.13/skins/elastic/images/favicon.ico
roundcubemail-1.4.13/skins/elastic/images/favicon.ico: MS Windows icon resource - 2 icons, 16x16, 32 bits/pixel, 16x16, 32 bits/pixel
$ md5 roundcubemail-1.4.13/skins/elastic/images/favicon.ico
MD5 (roundcubemail-1.4.13/skins/elastic/images/favicon.ico) = f1ac749564d5ba793550ec6bdc472e7c
```
* `skins/classic/images/favicon.ico` ([1.4.13](https://github.com/roundcube/roundcubemail/releases/tag/1.4.13))
* `skins/larry/images/favicon.ico` ([1.4.13](https://github.com/roundcube/roundcubemail/releases/tag/1.4.13))
```
$ file roundcubemail-1.4.13/skins/classic/images/favicon.ico
roundcubemail-1.4.13/skins/classic/images/favicon.ico: MS Windows icon resource - 5 icons, 16x16, 32 bits/pixel, 24x24, 32 bits/pixel
$ md5 roundcubemail-1.4.13/skins/classic/images/favicon.ico
MD5 (roundcubemail-1.4.13/skins/classic/images/favicon.ico) = ef9c0362bf20a086bb7c2e8ea346b9f0
$ md5 roundcubemail-1.4.13/skins/larry/images/favicon.ico
MD5 (roundcubemail-1.4.13/skins/larry/images/favicon.ico) = ef9c0362bf20a086bb7c2e8ea346b9f0
```


## Motivation and Context
Improved coverage


## How Has This Been Tested?
* `bundle exec ./bin/recog_verify xml/favicons.xml xml/html_title.xml xml/http_cookies.xml`
* `rake tests`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
