### PR TITLE
Fixing regex to be able to detect versions correctly for Huawei VRP

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3358,7 +3358,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
 
-  <fingerprint pattern="VRP.*Version ([\d.]+) \(([^\s]+) (V\d{3,4}R\d{3,4}(?:C\d{2,3})?(?:SPC\d+|SPH\d+|CP\d+|HP\d+)?)\)">
+  <fingerprint pattern="VRP(?:(?!VRP).)*?Version ([\d.]+) \(([^\s]+) (V\d{3,3}R\d{3,3}(?:C\d{2,2})?(?:SPC\d+|SPH\d+|CP\d+|HP\d+)?)\)">
     <description>HUAWEI VRP</description>
     <example hw.model="CE6870EI" hw.series="V200R001C00SPC700" os.device="CE6870EI" os.version="8.120">Huawei Versatile Routing Platform Software
       VRP (R) software, Version 8.120 (CE6870EI V200R001C00SPC700) Copyright (C) 2012-2016 Huawei Technologies Co., Ltd.

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3358,7 +3358,7 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
 
-  <fingerprint pattern="VRP(?:(?!VRP).)*?Version ([\d.]+) \(([^\s]+) (V\d{3,3}R\d{3,3}(?:C\d{2,2})?(?:SPC\d+|SPH\d+|CP\d+|HP\d+)?)\)">
+  <fingerprint pattern="VRP[^V]*Version ([\d.]+) \(([^\s]+) (V\d{3,3}R\d{3,3}(?:C\d{2,2})?(?:SPC\d+|SPH\d+|CP\d+|HP\d+)?)\)">
     <description>HUAWEI VRP</description>
     <example hw.model="CE6870EI" hw.series="V200R001C00SPC700" os.device="CE6870EI" os.version="8.120">Huawei Versatile Routing Platform Software
       VRP (R) software, Version 8.120 (CE6870EI V200R001C00SPC700) Copyright (C) 2012-2016 Huawei Technologies Co., Ltd.

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3360,7 +3360,7 @@ Copyright (c) 1995-2005 by Cisco Systems
 
   <fingerprint pattern="VRP.*Version ([\d.]+) \(([^\s]+) (V\d{3,4}R\d{3,4}(?:C\d{2,3})?(?:SPC\d+|SPH\d+|CP\d+|HP\d+)?)\)">
     <description>HUAWEI VRP</description>
-    <example hw.model="CE6870EI" hw.series="V200R001C00SPC700" os.device="AR2200" os.version="8.120">Huawei Versatile Routing Platform Software
+    <example hw.model="CE6870EI" hw.series="V200R001C00SPC700" os.device="CE6870EI" os.version="8.120">Huawei Versatile Routing Platform Software
       VRP (R) software, Version 8.120 (CE6870EI V200R001C00SPC700) Copyright (C) 2012-2016 Huawei Technologies Co., Ltd.
     </example>
     <example hw.model="AR2200" hw.series="V200R003C00" os.device="AR2200" os.version="5.120">Huawei Versatile Routing Platform Software

--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3358,17 +3358,21 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.device" value="WAP"/>
   </fingerprint>
 
-  <fingerprint pattern="VRP.*Version ([\d.]+) \((.+?) (V[\d.]+R[\d.]+C[\d.]+(?:SPC|SPH|CP|HP)?\d*)">
+  <fingerprint pattern="VRP.*Version ([\d.]+) \(([^\s]+) (V\d{3,4}R\d{3,4}(?:C\d{2,3})?(?:SPC\d+|SPH\d+|CP\d+|HP\d+)?)\)">
     <description>HUAWEI VRP</description>
-    <example hw.model="CE6870EI" hw.series="V200R001C00SPC700" os.version="8.120">Huawei Versatile Routing Platform Software
+    <example hw.model="CE6870EI" hw.series="V200R001C00SPC700" os.device="AR2200" os.version="8.120">Huawei Versatile Routing Platform Software
       VRP (R) software, Version 8.120 (CE6870EI V200R001C00SPC700) Copyright (C) 2012-2016 Huawei Technologies Co., Ltd.
     </example>
-    <example hw.model="AR2200" hw.series="V200R003C00" os.version="5.120">Huawei Versatile Routing Platform Software
+    <example hw.model="AR2200" hw.series="V200R003C00" os.device="AR2200" os.version="5.120">Huawei Versatile Routing Platform Software
       VRP (R) software, Version 5.120 (AR2200 V200R003C00) Copyright (C) 2011-2012 HUAWEI TECH CO., LTD
+    </example>
+    <example hw.model="5310EI" hw.series="V200R003" os.device="5310EI" os.version="5.111">Huawei Versatile Routing Platform Software
+      VRP (R) software, Version 5.111 (5310EI V200R003) Copyright (C) 2011-2012 HUAWEI TECH CO., LTD
     </example>
     <param pos="0" name="os.vendor" value="Huawei"/>
     <param pos="0" name="os.product" value="VRP"/>
     <param pos="1" name="os.version"/>
+    <param pos="2" name="os.device"/>
     <param pos="2" name="hw.model"/>
     <param pos="3" name="hw.series"/>
     <param pos="0" name="hw.vendor" value="Huawei"/>


### PR DESCRIPTION
## Description
Allowing to detect all the versions of Huawei VRP with or with out the hot patch attached along with adding the device associated with Huawei VRP as os.device

## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?
A clear and concise description of your changes were tested.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
