### PR TITLE
Bump the certainty for AdGuard

### DIFF
--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1987,7 +1987,6 @@
     <example>1b786be7a46bd96a503a81b7faf86263</example>
     <param pos="0" name="service.vendor" value="AdGuard"/>
     <param pos="0" name="service.product" value="AdGuard Home"/>
-    <param pos="0" name="service.certainty" value="0.5"/>
   </fingerprint>
 
   <fingerprint pattern="^4f52bd9a74742b08b0a152559da4d32a$">


### PR DESCRIPTION
md5 collision is highly unlikely, and it's the only (as far as I know) product with this favicon.