### PR TITLE
ssh_banners: match OpenSSH on Debian with +debNuM package suffix

### DIFF
--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -1468,11 +1468,12 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:12.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+(?:[~]?bpo[.]?\d+)?)$">
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-\d+(?:[~]?bpo[.]?\d+)?(?:\+deb\d+u\d+)?)$">
     <description>OpenSSH running on Debian (unknown release)</description>
     <example service.version="4.3p2" openssh.comment="Debian-5~bpo.1">OpenSSH_4.3p2 Debian-5~bpo.1</example>
     <example service.version="4.2p1" openssh.comment="Debian-4bpo1">OpenSSH_4.2p1 Debian-4bpo1</example>
     <example service.version="7.4p1" openssh.comment="Debian-10">OpenSSH_7.4p1 Debian-10</example>
+    <example service.version="10.0p2" openssh.comment="Debian-7+deb13u4">OpenSSH_10.0p2 Debian-7+deb13u4</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>


### PR DESCRIPTION
The generic "OpenSSH running on Debian (unknown release)" fingerprint matches bare `Debian-N` and `Debian-N~bpoX` package comments, but not the `+debNuM` revision suffix that current Debian (12/13) uses for security updates — e.g. `OpenSSH_10.0p2 Debian-7+deb13u4`.

Such banners are common on any patched Debian host, and today they fail to fingerprint at all — losing both the OpenSSH service identification and the Debian OS attribution.

This extends the `openssh.comment` capture group with an optional `(?:\+deb\d+u\d+)?` and adds a matching example. The three existing examples (`Debian-5~bpo.1`, `Debian-4bpo1`, `Debian-10`) still match unchanged.