### PR TITLE
Fix non-deterministic test order

### DIFF
--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -6,7 +6,7 @@ require 'nokogiri'
 
 describe Recog::DB do
   let(:schema) { Nokogiri::XML::Schema(open(File.join(FINGERPRINT_DIR, 'fingerprints.xsd'))) }
-  Dir[File.join(FINGERPRINT_DIR, '*.xml')].each do |xml_file_name|
+  Dir[File.join(FINGERPRINT_DIR, '*.xml')].sort.each do |xml_file_name|
     describe "##{File.basename(xml_file_name)}" do
       it 'is valid XML' do
         doc = Nokogiri::XML(open(xml_file_name))


### PR DESCRIPTION
## Description

Fix non-deterministic test order when running tests. A test failure on CI outputs an error with the reproducible test steps:

```
Failed examples:

rspec './spec/lib/fingerprint_self_test_spec.rb[1:29:120:3]' # Recog::DB#http_cookies.xml (?-mix:^(__Host-)?(nc_sameSiteCookiestrict|nc_sameSiteCookielax|oc_sessionPassphrase)=) uses capturing regular expressions properly
```

However - the test may not actually for a developer's local dev env, as `Dir` is used without an explicit sort:

> Overview. 'Dir` and `Dir. glob(…)` do not make any guarantees about the order in which files are returned. The final order is determined by the operating system and file system.

## Motivation and Context

Developers want consistency between CI and local testing env

## How Has This Been Tested?

CI Passes


## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
