### PR TITLE
2 match windows version from masscan output

### DIFF
--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -307,7 +307,10 @@ WebCSU
 Windows
 Windows 10
 Windows 10 Mobile
+Windows 10 or Windows Server
 Windows 10 or Windows Server 2016
+Windows 10 or Windows Server 2019
+Windows 11
 Windows 2000
 Windows 2000 Datacenter Server
 Windows 2000 Server
@@ -319,6 +322,8 @@ Windows 8.1
 Windows 8.1 or Windows Server 2012 R2
 Windows 95
 Windows CE
+Windows Home Server
+Windows Home Server 2011
 Windows NT
 Windows NT Server
 Windows NT Workstation
@@ -335,7 +340,9 @@ Windows Server 2012
 Windows Server 2012 R2
 Windows Server 2016
 Windows Server 2019
+Windows Server 2022
 Windows Vista
+Windows Vista or Windows Server 2008
 Windows XP
 Wireless Controller
 Wireless LAN Controller

--- a/xml/smb_banners.xml
+++ b/xml/smb_banners.xml
@@ -1,0 +1,296 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<fingerprints matches="smb.banner" protocol="smb" database_type="service" preference="0.90">
+
+    <fingerprint pattern="^10.0.19045$">
+        <description>Windows 10, Version 22H2</description>
+        <example os.build="19045">10.0.19045</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="22H2" />
+        <param pos="0" name="os.build" value="19045"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.22621$">
+        <description>Windows 11, Version 22H2</description>
+        <example os.build="22621">10.0.22621</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 11"/>
+        <param pos="0" name="os.version" value="22H2" />
+        <param pos="0" name="os.build" value="22621"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.19044$">
+        <description>Windows 10, Version 21H2</description>
+        <example os.build="19044">10.0.19044</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="21H2" />
+        <param pos="0" name="os.build" value="19044"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.22000$">
+        <description>Windows 11, Version 21H2</description>
+        <example os.build="22000">10.0.22000</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 11"/>
+        <param pos="0" name="os.version" value="21H2" />
+        <param pos="0" name="os.build" value="22000"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.20348$">
+        <description>Windows Server 2022</description>
+        <example os.build="20348">10.0.20348</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Server 2022"/>
+        <param pos="0" name="os.build" value="20348"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.19043$">
+        <description>Windows 10, Version 21H1</description>
+        <example os.build="19043">10.0.19043</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="21H1" />
+        <param pos="0" name="os.build" value="19043"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.19042$">
+        <description>Windows 10 / Windows Server, Version 20H2</description>
+        <example os.build="19042">10.0.19042</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10 or Windows Server"/>
+        <param pos="0" name="os.version" value="20H2" />
+        <param pos="0" name="os.build" value="19042"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.19041$">
+        <description>Windows 10 / Windows Server, Version 2004</description>
+        <example os.build="19041">10.0.19041</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10 or Windows Server"/>
+        <param pos="0" name="os.version" value="2004" />
+        <param pos="0" name="os.build" value="19041"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.18363$">
+        <description>Windows 10 / Windows Server, Version 1909</description>
+        <example os.build="18363">10.0.18363</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10 or Windows Server"/>
+        <param pos="0" name="os.version" value="1909" />
+        <param pos="0" name="os.build" value="18363"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.18362$">
+        <description>Windows 10, Version 1903</description>
+        <example os.build="18362">10.0.18362</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="1903" />
+        <param pos="0" name="os.build" value="18362"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.0.6003$">
+        <description>Windows Server 2008, Service Pack 2, Rollup KB4489887</description>
+        <example os.build="6003">6.0.6003</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Server 2008"/>
+        <param pos="0" name="os.version" value="Service Pack 2, Rollup KB4489887" />
+        <param pos="0" name="os.build" value="6003"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.17763$">
+        <description>Windows 10 / Windows Server 2019, Version 1809</description>
+        <example os.build="17763">10.0.17763</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10 or Windows Server 2019"/>
+        <param pos="0" name="os.version" value="1809" />
+        <param pos="0" name="os.build" value="17763"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.17134$">
+        <description>Windows 10, Version 1803</description>
+        <example os.build="17134">10.0.17134</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="1803" />
+        <param pos="0" name="os.build" value="17134"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.16299$">
+        <description>Windows 10, Version 1709</description>
+        <example os.build="16299">10.0.16299</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="1709" />
+        <param pos="0" name="os.build" value="16299"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.15063$">
+        <description>Windows 10, Version 1703</description>
+        <example os.build="15063">10.0.15063</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="1703" />
+        <param pos="0" name="os.build" value="15063"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.14393$">
+        <description>Windows 10 / Windows Server 2016, Version 1607</description>
+        <example os.build="14393">10.0.14393</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10 or Windows Server 2016"/>
+        <param pos="0" name="os.version" value="1607" />
+        <param pos="0" name="os.build" value="14393"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.10586$">
+        <description>Windows 10, Version 1511</description>
+        <example os.build="10586">10.0.10586</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="1511" />
+        <param pos="0" name="os.build" value="10586"/>
+    </fingerprint>
+
+    <fingerprint pattern="^10.0.10240$">
+        <description>Windows 10, Version 1507</description>
+        <example os.build="10240">10.0.10240</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 10"/>
+        <param pos="0" name="os.version" value="1507" />
+        <param pos="0" name="os.build" value="10240"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.3.9600$">
+        <description>Windows 8.1 / Windows Server 2012 R2</description>
+        <example os.build="9600">6.3.9600</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 8.1 or Windows Server 2012 R2"/>
+        <param pos="0" name="os.build" value="9600"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.2.9200$">
+        <description>Windows 8 / Windows Server 2012</description>
+        <example os.build="9200">6.2.9200</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 8 or Windows Server 2012"/>
+        <param pos="0" name="os.build" value="9200"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.1.8400$">
+        <description>Windows Home Server 2011</description>
+        <example os.build="8400">6.1.8400</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Home Server 2011"/>
+        <param pos="0" name="os.build" value="8400"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.1.7601$">
+        <description>Windows 7 / Windows Server 2008 R2, Service Pack 1</description>
+        <example os.build="7601">6.1.7601</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 7 or Windows Server 2008 R2"/>
+        <param pos="0" name="os.version" value="Service Pack 1" />
+        <param pos="0" name="os.build" value="7601"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.1.7600$">
+        <description>Windows 7 / Windows Server 2008 R2</description>
+        <example os.build="7600">6.1.7600</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows 7 or Windows Server 2008 R2"/>
+        <param pos="0" name="os.build" value="7600"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.0.6002$">
+        <description>Windows Vista / Windows Server 2008, Service Pack 2</description>
+        <example os.build="6002">6.0.6002</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Vista or Windows Server 2008"/>
+        <param pos="0" name="os.version" value="Service Pack 2" />
+        <param pos="0" name="os.build" value="6002"/>
+    </fingerprint>
+
+    <fingerprint pattern="^5.1.2600$">
+        <description>Windows XP, Service Pack 3</description>
+        <example os.build="2600">5.1.2600</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows XP"/>
+        <param pos="0" name="os.version" value="Service Pack 3" />
+        <param pos="0" name="os.build" value="2600"/>
+    </fingerprint>
+
+    <fingerprint pattern="^6.0.6001$">
+        <description>Windows Server 2008</description>
+        <example os.build="6001">6.0.6001</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Server 2008"/>
+        <param pos="0" name="os.build" value="6001"/>
+    </fingerprint>
+
+    <fingerprint pattern="^5.2.4500$">
+        <description>Windows Home Server</description>
+        <example os.build="4500">5.2.4500</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Home Server"/>
+        <param pos="0" name="os.build" value="4500"/>
+    </fingerprint>
+
+    <fingerprint pattern="^5.2.3790$">
+        <description>Windows Server 2003, Service Pack 2</description>
+        <example os.build="3790">5.2.3790</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Server 2003"/>
+        <param pos="0" name="os.version" value="Service Pack 2" />
+        <param pos="0" name="os.build" value="3790"/>
+    </fingerprint>
+
+    <fingerprint pattern="^5.2.3790$">
+        <description>Windows Server 2003 R2</description>
+        <example os.build="3790">5.2.3790</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
+        <param pos="0" name="os.build" value="3790"/>
+    </fingerprint>
+
+    <fingerprint pattern="^5.2.3790.1180$">
+        <description>Windows Server 2003, Service Pack 1</description>
+        <example os.build="3790.1180">5.2.3790.1180</example>
+        <param pos="0" name="os.certainty" value="1.0"/>
+        <param pos="0" name="os.vendor" value="Microsoft"/>
+        <param pos="0" name="os.product" value="Windows Server 2003"/>
+        <param pos="0" name="os.version" value="Service Pack 1" />
+        <param pos="0" name="os.build" value="3790.1180"/>
+    </fingerprint>
+
+</fingerprints>

--- a/xml/smb_banners.xml
+++ b/xml/smb_banners.xml
@@ -274,14 +274,4 @@
         <param pos="0" name="os.build" value="3790"/>
     </fingerprint>
 
-    <fingerprint pattern="5.2.3790.1180">
-        <description>Windows Server 2003, Service Pack 1</description>
-        <example os.build="3790.1180">5.2.3790.1180</example>
-        <param pos="0" name="os.certainty" value="1.0"/>
-        <param pos="0" name="os.vendor" value="Microsoft"/>
-        <param pos="0" name="os.product" value="Windows Server 2003"/>
-        <param pos="0" name="os.version" value="Service Pack 1" />
-        <param pos="0" name="os.build" value="3790.1180"/>
-    </fingerprint>
-
 </fingerprints>

--- a/xml/smb_banners.xml
+++ b/xml/smb_banners.xml
@@ -265,21 +265,12 @@
     </fingerprint>
 
     <fingerprint pattern="5.2.3790">
-        <description>Windows Server 2003, Service Pack 2</description>
-        <example os.build="3790">5.2.3790</example>
-        <param pos="0" name="os.certainty" value="1.0"/>
-        <param pos="0" name="os.vendor" value="Microsoft"/>
-        <param pos="0" name="os.product" value="Windows Server 2003"/>
-        <param pos="0" name="os.version" value="Service Pack 2" />
-        <param pos="0" name="os.build" value="3790"/>
-    </fingerprint>
-
-    <fingerprint pattern="5.2.3790">
-        <description>Windows Server 2003 R2</description>
+        <description>Windows Server 2003 R2, Service Pack 2</description>
         <example os.build="3790">5.2.3790</example>
         <param pos="0" name="os.certainty" value="1.0"/>
         <param pos="0" name="os.vendor" value="Microsoft"/>
         <param pos="0" name="os.product" value="Windows Server 2003 R2"/>
+        <param pos="0" name="os.version" value="Service Pack 2" />
         <param pos="0" name="os.build" value="3790"/>
     </fingerprint>
 

--- a/xml/smb_banners.xml
+++ b/xml/smb_banners.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <fingerprints matches="smb.banner" protocol="smb" database_type="service" preference="0.90">
 
-    <fingerprint pattern="^10.0.19045$">
+    <fingerprint pattern="10.0.19045">
         <description>Windows 10, Version 22H2</description>
         <example os.build="19045">10.0.19045</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -11,7 +11,7 @@
         <param pos="0" name="os.build" value="19045"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.22621$">
+    <fingerprint pattern="10.0.22621">
         <description>Windows 11, Version 22H2</description>
         <example os.build="22621">10.0.22621</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -21,7 +21,7 @@
         <param pos="0" name="os.build" value="22621"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.19044$">
+    <fingerprint pattern="10.0.19044">
         <description>Windows 10, Version 21H2</description>
         <example os.build="19044">10.0.19044</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -31,7 +31,7 @@
         <param pos="0" name="os.build" value="19044"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.22000$">
+    <fingerprint pattern="10.0.22000">
         <description>Windows 11, Version 21H2</description>
         <example os.build="22000">10.0.22000</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -41,7 +41,7 @@
         <param pos="0" name="os.build" value="22000"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.20348$">
+    <fingerprint pattern="10.0.20348">
         <description>Windows Server 2022</description>
         <example os.build="20348">10.0.20348</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -50,7 +50,7 @@
         <param pos="0" name="os.build" value="20348"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.19043$">
+    <fingerprint pattern="10.0.19043">
         <description>Windows 10, Version 21H1</description>
         <example os.build="19043">10.0.19043</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -60,7 +60,7 @@
         <param pos="0" name="os.build" value="19043"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.19042$">
+    <fingerprint pattern="10.0.19042">
         <description>Windows 10 / Windows Server, Version 20H2</description>
         <example os.build="19042">10.0.19042</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -70,7 +70,7 @@
         <param pos="0" name="os.build" value="19042"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.19041$">
+    <fingerprint pattern="10.0.19041">
         <description>Windows 10 / Windows Server, Version 2004</description>
         <example os.build="19041">10.0.19041</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -80,7 +80,7 @@
         <param pos="0" name="os.build" value="19041"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.18363$">
+    <fingerprint pattern="10.0.18363">
         <description>Windows 10 / Windows Server, Version 1909</description>
         <example os.build="18363">10.0.18363</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -90,7 +90,7 @@
         <param pos="0" name="os.build" value="18363"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.18362$">
+    <fingerprint pattern="10.0.18362">
         <description>Windows 10, Version 1903</description>
         <example os.build="18362">10.0.18362</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -100,7 +100,7 @@
         <param pos="0" name="os.build" value="18362"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.0.6003$">
+    <fingerprint pattern="6.0.6003">
         <description>Windows Server 2008, Service Pack 2, Rollup KB4489887</description>
         <example os.build="6003">6.0.6003</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -110,7 +110,7 @@
         <param pos="0" name="os.build" value="6003"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.17763$">
+    <fingerprint pattern="10.0.17763">
         <description>Windows 10 / Windows Server 2019, Version 1809</description>
         <example os.build="17763">10.0.17763</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -120,7 +120,7 @@
         <param pos="0" name="os.build" value="17763"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.17134$">
+    <fingerprint pattern="10.0.17134">
         <description>Windows 10, Version 1803</description>
         <example os.build="17134">10.0.17134</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -130,7 +130,7 @@
         <param pos="0" name="os.build" value="17134"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.16299$">
+    <fingerprint pattern="10.0.16299">
         <description>Windows 10, Version 1709</description>
         <example os.build="16299">10.0.16299</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -140,7 +140,7 @@
         <param pos="0" name="os.build" value="16299"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.15063$">
+    <fingerprint pattern="10.0.15063">
         <description>Windows 10, Version 1703</description>
         <example os.build="15063">10.0.15063</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -150,7 +150,7 @@
         <param pos="0" name="os.build" value="15063"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.14393$">
+    <fingerprint pattern="10.0.14393">
         <description>Windows 10 / Windows Server 2016, Version 1607</description>
         <example os.build="14393">10.0.14393</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -160,7 +160,7 @@
         <param pos="0" name="os.build" value="14393"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.10586$">
+    <fingerprint pattern="10.0.10586">
         <description>Windows 10, Version 1511</description>
         <example os.build="10586">10.0.10586</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -170,7 +170,7 @@
         <param pos="0" name="os.build" value="10586"/>
     </fingerprint>
 
-    <fingerprint pattern="^10.0.10240$">
+    <fingerprint pattern="10.0.10240">
         <description>Windows 10, Version 1507</description>
         <example os.build="10240">10.0.10240</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -180,7 +180,7 @@
         <param pos="0" name="os.build" value="10240"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.3.9600$">
+    <fingerprint pattern="6.3.9600">
         <description>Windows 8.1 / Windows Server 2012 R2</description>
         <example os.build="9600">6.3.9600</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -189,7 +189,7 @@
         <param pos="0" name="os.build" value="9600"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.2.9200$">
+    <fingerprint pattern="6.2.9200">
         <description>Windows 8 / Windows Server 2012</description>
         <example os.build="9200">6.2.9200</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -198,7 +198,7 @@
         <param pos="0" name="os.build" value="9200"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.1.8400$">
+    <fingerprint pattern="6.1.8400">
         <description>Windows Home Server 2011</description>
         <example os.build="8400">6.1.8400</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -207,7 +207,7 @@
         <param pos="0" name="os.build" value="8400"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.1.7601$">
+    <fingerprint pattern="6.1.7601">
         <description>Windows 7 / Windows Server 2008 R2, Service Pack 1</description>
         <example os.build="7601">6.1.7601</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -217,7 +217,7 @@
         <param pos="0" name="os.build" value="7601"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.1.7600$">
+    <fingerprint pattern="6.1.7600">
         <description>Windows 7 / Windows Server 2008 R2</description>
         <example os.build="7600">6.1.7600</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -226,7 +226,7 @@
         <param pos="0" name="os.build" value="7600"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.0.6002$">
+    <fingerprint pattern="6.0.6002">
         <description>Windows Vista / Windows Server 2008, Service Pack 2</description>
         <example os.build="6002">6.0.6002</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -236,7 +236,7 @@
         <param pos="0" name="os.build" value="6002"/>
     </fingerprint>
 
-    <fingerprint pattern="^5.1.2600$">
+    <fingerprint pattern="5.1.2600">
         <description>Windows XP, Service Pack 3</description>
         <example os.build="2600">5.1.2600</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -246,7 +246,7 @@
         <param pos="0" name="os.build" value="2600"/>
     </fingerprint>
 
-    <fingerprint pattern="^6.0.6001$">
+    <fingerprint pattern="6.0.6001">
         <description>Windows Server 2008</description>
         <example os.build="6001">6.0.6001</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -255,7 +255,7 @@
         <param pos="0" name="os.build" value="6001"/>
     </fingerprint>
 
-    <fingerprint pattern="^5.2.4500$">
+    <fingerprint pattern="5.2.4500">
         <description>Windows Home Server</description>
         <example os.build="4500">5.2.4500</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -264,7 +264,7 @@
         <param pos="0" name="os.build" value="4500"/>
     </fingerprint>
 
-    <fingerprint pattern="^5.2.3790$">
+    <fingerprint pattern="5.2.3790">
         <description>Windows Server 2003, Service Pack 2</description>
         <example os.build="3790">5.2.3790</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -274,7 +274,7 @@
         <param pos="0" name="os.build" value="3790"/>
     </fingerprint>
 
-    <fingerprint pattern="^5.2.3790$">
+    <fingerprint pattern="5.2.3790">
         <description>Windows Server 2003 R2</description>
         <example os.build="3790">5.2.3790</example>
         <param pos="0" name="os.certainty" value="1.0"/>
@@ -283,7 +283,7 @@
         <param pos="0" name="os.build" value="3790"/>
     </fingerprint>
 
-    <fingerprint pattern="^5.2.3790.1180$">
+    <fingerprint pattern="5.2.3790.1180">
         <description>Windows Server 2003, Service Pack 1</description>
         <example os.build="3790.1180">5.2.3790.1180</example>
         <param pos="0" name="os.certainty" value="1.0"/>


### PR DESCRIPTION
## Description
Added file smb_banners.xml to match smb banners _version_ field to identify windows versions

## Motivation and Context
Improved Coverage

## How Has This Been Tested?
bundle exec ./bin/recog_verify xml/smb_banners.xml
rake tests

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
