### PR TITLE
Add fingerprint for WHMCompleteSolution session cookie

### DIFF
--- a/xml/http_cookies.xml
+++ b/xml/http_cookies.xml
@@ -859,5 +859,15 @@
     <param pos="0" name="os.certainty" value="0.0"/>
     <param pos="0" name="service.certainty" value="0.0"/>
   </fingerprint>
+  
+  <fingerprint pattern="(?i)\bWHMCS(?:[a-zA-Z0-9]{8,})?=">
+    <description>WHMCompleteSolution (WHMCS) session cookie</description>
+    <example>WHMCSy551iLvnhYt7=f8d219ec7f0e78521ad21a9571f1caac; path=/; secure; HttpOnly</example>
+    <param pos="0" name="cookie" value="WHMCS"/>
+    <param pos="0" name="service.vendor" value="WHMCS"/>                                                                                                  
+    <param pos="0" name="service.product" value="WHMCompleteSolution"/>                                                                                   
+    <param pos="0" name="service.cpe23" value="cpe:2.3:a:whmcs:whmcompletesolution:*:*:*:*:*:*:*:*"/>
+    <param pos="0" name="tags" value="web,session,hosting-billing"/>
+  </fingerprint>
 
 </fingerprints>


### PR DESCRIPTION
## Description
I have added fingerprint in xml/http_cookies.xml to detect WHMCS login pages.


## Motivation and Context
I have used to detect WHMCS and did not found a fingerprint for the same so contributed here.


## How Has This Been Tested?
I have tested against a example URL using following command
 curl --silent -I -k <example_url> | grep --color=never -i '^Set-Cookie:' | cut -d: -f2- | bin/recog_match xml/http_cookies.xml -
 and output is 
 MATCH: {"matched"=>"WHMCompleteSolution (WHMCS) session cookie", "cookie"=>"WHMCS", "service.vendor"=>"WHMCS", "service.product"=>"WHMCompleteSolution", "service.cpe23"=>"cpe:2.3:a:whmcs:whmcompletesolution:*:*:*:*:*:*:*:*", "tags"=>"web,session,hosting-billing", "service.protocol"=>"http", "fingerprint_db"=>"http_header.cookie", "data"=>"WHMCSy551iLvnhYt7=fbadc7baf8acaac14c125682937f711a; path=/; secure; HttpOnly"}


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
