### PR TITLE
Fix nested repeat operator warnings in Ruby 3.3

### DIFF
--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -715,7 +715,7 @@
     <param pos="0" name="apache.variant" value="Oracle"/>
   </fingerprint>
 
-  <fingerprint pattern="^Oracle-HTTP-Server(?:(?:-(?:\d{2}[cg]\/?)?([\d.]+)?(?:\/[\d.]+)?)?(?:.{0,512}\([TF]?[HSUGMN]?(?:;max-age=\d+(?:\+\d+)?)?(?:;age=\d+)?;ecid=[^)]+\))?)?$">
+  <fingerprint pattern="^Oracle-HTTP-Server(?:(?:-(?:\d{2}[cg]\/?)?([\d.]+)?(?:\/[\d.]+)?)?(?:.{0,512}\([TF]?[HSUGMN]?(?:;max-age=\d+(?:\+\d*))?(?:;age=\d+)?;ecid=[^)]+\))?)?$">
     <description>Oracle HTTP Server</description>
     <example>Oracle-HTTP-Server</example>
     <example>Oracle-HTTP-Server-11g</example>
@@ -935,7 +935,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:acme:mini_httpd:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^LiteSpeed\/?([\d.]+)?(?: \S+)?">
+  <fingerprint pattern="^LiteSpeed\/?([\d.]*)(?: \S+)?">
     <description>LiteSpeed</description>
     <example>LiteSpeed</example>
     <example service.version="5.2.8">LiteSpeed/5.2.8 Enterprise</example>
@@ -954,7 +954,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^openresty\/?([\d.]+)?$">
+  <fingerprint pattern="^openresty\/?([\d.]*)$">
     <description>OpenResty OpenResty</description>
     <example>openresty</example>
     <example service.version="1.13.6.2">openresty/1.13.6.2</example>
@@ -1065,7 +1065,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:varnish_cache_project:varnish_cache:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^Tengine\/?([\d.]+)?$">
+  <fingerprint pattern="^Tengine\/?([\d.]*)$">
     <description>Tengine</description>
     <example>Tengine</example>
     <example service.version="2.0.0">Tengine/2.0.0</example>
@@ -1558,7 +1558,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:f5:nginx:-"/>
   </fingerprint>
 
-  <fingerprint pattern="^nginx\/?([\d.]+)?">
+  <fingerprint pattern="^nginx\/?([\d.]*)">
     <description>nginx with version info and/or mods</description>
     <example service.version="0.8.53">nginx/0.8.53 + Phusion Passenger 3.0.0 (mod_rails/mod_rack)</example>
     <example service.version="0.8.53">nginx/0.8.53</example>
@@ -2769,7 +2769,7 @@
     <param pos="1" name="service.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^Embedthis-(?:Appweb|http)\/?([\d.]+)?$">
+  <fingerprint pattern="^Embedthis-(?:Appweb|http)\/?([\d.]*)$">
     <description>Embedthis AppWeb</description>
     <example service.version="3.2.3">Embedthis-Appweb/3.2.3</example>
     <example>Embedthis-http</example>
@@ -3490,7 +3490,7 @@
     <param pos="0" name="os.device" value="Router"/>
   </fingerprint>
 
-  <fingerprint pattern="^UPnP/Tomato ([\d\.]+)?[\w\s\.-]{1,30} UPnP/[\d\.]+ MiniUPnPd/([\d\.]+)$">
+  <fingerprint pattern="^UPnP/Tomato ([\d\.]*)[\w\s\.-]{1,30} UPnP/[\d\.]+ MiniUPnPd/([\d\.]*)$">
     <description>TomatoUSB UPnP Server</description>
     <example os.version="1.28.9014" service.version="1.8">UPnP/Tomato 1.28.9014 MIPSR2-RAF-v1.3g K26 UPnP/1.1 MiniUPnPd/1.8</example>
     <example os.version="1.28.0000" service.version="1.9">UPnP/Tomato 1.28.0000 MIPSR2-132 K26 USB VPN UPnP/1.1 MiniUPnPd/1.9</example>

--- a/xml/operating_system.xml
+++ b/xml/operating_system.xml
@@ -6,7 +6,7 @@
 
   <!-- Windows begin -->
 
-  <fingerprint pattern="(?i)^(?:Microsoft )?(Windows (?:[a-z]+\s[a-z]+\s|[a-z]+\s)?Server (?:\d{4} R2|\d{4}))(?:,\s|\s)?([a-z]+)?(?: Evaluation)?(?: Edition)?(?:\s|\swith(?:out)? Hyper-V\s)?(SP\d|SP \d|Service Pack \d)?$">
+  <fingerprint pattern="(?i)^(?:Microsoft )?(Windows (?:[a-z]+\s[a-z]+\s|[a-z]+\s)?Server (?:\d{4} R2|\d{4}))(?:,\s|\s)?([a-z]*)(?: Evaluation)?(?: Edition)?(?:\s|\swith(?:out)? Hyper-V\s)?(SP\d|SP \d|Service Pack \d)?$">
     <description>Windows Server 2003 and later</description>
     <example os.product="Windows Compute Cluster Server 2003">Windows Compute Cluster Server 2003</example>
     <example os.product="Windows Server 2003" os.edition="Standard">Windows Server 2003, Standard Edition</example>

--- a/xml/smb_native_os.xml
+++ b/xml/smb_native_os.xml
@@ -635,7 +635,7 @@
     <param pos="0" name="hw.vendor" value="Apple"/>
   </fingerprint>
 
-  <fingerprint pattern="^EMC-SNAS:T([\d\.]+)?$">
+  <fingerprint pattern="^EMC-SNAS:T([\d\.]*)$">
     <description>EMC Celerra</description>
     <example service.version="7.1.80.7" os.version="7.1.80.7">EMC-SNAS:T7.1.80.7</example>
     <param pos="0" name="service.vendor" value="EMC"/>


### PR DESCRIPTION
This PR resolves the nested repeat operator warnings thrown by Ruby 3.3 during fingerprinting. 

Ruby 3.3's regex engine is much stricter and warns when redundant operators are used (e.g., `(?:[a-z]+)?`). I've audited the XML databases and updated these redundant `+)?` patterns to their mathematical equivalent `*)` (zero or more) to silence the warnings while preserving the exact same fingerprinting logic.

Tested locally with `bundle exec rspec` (195,555 examples, 0 failures).

Resolves [rapid7/metasploit-framework issue #20121](https://github.com/rapid7/metasploit-framework/issues/20121) (RegEx Replacement Warning in smb_version)