### PR TITLE
Add Overseerr and Prowlarr html_title fingerprints

### DIFF
--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -3265,6 +3265,22 @@
     <param pos="0" name="service.product" value="Jellyseerr"/>
   </fingerprint>
 
+  <fingerprint pattern="^(?:Sign In - )?Overseerr$">
+    <description>Overseerr</description>
+    <example>Overseerr</example>
+    <example>Sign In - Overseerr</example>
+    <param pos="0" name="service.vendor" value="Overseerr"/>
+    <param pos="0" name="service.product" value="Overseerr"/>
+  </fingerprint>
+
+  <fingerprint pattern="^(?:Login - )?Prowlarr$">
+    <description>Prowlarr</description>
+    <example>Prowlarr</example>
+    <example>Login - Prowlarr</example>
+    <param pos="0" name="service.vendor" value="Prowlarr"/>
+    <param pos="0" name="service.product" value="Prowlarr"/>
+  </fingerprint>
+
   <fingerprint pattern="^(?:Chorus 2 - )?Kodi(?: web interface)?$">
     <description>Kodi Media Server</description>
     <example>Kodi</example>


### PR DESCRIPTION
Two Servarr-ecosystem self-hosted apps that currently aren't identified by title:

- **Overseerr** — `<title>Sign In - Overseerr</title>`. Recog already has its fork **Jellyseerr** but not the original Overseerr; this mirrors that entry.
- **Prowlarr** — `<title>Login - Prowlarr</title>`. Recog's only Prowlarr entry is an HTTP-Basic-auth realm rule (`Basic realm="Prowlarr"`), but Prowlarr serves a login *page* (no Basic auth), so it goes unidentified (falls through to the Kestrel `Server` header). This adds the missing title fingerprint.

Both patterns verified against live instances and confirmed not to cross-match a sibling app's title.