### PR TITLE
Please rubocop

### DIFF
--- a/bin/recog_cleanup
+++ b/bin/recog_cleanup
@@ -9,7 +9,7 @@ Dir["#{File.expand_path(File.join(File.dirname(__FILE__), '..', 'xml'))}/*.xml"]
   data = File.read(f)
              .gsub(/\s+$/, '')                           # Trailing whitespace and empty lines
              .gsub('</fingerprint>', "</fingerprint>\n") # Every fingerprint should have an empty line after it
-             .gsub('-->', "-->\n")                        # Every comment should have an empty line after it
+             .gsub('-->', "-->\n")                       # Every comment should have an empty line after it
 
   File.write(f, data)
 end


### PR DESCRIPTION
This should fix the following issue:

```
== bin/recog_cleanup ==
C: 12: 35: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.

14 files inspected, 1 offense detected, 1 offense autocorrectable
Error: Process completed with exit code 1.
```