### PR TITLE
VC-12091: False Positive F+ FreeBSD Obsolete Version on Juniper Junos 23.4R2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec name: 'recog-content'
 
 gem 'ffi', '1.16.3'
+gem 'jar-dependencies', '0.4.1', platforms: :jruby
 gem 'recog', '~>3.1'
 
 group :test do

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -365,7 +365,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([0-9][^ ]*)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([\d][^ ]*)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on FreeBSD</description>
     <example service.version="4.2.6p2@1.2194" os.arch="i386" os.version="7.4-PRERELEASE">
       version="ntpd 4.2.6p2@1.2194 Wed Nov 24 15:54:11 UTC 2010 (1)",
@@ -382,7 +382,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([0-9][^ ]*)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([\d][^ ]*)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntp without a version on FreeBSD</description>
     <example os.arch="i386" os.version="4.1-RELEASE">
       processor="i386", system="FreeBSD4.1-RELEASE"

--- a/xml/ntp_banners.xml
+++ b/xml/ntp_banners.xml
@@ -365,7 +365,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:citrix:netscaler_firmware:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="version=&quot;ntpd ([^ ]+)[^&quot;]+&quot;,.*processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([0-9][^ ]*)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntpd running on FreeBSD</description>
     <example service.version="4.2.6p2@1.2194" os.arch="i386" os.version="7.4-PRERELEASE">
       version="ntpd 4.2.6p2@1.2194 Wed Nov 24 15:54:11 UTC 2010 (1)",
@@ -382,7 +382,7 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:freebsd:freebsd:{os.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([^ ]+)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
+  <fingerprint pattern="processor=&quot;([^ ]+)&quot;,.*system=&quot;FreeBSD/?([0-9][^ ]*)&quot;" flags="REG_DOT_NEWLINE,REG_ICASE">
     <description>ntp without a version on FreeBSD</description>
     <example os.arch="i386" os.version="4.1-RELEASE">
       processor="i386", system="FreeBSD4.1-RELEASE"


### PR DESCRIPTION
## Description

[SI-33792](https://rapid7.atlassian.net/browse/SI-33792)
[VC-12091](https://rapid7.atlassian.net/browse/VC-12091)

Unauthenticated NTP fingerprinting matched the kernel string `JNPR-12.1` against the `FreeBSD` NTP fingerprint patterns, which accepted any non-space characters after FreeBSD/. This caused Juniper Junos devices to be misidentified as `FreeBSD 12.1`, triggering the obsolete version check.

Changes:

`ntp_banners.xml` Tightened both FreeBSD NTP fingerprint regexes by requiring the version segment to start with a digit ([0-9][^ ]* instead of [^ ]*). This prevents non-numeric strings like JNPR-12.1 from matching as FreeBSD versions.

`Gemfile` — Pinned jar-dependencies to 0.4.1 on JRuby platform to resolve a gem activation conflict on JRuby 9.4.2 where the bundled default version (0.4.1) clashed with the version required by transitive dependencies.

## Motivation and Context

Fixing the false positives 



## How Has This Been Tested?

[Test Plan](https://rapid7.atlassian.net/wiki/spaces/VC/pages/2968223921/Test+Plan+False+Positive+F+FreeBSD+Obsolete+Version+on+Juniper+Junos+23.4R2)


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.


[SI-33792]: https://rapid7.atlassian.net/browse/SI-33792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VC-12091]: https://rapid7.atlassian.net/browse/VC-12091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ