### PR TITLE
VC-6928 : JunOS not properly fingerprinted over SNMP

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -3863,6 +3863,18 @@ Copyright (c) 1995-2005 by Cisco Systems
     <param pos="0" name="os.cpe23" value="cpe:/o:juniper:junos:{os.version}"/>
   </fingerprint>
 
+  <fingerprint pattern="^Juniper Networks, Inc\. (?:\S+) \[(\S+)\] internet router, kernel JUNOS (\S+?),? ">
+    <description>Juniper Router - bracketed model variant</description>
+    <example hw.model="MX10003" os.version="23.4R2.13">Juniper Networks, Inc. JNP10003 [MX10003] internet router, kernel JUNOS 23.4R2.13, Build date: 2024-07-05 17:12:30 UTC Copyright (c) 1996-2024 Juniper Networks, Inc.</example>
+    <param pos="0" name="os.vendor" value="Juniper"/>
+    <param pos="0" name="os.family" value="Junos"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.product" value="Junos OS"/>
+    <param pos="1" name="hw.model"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:juniper:junos:{os.version}"/>
+  </fingerprint>
+
   <fingerprint pattern="^Juniper Networks, Inc\. (\S+) Ethernet Switch, kernel JUNOS (\S+?),? ">
     <description>Juniper Ethernet Switch</description>
     <example hw.product="ex2300-c-12t" os.version="15.1X53-D590.1">Juniper Networks, Inc. ex2300-c-12t Ethernet Switch, kernel JUNOS 15.1X53-D590.1, Build date: 2018-11-14 20:31:32 UTC Copyright (c) 1996-2018 Juniper Networks, Inc.</example>


### PR DESCRIPTION
## Description

Fix Juniper Router bracketed model variant fingerprint - correct regex capture groups

## Motivation and Context

The Juniper Router fingerprint for systems with bracketed model numbers (e.g., [MX10003])

## How Has This Been Tested?

[Test Plan](https://rapid7.atlassian.net/wiki/spaces/VC/pages/3169910808/Test+Plan+VC-6928+JunOS+not+properly+fingerprinted+over+SNMP)

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
