### PR TITLE
VC-12795: Incorrect Fingerprinting and F+ for MariaDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Ruby (JRuby)
+      if: ${{ startsWith(matrix.ruby-version, 'jruby') }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler: latest
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Set up Ruby
+      if: ${{ !startsWith(matrix.ruby-version, 'jruby') }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler: latest
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        bundler: latest
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: |

--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1435,10 +1435,11 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,2}\.\d{1,2})-MariaDB-ubu+[0-9]{4}$" flags="REG_ICASE">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,2}\.\d{1,2})-MariaDB-ubu+[0-9]{4}(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB LTS alternate version format </description>
     <example service.version="10.5.27">5.5.5-10.5.27-MariaDB-ubu2004</example>
     <example service.version="10.11.9">5.5.5-10.11.9-MariaDB-ubu2204</example>
+    <example service.version="10.11.9">5.5.5-10.11.9-MariaDB-ubu2204-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1449,9 +1450,10 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:mariadb:mariadb:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+.[0-9]{4}$" flags="REG_ICASE">
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+.[0-9]{4}(?:-log)?$" flags="REG_ICASE">
     <description>MariaDB alternate version format </description>
     <example service.version="10.6.12">5.5.5-10.6.12-MariaDB-1:10.6.12+maria~ubu2004</example>
+    <example service.version="10.11.7">5.5.5-10.11.7-MariaDB-1:10.11.7+maria~ubu2204-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>


### PR DESCRIPTION
## Description

[VC-12795](https://rapid7.atlassian.net/browse/VC-12795)

### Problem

MariaDB 10.x uses a MySQL protocol compatibility shim that prepends `5.5.5-` to its actual version string in the handshake banner. When binary logging (`log_bin`) is enabled on the server, MariaDB additionally appends `-log` to the banner. For example:

```
Without binary logging: 5.5.5-10.11.9-MariaDB-ubu2204
With binary logging:    5.5.5-10.11.9-MariaDB-ubu2204-log

Without binary logging: 5.5.5-10.11.7-MariaDB-1:10.11.7+maria~ubu2004
With binary logging:    5.5.5-10.11.7-MariaDB-1:10.11.7+maria~ubu2204-log
```

Two fingerprint patterns in mysql_banners.xml terminate with `[0-9]{4}$` (matching the 4-digit Ubuntu release year code like `2204` or `2004`). This hard anchor at end-of-string means any additional characters after the year code — such as `-log` — cause the regex to fail.

When no recog pattern matches the banner, `MySQLProtocolHelper.java` (in protocol-fingerprinter) executes a fallback path that naively parses the `5.5.5-` prefix as the actual version and hardcodes the result as:

- **Vendor:** Oracle
- **Product:** MySQL
- **Version:** 5.5.5

This produces incorrect fingerprinting results for any MariaDB 10.x instance running with binary logging enabled.

### Impact

- **False identification:** MariaDB hosts are reported as Oracle MySQL 5.5.5, an outdated version that may trigger false-positive vulnerability findings.
- **Missing vulnerabilities:** Because the product is misidentified, MariaDB-specific CVEs are not matched, leading to false negatives.


### Root Cause

The two affected patterns:

1. **MariaDB LTS alternate version format** (line ~1438):
   ```
   ^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,2}\.\d{1,2})-MariaDB-ubu+[0-9]{4}$
   ```

2. **MariaDB alternate version format** (line ~1455):
   ```
   ^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB.+.[0-9]{4}$
   ```

Both use `$` immediately after `[0-9]{4}`, leaving no room for the optional `-log` suffix.

### Fix

Added `(?:-log)?` as an optional non-capturing group before the `$` anchor in both patterns:

```diff
- ^(...)-MariaDB-ubu+[0-9]{4}$
+ ^(...)-MariaDB-ubu+[0-9]{4}(?:-log)?$

- ^(...)-MariaDB.+.[0-9]{4}$
+ ^(...)-MariaDB.+.[0-9]{4}(?:-log)?$
```

This is consistent with existing patterns in the same file that already handle the `-log` suffix (e.g., the MariaDB Galera/wheezy-wsrep pattern uses `(?:-log)?$`).

Added `<example>` elements for both patterns to ensure the `-log` variant is tested:
- `5.5.5-10.11.9-MariaDB-ubu2204-log` (LTS pattern)
- `5.5.5-10.11.7-MariaDB-1:10.11.7+maria~ubu2204-log` (alternate pattern)

### Testing

- **Regex validation:** Confirmed both patterns match banners with and without `-log` using direct regex testing.
- **Backward compatibility:** Existing `<example>` elements (without `-log`) continue to match, ensuring no regression for hosts without binary logging.
- **Scan verification:** Tested against a live MariaDB 10.11.7 target (without `-log`) and confirmed correct fingerprinting as MariaDB with the proper version extracted.
- **Precedent:** The `(?:-log)?` idiom is already used in other MariaDB patterns in this file, confirming it is the expected approach.

### Files Changed

- `xml/mysql_banners.xml` — Two regex pattern updates + two new example elements


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.


[VC-12795]: https://rapid7.atlassian.net/browse/VC-12795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ