### PR TITLE
Fix of Aruba AOS-CX SNMP fingerprinter

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -809,10 +809,11 @@
     <param pos="2" name="os.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^Aruba\s+([^\s]+\s+[^\s]+)\s+(?:\D+\.)?(\d[\d\.]+)$">
+  <fingerprint pattern="^Aruba\s+([\w -]+)\s+(?:\D+\.)?(\d[\d\.]+)$">
     <description>Aruba OS CX</description>
     <example hw.model="ABC123 ArubaOS-CX_OVA" os.version="10.07.0010">Aruba ABC123 ArubaOS-CX_OVA Virtual.10.07.0010</example>
     <example hw.model="R8W85A 8100-24XT4XF4C" os.version="10.13.1060">Aruba R8W85A 8100-24XT4XF4C LL.10.13.1060</example>
+    <example hw.model="JL641A 6400M 32G CL4 PoE 4SFP55 Swch" os.version="10.10.1019">Aruba JL641A 6400M 32G CL4 PoE 4SFP55 Swch FL.10.10.1019</example>
     <param pos="0" name="os.vendor" value="Aruba"/>
     <param pos="0" name="os.family" value="Aruba"/>
     <param pos="0" name="os.product" value="AOS-CX"/>


### PR DESCRIPTION
## Description
The purpose of this change is to improve a coverage for Aruba AOS-CX SNMP fingerprinter. The current coverage is missing models with a multiple word model specification. Additional test strings were added and the regular expression for SNMP fingerprinter was updated.

## Motivation and Context

This change improves the coverage of Aruba AOS-CX switches to models with multiple word naming.


## How Has This Been Tested?

Additional controls strings where added next to the existing one. The regular expressions was tested with other Aruba test strings to prevent confusion with another switch model.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
