### PR TITLE
Update CPE values

### DIFF
--- a/cpe-remap.yaml
+++ b/cpe-remap.yaml
@@ -169,9 +169,6 @@ mappings:
       vendor: parallels
     proftpd_project:
       vendor: proftpd
-    progress:
-      products:
-        openedge_explorer: openedge
     pulse_secure:
       vendor: pulsesecure
     realvnc_ltd.:

--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -442,7 +442,7 @@
     <param pos="0" name="service.vendor" value="Progress"/>
     <param pos="0" name="service.product" value="OpenEdge Explorer"/>
     <param pos="0" name="service.certainty" value="0.5"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:progress:openedge:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:progress:openedge_explorer:-"/>
   </fingerprint>
 
   <fingerprint pattern="^297a81069094d00a052733d3a0537d18$">
@@ -945,6 +945,7 @@
     <param pos="0" name="service.vendor" value="Tenable"/>
     <param pos="0" name="service.product" value="Security Center"/>
     <param pos="0" name="service.certainty" value="0.5"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:tenable:security_center:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:78ee71862e89db1b1870197b40d026e5|799f70b71314a7508326d1d2f68f7519)$">
@@ -1333,12 +1334,12 @@
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.certainty" value="0.5"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.device" value="Firewall"/>
     <param pos="0" name="hw.certainty" value="0.5"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:af13b379bdb4ae7a5e68d9aa4419b2e4|cd844ad9671131f5464458a2ef58b7bc|c32e2dc4d7caedd5cefc9d44cc4f62ec)$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3000,7 +3000,7 @@
     <example>OpenEdge Explorer</example>
     <param pos="0" name="service.vendor" value="Progress"/>
     <param pos="0" name="service.product" value="OpenEdge Explorer"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:progress:openedge:-"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:progress:openedge_explorer:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Consul by HashiCorp$">

--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -205,11 +205,11 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
   </fingerprint>
 
   <fingerprint pattern="^st8id=">

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2198,11 +2198,11 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
   </fingerprint>
 
   <fingerprint pattern="^CE_E$">

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1572,6 +1572,7 @@
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MaxScale"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:maxscale:{service.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^(\d{1,2}\.\d{1,3}\.[a-f\d]{1,3})-falcon-alpha-community-nt" flags="REG_ICASE">

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -1610,11 +1610,11 @@
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.device" value="Firewall"/>
     <param pos="1" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:{os.version}"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
   </fingerprint>
 
   <fingerprint pattern="^Cisco 761 Software Version (.*) -">

--- a/xml/x509_issuers.xml
+++ b/xml/x509_issuers.xml
@@ -216,11 +216,11 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
   </fingerprint>
 
   <fingerprint pattern="^CN=Temporary CA [a-fA-F0-9]{8}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{12},OU=Temporary CA">

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -398,11 +398,11 @@
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="os.product" value="Adaptive Security Appliance"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:cisco:adaptive_security_appliance_software:-"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
     <param pos="0" name="hw.family" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.product" value="Adaptive Security Appliance"/>
     <param pos="0" name="hw.device" value="Firewall"/>
-    <param pos="0" name="hw.cpe23" value="cpe:/h:cisco:adaptive_security_appliance:-"/>
   </fingerprint>
 
   <fingerprint pattern="^SERIALNUMBER=([a-zA-Z0-9]+),CN=DEVICE-vWLC,O=Cisco Virtual WLC$">


### PR DESCRIPTION
## Description
Updates CPE values.

### Notes
* `a:progress:openedge_explorer` created on 2023-07-05
* `a:tenable:security_center` created on 2023-07-05
* `h:cisco:adaptive_security_appliance` deprecated by `o:cisco:adaptive_security_appliance_software` on 2023-08-15
* `a:mariadb:maxscale` created on 2023-08-21


## Motivation and Context
Valid CPE values are great!


## How Has This Been Tested?
* `rake tests`
* `bundle exec ./bin/recog_verify --no-warnings xml/*.xml`


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
