### PR TITLE
Added banner for MariaDB on ubuntu

### DIFF
--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1449,6 +1449,19 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+.[0-9]{4}$" flags="REG_ICASE">
+    <description>MariaDB alternate version format </description>
+    <example service.version="10.6.12">5.5.5-10.6.12-MariaDB-1:10.6.12+maria~ubu2004</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="MariaDB"/>
+    <param pos="0" name="service.family" value="MySQL"/>
+    <param pos="0" name="service.product" value="MariaDB"/>
+    <param pos="0" name="os.vendor" value="Ubuntu"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+~wheezy-wsrep(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB MariaDB with Galera Cluster on Debian 7.0 (wheezy)</description>
     <example service.version="10.1.1">5.5.5-10.1.1-MariaDB-1~wheezy-wsrep-log</example>


### PR DESCRIPTION
## Description
Recog does not have a MariaDB fingerprint for a banner that looks like: 
` 5.5.5-10.6.12-MariaDB-1:10.6.12+maria~ubu2004.`
When we see it, we end up asserting as MySQL instead of MariaDB.

Added a banner for the same. 


## How Has This Been Tested?
Not able to test it , could not find device with required configuration but attached screenshot matching the regex. 
and if the test pass then i believe the code is good .. 
<img width="1444" height="421" alt="Screenshot 2025-08-22 at 3 35 24 PM" src="https://github.com/user-attachments/assets/9b7d0aa9-114c-4199-bc16-885cd1b2bd24" />

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
