### PR TITLE
Update of the fingerprinters for Aruba AOS-CX and Aruba AOS-S

### DIFF
--- a/identifiers/os_product.txt
+++ b/identifiers/os_product.txt
@@ -15,6 +15,7 @@ AOS
 AOS-8
 AOS-10
 AOS-CX
+AOS-S
 ATEN Linux
 Access Gateway
 AccessRunner ADSL router

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -773,15 +773,18 @@
                            Aruba Networks
   =======================================================================-->
 
-  <fingerprint pattern="^Aruba\s(JL\d+A)\s(\d+[A-Z]?)\S+\sSwitch.+ROM\s([A-Z]+(?:\.\d+)+)">
+  <fingerprint pattern="^Aruba.*revision\s+(?:([^\.]+)\.)?([\d\.]+).*ROM.*$">
     <description>HP Aruba Network Switch</description>
-    <example hw.model="JL256A" hw.product="2930F" os.version="WC.16.01.0010">Aruba JL256A 2930F-48G-PoE+-4SFP+ Switch, revision WC.16.11.0004, ROM WC.16.01.0010</example>
-    <param pos="0" name="os.vendor" value="Aruba Networks"/>
-    <param pos="3" name="os.version"/>
-    <param pos="0" name="hw.vendor" value="Aruba Networks"/>
-    <param pos="2" name="hw.product"/>
-    <param pos="1" name="hw.model"/>
+    <example hw.model="WC" os.version="16.11.0004">Aruba JL256A 2930F-48G-PoE+-4SFP+ Switch, revision WC.16.11.0004, ROM WC.16.01.0010</example>
+    <example hw.model="KB" os.version="16.10.0002">Aruba JL074A 3810M-48G-PoE+-1-slot Switch, revision KB.16.10.0002, ROM KB.16.01.0009</example>
+    <example hw.model="WC" os.version="16.02.0014">Aruba JL258A 2930F-8G-PoE+-2SFP+ Switch, revision WC.16.02.0014, ROM WC.16.01.0003</example>
+    <example hw.model="KB" os.version="16.08.0012">Aruba 3810M Switch Stack, revision KB.16.08.0012, ROM KB.16.08.0007</example>
+    <param pos="0" name="os.vendor" value="Aruba"/>
+    <param pos="0" name="os.family" value="Aruba"/>
+    <param pos="0" name="os.product" value="AOS-S"/>
     <param pos="0" name="os.device" value="Switch"/>
+    <param pos="1" name="hw.model"/>
+    <param pos="2" name="os.version"/>
   </fingerprint>
 
   <fingerprint pattern="ArubaOS \(MODEL: ([^\)]+)\), Version (8\.[^\s]+)">
@@ -806,9 +809,10 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="Aruba\s+(.+)(?:\s+\D+\.|\s+)(\d[\d\.]+)">
+  <fingerprint pattern="^Aruba\s+([^\s]+\s+[^\s]+)\s+(?:\D+\.)?(\d[\d\.]+)$">
     <description>Aruba OS CX</description>
     <example hw.model="ABC123 ArubaOS-CX_OVA" os.version="10.07.0010">Aruba ABC123 ArubaOS-CX_OVA Virtual.10.07.0010</example>
+    <example hw.model="R8W85A 8100-24XT4XF4C" os.version="10.13.1060">Aruba R8W85A 8100-24XT4XF4C LL.10.13.1060</example>
     <param pos="0" name="os.vendor" value="Aruba"/>
     <param pos="0" name="os.family" value="Aruba"/>
     <param pos="0" name="os.product" value="AOS-CX"/>


### PR DESCRIPTION
## Description
Updated SNMP fingerprinters for Aruba AOS-CX and Aruba AOS-S.


## Motivation and Context
These updates increase accuracy of the SNMP fingerprinters of Aruba AOS-CX and Aruba AOS-S. The update of AOS-CX aim to prevent the fingerprinter pattern matching with another operating system The update Aruba AOS-S makes the fingeprinter more general and applicable for other hardware models.


## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.

Test scan performed: 

<img width="240" alt="image" src="https://github.com/user-attachments/assets/075588fb-268b-4ae0-87e1-5d75a2bf3b6f" />
