### PR TITLE
VC-13233 -Add coverage for CISA KEV CVE: CVE-2026-25089 Fortinet FortiSandbox OS Command Injection Vulnerability

### DIFF
--- a/identifiers/device.txt
+++ b/identifiers/device.txt
@@ -77,6 +77,7 @@ Relay Controller
 Remote Access Server
 Remote Terminal
 Router
+Sandbox
 SD-WAN Appliance
 SIP Device
 SIP Gateway

--- a/identifiers/hw_family.txt
+++ b/identifiers/hw_family.txt
@@ -19,6 +19,7 @@ FS
 Firewall-1
 Forms Printer
 FortiGate
+FortiSandbox
 FortiVoice
 GW25
 GXV

--- a/identifiers/service_product.txt
+++ b/identifiers/service_product.txt
@@ -238,6 +238,7 @@ Flower
 Flussonic Media Server
 Flyspray
 Fog Creek Fogbugz (6.1.44)
+FortiSandbox
 FortiVoice
 FortressSSH Server
 FreSSH

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -514,6 +514,18 @@
     <param pos="0" name="hw.device" value="Firewall"/>
   </fingerprint>
 
+  <fingerprint pattern="^FortiSandbox - Please login$">
+    <description>Fortinet FortiSandbox</description>
+    <example>FortiSandbox - Please login</example>
+    <param pos="0" name="service.vendor" value="Fortinet"/>
+    <param pos="0" name="service.product" value="FortiSandbox"/>
+    <param pos="0" name="service.device" value="Sandbox"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:fortinet:fortisandbox:-"/>
+    <param pos="0" name="hw.vendor" value="Fortinet"/>
+    <param pos="0" name="hw.family" value="FortiSandbox"/>
+    <param pos="0" name="hw.device" value="Sandbox"/>
+  </fingerprint>
+
   <!-- Various products by Ubiquiti networks -->
 
   <fingerprint pattern="^Ubiquiti Networks$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -514,19 +514,6 @@
     <param pos="0" name="hw.device" value="Firewall"/>
   </fingerprint>
 
-  <fingerprint pattern="^FortiSandbox - .+$">
-    <description>Fortinet FortiSandbox</description>
-    <example>FortiSandbox - Please login</example>
-    <example>FortiSandbox - Not Found</example>
-    <param pos="0" name="service.vendor" value="Fortinet"/>
-    <param pos="0" name="service.product" value="FortiSandbox"/>
-    <param pos="0" name="service.device" value="Sandbox"/>
-    <param pos="0" name="service.cpe23" value="cpe:/a:fortinet:fortisandbox:-"/>
-    <param pos="0" name="hw.vendor" value="Fortinet"/>
-    <param pos="0" name="hw.family" value="FortiSandbox"/>
-    <param pos="0" name="hw.device" value="Sandbox"/>
-  </fingerprint>
-
   <!-- Various products by Ubiquiti networks -->
 
   <fingerprint pattern="^Ubiquiti Networks$">

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -514,7 +514,7 @@
     <param pos="0" name="hw.device" value="Firewall"/>
   </fingerprint>
 
-  <fingerprint pattern="^FortiSandbox - (.+)$">
+  <fingerprint pattern="^FortiSandbox - .+$">
     <description>Fortinet FortiSandbox</description>
     <example>FortiSandbox - Please login</example>
     <example>FortiSandbox - Not Found</example>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -514,9 +514,10 @@
     <param pos="0" name="hw.device" value="Firewall"/>
   </fingerprint>
 
-  <fingerprint pattern="^FortiSandbox - Please login$">
+  <fingerprint pattern="^FortiSandbox - (.+)$">
     <description>Fortinet FortiSandbox</description>
     <example>FortiSandbox - Please login</example>
+    <example>FortiSandbox - Not Found</example>
     <param pos="0" name="service.vendor" value="Fortinet"/>
     <param pos="0" name="service.product" value="FortiSandbox"/>
     <param pos="0" name="service.device" value="Sandbox"/>

--- a/xml/http_header.x-fortisandbox-version.xml
+++ b/xml/http_header.x-fortisandbox-version.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<fingerprints matches="http_header.x-fortisandbox-version" protocol="http" database_type="service" preference="0.90">
+  <!-- HTTP X-Fortisandbox-Version headers are matched against these patterns to fingerprint Fortinet FortiSandbox appliances. -->
+
+  <fingerprint pattern="^(\d+\.\d+\.\d+)$">
+    <description>Fortinet FortiSandbox</description>
+    <example service.version="5.0.5">5.0.5</example>
+    <param pos="0" name="service.vendor" value="Fortinet"/>
+    <param pos="0" name="service.product" value="FortiSandbox"/>
+    <param pos="0" name="service.device" value="Sandbox"/>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.cpe23" value="cpe:/a:fortinet:fortisandbox:{service.version}"/>
+    <param pos="0" name="hw.vendor" value="Fortinet"/>
+    <param pos="0" name="hw.family" value="FortiSandbox"/>
+    <param pos="0" name="hw.device" value="Sandbox"/>
+  </fingerprint>
+
+</fingerprints>


### PR DESCRIPTION
## Description
A detailed description of your changes.
Added a fingerprint for Fortisandbox product found in [shodan](https://www.shodan.io/host/178.104.163.124)

## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.

Shodan : https://www.shodan.io/host/178.104.163.124
Reference link: https://nvd.nist.gov/vuln/detail/CVE-2026-25089

## How Has This Been Tested?
A clear and concise description of your changes were tested.
1.Linux
Vulnerable version
```
2026-08-06T10:04:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] Checking for X-FORTISANDBOX-VERSION match to: 5.0.0
2026-08-06T10:04:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] [http_header.x-fortisandbox-version] Matching against banner: 5.0.0
2026-08-06T10:04:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] Revoking ServiceFingerprint [[certainty=0.9][description=Apache HTTPD][family=Apache][product=HTTPD][protocol=HTTP][vendor=Apache][version=null]]
2026-08-06T10:04:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] Creating ServiceFingerprint [[certainty=0.9][description=Fortinet FortiSandbox 5.0.0][family=null][product=FortiSandbox][protocol=HTTP][vendor=Fortinet][version=5.0.0]]
```
```
2026-08-06T10:05:14 [INFO] [Thread: VulnerabilityCheckContext.performTests-1@10.4.94.114:80] [Site: VC-13233] [10.4.94.114:80] [Duration: 00:00:00.003] fortinet-fortisandbox-cve-2026-25089 (fortinet-fortisandbox-cve-2026-25089) - VULNERABLE VERSION
2026-08-06T10:05:14 [DEBUG] [Thread: VulnerabilityCheckContext.performTests-1@10.4.94.114:80] [Site: VC-13233] [Status: Complete] [Duration: 0:00:00.017]
```

Non-Vulnerable Version

```
2026-08-06T10:09:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] Checking for X-FORTISANDBOX-VERSION match to: 5.0.7
2026-08-06T10:09:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] [http_header.x-fortisandbox-version] Matching against banner: 5.0.7
2026-08-06T10:09:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] Revoking ServiceFingerprint [[certainty=0.9][description=Apache HTTPD][family=Apache][product=HTTPD][protocol=HTTP][vendor=Apache][version=null]]
2026-08-06T10:09:54 [INFO] [Thread: 10.4.94.114:80/TCP] [Site: VC-13233] Creating ServiceFingerprint [[certainty=0.9][description=Fortinet FortiSandbox 5.0.7][family=null][product=FortiSandbox][protocol=HTTP][vendor=Fortinet][version=5.0.7]]
```

```
2026-08-06T10:10:14 [DEBUG] [Thread: VulnerabilityCheckContext.performTests-1@10.4.94.114:80] [Site: VC-13233] Scan: [10.4.94.114:80] [Duration: 00:00:00.000] fortinet-fortisandbox-cve-2026-25089 (fortinet-fortisandbox-cve-2026-25089) - NOT VULNERABLE VERSION(U)
2026-08-06T10:10:14 [DEBUG] [Thread: VulnerabilityCheckContext.performTests-1@10.4.94.114:80] [Site: VC-13233] [Status: Complete] [Duration: 0:00:00.000]
```

2. Windows
Vulnerable version
```
2026-08-07T07:35:04 [INFO] [Thread: convert-open-tcp-ports-to-services@10.4.25.68] [Site: VC-13233] [10.4.25.68:80/tcp] Running TCP service HTTP
2026-08-07T07:35:04 [INFO] [Thread: convert-open-tcp-ports-to-services@10.4.25.68] [Site: VC-13233] [10.4.25.68:80/tcp] Service running: ServiceFingerprint [[certainty=0.9][description=Fortinet FortiSandbox 4.4.0][family=null][product=FortiSandbox][protocol=HTTP][vendor=Fortinet][version=4.4.0]]
```

```
2026-08-07T07:35:11 [INFO] [Thread: VulnerabilityCheckContext.performTests-1@10.4.25.68:80] [Site: VC-13233] [10.4.25.68:80] [Duration: 00:00:00.003] fortinet-fortisandbox-cve-2026-25089 (fortinet-fortisandbox-cve-2026-25089) - VULNERABLE VERSION
2026-08-07T07:35:11 [DEBUG] [Thread: VulnerabilityCheckContext.performTests-1@10.4.25.68:80] [Site: VC-13233] [Status: Complete] [Duration: 0:00:00.017]
```

Non-Vulnerable version
```
2026-08-07T07:45:49 [INFO] [Thread: convert-open-tcp-ports-to-services@10.4.25.68] [Site: VC-13233] [10.4.25.68:80/tcp] Running TCP service HTTP
2026-08-07T07:45:49 [INFO] [Thread: convert-open-tcp-ports-to-services@10.4.25.68] [Site: VC-13233] [10.4.25.68:80/tcp] Service running: ServiceFingerprint [[certainty=0.9][description=Fortinet FortiSandbox 5.0.7][family=null][product=FortiSandbox][protocol=HTTP][vendor=Fortinet][version=5.0.7]]
```

```
2026-08-07T07:45:56 [DEBUG] [Thread: VulnerabilityCheckContext.performTests-1@10.4.25.68:80] [Site: VC-13233] Scan: [10.4.25.68:80] [Duration: 00:00:00.001] fortinet-fortisandbox-cve-2026-25089 (fortinet-fortisandbox-cve-2026-25089) - NOT VULNERABLE VERSION(U)
2026-08-07T07:45:56 [DEBUG] [Thread: VulnerabilityCheckContext.performTests-1@10.4.25.68:80] [Site: VC-13233] [Status: Complete] [Duration: 0:00:00.001]
```


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
