### PR TITLE
update openldap root dse fp pattern

### DIFF
--- a/xml/ldap_searchresult.xml
+++ b/xml/ldap_searchresult.xml
@@ -347,7 +347,7 @@
 
   <!-- End of Microsoft Windows Section -->
 
-  <fingerprint pattern="(?im:top\x04..penLDAProotDSE)">
+  <fingerprint pattern="(?im:\x04..penLDAProotDSE)">
     <description>OpenLDAP</description>
     <example _encoding="base64">
       dm9iamVjdENsYXNzMRYEA3RvcAQPT3BlbkxEQVByb290RFNFMA==


### PR DESCRIPTION
## Description
Updated the fingerprint matching pattern to identify more OpenLDAP instances.


## Motivation and Context
Servers responding with OpenLDAP do not only use objectClass attribute name in their 
The OpenLDAP servers were initially identified under the objectClass attribute name when queried by the RootDSE. However, the structuralObjectClass attribute name also has OpenLDAP. Hence, it is necessary to adapt the current matching pattern to identify such servers.


## How Has This Been Tested?
Here are a few examples:
With objectClass: 
https://search.censys.io/hosts/61.222.164.42/data/table#389-TCP-LDAP
With structuralObjectClass: 
https://search.censys.io/hosts/213.55.162.229/data/table#636-TCP-LDAP

```shell
bin/recog_verify xml/ldap_searchresult.xml
xml/ldap_searchresult.xml: SUMMARY: Test completed with 69 successful, 0 warnings, and 0 failures
```

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
