### PR TITLE
Add HTTP Server header fingerprints for Ollama

### DIFF
--- a/identifiers/service_family.txt
+++ b/identifiers/service_family.txt
@@ -133,6 +133,7 @@ NetWeaver
 Netscaler
 Network Printer Manager
 Niagara
+Ollama
 OpenAdStream
 OpenSMTPD
 OpenSSH

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -489,6 +489,9 @@ Node
 Notebook
 Nucleus SNMP Agent
 Nuggets Learning Server
+Ollama
+ollama-auth-proxy
+OllamaProxy
 OPNSense
 OSSDL.de Openmailadmin
 OTRS x

--- a/identifiers/vendor.txt
+++ b/identifiers/vendor.txt
@@ -586,6 +586,7 @@ Nortel
 Norton
 Novell
 Nuuo
+Ollama
 OPNSense
 OPNsense
 OSSDL.de

--- a/xml/http_servers.xml
+++ b/xml/http_servers.xml
@@ -5208,4 +5208,58 @@
   <param pos="0" name="service.cpe23" value="cpe:/a:mirasvit:cache_warmer:{service.version}"/>
 </fingerprint>
 
+  <fingerprint pattern="^ollama(?: Python/[\d.]+)?$">
+  <description>Ollama LLM inference server (version not disclosed)</description>
+  <example>ollama</example>
+  <example>ollama Python/3.11.15</example>
+  <param pos="0" name="service.vendor" value="Ollama"/>
+  <param pos="0" name="service.product" value="Ollama"/>
+  <param pos="0" name="service.family" value="Ollama"/>
+  <param pos="0" name="service.cpe23" value="cpe:/a:ollama:ollama:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ollama/([\d.]+)(?: Python/[\d.]+)?$">
+  <description>Ollama LLM inference server</description>
+  <example service.version="0.12.10">ollama/0.12.10</example>
+  <example service.version="0.11.4">ollama/0.11.4 Python/3.12.3</example>
+  <param pos="0" name="service.vendor" value="Ollama"/>
+  <param pos="0" name="service.product" value="Ollama"/>
+  <param pos="0" name="service.family" value="Ollama"/>
+  <param pos="1" name="service.version"/>
+  <param pos="0" name="service.cpe23" value="cpe:/a:ollama:ollama:{service.version}"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ollama/([\d.]+) \((\S+) on linux\)$">
+  <description>Ollama LLM inference server on Linux</description>
+  <example service.version="0.1.45" os.arch="amd64">ollama/0.1.45 (amd64 on linux)</example>
+  <param pos="0" name="service.vendor" value="Ollama"/>
+  <param pos="0" name="service.product" value="Ollama"/>
+  <param pos="0" name="service.family" value="Ollama"/>
+  <param pos="1" name="service.version"/>
+  <param pos="0" name="service.cpe23" value="cpe:/a:ollama:ollama:{service.version}"/>
+  <param pos="2" name="os.arch"/>
+  <param pos="0" name="os.vendor" value="Linux"/>
+  <param pos="0" name="os.family" value="Linux"/>
+  <param pos="0" name="os.product" value="Linux"/>
+  <param pos="0" name="os.cpe23" value="cpe:/o:linux:linux_kernel:-"/>
+  </fingerprint>
+
+  <fingerprint pattern="^ollama-auth-proxy/([\d.]+)(?: Python/[\d.]+)?$">
+  <description>ollama-auth-proxy - community authenticating reverse proxy for Ollama</description>
+  <example service.version="1.0">ollama-auth-proxy/1.0 Python/3.14.3</example>
+  <param pos="0" name="service.vendor" value="Ollama"/>
+  <param pos="0" name="service.product" value="ollama-auth-proxy"/>
+  <param pos="0" name="service.family" value="Ollama"/>
+  <param pos="1" name="service.version"/>
+  </fingerprint>
+
+  <fingerprint pattern="^OllamaProxy/([\d.]+)(?: Python/[\d.]+)?$">
+  <description>OllamaProxy - community reverse proxy for Ollama</description>
+  <example service.version="1.0">OllamaProxy/1.0 Python/3.9.6</example>
+  <param pos="0" name="service.vendor" value="Ollama"/>
+  <param pos="0" name="service.product" value="OllamaProxy"/>
+  <param pos="0" name="service.family" value="Ollama"/>
+  <param pos="1" name="service.version"/>
+  </fingerprint>
+
 </fingerprints>


### PR DESCRIPTION
## Description
Add HTTP `Server` header fingerprints for the [Ollama](https://ollama.com/) LLM inference server (default port 11434) and two community reverse proxies (`ollama-auth-proxy`, `OllamaProxy`).

Five fingerprints are added to `xml/http_servers.xml`, covering the banner shapes observed in the wild:

| Banner | Example |
| --- | --- |
| `ollama` (optionally followed by `Python/<ver>`) | `ollama`, `ollama Python/3.11.15` |
| `ollama/<ver>` (optionally followed by `Python/<ver>`) | `ollama/0.12.10`, `ollama/0.11.4 Python/3.12.3` |
| `ollama/<ver> (<arch> on linux)` (Ollama's Go build-info form) | `ollama/0.1.45 (amd64 on linux)` |
| `ollama-auth-proxy/<ver>` | `ollama-auth-proxy/1.0 Python/3.14.3` |
| `OllamaProxy/<ver>` | `OllamaProxy/1.0 Python/3.9.6` |

CPE assertions use `cpe:/a:ollama:ollama` (existing in the [NVD CPE dictionary](https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Aollama%3Aollama)).

New identifier values were added via `bin/recog_standardize`:
- vendor: `Ollama`
- service.family: `Ollama`
- service.product: `Ollama`, `ollama-auth-proxy`, `OllamaProxy`

## Motivation and Context
Ollama has become a widely deployed LLM inference server (recent public research reported ~175k publicly exposed instances).

## How Has This Been Tested?
Local run of `bundle exec bin/recog_verify xml/http_servers.xml`:

```
xml/http_servers.xml: SUMMARY: Test completed with 751 successful, 28 warnings, and 0 failures
```

`bundle exec ruby bin/recog_standardize xml/*.xml` reports no new identifiers introduced (all Ollama values were added to the identifier files in this PR).

`bundle exec rake tests` has the same pre-existing failures on `main` as on this branch (unrelated cucumber fixture tests in `features/`).

Sample header matches captured from scans on TCP/11434:

```
ollama
ollama Python/3.11.15
ollama/0.12.10
ollama/0.11.4 Python/3.12.3
ollama/0.1.45 (amd64 on linux)
ollama-auth-proxy/1.0 Python/3.14.3
OllamaProxy/1.0 Python/3.9.6
```

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
