### PR TITLE
Update sip_banners record for Cisco Telepresence

### DIFF
--- a/identifiers/os_family.txt
+++ b/identifiers/os_family.txt
@@ -189,6 +189,7 @@ System Storage
 T3 Termination
 TASKalfa
 TDS750 Series
+TelePresence
 Teradici
 Time Capsule
 TippingPoint

--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -69,15 +69,16 @@ Document Centre
 Dynix
 EDR G902 Firmware
 EDR-G903 Firmware
+EOS
 EdgeBlaster
 EdgeOS
 Email Appliance
 Enterprise AP
 Enterprise Linux
 Enterprise WAP
-EOS
 EqualLogic
 Excella
+Expressway
 FRITZ!OS
 Fabric OS
 Fastmark M5

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -163,10 +163,9 @@
     <param pos="2" name="hw.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^TANDBERG/(\d+) \((.*)\) Cisco-(\S+)$">
+  <fingerprint pattern="^TANDBERG\/(\d+) \((X\d+\S*|XC\d+\S*|TC\d+\S*|TCNC\d+\S*).*\) Cisco-(\S+)$">
     <description>Cisco/Tandberg TelePresence w/Cisco Model Name</description>
     <example os.version="TC7.3.7.01c84fd" tandberg.model="528" hw.product="EX60">TANDBERG/528 (TC7.3.7.01c84fd) Cisco-EX60</example>
-    <example os.version="ce9.6.0.76c1685b70e" tandberg.model="529" hw.product="RoomKitMini">TANDBERG/529 (ce9.6.0.76c1685b70e) Cisco-RoomKitMini</example>
     <param pos="0" name="os.vendor" value="Cisco"/>
     <param pos="0" name="os.family" value="TelePresence"/>
     <param pos="0" name="os.product" value="Expressway"/>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -167,9 +167,9 @@
     <description>Cisco/Tandberg TelePresence w/Cisco Model Name</description>
     <example os.version="TC7.3.7.01c84fd" tandberg.model="528" hw.product="EX60">TANDBERG/528 (TC7.3.7.01c84fd) Cisco-EX60</example>
     <example os.version="ce9.6.0.76c1685b70e" tandberg.model="529" hw.product="RoomKitMini">TANDBERG/529 (ce9.6.0.76c1685b70e) Cisco-RoomKitMini</example>
-    <param pos="0" name="os.vendor" value="Tandberg"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="TelePresence"/>
+    <param pos="0" name="os.product" value="Expressway"/>
     <param pos="1" name="tandberg.model"/>
     <param pos="2" name="os.version"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -178,7 +178,7 @@
     <param pos="3" name="hw.product"/>
   </fingerprint>
 
-  <fingerprint pattern="^(TANDBERG/(\d+)) \((\S+).*\)$">
+  <fingerprint pattern="^(TANDBERG\/(\d+)) \((X\d+\S*|XC\d+\S*|TC\d+\S*|TCNC\d+\S*).*\)$">
     <description>Cisco/Tandberg TelePresence</description>
     <example os.version="TC7.0.2.aecf2d9" tandberg.model="519" hw.product="TANDBERG/519">TANDBERG/519 (TC7.0.2.aecf2d9)</example>
     <example os.version="X12.5.2" tandberg.model="4137" hw.product="TANDBERG/4137">TANDBERG/4137 (X12.5.2 (TEST SW))</example>
@@ -186,9 +186,10 @@
     <example os.version="XC2.2.1-b2bua-1.0" hw.product="TANDBERG/4353" tandberg.model="4353">TANDBERG/4353 (XC2.2.1-b2bua-1.0)</example>
     <example os.version="TC5.1.4.295090" hw.product="TANDBERG/516" tandberg.model="516">TANDBERG/516 (TC5.1.4.295090)</example>
     <example os.version="TCNC5.1.4.295090" hw.product="TANDBERG/517" tandberg.model="517">TANDBERG/517 (TCNC5.1.4.295090)</example>
-    <param pos="0" name="os.vendor" value="Tandberg"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.vendor" value="Cisco"/>
+    <param pos="0" name="os.family" value="TelePresence"/>
+    <param pos="0" name="os.product" value="Expressway"/>
+    <param pos="0" name="os.device" value="Video Conferencing"/>
     <param pos="2" name="tandberg.model"/>
     <param pos="3" name="os.version"/>
     <param pos="0" name="hw.vendor" value="Cisco"/>
@@ -196,7 +197,6 @@
     <param pos="0" name="hw.device" value="Video Conferencing"/>
     <param pos="1" name="hw.product"/>
   </fingerprint>
-
   <!-- NEC -->
 
   <fingerprint pattern="^NEC SL2100/([\d.]+)$">


### PR DESCRIPTION
## Description
A detailed description of your changes.
Updated sip-banner record for Cisco Telepresence to reflect the current product naming, vendor, family. Make regex more strict to match only versions starting with X and TC. 
SIP protocol example:

SIP/2.0 403 Forbidden
Via: SIP/2.0/UDP nm;branch=foo;received=224.85.86.107;rport=26810;ingress-zone=DefaultZone
Call-ID: 50000
CSeq: 42 OPTIONS
From: <sip:nm@nm>;tag=root
To: <sip:nm2@nm2>;tag=dba04991a2a1090f
Server: TANDBERG/4145 (X15.0.3)

## Motivation and Context


## How Has This Been Tested?
Tested with bin/recog_verify


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
