### PR TITLE
Update SIMATIC NET and S7 Info

### DIFF
--- a/xml/snmp_sysdescr.xml
+++ b/xml/snmp_sysdescr.xml
@@ -6815,13 +6815,10 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example hw.product="CP 343-1" hw.version="2.2.20">Siemens, SIMATIC NET, CP 343-1, 6GK7 343-1EX30-0XE0, HW: Version 3, FW: Version V2.2.20, VPXN545808</example>
     <example hw.product="SCALANCE X204-2" hw.version="4.01">Siemens, SIMATIC NET, SCALANCE X204-2, 6GK5 204-2BB10-2AA3, HW: 4, FW: V4.01</example>
     <example hw.product="Scalance S612" hw.version="T03.00.00.00_25.00.00.01">Siemens, SIMATIC NET, Scalance S612, 6GK56120BA102AA3, HW: Version 6, FW: Version T03.00.00.00_25.00.00.01, VPB9542952</example>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.product" value="Windows 7"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_7:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:siemens:simatic_net_{hw.product}:-"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
     <param pos="0" name="hw.family" value="Simatic NET"/>
-    <param pos="0" name="hw.device" value="Monitoring"/>
+    <param pos="0" name="hw.device" value="Networking"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="hw.version"/>
   </fingerprint>
@@ -6829,13 +6826,10 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^Siemens, SIMATIC NET (\S+) FW V (\S+)$">
     <description>Siemens NET</description>
     <example hw.product="CP1613" hw.version="06.33">Siemens, SIMATIC NET CP1613 FW V 06.33</example>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.family" value="Windows"/>
-    <param pos="0" name="os.product" value="Windows 7"/>
-    <param pos="0" name="os.cpe23" value="cpe:/o:microsoft:windows_7:-"/>
+    <param pos="0" name="hw.cpe23" value="cpe:/h:siemens:simatic_net_{hw.product}:-"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
     <param pos="0" name="hw.family" value="Simatic NET"/>
-    <param pos="0" name="hw.device" value="Monitoring"/>
+    <param pos="0" name="hw.device" value="Networking"/>
     <param pos="1" name="hw.product"/>
     <param pos="2" name="hw.version"/>
   </fingerprint>
@@ -6845,8 +6839,6 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example hw.product="CPU-1200" hw.version="2.0.2">Siemens, SIMATIC S7, CPU-1200, 6ES7 211-1BD30-0XB0, HW: 1, FW: V.2.0.2, SZVX8YU9000553</example>
     <example hw.product="CPU315-2 PN/DP" hw.version="2.5.0">Siemens, SIMATIC S7, CPU315-2 PN/DP, 6ES7 315-2EH13-0AB0 , HW: 3, FW: V2.5.0, S C-V4P07826200</example>
     <example hw.product="IM151-8" hw.version="3.2.3">Siemens, SIMATIC S7, IM151-8, 6ES7 151-8AB01-0AB0 , HW: 2, FW: V3.2.3, S C-B3UC78192011</example>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
     <param pos="0" name="hw.family" value="Simatic S7"/>
     <param pos="1" name="hw.product"/>
@@ -6858,8 +6850,6 @@ Copyright (c) 1995-2005 by Cisco Systems
     <example hw.product="CPU-1200" hw.version="1.0.1">Siemens, SIMATIC S7, CPU-1200, 6ES7 212-1BD30-0XB0 SZVA1YU6008610 , 1, V.1.0.1, SZVA1YU6008610</example>
     <example hw.version="1.0.1" hw.product="CPU-1200">Siemens, SIMATIC S7, CPU-1200, 6ES7 212-1HD30-0XB0 SZVA3YU7002312 , 1, V.1.0.1, SZVA3YU7002312</example>
     <example hw.product="CPU-1200" hw.version="1.0.2">Siemens, SIMATIC S7, CPU-1200, 6ES7 214-1BE30-0XB0 SZVA2YYY007305 , 1, V.1.0.2, SZVA2YYY007305</example>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
     <param pos="0" name="hw.family" value="Simatic S7"/>
     <param pos="1" name="hw.product"/>
@@ -6869,8 +6859,6 @@ Copyright (c) 1995-2005 by Cisco Systems
   <fingerprint pattern="^Siemens, SIMATIC, (\S+)$">
     <description>Siemens S7 - model only variant</description>
     <example hw.product="S7-300">Siemens, SIMATIC, S7-300</example>
-    <param pos="0" name="os.vendor" value="Microsoft"/>
-    <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="hw.vendor" value="Siemens"/>
     <param pos="0" name="hw.family" value="Simatic S7"/>
     <param pos="1" name="hw.product"/>


### PR DESCRIPTION
The OS and CPE information were incorrectly attributed to the S7 and SIMATIC NET signatures.

## Description
Removed incorrect Microsoft Windows OS and CPE metadata from the SIMATIC S7 and SIMATIC NET fingerprints. These devices do not run Windows.


## Motivation and Context
The existing metadata caused S7 and SIMATIC NET devices to be incorrectly identified as Windows systems.


## How Has This Been Tested?
Verified that the affected signatures no longer report Windows OS or CPE information while retaining the existing Siemens hardware identification.


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
