### PR TITLE
VC-2316 Add fingerprinting for ivanti pulse secure

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3586,10 +3586,12 @@ Copyright (c) 1995-2005 by Cisco Systems
                             Ivanti (Pulse Secure)
    =======================================================================-->
 
-  <fingerprint pattern="^Pulse Secure, LLC,Ivanti Connect Secure,ISA-V,(\d+\.\d+R\d+(?:\.\d+)?) \(build .*\)$">
+  <fingerprint pattern="^(?:Pulse Secure, LLC|Ivanti Connect Secure),.*,(\d+\.\d+R\d+(?:\.\d+)?) \(build \d+\)$">
     <description>Pulse Secure, LLC, Ivanti Connect Secure</description>
     <example os.version="22.3R1">Pulse Secure, LLC,Ivanti Connect Secure,ISA-V,22.3R1 (build 1647)</example>
     <example os.version="22.3R2.1245">Pulse Secure, LLC,Ivanti Connect Secure,ISA-V,22.3R2.1245 (build 1647)</example>
+    <example os.version="22.3R1">Pulse Secure, LLC,ISA-V,22.3R1 (build 1647)</example>
+    <example os.version="22.3R2.1245">Ivanti Connect Secure,ISA-V,22.3R2.1245 (build 1647)</example>
     <param pos="0" name="os.certainty" value="0.99"/>
     <param pos="0" name="os.vendor" value="Pulse Secure"/>
     <param pos="0" name="os.product" value="Pulse Connect Secure"/>

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3583,6 +3583,20 @@ Copyright (c) 1995-2005 by Cisco Systems
   </fingerprint>
 
   <!--======================================================================
+                            Ivanti (Pulse Secure)
+   =======================================================================-->
+
+  <fingerprint pattern="^Pulse Secure, LLC,Ivanti Connect Secure,ISA-V,(\d+\.\d+R\d+(?:\.\d+)?) \(build .*\)$">
+    <description>Pulse Secure, LLC, Ivanti Connect Secure</description>
+    <example os.version="22.3R1">Pulse Secure, LLC,Ivanti Connect Secure,ISA-V,22.3R1 (build 1647)</example>
+    <example os.version="22.3R2.1245">Pulse Secure, LLC,Ivanti Connect Secure,ISA-V,22.3R2.1245 (build 1647)</example>
+    <param pos="0" name="os.certainty" value="0.99"/>
+    <param pos="0" name="os.vendor" value="Pulse Secure"/>
+    <param pos="0" name="os.product" value="Pulse Connect Secure"/>
+    <param pos="1" name="os.version"/>
+  </fingerprint>
+
+  <!--======================================================================
                               Juniper
    =======================================================================-->
 


### PR DESCRIPTION
## Description
Added Fingerprinting for Ivanti Pulse Secure 


## Motivation and Context
After rebranding Pulse Secure to Ivanti, the vendor hid information about subsequent versions and their hashes, we had to come up with a new approach for retrieving information about the version of the product, this approach uses SNMP  to collect version information.


## How Has This Been Tested?
Ran nexpose with these arguments on vCenter:
```
./run.sh nexpose -Dr7.deploy.local.recog=true -Drecog.dir=~/rapid7/recog
```
And then scanned an existing Ivanti Connect Secure scan target.

Scan results before change:
![image](https://github.com/rapid7/recog/assets/159146003/4c7975af-27ea-4f46-b771-62e12bea4f35)

Scan results after change:
![image](https://github.com/rapid7/recog/assets/159146003/1b536bf5-7ea0-4358-9a73-453349102539)


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature, Added new fingerprinting for Ivanti Connect Secure



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
<img width="652" alt="image" src="https://github.com/rapid7/recog/assets/150266617/5c233bac-2231-427f-9cd0-4449cba4e66c">
