### PR TITLE
extend D-Link DCS wwwauth record

### DIFF
--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -182,9 +182,10 @@
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;(DCS-[^&quot;]+)&quot;">
     <description>D-Link DCS IP Cameras</description>
-    <example hw.product="DCS-5222LB1">Basic realm="DCS-5222LB1"</example>
-    <example hw.product="DCS-2530L">Basic realm="DCS-2530L"</example>
-    <param pos="0" name="os.vendor" value="D-Link"/>
+    <example os.vendor="D-Link" hw.vendor="D-Link" hw.device="IP Camera" hw.product="DCS-5222LB1" hw.model="DCS-5222LB1">Basic realm="DCS-5222LB1"</example>
+    <example os.vendor="D-Link" hw.vendor="D-Link" hw.device="IP Camera" hw.product="DCS-2530L" hw.model="DCS-2530L">Basic realm="DCS-2530L"</example>
+    <example os.vendor="D-Link" hw.vendor="D-Link" hw.device="IP Camera" hw.product="DCS-932LB1_BC" hw.model="DCS-932LB1_BC">Digest realm="DCS-932LB1_BC",qop="auth", nonce="ab08230abdfae0061bb2b657537e7eea"†</example>
+    <param pos="0" name="os.vendor" value="D-Link"/>    
     <param pos="0" name="hw.vendor" value="D-Link"/>
     <param pos="0" name="hw.device" value="IP Camera"/>
     <param pos="1" name="hw.product"/>

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -184,9 +184,11 @@
     <description>D-Link DCS IP Cameras</description>
     <example hw.product="DCS-5222LB1">Basic realm="DCS-5222LB1"</example>
     <example hw.product="DCS-2530L">Basic realm="DCS-2530L"</example>
+    <param pos="0" name="os.vendor" value="D-Link"/>
     <param pos="0" name="hw.vendor" value="D-Link"/>
     <param pos="0" name="hw.device" value="IP Camera"/>
     <param pos="1" name="hw.product"/>
+    <param pos="1" name="hw.model"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:Basic|Digest) realm=&quot;GoAhead&quot;">

--- a/xml/http_wwwauth.xml
+++ b/xml/http_wwwauth.xml
@@ -184,7 +184,7 @@
     <description>D-Link DCS IP Cameras</description>
     <example os.vendor="D-Link" hw.vendor="D-Link" hw.device="IP Camera" hw.product="DCS-5222LB1" hw.model="DCS-5222LB1">Basic realm="DCS-5222LB1"</example>
     <example os.vendor="D-Link" hw.vendor="D-Link" hw.device="IP Camera" hw.product="DCS-2530L" hw.model="DCS-2530L">Basic realm="DCS-2530L"</example>
-    <example os.vendor="D-Link" hw.vendor="D-Link" hw.device="IP Camera" hw.product="DCS-932LB1_BC" hw.model="DCS-932LB1_BC">Digest realm="DCS-932LB1_BC",qop="auth", nonce="ab08230abdfae0061bb2b657537e7eea"†</example>
+    <example os.vendor="D-Link" hw.vendor="D-Link" hw.device="IP Camera" hw.product="DCS-932LB1_BC" hw.model="DCS-932LB1_BC">Digest realm="DCS-932LB1_BC",qop="auth", nonce="ab08230abdfae0061bb2b657537e7eea"</example>
     <param pos="0" name="os.vendor" value="D-Link"/>    
     <param pos="0" name="hw.vendor" value="D-Link"/>
     <param pos="0" name="hw.device" value="IP Camera"/>


### PR DESCRIPTION
## Description
I am extending the D-Link record to also have some trivial information about the OS.

## Motivation and Context
A downstream consumer of wwwauth is unable to work with records that have only information about HW. At least trivial information about the os.vendor is needed.


## How Has This Been Tested?
I am intentionally leaving the `hw.product` in place, so that the implementation is backward compatible.

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
