### PR TITLE
Pin ffi gem version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec name: 'recog-content'
 
+gem 'ffi', '1.16.3'
 gem 'recog', '~>3.1'
 
 group :test do

--- a/bin/recog_cleanup
+++ b/bin/recog_cleanup
@@ -9,7 +9,7 @@ Dir["#{File.expand_path(File.join(File.dirname(__FILE__), '..', 'xml'))}/*.xml"]
   data = File.read(f)
              .gsub(/\s+$/, '')                           # Trailing whitespace and empty lines
              .gsub('</fingerprint>', "</fingerprint>\n") # Every fingerprint should have an empty line after it
-             .gsub('-->', "-->\n")                        # Every comment should have an empty line after it
+             .gsub('-->', "-->\n") # Every comment should have an empty line after it
 
   File.write(f, data)
 end


### PR DESCRIPTION
## Description

Fix CI build failure when running in Ruby 2.7.5 docker environment:

```
docker run -it -w $(pwd) -v $(pwd):$(pwd) --rm ruby:2.7.5 /bin/sh
```

Before:

```
# bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is incompatible with the current version, 3.1.6
```

After:

```
# bundle
...
Bundle complete! 12 Gemfile dependencies, 49 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
# 
```


## Motivation and Context
Fix CI failing on ffi dependency issues

## How Has This Been Tested?
CI passes

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix 

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
