### PR TITLE
Add pattern for OpenSSH on Debian 12

### DIFF
--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1452,6 +1452,22 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:11.0"/>
   </fingerprint>
 
+  <fingerprint pattern="^OpenSSH_(9\.2p1) (Debian-\d\d?\+deb12u\d+)$">
+    <description>OpenSSH running on Debian 12.x (bookworm)</description>
+    <example service.version="9.2p1" openssh.comment="Debian-2+deb12u3">OpenSSH_9.2p1 Debian-2+deb12u3</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:openbsd:openssh:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="12.0"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:12.0"/>
+  </fingerprint>
+
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+(?:[~]?bpo[.]?\d+)?)$">
     <description>OpenSSH running on Debian (unknown release)</description>
     <example service.version="4.3p2" openssh.comment="Debian-5~bpo.1">OpenSSH_4.3p2 Debian-5~bpo.1</example>


### PR DESCRIPTION
## Description

Updated ssh_banners.xml to include pattern for OpenSSH on Debian 12 (bookworm).


## Motivation and Context

Currently only Debian 11 and older are detected via SSH banner.


## How Has This Been Tested?

I consume the patterns from the XML file directly instead of using the ruby or other software that includes them. The regular expression has been tested against expected SSH banners and package versions (e.g. https://tracker.debian.org/news/1541136/accepted-openssh-192p1-2deb12u3-source-into-stable-security/) but integration with other tools has not been tested.


## Types of changes

- New feature (non-breaking change which adds functionality)


## Checklist:

- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required). - I added an example entry to the XML
- [ ] All new and existing tests passed.
