### PR TITLE
VC-12272: Added OS fingerpriting support for Polycom devices

### DIFF
--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -740,11 +740,11 @@
 
   <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(SoundPoint|VVX|SoundStation)\S+_(\d+)-UA/([\d\.]+)(?:_(.{12}))?$">
     <description>Polycom SoundPoint, SountdStation, VVX VoIP phones</description>
-    <example hw.version="5.8.0.13337" hw.family="VVX" hw.product="VVX 350" hw.model="350">PolycomVVX-VVX_350-UA/5.8.0.13337</example>
-    <example hw.version="4.1.4.7430" hw.family="VVX" hw.product="VVX 400" host.mac="010203040506" hw.model="400">PolycomVVX-VVX_400-UA/4.1.4.7430_010203040506</example>
-    <example hw.version="5.5.0.23866" hw.family="VVX" hw.product="VVX 501" hw.model="501">Polycom/5.5.0.23866 PolycomVVX-VVX_501-UA/5.5.0.23866</example>
-    <example hw.version="4.0.7.2514" hw.family="SoundPoint" hw.product="SoundPoint 670" hw.model="670">PolycomSoundPointIP-SPIP_670-UA/4.0.7.2514</example>
-    <example hw.version="4.0.8.1608" hw.model="7000" hw.family="SoundStation" hw.product="SoundStation 7000">PolycomSoundStationIP-SSIP_7000-UA/4.0.8.1608</example>
+    <example hw.version="5.8.0.13337" hw.family="VVX" hw.product="VVX 350" hw.model="350" os.version="5.8.0.13337">PolycomVVX-VVX_350-UA/5.8.0.13337</example>
+    <example hw.version="4.1.4.7430" hw.family="VVX" hw.product="VVX 400" host.mac="010203040506" hw.model="400" os.version="4.1.4.7430">PolycomVVX-VVX_400-UA/4.1.4.7430_010203040506</example>
+    <example hw.version="5.5.0.23866" hw.family="VVX" hw.product="VVX 501" hw.model="501" os.version="5.5.0.23866">Polycom/5.5.0.23866 PolycomVVX-VVX_501-UA/5.5.0.23866</example>
+    <example hw.version="4.0.7.2514" hw.family="SoundPoint" hw.product="SoundPoint 670" hw.model="670" os.version="4.0.7.2514">PolycomSoundPointIP-SPIP_670-UA/4.0.7.2514</example>
+    <example hw.version="4.0.8.1608" hw.model="7000" hw.family="SoundStation" hw.product="SoundStation 7000" os.version="4.0.8.1608">PolycomSoundStationIP-SSIP_7000-UA/4.0.8.1608</example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="1" name="hw.family"/>
@@ -757,20 +757,22 @@
     <param pos="0" name="os.device" value="VoIP"/>
     <param pos="0" name="os.product" value="{hw.family} {hw.model}"/>
     <param pos="3" name="os.version"/>
+
   </fingerprint>
 
   <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(?:RealPresenceTrio)-Trio_(\S+)-UA/([\d\.]+)(?:_(.{12}))?$">
     <description>Polycom RealPresence Trio Phones</description>
-    <example hw.version="5.4.0.12197" hw.product="RealPresence Trio 8800" hw.model="8800">PolycomRealPresenceTrio-Trio_8800-UA/5.4.0.12197</example>
-    <example hw.version="5.7.2.3123" hw.product="RealPresence Trio Visual+" hw.model="Visual+">PolycomRealPresenceTrio-Trio_Visual+-UA/5.7.2.3123</example>
-    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389</example>
-    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800" host.mac="DEADBEEF0000">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389_DEADBEEF0000</example>
+    <example hw.version="5.4.0.12197" hw.product="RealPresence Trio 8800" hw.model="8800" os.version="5.4.0.12197">PolycomRealPresenceTrio-Trio_8800-UA/5.4.0.12197</example>
+    <example hw.version="5.7.2.3123" hw.product="RealPresence Trio Visual+" hw.model="Visual+" os.version="5.7.2.3123">PolycomRealPresenceTrio-Trio_Visual+-UA/5.7.2.3123</example>
+    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800" os.version="5.4.3.2389">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389</example>
+    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800" host.mac="DEADBEEF0000" os.version="5.4.3.2389">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389_DEADBEEF0000</example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.family" value="RealPresence"/>
     <param pos="0" name="hw.product" value="RealPresence Trio {hw.model}"/>
     <param pos="1" name="hw.model"/>
     <param pos="2" name="hw.version"/>
+    <param pos="2" name="os.version"/>
     <param pos="3" name="host.mac"/>
     <param pos="0" name="os.vendor" value="Polycom"/>
     <param pos="0" name="os.device" value="VoIP"/>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -751,6 +751,7 @@
     <param pos="0" name="hw.product" value="{hw.family} {hw.model}"/>
     <param pos="2" name="hw.model"/>
     <param pos="3" name="hw.version"/>
+    <param pos="3" name="os.version"/>
     <param pos="4" name="host.mac"/>
     <param pos="0" name="os.vendor" value="Polycom"/>
     <param pos="0" name="os.device" value="VoIP"/>

--- a/xml/sip_banners.xml
+++ b/xml/sip_banners.xml
@@ -738,4 +738,43 @@
     <param pos="0" name="hw.device" value="Router"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(SoundPoint|VVX|SoundStation)\S+_(\d+)-UA/([\d\.]+)(?:_(.{12}))?$">
+    <description>Polycom SoundPoint, SountdStation, VVX VoIP phones</description>
+    <example hw.version="5.8.0.13337" hw.family="VVX" hw.product="VVX 350" hw.model="350">PolycomVVX-VVX_350-UA/5.8.0.13337</example>
+    <example hw.version="4.1.4.7430" hw.family="VVX" hw.product="VVX 400" host.mac="010203040506" hw.model="400">PolycomVVX-VVX_400-UA/4.1.4.7430_010203040506</example>
+    <example hw.version="5.5.0.23866" hw.family="VVX" hw.product="VVX 501" hw.model="501">Polycom/5.5.0.23866 PolycomVVX-VVX_501-UA/5.5.0.23866</example>
+    <example hw.version="4.0.7.2514" hw.family="SoundPoint" hw.product="SoundPoint 670" hw.model="670">PolycomSoundPointIP-SPIP_670-UA/4.0.7.2514</example>
+    <example hw.version="4.0.8.1608" hw.model="7000" hw.family="SoundStation" hw.product="SoundStation 7000">PolycomSoundStationIP-SSIP_7000-UA/4.0.8.1608</example>
+    <param pos="0" name="hw.vendor" value="Polycom"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="1" name="hw.family"/>
+    <param pos="0" name="hw.product" value="{hw.family} {hw.model}"/>
+    <param pos="2" name="hw.model"/>
+    <param pos="3" name="hw.version"/>
+    <param pos="4" name="host.mac"/>
+    <param pos="0" name="os.vendor" value="Polycom"/>
+    <param pos="0" name="os.device" value="VoIP"/>
+    <param pos="0" name="os.product" value="{hw.family} {hw.model}"/>
+    <param pos="3" name="os.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(?:RealPresenceTrio)-Trio_(\S+)-UA/([\d\.]+)(?:_(.{12}))?$">
+    <description>Polycom RealPresence Trio Phones</description>
+    <example hw.version="5.4.0.12197" hw.product="RealPresence Trio 8800" hw.model="8800">PolycomRealPresenceTrio-Trio_8800-UA/5.4.0.12197</example>
+    <example hw.version="5.7.2.3123" hw.product="RealPresence Trio Visual+" hw.model="Visual+">PolycomRealPresenceTrio-Trio_Visual+-UA/5.7.2.3123</example>
+    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389</example>
+    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800" host.mac="DEADBEEF0000">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389_DEADBEEF0000</example>
+    <param pos="0" name="hw.vendor" value="Polycom"/>
+    <param pos="0" name="hw.device" value="VoIP"/>
+    <param pos="0" name="hw.family" value="RealPresence"/>
+    <param pos="0" name="hw.product" value="RealPresence Trio {hw.model}"/>
+    <param pos="1" name="hw.model"/>
+    <param pos="2" name="hw.version"/>
+    <param pos="3" name="host.mac"/>
+    <param pos="0" name="os.vendor" value="Polycom"/>
+    <param pos="0" name="os.device" value="VoIP"/>
+    <param pos="0" name="os.product" value="RealPresence Trio {hw.model}"/>
+    <param pos="2" name="os.version"/>
+  </fingerprint>
+
 </fingerprints>

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -281,6 +281,11 @@
     <param pos="2" name="hw.model"/>
     <param pos="3" name="hw.version"/>
     <param pos="4" name="host.mac"/>
+    <param pos="0" name="os.vendor" value="Polycom"/>
+    <param pos="0" name="os.device" value="VoIP"/>
+    <param pos="0" name="os.product" value="{hw.family} {hw.model}"/>
+    <param pos="3" name="os.version"/>
+
   </fingerprint>
 
   <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(?:RealPresenceTrio)-Trio_(\S+)-UA/([\d\.]+)(?:_(.{12}))?$">
@@ -296,6 +301,10 @@
     <param pos="1" name="hw.model"/>
     <param pos="2" name="hw.version"/>
     <param pos="3" name="host.mac"/>
+    <param pos="0" name="os.vendor" value="Polycom"/>
+    <param pos="0" name="os.device" value="VoIP"/>
+    <param pos="0" name="os.product" value="RealPresence Trio {hw.model}"/>
+    <param pos="2" name="os.version"/>
   </fingerprint>
 
   <fingerprint pattern="^Polycom ?HDX ?(\d+)(?: ?HD)?(?:/| \(Release - )([^\)]+)\)?">

--- a/xml/sip_user_agents.xml
+++ b/xml/sip_user_agents.xml
@@ -269,32 +269,34 @@
 
   <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(SoundPoint|VVX|SoundStation)\S+_(\d+)-UA/([\d\.]+)(?:_(.{12}))?$">
     <description>Polycom SoundPoint, SountdStation, VVX VoIP phones</description>
-    <example hw.version="5.8.0.13337" hw.family="VVX" hw.product="VVX 350" hw.model="350">PolycomVVX-VVX_350-UA/5.8.0.13337</example>
-    <example hw.version="4.1.4.7430" hw.family="VVX" hw.product="VVX 400" host.mac="010203040506" hw.model="400">PolycomVVX-VVX_400-UA/4.1.4.7430_010203040506</example>
-    <example hw.version="5.5.0.23866" hw.family="VVX" hw.product="VVX 501" hw.model="501">Polycom/5.5.0.23866 PolycomVVX-VVX_501-UA/5.5.0.23866</example>
-    <example hw.version="4.0.7.2514" hw.family="SoundPoint" hw.product="SoundPoint 670" hw.model="670">PolycomSoundPointIP-SPIP_670-UA/4.0.7.2514</example>
-    <example hw.version="4.0.8.1608" hw.model="7000" hw.family="SoundStation" hw.product="SoundStation 7000">PolycomSoundStationIP-SSIP_7000-UA/4.0.8.1608</example>
+    <example hw.version="5.8.0.13337" hw.family="VVX" hw.product="VVX 350" hw.model="350" os.version="5.8.0.13337">PolycomVVX-VVX_350-UA/5.8.0.13337</example>
+    <example hw.version="4.1.4.7430" hw.family="VVX" hw.product="VVX 400" host.mac="010203040506" hw.model="400" os.version="4.1.4.7430">PolycomVVX-VVX_400-UA/4.1.4.7430_010203040506</example>
+    <example hw.version="5.5.0.23866" hw.family="VVX" hw.product="VVX 501" hw.model="501" os.version="5.5.0.23866">Polycom/5.5.0.23866 PolycomVVX-VVX_501-UA/5.5.0.23866</example>
+    <example hw.version="4.0.7.2514" hw.family="SoundPoint" hw.product="SoundPoint 670" hw.model="670" os.version="4.0.7.2514">PolycomSoundPointIP-SPIP_670-UA/4.0.7.2514</example>
+    <example hw.version="4.0.8.1608" hw.model="7000" hw.family="SoundStation" hw.product="SoundStation 7000" os.version="4.0.8.1608">PolycomSoundStationIP-SSIP_7000-UA/4.0.8.1608</example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="1" name="hw.family"/>
     <param pos="0" name="hw.product" value="{hw.family} {hw.model}"/>
     <param pos="2" name="hw.model"/>
     <param pos="3" name="hw.version"/>
+    <param pos="3" name="os.version"/>
     <param pos="4" name="host.mac"/>
   </fingerprint>
 
   <fingerprint pattern="^(?:Polycom/[\d\.]+ )?Polycom(?:RealPresenceTrio)-Trio_(\S+)-UA/([\d\.]+)(?:_(.{12}))?$">
     <description>Polycom RealPresence Trio Phones</description>
-    <example hw.version="5.4.0.12197" hw.product="RealPresence Trio 8800" hw.model="8800">PolycomRealPresenceTrio-Trio_8800-UA/5.4.0.12197</example>
-    <example hw.version="5.7.2.3123" hw.product="RealPresence Trio Visual+" hw.model="Visual+">PolycomRealPresenceTrio-Trio_Visual+-UA/5.7.2.3123</example>
-    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389</example>
-    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800" host.mac="DEADBEEF0000">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389_DEADBEEF0000</example>
+    <example hw.version="5.4.0.12197" hw.product="RealPresence Trio 8800" hw.model="8800" os.version="5.4.0.12197">PolycomRealPresenceTrio-Trio_8800-UA/5.4.0.12197</example>
+    <example hw.version="5.7.2.3123" hw.product="RealPresence Trio Visual+" hw.model="Visual+" os.version="5.7.2.3123">PolycomRealPresenceTrio-Trio_Visual+-UA/5.7.2.3123</example>
+    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800" os.version="5.4.3.2389">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389</example>
+    <example hw.version="5.4.3.2389" hw.product="RealPresence Trio 8800" hw.model="8800" host.mac="DEADBEEF0000" os.version="5.4.3.2389">Polycom/5.4.3.2389 PolycomRealPresenceTrio-Trio_8800-UA/5.4.3.2389_DEADBEEF0000</example>
     <param pos="0" name="hw.vendor" value="Polycom"/>
     <param pos="0" name="hw.device" value="VoIP"/>
     <param pos="0" name="hw.family" value="RealPresence"/>
     <param pos="0" name="hw.product" value="RealPresence Trio {hw.model}"/>
     <param pos="1" name="hw.model"/>
     <param pos="2" name="hw.version"/>
+    <param pos="2" name="os.version"/>
     <param pos="3" name="host.mac"/>
   </fingerprint>
 


### PR DESCRIPTION
## Description

<!-- Start by linking to the VC ticket or other relevant Jira ticket which provides context for this change. -->
[VC-12272](https://rapid7.atlassian.net/browse/VC-12272) Add content against HP Polycom advisory

Adding content against advisory for HP polyocm
Add content against HP Polycom advisory

<!-- Describe what this change does and why it is needed. -->
<!-- Add Confluence links, screenshots, log snippets, etc. if applicable -->

<!-- ## Related PRs -->
<!-- Provide links to related PRs (if any) and provide guidance on required order of merging if needed. -->

## Testing
<!-- Describe how this change was tested or why a test is not required -->

**Validated the vulnerability for Poly Trio**
```
2026-05-29T12:24:14 [INFO] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] [Preference: 1.0] Attempting handshake via SIP
2026-05-29T12:24:14 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: Via: SIP/2.0/TCP 127.0.0.1:5060;rport
2026-05-29T12:24:14 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: User-Agent: PolycomRealPresenceTrio-Trio_8800-UA/7.2.2.1011
2026-05-29T12:24:14 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: Allow: INVITE, OPTIONS, BYE, CANCEL, ACK, PRACK, UPDATE, REFER, SUBSCRIBE, NOTIFY, INFO, REGISTER
2026-05-29T12:24:14 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: Allow-Events: telephone-event
2026-05-29T12:24:14 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] No SIP Server header found.
2026-05-29T12:24:14 [INFO] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] [sip_header.user_agent] Matching against banner: PolycomRealPresenceTrio-Trio_8800-UA/7.2.2.1011
2026-05-29T12:24:14 [INFO] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Creating SystemFingerprint [[architecture=null][certainty=0.8][description=Polycom RealPresence Trio 8800 7.2.2.1011][deviceClass=VoIP][family=null][product=RealPresence Trio 8800][vendor=Polycom][version=7.2.2.1011]]
```
```
NOTIFY, INFO, REGISTER, sip.headers.allow-events=telephone-event, sip.headers.user-agent=PolycomRealPresenceTrio-Trio_8800-UA/7.2.2.1011, sip.headers.via=SIP/2.0/TCP 127.0.0.1:5060;rport, sip.version=2.0}
2026-05-29T12:24:14 [INFO] [Thread: convert-open-tcp-ports-to-services@10.4.82.204] [Site: VC-12272] [10.4.82.204] SystemFingerprint [[architecture=null][certainty=0.8][description=Polycom RealPresence Trio 8800 7.2.2.1011][deviceClass=VoIP][family=null][product=RealPresence Trio 8800][vendor=Polycom][version=7.2.2.1011]] source: SIP
```
`2026-05-29T12:24:14 [INFO] [Thread: VulnerabilityCheckContext.performTests-1@10.4.82.204] [Site: VC-12272] [10.4.82.204] [Duration: 00:00:00.000] hp-poly-cve-2026-0826 (hp-poly-trio-cve-2026-0826) - VULNERABLE VERSION`

**Validated the fingerprint and vulnerability for Poly VVX**

```
2026-05-29T11:45:07 [INFO] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] [Preference: 1.0] Attempting handshake via SIP
2026-05-29T11:45:07 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: Via: SIP/2.0/TCP 127.0.0.1:5060;rport
2026-05-29T11:45:07 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: User-Agent: PolycomVVX-VVX_400-UA/6.4.7.4477
2026-05-29T11:45:07 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: Allow: INVITE, OPTIONS, BYE, CANCEL, ACK, PRACK, UPDATE, REFER, SUBSCRIBE, NOTIFY, INFO, REGISTER
2026-05-29T11:45:07 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Found SIP header: Allow-Events: telephone-event
2026-05-29T11:45:07 [DEBUG] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] No SIP Server header found.
```
`2026-05-29T11:45:07 [INFO] [Thread: 10.4.82.204:5060/TCP] [Site: VC-12272] Creating SystemFingerprint [[architecture=null][certainty=0.8][description=Polycom VVX 400 6.4.7.4477][deviceClass=VoIP][family=null][product=VVX 400][vendor=Polycom][version=6.4.7.4477]]`
`2026-05-29T12:24:14 [INFO] [Thread: VulnerabilityCheckContext.performTests-1@10.4.82.204] [Site: VC-12272] [10.4.82.204] [Duration: 00:00:00.000] hp-poly-cve-2026-0826 (hp-poly-vvx-cve-2026-0826) - VULNERABLE VERSION`


## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?
A clear and concise description of your changes were tested.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.


[VC-12272]: https://rapid7.atlassian.net/browse/VC-12272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ