### PR TITLE
Add Proxmox Backup Server html_title fingerprint

### DIFF
--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3365,6 +3365,17 @@
     <param pos="0" name="os.product" value="Proxmox"/>
   </fingerprint>
 
+  <fingerprint pattern="^.{1,256} - Proxmox Backup Server$">
+    <description>Proxmox Backup Server web interface</description>
+    <example>proxmox-backup-server - Proxmox Backup Server</example>
+    <param pos="0" name="service.vendor" value="Proxmox"/>
+    <param pos="0" name="service.product" value="Backup Server"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:proxmox:proxmox_backup_server:-"/>
+    <param pos="0" name="os.vendor" value="Proxmox"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Proxmox"/>
+  </fingerprint>
+
   <fingerprint pattern="^Sony Network Camera$">
     <description>Sony Network Camera</description>
     <example>Sony Network Camera</example>


### PR DESCRIPTION
Adds an `html_title` fingerprint for **Proxmox Backup Server** (PBS), which is currently unidentified. Its web UI (port 8007) serves `<title>… - Proxmox Backup Server</title>`, mirroring the existing Proxmox VE title fingerprint.

Without it, a PBS host falls through to the **shared Proxmox-family favicon** fingerprint (`908db8e5…`), which labels it `Virtual Environment` — a misidentification, since PBS, PVE, and PMG all serve that same favicon. The title is the disambiguating signal.

- Pattern: `^.{1,256} - Proxmox Backup Server$`
- Example: `proxmox-backup-server - Proxmox Backup Server` (verified against a live PBS 4.x instance)
- CPE: `cpe:/a:proxmox:proxmox_backup_server:-`

(Side note for maintainers: the shared favicon entry asserting `Virtual Environment` specifically may be worth demoting to vendor/family, since it can't distinguish PVE/PBS/PMG — happy to follow up separately.)