### PR TITLE
Pin ubuntu version to 22.04 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: 'Ruby: ${{ matrix.ruby-version }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description
This PR pins the ubuntu version to `ubuntu-22.04` in the Github Action CI pipeline, as `jruby-9.2` and `'jruby-9.4.2` versions are no longer supported on `ubuntu-latest` (currently `ubuntu-24.10`).


## Motivation and Context
Fixes failing PR checks i.e. https://github.com/rapid7/recog/actions/runs/12926372714/job/36055534595?pr=635


## Types of changes
- Bug fix (non-breaking change which fixes an issue)
