### PR TITLE
VC-8268 : F+ for debian-obsolete-remote

### DIFF
--- a/xml/mysql_banners.xml
+++ b/xml/mysql_banners.xml
@@ -1706,9 +1706,10 @@
     <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:9.0"/>
   </fingerprint>
 
-  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)(\d*\.\d*\.\d*)-MariaDB\S*deb\S*$" flags="REG_ICASE">
-    <description>MariaDB MariaDB on Debian 9.1 (stretch)</description>
-    <example service.version="10.1.23">5.5.5-10.1.23-MariaDB-9+deb9u1</example>
+  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)(\d*\.\d*\.\d*)-MariaDB\S*\+deb(\d{1,2})u\d\S*$" flags="REG_ICASE">
+    <description>MariaDB MariaDB packaged for Debian</description>
+    <example service.version="10.1.23" os.version="9">5.5.5-10.1.23-MariaDB-9+deb9u1</example>
+    <example service.version="10.5.29" os.version="11">5.5.5-10.5.29-MariaDB-0+deb11u1-log</example>
     <param pos="1" name="service.version"/>
     <param pos="0" name="service.vendor" value="MariaDB"/>
     <param pos="0" name="service.family" value="MySQL"/>
@@ -1717,8 +1718,8 @@
     <param pos="0" name="os.vendor" value="Debian"/>
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
-    <param pos="0" name="os.version" value="9.1"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:9.1"/>
+    <param pos="2" name="os.version"/>
+    <param pos="0" name="os.cpe23" value="cpe:/o:debian:debian_linux:{os.version}"/>
   </fingerprint>
 
   <fingerprint pattern="^^(\d{1,2}\.\d{1,2}\.[a-f\d]{1,3})-Sphinx" flags="REG_ICASE">


### PR DESCRIPTION
## Description
The "MariaDB packaged for Debian" fingerprint in xml/mysql_banners.xml hardcoded os.version to 9.1, so any matching banner was mislabeled as Debian 9.1 regardless of the actual Debian release in the banner.

**Changes**

1. Updated the regex to capture the Debian release from the +deb<N>u<N> suffix (...\+deb(\d{1,2})u\d\S*$).
2. Set os.version dynamically from the captured group (pos="2") instead of the hardcoded 9.1.
3. Changed os.cpe23 to interpolate the value: cpe:/o:debian:debian_linux:{os.version}.
4. Added a Debian 11 example and updated the description. 

Note - The extracted os.version is just the major number (9, 11) rather than the previous 9.1, so os.cpe23 becomes cpe:/o:debian:debian_linux:9 instead of 9.1. That's actually more accurate since the banner only tells you the major Debian release.

## How Has This Been Tested?

**Issue Replication** - Tested on a VM running Debian 11.11. As shown in the screenshot below, a false positive occurred where the version was incorrectly fingerprinted as 9.1 on remote scanning
<img width="4264" height="1500" alt="image" src="https://github.com/user-attachments/assets/e83e2ed9-3111-4b1f-b7f5-99fd4b9e0ace" />

**Post fix testing** - The fingerprint now correctly identifies version 11, and the obsolete check is no longer flagged, as expected.
<img width="4264" height="1500" alt="image" src="https://github.com/user-attachments/assets/55917589-51a9-42bc-9e36-7e00416ccd68" />

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
