### PR TITLE
Added banner for MariaDB 

### DIFF
--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1370,6 +1370,166 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:20.04"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~groovy(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 20.10 (Groovy Gorilla)</description>
+    <example service.version="10.5.2">5.5.5-10.5.2-MariaDB-1:10.5.2+maria~groovy</example>
+    <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1:10.1.1+maria~groovy-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="20.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:20.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~hirsute(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 21.04 (Hirsute Hippo)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="21.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:21.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~impish(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 21.10 (Impish Indri)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="21.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:21.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~jammy(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 22.04 (Jammy Jellyfish)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="22.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:22.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~kinetic(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 22.10 (Kinetic Kudu)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+kinetic~jammy</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~kinetic-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="22.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:22.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~lunar(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 23.04 (Lunar Lobster)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="23.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:23.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~mantic(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 23.10 (Mantic Minotaur)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="23.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:23.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~noble(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 24.04 (Noble Numbat)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="24.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:24.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~oracular(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 24.10 (Oracular Oriole)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="24.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:24.04"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~plucky(?:-log)?$" flags="REG_ICASE">
+    <description>MariaDB MariaDB on Ubuntu 25.04 (Plucky Puffin)</description>
+    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky</example>
+    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky-log</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="25.04"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:25.04"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-mariadb\d\Smaverick$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 10.10 (Maverick Meerkat)</description>
     <example service.version="5.5.29">5.5.29-MariaDB-mariadb1~maverick</example>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1388,8 +1388,8 @@
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~hirsute(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 21.04 (Hirsute Hippo)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1404,8 +1404,8 @@
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~impish(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 21.10 (Impish Indri)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1414,14 +1414,14 @@
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="21.04"/>
+    <param pos="0" name="os.version" value="21.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:21.04"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~jammy(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 22.04 (Jammy Jellyfish)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1436,8 +1436,8 @@
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~kinetic(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 22.10 (Kinetic Kudu)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+kinetic~jammy</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~kinetic-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+kinetic~jammy</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~kinetic-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1452,8 +1452,8 @@
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~lunar(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 23.04 (Lunar Lobster)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1468,8 +1468,8 @@
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~mantic(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 23.10 (Mantic Minotaur)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1478,14 +1478,14 @@
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="23.04"/>
+    <param pos="0" name="os.version" value="23.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:23.04"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~noble(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 24.04 (Noble Numbat)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1500,8 +1500,8 @@
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~oracular(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 24.10 (Oracular Oriole)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1510,14 +1510,14 @@
     <param pos="0" name="os.vendor" value="Ubuntu"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="24.04"/>
+    <param pos="0" name="os.version" value="24.10"/>
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:24.04"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~plucky(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 25.04 (Plucky Puffin)</description>
-    <example service.version="10.5.2">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky</example>
-    <example service.version="10.1.1">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky-log</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1436,7 +1436,7 @@
 
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~kinetic(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 22.10 (Kinetic Kudu)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+kinetic~jammy</example>
+    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~kinetic</example>
     <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~kinetic-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -863,8 +863,6 @@
     Reference: https://mariadb.org/explanation-on-mariadb-10-0/
   -->
 
-
-
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB(?:-log)?-cll-lve$" flags="REG_ICASE">
     <description>MariaDB MariaDB on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-cll-lve</example>

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -863,6 +863,8 @@
     Reference: https://mariadb.org/explanation-on-mariadb-10-0/
   -->
 
+
+
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB(?:-log)?-cll-lve$" flags="REG_ICASE">
     <description>MariaDB MariaDB on CloudLinux in a Lightweight Virtual Environment (LVE)</description>
     <example service.version="5.5.34">5.5.34-MariaDB-cll-lve</example>
@@ -1370,166 +1372,6 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:20.04"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~groovy(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 20.10 (Groovy Gorilla)</description>
-    <example service.version="10.5.2">5.5.5-10.5.2-MariaDB-1:10.5.2+maria~groovy</example>
-    <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1:10.1.1+maria~groovy-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="20.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:20.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~hirsute(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 21.04 (Hirsute Hippo)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~hirsute-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="21.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:21.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~impish(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 21.10 (Impish Indri)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~impish-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="21.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:21.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~jammy(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 22.04 (Jammy Jellyfish)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~jammy-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="22.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:22.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~kinetic(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 22.10 (Kinetic Kudu)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~kinetic</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~kinetic-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="22.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:22.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~lunar(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 23.04 (Lunar Lobster)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~lunar-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="23.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:23.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~mantic(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 23.10 (Mantic Minotaur)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~mantic-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="23.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:23.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~noble(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 24.04 (Noble Numbat)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~noble-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="24.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:24.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~oracular(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 24.10 (Oracular Oriole)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~oracular-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="24.10"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:24.04"/>
-  </fingerprint>
-
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-\d\:.*\+maria\~plucky(?:-log)?$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Ubuntu 25.04 (Plucky Puffin)</description>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky</example>
-    <example service.version="11.4.7">5.5.5-11.4.7-MariaDB-1:11.4.7+maria~plucky-log</example>
-    <param pos="1" name="service.version"/>
-    <param pos="0" name="service.vendor" value="MariaDB"/>
-    <param pos="0" name="service.family" value="MySQL"/>
-    <param pos="0" name="service.product" value="MariaDB"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
-    <param pos="0" name="os.vendor" value="Ubuntu"/>
-    <param pos="0" name="os.family" value="Linux"/>
-    <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="25.04"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:canonical:ubuntu_linux:25.04"/>
-  </fingerprint>
-
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-mariadb\d\Smaverick$" flags="REG_ICASE">
     <description>MariaDB MariaDB on Ubuntu 10.10 (Maverick Meerkat)</description>
     <example service.version="5.5.29">5.5.29-MariaDB-mariadb1~maverick</example>
@@ -1592,6 +1434,20 @@
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
     <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,2}\.\d{1,2})-MariaDB-ubu+[0-9]{4}$" flags="REG_ICASE">
+    <description>MariaDB LTS alternate version format </description>
+    <example service.version="10.5.27">5.5.5-10.5.27-MariaDB-ubu2004</example>
+    <example service.version="10.11.9">5.5.5-10.11.9-MariaDB-ubu2204</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
   </fingerprint>
 


### PR DESCRIPTION
## Description


Added banner for MariaDB on Ubuntu20 


<img width="869" alt="Screenshot 2025-06-19 at 2 49 35 PM" src="https://github.com/user-attachments/assets/bc731bc3-5314-4409-a785-111cb011a146" />


## How this was tested ? 
Installed the required MariaDB version on the VM, ran the scan. 
Result :  `[mysql.banners] Matching against banner: 11.8.2-MariaDB-ubu2204`



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
