### PR TITLE
Fixed mercurity issue

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -2045,7 +2045,7 @@
   </fingerprint>
 
   <fingerprint pattern="^TargetWeb/[\d\.]+ \(TargetOS\)$">
-    <description>Mercurity Security TargetOS</description>
+    <description>Mercury Security TargetOS</description>
     <example>TargetWeb/2011.0 (TargetOS)</example>
     <param pos="0" name="hw.vendor" value="Mercury Security"/>
     <param pos="0" name="hw.device" value="Access Control"/>

--- a/xml/x509_subjects.xml
+++ b/xml/x509_subjects.xml
@@ -1133,7 +1133,7 @@
   </fingerprint>
 
   <fingerprint pattern="^CN=MAC([a-fA-F0-9]{12}),OU=([^,]+),O=Mercury Security Products\\, LLC,L=Long Beach,ST=CA,C=US(?:,\S+)?$">
-    <description>Mercurity Security (now HID Global)</description>
+    <description>Mercury Security (now HID Global)</description>
     <example hw.product="M5IC" host.mac="000FE507A1F1">CN=MAC000FE507A1F1,OU=M5IC,O=Mercury Security Products\, LLC,L=Long Beach,ST=CA,C=US</example>
     <example hw.product="EP-1502" host.mac="000FE508BC71">CN=MAC000FE508BC71,OU=EP-1502,O=Mercury Security Products\, LLC,L=Long Beach,ST=CA,C=US</example>
     <example hw.product="LP-1501" host.mac="000FE5091111">CN=MAC000FE5091111,OU=LP-1501,O=Mercury Security Products\, LLC,L=Long Beach,ST=CA,C=US,2.5.4.4=#111111111111111111</example>
@@ -1144,7 +1144,7 @@
   </fingerprint>
 
   <fingerprint pattern="^CN=Mercury Security EP-series,O=Mercury Security Corp\.,L=Long Beach,ST=CA,C=US$">
-    <description>Mercurity Security (now HID Global) No MAC</description>
+    <description>Mercury Security (now HID Global) No MAC</description>
     <example>CN=Mercury Security EP-series,O=Mercury Security Corp.,L=Long Beach,ST=CA,C=US</example>
     <param pos="0" name="hw.vendor" value="Mercury Security"/>
     <param pos="0" name="hw.device" value="Access Control"/>


### PR DESCRIPTION
## Description
I fixed the "Mercurity" misspelling as inspired by #631 in the http_servers.xml and x509_subjects.xml file. 


## Motivation and Context
This is related to #631. 

## How Has This Been Tested?
This was tested by showing that "Mercurity Security" was not found.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
I fixed the misspellings of "Mercurity Security" in the http_servers.xml and x509_subjects.xml file. 

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [+] I have updated the documentation accordingly (or changes are not required).
- [+] I have added tests to cover my changes (or new tests are not required).
- [+] All new and existing tests passed.
